### PR TITLE
CLDC-512: Display answered fields

### DIFF
--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
       status { 0 }
       tenant_code { "TH356" }
       postcode { "SW2 6HI" }
+      previous_postcode { "P0 5ST" }
+      tenant_age { "12" }
     end
     trait :submitted do
       status { 1 }

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe "Test Features" do
     household_number_of_other_members: { type: "numeric", answer: 2 },
   }
 
+  def fill_in_number_question(case_log_id, question, value)
+    visit("/case_logs/#{case_log_id}/#{question}")
+    fill_in("case-log-#{question.to_s.dasherize}-field", with: value)
+    click_button("Save and continue")
+  end
+
   def answer_all_questions_in_income_subsection
     visit("/case_logs/#{empty_case_log.id}/net_income")
     fill_in("case-log-net-income-field", with: 18_000)
@@ -130,6 +136,20 @@ RSpec.describe "Test Features" do
         fill_in("case-log-support-charge-field", with: 4)
         expect(page).to have_field("case-log-total-charge-field", with: "10")
       end
+
+      it "displays number answers in inputs if they are already saved" do
+        fill_in_number_question(id, "previous_postcode", "P0 5ST")
+
+        visit("/case_logs/#{id}/previous_postcode")
+        expect(page).to have_field("case-log-previous-postcode-field", with: "P0 5ST")
+      end
+
+      it "displays text answers in inputs if they are already saved" do
+        fill_in_number_question(id, "tenant_age", "12")
+
+        visit("/case_logs/#{id}/tenant_age")
+        expect(page).to have_field("case-log-tenant-age-field", with: "12")
+      end
     end
 
     describe "Back link directs correctly" do
@@ -164,12 +184,6 @@ RSpec.describe "Test Features" do
     let(:subsection) { "household_characteristics" }
 
     context "when the user needs to check their answers for a subsection" do
-      def fill_in_number_question(case_log_id, question, value)
-        visit("/case_logs/#{case_log_id}/#{question}")
-        fill_in("case-log-#{question.to_s.dasherize}-field", with: value)
-        click_button("Save and continue")
-      end
-
       it "can be visited by URL" do
         visit("case_logs/#{id}/#{subsection}/check_answers")
         expect(page).to have_content("Check the answers you gave for #{subsection.tr('_', ' ')}")

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -138,15 +138,11 @@ RSpec.describe "Test Features" do
       end
 
       it "displays number answers in inputs if they are already saved" do
-        fill_in_number_question(id, "previous_postcode", "P0 5ST")
-
         visit("/case_logs/#{id}/previous_postcode")
         expect(page).to have_field("case-log-previous-postcode-field", with: "P0 5ST")
       end
 
       it "displays text answers in inputs if they are already saved" do
-        fill_in_number_question(id, "tenant_age", "12")
-
         visit("/case_logs/#{id}/tenant_age")
         expect(page).to have_field("case-log-tenant-age-field", with: "12")
       end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe TasklistHelper do
 
     it "returns the number of sections in progress" do
       @form = Form.new(2021, 2022)
-      expect(get_sections_count(@form, case_log, :in_progress)).to eq(1)
+      expect(get_sections_count(@form, case_log, :in_progress)).to eq(2)
     end
 
     it "returns 0 for invalid state" do


### PR DESCRIPTION
Answered fields are now displaying by default, I assume due to [this PR](https://github.com/communitiesuk/mhclg-data-collection-beta/pull/36)

In current PR: add tests for prepopulating answered questions

Will likely need more work after CLDC-342 ticket which allows saving values for multiple choice questions.