### PR TITLE
CLDC-275: Form flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-debug.log*
 
 # Code coverage results
 /coverage
+
+#IDE specific files
+/.idea
+/.idea/*

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -17,12 +17,9 @@ module TasklistHelper
     if subsection_name == "declaration"
       return all_questions_completed(case_log) ? :not_started : :cannot_start_yet
     end
-    if questions.all? {|question| case_log[question].blank?}
-      return :not_started
-    end
-    if questions.all? {|question| case_log[question].present?}
-      return :completed
-    end
+
+    return :not_started if questions.all? {|question| case_log[question].blank?}
+    return :completed if questions.all? {|question| case_log[question].present?}
     :in_progress
   end
 

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -24,14 +24,6 @@ module TasklistHelper
     :in_progress
   end
 
-  def get_status_style(status_label)
-    STYLES[status_label]
-  end
-
-  def get_status_label(status)
-    STATUSES[status]
-  end
-
   def get_next_incomplete_section(form, case_log)
     subsections = form.all_subsections.keys
     subsections.find { |subsection| is_incomplete?(subsection, case_log, form.questions_for_subsection(subsection).keys) }

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -13,10 +13,7 @@ module TasklistHelper
     :in_progress => "govuk-tag--blue"
   }
 
-  def get_subsection_status(subsection_name, case_log)
-    @form = Form.new(2021, 2022)
-    questions = @form.questions_for_subsection(subsection_name).keys
-
+  def get_subsection_status(subsection_name, case_log, questions)
     if subsection_name == "declaration"
       return all_questions_completed(case_log) ? :not_started : :cannot_start_yet
     end
@@ -39,7 +36,7 @@ module TasklistHelper
 
   def get_next_incomplete_section(form, case_log)
     subsections = form.all_subsections.keys
-    return subsections.find { |subsection| is_incomplete?(subsection, case_log) }
+    return subsections.find { |subsection| is_incomplete?(subsection, case_log, form.questions_for_subsection(subsection).keys) }
   end
 
   private
@@ -47,8 +44,8 @@ module TasklistHelper
     case_log.attributes.all? { |_question, answer| answer.present?}
   end
 
-  def is_incomplete?(subsection, case_log)
-    status = get_subsection_status(subsection, case_log)
+  def is_incomplete?(subsection, case_log, questions)
+    status = get_subsection_status(subsection, case_log, questions)
     return status == :not_started || status == :in_progress
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -29,15 +29,26 @@ module TasklistHelper
     :in_progress
   end
 
-  def all_questions_completed(case_log)
-    case_log.attributes.all? { |_question, answer| answer.present?}
-  end
-
   def get_status_style(status_label)
     STYLES[status_label]
   end
 
   def get_status_label(status)
     STATUSES[status]
+  end
+
+  def get_next_incomplete_section(form, case_log)
+    subsections = form.all_subsections.keys
+    return subsections.find { |subsection| is_incomplete?(subsection, case_log) }
+  end
+
+  private
+  def all_questions_completed(case_log)
+    case_log.attributes.all? { |_question, answer| answer.present?}
+  end
+
+  def is_incomplete?(subsection, case_log)
+    status = get_subsection_status(subsection, case_log)
+    return status == :not_started || status == :in_progress
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -1,25 +1,26 @@
 module TasklistHelper
   STATUSES = {
-    :not_started => "Not started",
-    :cannot_start_yet =>  "Cannot start yet",
-    :completed => "Completed",
-    :in_progress => "In progress"
-  }
+    not_started: "Not started",
+    cannot_start_yet: "Cannot start yet",
+    completed: "Completed",
+    in_progress: "In progress",
+  }.freeze
 
   STYLES = {
-    :not_started => "govuk-tag--grey",
-    :cannot_start_yet => "govuk-tag--grey",
-    :completed => "",
-    :in_progress => "govuk-tag--blue"
-  }
+    not_started: "govuk-tag--grey",
+    cannot_start_yet: "govuk-tag--grey",
+    completed: "",
+    in_progress: "govuk-tag--blue",
+  }.freeze
 
   def get_subsection_status(subsection_name, case_log, questions)
     if subsection_name == "declaration"
       return all_questions_completed(case_log) ? :not_started : :cannot_start_yet
     end
 
-    return :not_started if questions.all? {|question| case_log[question].blank?}
-    return :completed if questions.all? {|question| case_log[question].present?}
+    return :not_started if questions.all? { |question| case_log[question].blank? }
+    return :completed if questions.all? { |question| case_log[question].present? }
+
     :in_progress
   end
 
@@ -39,16 +40,18 @@ module TasklistHelper
   def get_sections_count(form, case_log, status = :all)
     subsections = form.all_subsections.keys
     return subsections.count if status == :all
+
     subsections.count { |subsection| get_subsection_status(subsection, case_log, form.questions_for_subsection(subsection).keys) == status }
   end
 
-  private
+private
+
   def all_questions_completed(case_log)
-    case_log.attributes.all? { |_question, answer| answer.present?}
+    case_log.attributes.all? { |_question, answer| answer.present? }
   end
 
   def is_incomplete?(subsection, case_log, questions)
     status = get_subsection_status(subsection, case_log, questions)
-    status == :not_started || status == :in_progress
+    %i[not_started in_progress].include?(status)
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -33,15 +33,13 @@ module TasklistHelper
 
   def get_next_incomplete_section(form, case_log)
     subsections = form.all_subsections.keys
-    return subsections.find { |subsection| is_incomplete?(subsection, case_log, form.questions_for_subsection(subsection).keys) }
+    subsections.find { |subsection| is_incomplete?(subsection, case_log, form.questions_for_subsection(subsection).keys) }
   end
 
   def get_sections_count(form, case_log, status = :all)
     subsections = form.all_subsections.keys
-    if status == :all
-      return subsections.count
-    end
-    return subsections.count { |subsection| get_subsection_status(subsection, case_log, form.questions_for_subsection(subsection).keys) == status }
+    return subsections.count if status == :all
+    subsections.count { |subsection| get_subsection_status(subsection, case_log, form.questions_for_subsection(subsection).keys) == status }
   end
 
   private
@@ -51,6 +49,6 @@ module TasklistHelper
 
   def is_incomplete?(subsection, case_log, questions)
     status = get_subsection_status(subsection, case_log, questions)
-    return status == :not_started || status == :in_progress
+    status == :not_started || status == :in_progress
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -39,6 +39,14 @@ module TasklistHelper
     return subsections.find { |subsection| is_incomplete?(subsection, case_log, form.questions_for_subsection(subsection).keys) }
   end
 
+  def get_sections_count(form, case_log, status = :all)
+    subsections = form.all_subsections.keys
+    if status == :all
+      return subsections.count
+    end
+    return subsections.count { |subsection| get_subsection_status(subsection, case_log, form.questions_for_subsection(subsection).keys) == status }
+  end
+
   private
   def all_questions_completed(case_log)
     case_log.attributes.all? { |_question, answer| answer.present?}

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -1,0 +1,21 @@
+module TasklistHelper
+  def get_subsection_status(subsection_name, case_log)
+    @form = Form.new(2021, 2022)
+    questions = @form.questions_for_subsection(subsection_name).keys
+
+    if subsection_name == "declaration"
+      return all_questions_completed(case_log) ? "Not started" : "Cannot start yet"
+    end
+    if questions.all? {|question| case_log[question].blank?}
+      return "Not started"
+    end
+    if questions.all? {|question| case_log[question].present?}
+      return "Completed"
+    end
+    "In progress"
+  end
+
+  def all_questions_completed(case_log)
+    case_log.attributes.all? { |_question, answer| answer.present?}
+  end
+end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -1,21 +1,43 @@
 module TasklistHelper
+  STATUSES = {
+    :not_started => "Not started",
+    :cannot_start_yet =>  "Cannot start yet",
+    :completed => "Completed",
+    :in_progress => "In progress"
+  }
+
+  STYLES = {
+    :not_started => "govuk-tag--grey",
+    :cannot_start_yet => "govuk-tag--grey",
+    :completed => "",
+    :in_progress => "govuk-tag--blue"
+  }
+
   def get_subsection_status(subsection_name, case_log)
     @form = Form.new(2021, 2022)
     questions = @form.questions_for_subsection(subsection_name).keys
 
     if subsection_name == "declaration"
-      return all_questions_completed(case_log) ? "Not started" : "Cannot start yet"
+      return all_questions_completed(case_log) ? :not_started : :cannot_start_yet
     end
     if questions.all? {|question| case_log[question].blank?}
-      return "Not started"
+      return :not_started
     end
     if questions.all? {|question| case_log[question].present?}
-      return "Completed"
+      return :completed
     end
-    "In progress"
+    :in_progress
   end
 
   def all_questions_completed(case_log)
     case_log.attributes.all? { |_question, answer| answer.present?}
+  end
+
+  def get_status_style(status_label)
+    STYLES[status_label]
+  end
+
+  def get_status_label(status)
+    STATUSES[status]
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -62,6 +62,6 @@ class Form
   end
 
   def questions_for_subsection(subsection)
-    pages_for_subsection(subsection).map {|title, _value| questions_for_page(title)}.reduce(:merge)
+    pages_for_subsection(subsection).map { |title, _value| questions_for_page(title) }.reduce(:merge)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -60,4 +60,8 @@ class Form
 
     pages_for_subsection(subsection).keys[current_page_idx - 1]
   end
+
+  def questions_for_subsection(subsection)
+    pages_for_subsection(subsection).map {|title, _value| questions_for_page(title)}.reduce(:merge)
+  end
 end

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -12,8 +12,8 @@
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
             <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name" %>
             <% subsection_status=get_subsection_status(subsection_key, @case_log) %>
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              <%= subsection_status %>
+            <strong class="govuk-tag app-task-list__tag <%= get_status_style(subsection_status) %>">
+              <%= get_status_label(subsection_status) %>
             </strong>
           </li>
         <% end %>

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -10,8 +10,8 @@
         <% section_value["subsections"].map do |subsection_key, subsection_value| %>
           <li class="app-task-list__item" id=<%= subsection_key %>>
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
-            <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name" %>
-            <% subsection_status=get_subsection_status(subsection_key, @case_log) %>
+            <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name govuk-link" %>
+            <% subsection_status=get_subsection_status(subsection_key, @case_log, @form.questions_for_subsection(subsection_key)) %>
             <strong class="govuk-tag app-task-list__tag <%= get_status_style(subsection_status) %>">
               <%= get_status_label(subsection_status) %>
             </strong>

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -12,8 +12,8 @@
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
             <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name govuk-link" %>
             <% subsection_status=get_subsection_status(subsection_key, @case_log, @form.questions_for_subsection(subsection_key).keys) %>
-            <strong class="govuk-tag app-task-list__tag <%= get_status_style(subsection_status) %>">
-              <%= get_status_label(subsection_status) %>
+            <strong class="govuk-tag app-task-list__tag <%= TasklistHelper::STYLES[subsection_status] %>">
+              <%= TasklistHelper::STATUSES[subsection_status] %>
             </strong>
           </li>
         <% end %>

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -8,7 +8,7 @@
       </h2>
       <ul class="app-task-list__items">
         <% section_value["subsections"].map do |subsection_key, subsection_value| %>
-          <li class="app-task-list__item">
+          <li class="app-task-list__item" id=<%= subsection_key %>>
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
             <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name" %>
             <% subsection_status=get_subsection_status(subsection_key, @case_log) %>

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -11,7 +11,7 @@
           <li class="app-task-list__item" id=<%= subsection_key %>>
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
             <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name govuk-link" %>
-            <% subsection_status=get_subsection_status(subsection_key, @case_log, @form.questions_for_subsection(subsection_key)) %>
+            <% subsection_status=get_subsection_status(subsection_key, @case_log, @form.questions_for_subsection(subsection_key).keys) %>
             <strong class="govuk-tag app-task-list__tag <%= get_status_style(subsection_status) %>">
               <%= get_status_label(subsection_status) %>
             </strong>

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -11,8 +11,9 @@
           <li class="app-task-list__item">
             <% first_page = @form.first_page_for_subsection(subsection_key) %>
             <%= link_to subsection_value["label"], send("case_log_#{first_page}_path", @case_log), class: "task-name" %>
+            <% subsection_status=get_subsection_status(subsection_key, @case_log) %>
             <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              Not started
+              <%= subsection_status %>
             </strong>
           </li>
         <% end %>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -6,7 +6,7 @@
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">This submission is
         <%= @case_log.status %></h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You've completed 0 of 9 sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You've completed <%= get_sections_count(@form, @case_log, :completed) %> of <%= get_sections_count(@form, @case_log, :all) %> sections.</p>
       <p class="govuk-body govuk-!-margin-bottom-7">
         <a href="#<%= get_next_incomplete_section(@form, @case_log) %>">Skip to next incomplete section</a>
       </p>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -8,7 +8,7 @@
         <%= @case_log.status %></h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You've completed 0 of 9 sections.</p>
       <p class="govuk-body govuk-!-margin-bottom-7">
-        <a href="#">Skip to next incomplete section</a>
+        <a href="#<%= get_next_incomplete_section(@form, @case_log) %>">Skip to next incomplete section</a>
       </p>
 
       <%= render "tasklist", locals: { form: @form } %>

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Test Features" do
     click_button("Save and continue")
   end
 
-
   describe "Create new log" do
     it "redirects to the task list for the new log" do
       visit("/case_logs")
@@ -63,7 +62,7 @@ RSpec.describe "Test Features" do
 
       it "skips to the first section if no answers are completed" do
         visit("/case_logs/#{empty_case_log.id}")
-        expect(page).to have_link("Skip to next incomplete section", :href => /#household_characteristics/)
+        expect(page).to have_link("Skip to next incomplete section", href: /#household_characteristics/)
       end
 
       it "shows the number of completed sections if no sections are completed" do

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe "Test Features" do
         assert_selector ".govuk-tag", text: /Completed/, count: 0
         assert_selector ".govuk-tag", text: /Cannot start yet/, count: 1
       end
+
+      it "skips to the first section if no answers are completed" do
+        visit("/case_logs/#{empty_case_log.id}")
+        expect(page).to have_link("Skip to next incomplete section", :href => /#household_characteristics/)
+      end
     end
 
     it "displays the household questions when you click into that section" do

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -25,10 +25,20 @@ RSpec.describe "Test Features" do
   end
 
   describe "Viewing a log" do
-    it "displays a tasklist header" do
-      visit("/case_logs/#{id}")
-      expect(page).to have_content("Tasklist for log #{id}")
-      expect(page).to have_content("This submission is #{status}")
+    context "tasklist page" do
+      it "displays a tasklist header" do
+        visit("/case_logs/#{id}")
+        expect(page).to have_content("Tasklist for log #{id}")
+        expect(page).to have_content("This submission is #{status}")
+      end
+
+      it "displays a section status" do
+        visit("/case_logs/#{empty_case_log.id}")
+
+        assert_selector ".govuk-tag", text: /Not started/, count: 8
+        assert_selector ".govuk-tag", text: /Completed/, count: 0
+        assert_selector ".govuk-tag", text: /Cannot start yet/, count: 1
+      end
     end
 
     it "displays the household questions when you click into that section" do

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe "Test Features" do
     household_number_of_other_members: { type: "numeric", answer: 2 },
   }
 
+  def answer_all_questions_in_income_subsection
+    visit("/case_logs/#{empty_case_log.id}/net_income")
+    fill_in("net_income", with: 18_000)
+    choose("net-income-frequency-yearly-field")
+    click_button("Save and continue")
+    choose("net-income-uc-proportion-all-field")
+    click_button("Save and continue")
+    choose("housing-benefit-housing-benefit-but-not-universal-credit-field")
+    click_button("Save and continue")
+  end
+
+
   describe "Create new log" do
     it "redirects to the task list for the new log" do
       visit("/case_logs")
@@ -43,6 +55,17 @@ RSpec.describe "Test Features" do
       it "skips to the first section if no answers are completed" do
         visit("/case_logs/#{empty_case_log.id}")
         expect(page).to have_link("Skip to next incomplete section", :href => /#household_characteristics/)
+      end
+
+      it "shows the number of completed sections if no sections are completed" do
+        visit("/case_logs/#{empty_case_log.id}")
+        expect(page).to have_content("You've completed 0 of 9 sections.")
+      end
+
+      it "shows the number of completed sections if one section is completed" do
+        answer_all_questions_in_income_subsection
+        visit("/case_logs/#{empty_case_log.id}")
+        expect(page).to have_content("You've completed 1 of 9 sections.")
       end
     end
 
@@ -120,17 +143,6 @@ RSpec.describe "Test Features" do
       def fill_in_number_question(case_log_id, question, value)
         visit("/case_logs/#{case_log_id}/#{question}")
         fill_in(question.to_s, with: value)
-        click_button("Save and continue")
-      end
-
-      def answer_all_questions_in_income_subsection
-        visit("/case_logs/#{empty_case_log.id}/net_income")
-        fill_in("net_income", with: 18_000)
-        choose("net-income-frequency-yearly-field")
-        click_button("Save and continue")
-        choose("net-income-uc-proportion-all-field")
-        click_button("Save and continue")
-        choose("housing-benefit-housing-benefit-but-not-universal-credit-field")
         click_button("Save and continue")
       end
 

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe "Test Features" do
         assert_selector ".govuk-tag", text: /Cannot start yet/, count: 1
       end
 
+      it "shows the correct status if one section is completed" do
+        answer_all_questions_in_income_subsection
+        visit("/case_logs/#{empty_case_log.id}")
+
+        assert_selector ".govuk-tag", text: /Not started/, count: 7
+        assert_selector ".govuk-tag", text: /Completed/, count: 1
+        assert_selector ".govuk-tag", text: /Cannot start yet/, count: 1
+      end
+
       it "skips to the first section if no answers are completed" do
         visit("/case_logs/#{empty_case_log.id}")
         expect(page).to have_link("Skip to next incomplete section", :href => /#household_characteristics/)

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -51,4 +51,34 @@ RSpec.describe TasklistHelper do
       expect(get_next_incomplete_section(@form, case_log)).to eq("household_characteristics")
     end
   end
+
+  describe "get sections count" do
+    let!(:empty_case_log) { FactoryBot.create(:case_log) }
+    let!(:case_log) { FactoryBot.create(:case_log, :in_progress) }
+
+    it "returns the total of sections if no status is given" do
+      @form = Form.new(2021, 2022)
+      expect(get_sections_count(@form, empty_case_log)).to eq(9)
+    end
+
+    it "returns 0 sections for completed sections if no sections are completed" do
+      @form = Form.new(2021, 2022)
+      expect(get_sections_count(@form, empty_case_log, :completed)).to eq(0)
+    end
+
+    it "returns the number of not started sections" do
+      @form = Form.new(2021, 2022)
+      expect(get_sections_count(@form, empty_case_log, :not_started)).to eq(8)
+    end
+
+    it "returns the number of sections in progress" do
+      @form = Form.new(2021, 2022)
+      expect(get_sections_count(@form, case_log, :in_progress)).to eq(1)
+    end
+
+    it "returns 0 for invalid state" do
+      @form = Form.new(2021, 2022)
+      expect(get_sections_count(@form, case_log, :fake)).to eq(0)
+    end
+  end
 end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe TasklistHelper do
+  describe "get subsection status" do
+    let!(:case_log) { FactoryBot.create(:case_log) }
+    @form = Form.new(2021, 2022)
+
+    it "returns not started if none of the questions in the subsection are answered" do
+      expect(get_subsection_status("income_and_benefits", case_log)).to eq("Not started")
+    end
+
+    it "returns cannot start yet if the subsection is declaration" do
+      expect(get_subsection_status("declaration", case_log)).to eq("Cannot start yet")
+    end
+
+    it "returns in progress if some of the questions have been answered" do
+      case_log["previous_postcode"] = "P0 5TT"
+      expect(get_subsection_status("local_authority", case_log)).to eq("In progress")
+    end
+
+    it "returns completed if all the questions in the subsection have been answered" do
+      %w(net_income net_income_frequency net_income_uc_proportion housing_benefit).each {|x| case_log[x] = "value" }
+      expect(get_subsection_status("income_and_benefits", case_log)).to eq("Completed")
+    end
+
+    it "returns not started if the subsection is declaration and all the questions are completed" do
+      completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"]  }.reduce(:merge))
+      expect(get_subsection_status("declaration", completed_case_log)).to eq("Not started")
+    end
+  end
+end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe TasklistHelper do
     end
 
     it "returns completed if all the questions in the subsection have been answered" do
-      %w(net_income net_income_frequency net_income_uc_proportion housing_benefit).each {|x| case_log[x] = "value" }
+      %w[net_income net_income_frequency net_income_uc_proportion housing_benefit].each { |x| case_log[x] = "value" }
       status = get_subsection_status("income_and_benefits", case_log, income_and_benefits_questions)
       expect(status).to eq(:completed)
     end
 
     it "returns not started if the subsection is declaration and all the questions are completed" do
-      completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"]  }.reduce(:merge))
+      completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"] }.reduce(:merge))
       status = get_subsection_status("declaration", completed_case_log, declaration_questions)
       expect(status).to eq(:not_started)
     end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe TasklistHelper do
   describe "get subsection status" do
     let!(:case_log) { FactoryBot.create(:case_log) }
-    @form = Form.new(2021, 2022)
 
     it "returns not started if none of the questions in the subsection are answered" do
       expect(get_subsection_status("income_and_benefits", case_log)).to eq(:not_started)
@@ -26,6 +25,21 @@ RSpec.describe TasklistHelper do
     it "returns not started if the subsection is declaration and all the questions are completed" do
       completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"]  }.reduce(:merge))
       expect(get_subsection_status("declaration", completed_case_log)).to eq(:not_started)
+    end
+  end
+
+  describe "get next incomplete section" do
+    let!(:case_log) { FactoryBot.create(:case_log) }
+
+    it "returns the first subsection name if it is not completed" do
+      @form = Form.new(2021, 2022)
+      expect(get_next_incomplete_section(@form, case_log)).to eq("household_characteristics")
+    end
+
+    it "returns the first subsection name if it is partially completed" do
+      @form = Form.new(2021, 2022)
+      case_log["tenant_code"] = 123
+      expect(get_next_incomplete_section(@form, case_log)).to eq("household_characteristics")
     end
   end
 end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -6,26 +6,26 @@ RSpec.describe TasklistHelper do
     @form = Form.new(2021, 2022)
 
     it "returns not started if none of the questions in the subsection are answered" do
-      expect(get_subsection_status("income_and_benefits", case_log)).to eq("Not started")
+      expect(get_subsection_status("income_and_benefits", case_log)).to eq(:not_started)
     end
 
     it "returns cannot start yet if the subsection is declaration" do
-      expect(get_subsection_status("declaration", case_log)).to eq("Cannot start yet")
+      expect(get_subsection_status("declaration", case_log)).to eq(:cannot_start_yet)
     end
 
     it "returns in progress if some of the questions have been answered" do
       case_log["previous_postcode"] = "P0 5TT"
-      expect(get_subsection_status("local_authority", case_log)).to eq("In progress")
+      expect(get_subsection_status("local_authority", case_log)).to eq(:in_progress)
     end
 
     it "returns completed if all the questions in the subsection have been answered" do
       %w(net_income net_income_frequency net_income_uc_proportion housing_benefit).each {|x| case_log[x] = "value" }
-      expect(get_subsection_status("income_and_benefits", case_log)).to eq("Completed")
+      expect(get_subsection_status("income_and_benefits", case_log)).to eq(:completed)
     end
 
     it "returns not started if the subsection is declaration and all the questions are completed" do
       completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"]  }.reduce(:merge))
-      expect(get_subsection_status("declaration", completed_case_log)).to eq("Not started")
+      expect(get_subsection_status("declaration", completed_case_log)).to eq(:not_started)
     end
   end
 end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -2,29 +2,38 @@ require "rails_helper"
 
 RSpec.describe TasklistHelper do
   describe "get subsection status" do
+    @form = Form.new(2021, 2022)
+    income_and_benefits_questions = @form.questions_for_subsection("income_and_benefits").keys
+    declaration_questions = @form.questions_for_subsection("declaration").keys
+    local_authority_questions = @form.questions_for_subsection("local_authority").keys
     let!(:case_log) { FactoryBot.create(:case_log) }
 
     it "returns not started if none of the questions in the subsection are answered" do
-      expect(get_subsection_status("income_and_benefits", case_log)).to eq(:not_started)
+      status = get_subsection_status("income_and_benefits", case_log, income_and_benefits_questions)
+      expect(status).to eq(:not_started)
     end
 
     it "returns cannot start yet if the subsection is declaration" do
-      expect(get_subsection_status("declaration", case_log)).to eq(:cannot_start_yet)
+      status = get_subsection_status("declaration", case_log, declaration_questions)
+      expect(status).to eq(:cannot_start_yet)
     end
 
     it "returns in progress if some of the questions have been answered" do
       case_log["previous_postcode"] = "P0 5TT"
-      expect(get_subsection_status("local_authority", case_log)).to eq(:in_progress)
+      status = get_subsection_status("local_authority", case_log, local_authority_questions)
+      expect(status).to eq(:in_progress)
     end
 
     it "returns completed if all the questions in the subsection have been answered" do
       %w(net_income net_income_frequency net_income_uc_proportion housing_benefit).each {|x| case_log[x] = "value" }
-      expect(get_subsection_status("income_and_benefits", case_log)).to eq(:completed)
+      status = get_subsection_status("income_and_benefits", case_log, income_and_benefits_questions)
+      expect(status).to eq(:completed)
     end
 
     it "returns not started if the subsection is declaration and all the questions are completed" do
       completed_case_log = CaseLog.new(case_log.attributes.map { |key, value| Hash[key, value || "value"]  }.reduce(:merge))
-      expect(get_subsection_status("declaration", completed_case_log)).to eq(:not_started)
+      status = get_subsection_status("declaration", completed_case_log, declaration_questions)
+      expect(status).to eq(:not_started)
     end
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -32,4 +32,13 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe ".questions_for_subsection" do
+    let(:subsection) { "income_and_benefits" }
+    it "returns all questions for subsection" do
+      result = form.questions_for_subsection(subsection)
+      expect(result.length).to eq(4)
+      expect(result.keys).to eq(["net_income", "net_income_frequency", "net_income_uc_proportion", "housing_benefit"])
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Form, type: :model do
     it "returns all questions for subsection" do
       result = form.questions_for_subsection(subsection)
       expect(result.length).to eq(4)
-      expect(result.keys).to eq(["net_income", "net_income_frequency", "net_income_uc_proportion", "housing_benefit"])
+      expect(result.keys).to eq(%w[net_income net_income_frequency net_income_uc_proportion housing_benefit])
     end
   end
 end


### PR DESCRIPTION
- [x] Add "in progress", "completed" tags to form sections based on completed questions to each section in the task list page
<img width="350" alt="image" src="https://user-images.githubusercontent.com/54268893/135872586-c0a927ae-c0d9-43de-b7bb-0ec8511b7c7c.png">

- [ ] Add status to check answers pages:
Was done as part of the [277 ticket](https://github.com/communitiesuk/mhclg-data-collection-beta/pull/25)

- [x] Include skip to next incomplete/in progress section in tasklist
<img width="405" alt="image" src="https://user-images.githubusercontent.com/54268893/135872683-3cf83b32-8de2-47d4-9daa-dad17f83bd94.png">

- [ ] Check answers page shows progress:
Was done as part of the [277 ticket](https://github.com/communitiesuk/mhclg-data-collection-beta/pull/25)

- [ ] Check answers page has working answer missing link:
Was done as part of the [277 ticket](https://github.com/communitiesuk/mhclg-data-collection-beta/pull/25)



**Anything else**
Update gitignore file
Make calculation of completed subsections dynamic (_You've completed x of x sections._)

