### PR TITLE
Cldc 358 multiple conditions routing

### DIFF
--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -61,7 +61,7 @@ class CaseLogsController < ApplicationController
     responses_for_page = question_responses(questions_for_page)
     @case_log.previous_page = previous_page
     if @case_log.update(responses_for_page)
-      redirect_path = get_next_page_path(form, previous_page, responses_for_page)
+      redirect_path = get_next_page_path(form, previous_page, @case_log)
       redirect_to(send(redirect_path, @case_log))
     else
       page_info = form.all_pages[previous_page]
@@ -129,13 +129,13 @@ private
     params.require(:case_log).permit(CaseLog.editable_fields)
   end
 
-  def get_next_page_path(form, previous_page, responses_for_page = {})
+  def get_next_page_path(form, previous_page, case_log = {})
     questions_for_page = form.questions_for_page(previous_page)
     questions_for_page.each do |_question, content|
       next unless content.key?("conditional_route_to")
 
       content["conditional_route_to"].each do |route, conditions|
-        if responses_for_page[conditions.keys[0]].present? && conditions.values[0].include?(responses_for_page[conditions.keys[0]])
+        if conditions.keys.all? { |x| case_log[x].present? } && conditions.all? { |k, v| v.include?(case_log[k]) }
           return "case_log_#{route}_path"
         end
       end

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -131,11 +131,11 @@ private
 
   def get_next_page_path(form, previous_page, responses_for_page = {})
     questions_for_page = form.questions_for_page(previous_page)
-    questions_for_page.each do |question, content|
+    questions_for_page.each do |_question, content|
       next unless content.key?("conditional_route_to")
 
-      content["conditional_route_to"].each do |route, answer|
-        if responses_for_page[question].present? && answer.include?(responses_for_page[question])
+      content["conditional_route_to"].each do |route, conditions|
+        if responses_for_page[conditions.keys[0]].present? && conditions.values[0].include?(responses_for_page[conditions.keys[0]])
           return "case_log_#{route}_path"
         end
       end

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -131,16 +131,16 @@ private
 
   def get_next_page_path(form, previous_page, case_log = {})
     questions_for_page = form.questions_for_page(previous_page)
-    questions_for_page.each do |_question, content|
-      next unless content.key?("conditional_route_to")
+    content = form.all_pages[previous_page]
 
+    if content.key?("conditional_route_to")
       content["conditional_route_to"].each do |route, conditions|
         if conditions.keys.all? { |x| case_log[x].present? } && conditions.all? { |k, v| v.include?(case_log[k]) }
           return "case_log_#{route}_path"
         end
+        # raise ""
       end
     end
-
     form.next_page_redirect_path(previous_page)
   end
 end

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -130,7 +130,6 @@ private
   end
 
   def get_next_page_path(form, previous_page, case_log = {})
-    questions_for_page = form.questions_for_page(previous_page)
     content = form.all_pages[previous_page]
 
     if content.key?("conditional_route_to")
@@ -138,7 +137,6 @@ private
         if conditions.keys.all? { |x| case_log[x].present? } && conditions.all? { |k, v| v.include?(case_log[k]) }
           return "case_log_#{route}_path"
         end
-        # raise ""
       end
     end
     form.next_page_redirect_path(previous_page)

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -43,7 +43,7 @@ module CheckAnswersHelper
   def get_next_page_name(form, page_name, applicable_questions, question_key, case_log, question_value)
     if applicable_questions[question_key].key?("conditional_route_to")
       applicable_questions[question_key]["conditional_route_to"].each do |conditional_page_key, condition|
-        unless condition_not_met(case_log, condition.keys[0], question_value, condition.values[0])
+        unless condition.any? { |k, v| condition_not_met(case_log, k, question_value, v) }
           return conditional_page_key
         end
       end

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -43,9 +43,9 @@ module CheckAnswersHelper
 
   def get_next_page_name(form, page_name, case_log)
     page = form.all_pages[page_name]
-    if page.key?("conditional_route_to")    
+    if page.key?("conditional_route_to")
       page["conditional_route_to"].each do |conditional_page_name, condition|
-        unless condition.any? { |field, value| condition_not_met(case_log, field, form.questions_for_page[field], value) }
+        unless condition.any? { |field, value| case_log[field].blank? || !value.include?(case_log[field]) }
           return conditional_page_name
         end
       end

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -43,7 +43,7 @@ module CheckAnswersHelper
   def get_next_page_name(form, page_name, applicable_questions, question_key, case_log, question_value)
     if applicable_questions[question_key].key?("conditional_route_to")
       applicable_questions[question_key]["conditional_route_to"].each do |conditional_page_key, condition|
