### PR TITLE
Devise doesn't play nice with Turbo yet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,8 @@ gem "roo"
 # Json Schema
 gem "json-schema"
 # Authentication
-gem "devise"
+# Point at branch until devise is compatible with Turbo, see https://github.com/heartcombo/devise/pull/5340
+gem "devise", github: "ghiculescu/devise", branch: "error-code-422"
 gem "turbo-rails", "~> 0.8"
 gem "uk_postcode"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,16 @@
 GIT
+  remote: https://github.com/ghiculescu/devise.git
+  revision: 3b2d9ae3d47be5c9228c4446119b04b0e98917c1
+  branch: error-code-422
+  specs:
+    devise (4.8.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+
+GIT
   remote: https://github.com/rspec/rspec-core.git
   revision: e36aa2a9ebe68acee3ce05190fc2124947b45925
   branch: main
@@ -148,12 +160,6 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     deep_merge (1.2.1)
-    devise (4.8.0)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     diff-lcs (1.4.4)
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
@@ -408,7 +414,7 @@ DEPENDENCIES
   capybara
   capybara-lockstep
   chartkick
-  devise
+  devise!
   discard
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,7 @@ class Users::SessionsController < Devise::SessionsController
   def create
     self.resource = resource_class.new
     if params.dig("user", "email").empty?
-      resource.errors.add :email, "Please enter email address"
+      resource.errors.add :email, "Enter an email address"
     elsif !email_valid?(params.dig("user", "email"))
       resource.errors.add :email, "Enter an email address in the correct format, like name@example.com"
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,16 @@
+class Users::SessionsController < Devise::SessionsController
+  def create
+    self.resource = resource_class.new
+    if params.dig("user", "email").empty?
+      resource.errors.add :email, "Please enter email address"
+    end
+    if params.dig("user", "password").empty?
+      resource.errors.add :password, "Please enter password"
+    end
+    if resource.errors.present?
+      render :new, status: :unprocessable_entity
+    else
+      super
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,7 +7,7 @@ class Users::SessionsController < Devise::SessionsController
       resource.errors.add :email, "Enter an email address in the correct format, like name@example.com"
     end
     if params.dig("user", "password").empty?
-      resource.errors.add :password, "Please enter password"
+      resource.errors.add :password, "Enter a password"
     end
     if resource.errors.present?
       render :new, status: :unprocessable_entity

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,7 +4,7 @@ class Users::SessionsController < Devise::SessionsController
     if params.dig("user", "email").empty?
       resource.errors.add :email, "Please enter email address"
     elsif !email_valid?(params.dig("user", "email"))
-      resource.errors.add :email, "Email addess is not valid"
+      resource.errors.add :email, "Enter an email address in the correct format, like name@example.com"
     end
     if params.dig("user", "password").empty?
       resource.errors.add :password, "Please enter password"

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,8 @@ class Users::SessionsController < Devise::SessionsController
     self.resource = resource_class.new
     if params.dig("user", "email").empty?
       resource.errors.add :email, "Please enter email address"
+    elsif !email_valid?(params.dig("user", "email"))
+      resource.errors.add :email, "Email addess is not valid"
     end
     if params.dig("user", "password").empty?
       resource.errors.add :password, "Please enter password"
@@ -12,5 +14,11 @@ class Users::SessionsController < Devise::SessionsController
     else
       super
     end
+  end
+
+private
+
+  def email_valid?(email)
+    email =~ URI::MailTo::EMAIL_REGEXP
   end
 end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,8 @@
+module DeviseHelper
+  def flash_to_model_errors(resource)
+    if flash.alert
+      resource.errors.add :base, flash.alert
+      flash.discard
+    end
+  end
+end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,7 +1,9 @@
 module DeviseHelper
   def flash_to_model_errors(resource)
     if flash.alert
-      resource.errors.add :base, flash.alert
+      if flash.alert != I18n.t("devise.failure.unauthenticated")
+        resource.errors.add :base, flash.alert
+      end
       flash.discard
     end
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,10 +1,10 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Sign in to your account to submit CORE data</h1>
-
       <% flash_to_model_errors(resource) %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Sign in to your account to submit CORE data</h1>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,6 +3,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Sign in to your account to submit CORE data</h1>
 
+      <% flash_to_model_errors(resource) %>
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },
         autocomplete: "email"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,12 +56,12 @@
       </div>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <% flash.each do |type, msg| %>
