### PR TITLE
CLDC-711: Refactor Validations

### DIFF
--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -57,8 +57,7 @@ class CaseLogsController < ApplicationController
   def submit_form
     form = FormHandler.instance.get_form("2021_2022")
     @case_log = CaseLog.find(params[:id])
-    @case_log.page_id = params[:case_log][:page]
-    page = form.get_page(@case_log.page_id)
+    page = form.get_page(params[:case_log][:page])
     responses_for_page = responses_for_page(page)
     if @case_log.update(responses_for_page) && @case_log.has_no_unresolved_soft_errors?
       redirect_path = form.next_page_redirect_path(page, @case_log)

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -1,6 +1,6 @@
 class CaseLogValidator < ActiveModel::Validator
-  # Validations methods need to be called 'validate_<page_name>' to run on model save
-  # or 'validate_' to run on submit as well
+  # Validations methods need to be called 'validate_' to run on model save
+  # or form page submission
   include HouseholdValidations
   include PropertyValidations
   include FinancialValidations
@@ -8,16 +8,8 @@ class CaseLogValidator < ActiveModel::Validator
   include DateValidations
 
   def validate(record)
-    # If we've come from the form UI we only want to validate the specific fields
-    # that have just been submitted. If we're submitting a log via API or Bulk Upload
-    # we want to validate all data fields.
-    page_to_validate = record.page_id
-    if page_to_validate
-      public_send("validate_#{page_to_validate}", record) if respond_to?("validate_#{page_to_validate}")
-    else
-      validation_methods = public_methods.select { |method| method.starts_with?("validate_") }
-      validation_methods.each { |meth| public_send(meth, record) }
-    end
+    validation_methods = public_methods.select { |method| method.starts_with?("validate_") }
+    validation_methods.each { |meth| public_send(meth, record) }
   end
 
 private
@@ -43,8 +35,6 @@ class CaseLog < ApplicationRecord
 
   validates_with CaseLogValidator
   before_save :update_status!
-
-  attr_accessor :page_id
 
   enum status: { "not_started" => 0, "in_progress" => 1, "completed" => 2 }
 

--- a/spec/requests/case_log_controller_spec.rb
+++ b/spec/requests/case_log_controller_spec.rb
@@ -311,6 +311,23 @@ RSpec.describe CaseLogsController, type: :request do
       it "re-renders the same page with errors if validation fails" do
         expect(response).to have_http_status(:redirect)
       end
+
+      let(:params) do
+        {
+          id: case_log.id,
+          case_log: {
+            page: page_id,
+            age1: answer,
+            age2: 2000
+          },
+        }
+      end
+
+      it "only updates answers that apply to the page being submitted" do
+        case_log.reload
+        expect(case_log.age1).to eq(answer)
+        expect(case_log.age2).to be nil
+      end
     end
   end
 end


### PR DESCRIPTION
Originally we thought that we'd need to have a way of determining which validations should run for a page on form submit, and separate that from validations running for an API or Bulk Upload create, because a form page submission, wouldn't have all the fields yet and so wouldn't be able to validate everything.

Our new design means this isn't actually the case anymore though because:

- We don't check for "presence" of data as an ActiveModel validation anymore, we do that as part of determining the Case Log's `status`. This means that validating records with missing mandatory data is now fine.
- The form submit controller method only permits the response params expected for each page based on the questions that page is defined to have, so there's no danger of it trying to set other random data.

As a result I think we can simplify our code a bit with this PR. We no longer need to couple validation method names to the JSON form definition (`validate_<page_name>`), we can just validate the entire record on each page submit. This also means, people writing the Form Definition don't need to know anything about the validations that will run.