### PR TITLE
CLDC-466: Add fixed term tenancy validation

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -186,6 +186,10 @@ private
       dynamically_not_required << "net_income_frequency"
     end
 
+    if tenancy_type == "Fixed term – Secure"
+      dynamically_not_required << "fixed_term_tenancy"
+    end
+
     required.delete_if { |key, _value| dynamically_not_required.include?(key) }
   end
 end

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -74,6 +74,20 @@ class CaseLogValidator < ActiveModel::Validator
     end
   end
 
+  def validate_fixed_term_tenancy(record)
+    if !(record.tenancy_type == "Fixed term – Secure" || record.tenancy_type == "Fixed term – Assured Shorthold Tenancy (AST)") && record.fixed_term_tenancy.present?
+      record.errors.add :fixed_term_tenancy, "You must only answer the fixed term tenancy length question if the tenancy type is fixed term"
+    end
+
+    if record.tenancy_type == "Fixed term – Assured Shorthold Tenancy (AST)" && !record.fixed_term_tenancy.to_i.between?(2, 99)
+      record.errors.add :fixed_term_tenancy, "Fixed term – Assured Shorthold Tenancy (AST) should be between 2 and 99 years"
+    end
+
+    if record.tenancy_type == "Fixed term – Secure" && (!record.fixed_term_tenancy.to_i.between?(2, 99) && record.fixed_term_tenancy.present?)
+      record.errors.add :fixed_term_tenancy, "Fixed term – Secure should be between 2 and 99 years or not specified"
+    end
+  end
+
   def validate(record)
     # If we've come from the form UI we only want to validate the specific fields
     # that have just been submitted. If we're submitting a log via API or Bulk Upload

--- a/docs/api/DLUHC-CORE-Data.v1.json
+++ b/docs/api/DLUHC-CORE-Data.v1.json
@@ -873,7 +873,8 @@
           },
           "fixed_term_tenancy": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "((?!1|0)([0-9][0-9]))+"
           },
           "tenancy_type": {
             "type": "string",

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -51,7 +51,7 @@
       "tenancy_code": "BZ757",
       "tenancy_start_date": "12/03/2019",
       "starter_tenancy": "No",
-      "fixed_term_tenancy": "No",
+      "fixed_term_tenancy": "5",
       "tenancy_type": "Fixed term – Secure",
       "letting_type": "Affordable Rent - General Needs",
       "letting_provider": "This landlord",

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -82,14 +82,14 @@ RSpec.describe Form, type: :model do
     end
 
     context "armed forces injured validation" do
-      it "must be anwered if tenant was a regular or reserve in armed forces" do
+      it "must be answered if tenant was a regular or reserve in armed forces" do
         expect {
           CaseLog.create!(armed_forces: "Yes - a regular",
                           armed_forces_injured: nil)
         }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
-      it "must be anwered if tenant was not a regular or reserve in armed forces" do
+      it "must be answered if tenant was not a regular or reserve in armed forces" do
         expect {
           CaseLog.create!(armed_forces: "No",
                           armed_forces_injured: "Yes")
@@ -114,6 +114,53 @@ RSpec.describe Form, type: :model do
         expect {
           CaseLog.create!(net_income_uc_proportion: "All", person_2_relationship: "Partner", person_2_economic_status: "Part-time - Less than 30 hours")
         }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+    context "fixed term tenancy length" do
+      it "Must not be completed if Type of main tenancy is not responded with either Secure or Assured shorthold " do
+        expect {
+          CaseLog.create!(tenancy_type: "Other",
+                          fixed_term_tenancy: 10)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "Must be completed and between 2 and 99 if type of tenancy is Assured shorthold" do
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Assured Shorthold Tenancy (AST)",
+                          fixed_term_tenancy: 1)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Assured Shorthold Tenancy (AST)",
+                          fixed_term_tenancy: nil)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Assured Shorthold Tenancy (AST)",
+                          fixed_term_tenancy: 2)
+        }.not_to raise_error
+      end
+
+      it "Must be empty or between 2 and 99 if type of tenancy is Secure" do
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Secure",
+                          fixed_term_tenancy: 1)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Secure",
+                          fixed_term_tenancy: 100)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Secure",
+                          fixed_term_tenancy: nil)
+        }.not_to raise_error
+
+        expect {
+          CaseLog.create!(tenancy_type: "Fixed term – Secure",
+                          fixed_term_tenancy: 2)
+        }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Add fixed term tenancy validation:
- Must not be completed if "Type of main tenancy" is not responded with either Secure or Assured shorthold 
- Must be completed and between 2 and 99 if "Type of main tenancy" is Assured shorthold
- Must be empty or between 2 and 99 if "Type of main tenancy" is Secure