-        unless condition_not_met(case_log, question_key, question_value, condition)
+        unless condition_not_met(case_log, condition.keys[0], question_value, condition.values[0])
           return conditional_page_key
         end
       end

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe "Test Features" do
       visit("/case_logs/#{id}/conditional_question")
       choose("case-log-pregnancy-yes-field", allow_label_click: true)
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/basic_rent")
+      expect(page).to have_current_path("/case_logs/#{id}/rent")
     end
   end
 end

--- a/spec/features/case_log_spec.rb
+++ b/spec/features/case_log_spec.rb
@@ -361,5 +361,15 @@ RSpec.describe "Test Features" do
       click_button("Save and continue")
       expect(page).to have_current_path("/case_logs/#{id}/conditional_question/check_answers")
     end
+
+    it "can route based on multiple conditions" do
+      visit("/case_logs/#{id}/tenant_gender")
+      choose("case-log-tenant-gender-female-field", allow_label_click: true)
+      click_button("Save and continue")
+      visit("/case_logs/#{id}/conditional_question")
+      choose("case-log-pregnancy-yes-field", allow_label_click: true)
+      click_button("Save and continue")
+      expect(page).to have_current_path("/case_logs/#{id}/basic_rent")
+    end
   end
 end

--- a/spec/fixtures/forms/test_form.json
+++ b/spec/fixtures/forms/test_form.json
@@ -250,8 +250,8 @@
                     "1": "No"
                   },
                   "conditional_route_to": {
-                    "conditional_question_yes_page": "Yes",
-                    "conditional_question_no_page": "No"
+                    "conditional_question_yes_page": {"pregnancy": "Yes"},
+                    "conditional_question_no_page": {"pregnancy": "No"}
                   }
                 }
               },

--- a/spec/fixtures/forms/test_form.json
+++ b/spec/fixtures/forms/test_form.json
@@ -248,13 +248,13 @@
                   "answer_options": {
                     "0": "Yes",
                     "1": "No"
-                  },
-                  "conditional_route_to": {
-                    "rent": { "pregnancy": "Yes", "tenant_gender": "Female" },
-                    "conditional_question_yes_page": { "pregnancy": "Yes" },
-                    "conditional_question_no_page": { "pregnancy": "No" }
                   }
                 }
+              },
+              "conditional_route_to": {
+                "rent": { "pregnancy": "Yes", "tenant_gender": "Female" },
+                "conditional_question_yes_page": { "pregnancy": "Yes" },
+                "conditional_question_no_page": { "pregnancy": "No" }
               },
               "default_next_page": "check_answers"
             },

--- a/spec/fixtures/forms/test_form.json
+++ b/spec/fixtures/forms/test_form.json
@@ -250,8 +250,9 @@
                     "1": "No"
                   },
                   "conditional_route_to": {
-                    "conditional_question_yes_page": {"pregnancy": "Yes"},
-                    "conditional_question_no_page": {"pregnancy": "No"}
+                    "conditional_question_yes_page": { "pregnancy": "Yes" },
+                    "conditional_question_no_page": { "pregnancy": "No" },
+                    "basic_rent": { "pregnancy": "Yes", "tenant_gender": "Female" }
                   }
                 }
               },

--- a/spec/fixtures/forms/test_form.json
+++ b/spec/fixtures/forms/test_form.json
@@ -250,9 +250,9 @@
                     "1": "No"
                   },
                   "conditional_route_to": {
+                    "rent": { "pregnancy": "Yes", "tenant_gender": "Female" },
                     "conditional_question_yes_page": { "pregnancy": "Yes" },
-                    "conditional_question_no_page": { "pregnancy": "No" },
-                    "basic_rent": { "pregnancy": "Yes", "tenant_gender": "Female" }
+                    "conditional_question_no_page": { "pregnancy": "No" }
                   }
                 }
               },

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -153,8 +153,16 @@ RSpec.describe CheckAnswersHelper do
 
         it "it includes conditional pages and questions that were displayed" do
           case_log["pregnancy"] = "Yes"
+          case_log["tenant_gender"] = "Female"
           result = total_questions(conditional_routing_subsection, case_log, form)
-          expected_keys = %w[pregnancy cbl_letting]
+          expected_keys = %w[pregnancy]
+          expect(result.keys).to match_array(expected_keys)
+        end
+
+        it "it includes conditional pages and questions that were displayed" do
+          case_log["pregnancy"] = "No"
+          result = total_questions(conditional_routing_subsection, case_log, form)
+          expected_keys = %w[pregnancy conditional_question_no_question conditional_question_no_second_question]
           expect(result.keys).to match_array(expected_keys)
         end
       end


### PR DESCRIPTION
Enable multiple condition routing based on answers to questions anywhere within the form.

Extract conditional routing to a page level in JSON. 