### PR TITLE
CLDC-513: Refused income validation

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -248,8 +248,13 @@ private
       dynamically_not_required << "fixed_term_tenancy"
     end
 
-    if tenancy_type != "Other"
+    unless tenancy_type == "Other"
       dynamically_not_required << "other_tenancy_type"
+    end
+
+    unless net_income_known == "Yes"
+      dynamically_not_required << "net_income"
+      dynamically_not_required << "net_income_frequency"
     end
 
     required.delete_if { |key, _value| dynamically_not_required.include?(key) }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1458,6 +1458,21 @@
               "header": "",
               "description": "",
               "questions": {
+                "net_income_known": {
+                  "check_answer_label": "Income known",
+                  "header": "Do you know the tenant and their partner's net income?",
+                  "hint_text": "",
+                  "type": "radio",
+                  "answer_options": {
+                    "0": "Yes",
+                    "1": "No",
+                    "2": "Tenant prefers no to say"
+                  },
+                  "conditional_for": {
+                    "net_income": ["Yes"],
+                    "net_income_frequency": ["Yes"]
+                  }
+                },
                 "net_income": {
                   "check_answer_label": "Income",
                   "header": "What is the tenant’s /and partner’s combined income after tax?",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1466,7 +1466,7 @@
                   "answer_options": {
                     "0": "Yes",
                     "1": "No",
-                    "2": "Tenant prefers no to say"
+                    "2": "Tenant prefers not to say"
                   },
                   "conditional_for": {
                     "net_income": ["Yes"],

--- a/db/migrate/20211028095000_add_net_income_known_field.rb
+++ b/db/migrate/20211028095000_add_net_income_known_field.rb
@@ -1,0 +1,7 @@
+class AddNetIncomeKnownField < ActiveRecord::Migration[6.1]
+  def change
+    change_table :case_logs, bulk: true do |t|
+      t.column :net_income_known, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_083105) do
+ActiveRecord::Schema.define(version: 2021_10_28_095000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_083105) do
     t.boolean "reasonable_preference_reason_do_not_know"
     t.datetime "discarded_at"
     t.string "other_tenancy_type"
+    t.string "net_income_known"
     t.index ["discarded_at"], name: "index_case_logs_on_discarded_at"
   end
 

--- a/docs/api/DLUHC-CORE-Data.v1.json
+++ b/docs/api/DLUHC-CORE-Data.v1.json
@@ -937,6 +937,15 @@
           "property_wheelchair_accessible": {
             "type": "boolean"
           },
+          "net_income_known": {
+            "type": "string",
+            "minLength": 1,
+            "enum": [
+              "Yes",
+              "No",
+              "Tenant prefers not to say"
+            ]
+          },
           "net_income": {
             "type": "number"
           },
@@ -1208,7 +1217,8 @@
           "reasonable_preference_reason_medical_grounds",
           "reasonable_preference_reason_avoid_hardship",
           "reasonable_preference_reason_do_not_know",
-          "other_tenancy-type"
+          "other_tenancy-type",
+          "net_income_known"
         ]
       }
     },

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -68,6 +68,7 @@
       "property_major_repairs_date": "05/05/2020",
       "property_number_of_times_relet": 2,
       "property_wheelchair_accessible": true,
+      "net_income_known": "Yes",
       "net_income": 0,
       "net_income_frequency": null,
       "net_income_uc_proportion": "Some",

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -198,10 +198,11 @@ RSpec.describe Form, type: :model do
 
       # Crossover over tests here as injured must be answered as well for no error
       it "must be answered if ever served in the forces as a regular" do
-        expect {
+        expect do
           CaseLog.create!(armed_forces: "Yes - a regular",
                           armed_forces_active: "Yes",
-                          armed_forces_injured: "Yes")}
+                          armed_forces_injured: "Yes")
+        end
       end
     end
 


### PR DESCRIPTION
only require the income if it is known
the validation in the ticket is only for the `net_income`, but also added `net_income_frequency` to the `conditional_for` as it wouldn't make sense without `net_income` value present