+        <% if flash.notice %>
           <%= govuk_notification_banner(
             title_text: 'Success',
             success: true, title_heading_level: 3,
             title_id: "swanky-notifications") do |notification_banner|
-              notification_banner.heading(text: msg)
+              notification_banner.heading(text: flash.notice)
             end
           %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
-  devise_for :users, controllers: { passwords: "users/passwords" }, skip: [:registrations]
+  devise_for :users, controllers: { passwords: "users/passwords", sessions: "users/sessions" }, skip: [:registrations]
   devise_scope :user do
     get "confirmations/reset", to: "users/passwords#reset_confirmation"
     get "users/edit" => "devise/registrations#edit", :as => "edit_user_registration"

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -98,6 +98,15 @@ RSpec.describe "User Features" do
       expect(page).to have_selector("#user-email-field-error")
       expect(page).to have_selector("#user-password-field-error")
     end
+
+    it "show specific field error messages if an invalid email address is entered" do
+      visit("/case_logs")
+      fill_in("user[email]", with: "thisisn'tanemail")
+      click_button("Sign in")
+      expect(page).to have_selector("#error-summary-title")
+      expect(page).to have_selector("#user-email-field-error")
+      expect(page).to have_content(/Email addess is not valid/)
+    end
   end
 
   context "Your Account " do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "User Features" do
       click_button("Sign in")
       expect(page).to have_selector("#error-summary-title")
       expect(page).to have_selector("#user-email-field-error")
-      expect(page).to have_content(/Email addess is not valid/)
+      expect(page).to have_content(/Enter an email address in the correct format, like name@example.com/)
     end
   end
 

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe "User Features" do
       expect(page).to have_selector("#error-summary-title")
       expect(page).to have_no_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
+
+    it "show specific field error messages if a field was omitted" do
+      visit("/case_logs")
+      click_button("Sign in")
+      expect(page).to have_selector("#error-summary-title")
+      expect(page).to have_selector("#user-email-field-error")
+      expect(page).to have_selector("#user-password-field-error")
+    end
   end
 
   context "Your Account " do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe "User Features" do
       expect(page).to have_current_path("/users/sign_in")
     end
 
+    it "does not see the default devise error message" do
+      visit("/case_logs")
+      expect(page).to have_no_content("You need to sign in or sign up before continuing.")
+    end
+
     it " is redirected to case logs after signing in" do
       visit("/case_logs")
       fill_in("user[email]", with: user.email)

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "User Features" do
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
       expect(page).to have_current_path("/case_logs")
+      expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
   end
 
@@ -77,6 +78,17 @@ RSpec.describe "User Features" do
     it "tries to access account page, redirects to log in page" do
       visit("/users/account")
       expect(page).to have_content("Sign in to your account to submit CORE data")
+    end
+  end
+
+  context "Trying to log in with incorrect credentials" do
+    it "shows a gov uk error summary and no flash message" do
+      visit("/case_logs")
+      fill_in("user[email]", with: user.email)
+      fill_in("user[password]", with: "nonsense")
+      click_button("Sign in")
+      expect(page).to have_selector("#error-summary-title")
+      expect(page).to have_no_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
   end
 


### PR DESCRIPTION
This points at a branch of Devise that fixes it for Turbo (Rails 7 is expected before the end of the year so hopefully not too long until this is merged or supported in main) https://github.com/heartcombo/devise/pull/5340.

It also swaps devises default flash message on error for Gov UK errors. Needs some tests still but otherwise looks like it works.

Could also fix this by turning off Turbo for the login form specifically by adding `html: {"data-turbo" => "false"}` but then you lose the SPA-like goodness:

```
# app/views/devise/sessions/new.html.erb

<%= form_for(resource, as: resource_name, html: {"data-turbo" => "false"}, url: session_path(resource_name)) do |f| %>
```

![image](https://user-images.githubusercontent.com/5101747/144043138-fa5b9d66-ab23-4b23-8c4e-5f68ac9456de.png)
![image](https://user-images.githubusercontent.com/5101747/144050998-d08d89a9-bc5e-4248-8325-a0fc24fe7813.png)
![image](https://user-images.githubusercontent.com/5101747/144053790-64fa643b-d11b-4c6b-933d-67dfa100316a.png)

![image](https://user-images.githubusercontent.com/5101747/143946948-544d16d9-60ac-4585-905e-68116cdb047e.png)
![image](https://user-images.githubusercontent.com/5101747/143947016-4ac21ec5-18eb-479c-a495-d2c2f381e032.png)
