### PR TITLE
Uses dashes to separate words in URLs

### DIFF
--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -16,7 +16,7 @@ private
 
   def create_next_missing_question_link(subsection, case_log)
     pages_to_fill_in = subsection.unanswered_questions(case_log).map(&:page)
-    url = "/case_logs/#{case_log.id}/#{pages_to_fill_in.first.id}"
+    url = "/case-logs/#{case_log.id}/#{pages_to_fill_in.first.id.to_s.dasherize}"
     govuk_link_to("Answer the missing questions", url).html_safe
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -40,6 +40,6 @@ module TasklistHelper
                      else
                        "#"
                      end
-    govuk_link_to(subsection.label, next_page_path, class: "task-name")
+    govuk_link_to(subsection.label, next_page_path.to_s.dasherize, class: "task-name")
   end
 end

--- a/app/javascript/controllers/soft_validations_controller.js
+++ b/app/javascript/controllers/soft_validations_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = [ "override" ]
 
   initialize() {
-    let url = window.location.href + "/soft_validations"
+    let url = window.location.href + "/soft-validations"
     let div = this.overrideTarget
     fetch(url, { headers: { accept: "application/json" } })
       .then(response => response.json())

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -12,11 +12,11 @@ class Form
   end
 
   def get_subsection(id)
-    subsections.find { |s| s.id == id }
+    subsections.find { |s| s.id == id.to_s.underscore }
   end
 
   def get_page(id)
-    pages.find { |p| p.id == id }
+    pages.find { |p| p.id == id.to_s.underscore }
   end
 
   def subsection_for_page(page)

--- a/app/views/form/_check_answers_table.html.erb
+++ b/app/views/form/_check_answers_table.html.erb
@@ -6,6 +6,6 @@
     <%= question.answer_label(@case_log) %>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= govuk_link_to(question.update_answer_link_name(@case_log), "/case_logs/#{@case_log.id}/#{question.page.id}").html_safe %>
+    <%= govuk_link_to(question.update_answer_link_name(@case_log), "/case-logs/#{@case_log.id}/#{question.page.id.to_s.dasherize}").html_safe %>
   </dd>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
         service_url: '/'
       ) do |component|
         if current_user.nil?
-          component.navigation_item(text: 'Case logs', href: '/case_logs')
+          component.navigation_item(text: 'Case logs', href: case_logs_path)
         elsif
           component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
           component.navigation_item(text: 'Your account', href: '/users/account')

--- a/app/views/users/account/index.html.erb
+++ b/app/views/users/account/index.html.erb
@@ -10,13 +10,13 @@
       <%= summary_list.row do |row|
         row.key { 'Name' }
         row.value { current_user.name }
-        row.action(visually_hidden_text: 'name', href: '/users/account/personal_details', html_attributes: { 'data-qa': 'change-name' })
+        row.action(visually_hidden_text: 'name', href: '/users/account/personal-details', html_attributes: { 'data-qa': 'change-name' })
       end %>
 
       <%= summary_list.row() do |row|
         row.key { 'Email address' }
         row.value { current_user.email }
-        row.action(visually_hidden_text: 'email address', href: '/users/account/personal_details', html_attributes: { 'data-qa': 'change-email' })
+        row.action(visually_hidden_text: 'email address', href: '/users/account/personal-details', html_attributes: { 'data-qa': 'change-email' })
       end %>
 
       <%= summary_list.row do |row|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
-  devise_for :users, controllers: { passwords: "users/passwords", sessions: "users/sessions" }, skip: [:registrations]
+  devise_for :users, controllers: { passwords: "users/passwords", sessions: "users/sessions" }, path_names: { sign_in: 'sign-in', sign_out: 'sign-out' }, skip: [:registrations]
   devise_scope :user do
     get "confirmations/reset", to: "users/passwords#reset_confirmation"
     get "users/edit" => "devise/registrations#edit", :as => "edit_user_registration"
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   resources :users do
     collection do
-      get "account/personal_details", to: "users/account#personal_details"
+      get "account/personal-details", to: "users/account#personal_details"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,10 +30,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :case_logs do
+  resources :case_logs, :path => '/case-logs' do
     collection do
-      post "/bulk_upload", to: "bulk_upload#bulk_upload"
-      get "/bulk_upload", to: "bulk_upload#show"
+      post "/bulk-upload", to: "bulk_upload#bulk_upload"
+      get "/bulk-upload", to: "bulk_upload#show"
     end
 
     member do
@@ -41,12 +41,12 @@ Rails.application.routes.draw do
     end
 
     form.pages.map do |page|
-      get page.id.to_s, to: "case_logs##{page.id}"
-      get "#{page.id}/soft_validations", to: "soft_validations#show" if page.has_soft_validations?
+      get page.id.to_s.dasherize, to: "case_logs##{page.id}"
+      get "#{page.id.to_s.dasherize}/soft-validations", to: "soft_validations#show" if page.has_soft_validations?
     end
 
     form.subsections.map do |subsection|
-      get "#{subsection.id}/check_answers", to: "case_logs#check_answers"
+      get "#{subsection.id.to_s.dasherize}/check-answers", to: "case_logs#check_answers"
     end
   end
 end

--- a/docs/api/DLUHC-CORE-Data.v1.json
+++ b/docs/api/DLUHC-CORE-Data.v1.json
@@ -12,7 +12,7 @@
     }
   ],
   "paths": {
-    "/case_logs/:id": {
+    "/case-logs/:id": {
       "parameters": [],
       "get": {
         "summary": "Get Case Log Info by Case Log ID",
@@ -180,7 +180,7 @@
         ]
       }
     },
-    "/case_logs": {
+    "/case-logs": {
       "post": {
         "summary": "Create New Case Log",
         "operationId": "post-caselog",

--- a/spec/controllers/case_logs_controller_spec.rb
+++ b/spec/controllers/case_logs_controller_spec.rb
@@ -162,10 +162,10 @@ RSpec.describe CaseLogsController, type: :controller do
 
       it "routes to the appropriate conditional page based on the question answer of the current page" do
         post :submit_form, params: { id: id, case_log: case_log_form_conditional_question_yes_params }
-        expect(response).to redirect_to("/case_logs/#{id}/conditional_question_yes_page")
+        expect(response).to redirect_to("/case-logs/#{id}/conditional-question-yes-page")
 
         post :submit_form, params: { id: id, case_log: case_log_form_conditional_question_no_params }
-        expect(response).to redirect_to("/case_logs/#{id}/conditional_question_no_page")
+        expect(response).to redirect_to("/case-logs/#{id}/conditional-question-no-page")
       end
     end
   end

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -25,23 +25,23 @@ RSpec.describe "Form Check Answers Page" do
     sign_in user
   end
 
-  let(:subsection) { "household_characteristics" }
-  let(:conditional_subsection) { "conditional_question" }
+  let(:subsection) { "household-characteristics" }
+  let(:conditional_subsection) { "conditional-question" }
 
   context "when the user needs to check their answers for a subsection" do
     it "can be visited by URL" do
-      visit("case_logs/#{id}/#{subsection}/check_answers")
-      expect(page).to have_content("Check the answers you gave for #{subsection.tr('_', ' ')}")
+      visit("case-logs/#{id}/#{subsection}/check-answers")
+      expect(page).to have_content("Check the answers you gave for #{subsection.tr('-', ' ')}")
     end
 
-    let(:last_question_for_subsection) { "household_number_of_other_members" }
+    let(:last_question_for_subsection) { "household-number-of-other-members" }
     it "redirects to the check answers page when answering the last question and clicking save and continue" do
       fill_in_number_question(id, "other_hhmemb", 0, last_question_for_subsection)
-      expect(page).to have_current_path("/case_logs/#{id}/#{subsection}/check_answers")
+      expect(page).to have_current_path("/case-logs/#{id}/#{subsection}/check-answers")
     end
 
     it "has question headings based on the subsection" do
-      visit("case_logs/#{id}/#{subsection}/check_answers")
+      visit("case-logs/#{id}/#{subsection}/check-answers")
       question_labels = ["Tenant code", "Tenant's age", "Tenant's gender", "Number of Other Household Members"]
       question_labels.each do |label|
         expect(page).to have_content(label)
@@ -49,54 +49,54 @@ RSpec.describe "Form Check Answers Page" do
     end
 
     it "should display answers given by the user for the question in the subsection" do
-      fill_in_number_question(empty_case_log.id, "age1", 28, "person_1_age")
+      fill_in_number_question(empty_case_log.id, "age1", 28, "person-1-age")
       choose("case-log-sex1-non-binary-field")
       click_button("Save and continue")
-      visit("/case_logs/#{empty_case_log.id}/#{subsection}/check_answers")
+      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
       expect(page).to have_content("28")
       expect(page).to have_content("Non-binary")
     end
 
     it "should have an answer link for questions missing an answer" do
-      visit("case_logs/#{empty_case_log.id}/#{subsection}/check_answers")
+      visit("case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
       assert_selector "a", text: /Answer\z/, count: 4
       assert_selector "a", text: "Change", count: 0
-      expect(page).to have_link("Answer", href: "/case_logs/#{empty_case_log.id}/person_1_age")
+      expect(page).to have_link("Answer", href: "/case-logs/#{empty_case_log.id}/person-1-age")
     end
 
     it "should have a change link for answered questions" do
-      fill_in_number_question(empty_case_log.id, "age1", 28, "person_1_age")
-      visit("/case_logs/#{empty_case_log.id}/#{subsection}/check_answers")
+      fill_in_number_question(empty_case_log.id, "age1", 28, "person-1-age")
+      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
       assert_selector "a", text: /Answer\z/, count: 3
       assert_selector "a", text: "Change", count: 1
-      expect(page).to have_link("Change", href: "/case_logs/#{empty_case_log.id}/person_1_age")
+      expect(page).to have_link("Change", href: "/case-logs/#{empty_case_log.id}/person-1-age")
     end
 
     it "should have a change link for answered questions" do
-      visit("/case_logs/#{empty_case_log.id}/household_needs/check_answers")
+      visit("/case-logs/#{empty_case_log.id}/household-needs/check-answers")
       assert_selector "a", text: /Answer\z/, count: 4
       assert_selector "a", text: "Change", count: 0
-      visit("/case_logs/#{empty_case_log.id}/accessibility_requirements")
+      visit("/case-logs/#{empty_case_log.id}/accessibility-requirements")
       check("case-log-accessibility-requirements-housingneeds-c-field")
       click_button("Save and continue")
-      visit("/case_logs/#{empty_case_log.id}/household_needs/check_answers")
+      visit("/case-logs/#{empty_case_log.id}/household-needs/check-answers")
       assert_selector "a", text: /Answer\z/, count: 3
       assert_selector "a", text: "Change", count: 1
-      expect(page).to have_link("Change", href: "/case_logs/#{empty_case_log.id}/accessibility_requirements")
+      expect(page).to have_link("Change", href: "/case-logs/#{empty_case_log.id}/accessibility-requirements")
     end
 
     it "should have a link pointing to the first question if no questions are answered" do
-      visit("/case_logs/#{empty_case_log.id}/#{subsection}/check_answers")
+      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
       expect(page).to have_content("You answered 0 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/case_logs/#{empty_case_log.id}/tenant_code")
+      expect(page).to have_link("Answer the missing questions", href: "/case-logs/#{empty_case_log.id}/tenant-code")
     end
 
     it "should have a link pointing to the next empty question if some questions are answered" do
-      fill_in_number_question(empty_case_log.id, "earnings", 18_000, "net_income")
+      fill_in_number_question(empty_case_log.id, "earnings", 18_000, "net-income")
 
-      visit("/case_logs/#{empty_case_log.id}/income_and_benefits/check_answers")
+      visit("/case-logs/#{empty_case_log.id}/income-and-benefits/check-answers")
       expect(page).to have_content("You answered 1 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/case_logs/#{empty_case_log.id}/net_income")
+      expect(page).to have_link("Answer the missing questions", href: "/case-logs/#{empty_case_log.id}/net-income")
     end
 
     it "should not display the missing answer questions link if all questions are answered" do
@@ -106,7 +106,7 @@ RSpec.describe "Form Check Answers Page" do
     end
 
     it "does not display conditional questions that were not visited" do
-      visit("case_logs/#{id}/#{conditional_subsection}/check_answers")
+      visit("case-logs/#{id}/#{conditional_subsection}/check-answers")
       question_labels = ["Has the condition been met?"]
       question_labels.each do |label|
         expect(page).to have_content(label)
@@ -119,10 +119,10 @@ RSpec.describe "Form Check Answers Page" do
     end
 
     it "displays conditional question that were visited" do
-      visit("/case_logs/#{id}/conditional_question")
+      visit("/case-logs/#{id}/conditional-question")
       choose("case-log-preg-occ-no-field")
       click_button("Save and continue")
-      visit("/case_logs/#{id}/#{conditional_subsection}/check_answers")
+      visit("/case-logs/#{id}/#{conditional_subsection}/check-answers")
       question_labels = ["Has the condition been met?", "Has the condition not been met?"]
       question_labels.each do |label|
         expect(page).to have_content(label)

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe "Form Conditional Questions" do
 
   context "given a page where some questions are only conditionally shown, depending on how you answer the first question" do
     it "initially hides conditional questions" do
-      visit("/case_logs/#{id}/armed_forces")
+      visit("/case-logs/#{id}/armed-forces")
       expect(page).not_to have_selector("#armed_forces_injured_div")
     end
 
     it "shows conditional questions if the required answer is selected and hides it again when a different answer option is selected", js: true do
-      visit("/case_logs/#{id}/armed_forces")
+      visit("/case-logs/#{id}/armed-forces")
       # Something about our styling makes the selenium webdriver think the actual radio buttons are not visible so we allow label click here
       choose("case-log-armedforces-a-current-or-former-regular-in-the-uk-armed-forces-exc-national-service-field", allow_label_click: true)
       expect(page).to have_selector("#reservist_div")

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "Form Navigation" do
   let(:id) { case_log.id }
   let(:question_answers) do
     {
-      tenant_code: { type: "text", answer: "BZ737", path: "tenant_code" },
-      age1: { type: "numeric", answer: 25, path: "person_1_age" },
-      sex1: { type: "radio", answer: "Female", path: "person_1_gender" },
-      other_hhmemb: { type: "numeric", answer: 2, path: "household_number_of_other_members" },
+      tenant_code: { type: "text", answer: "BZ737", path: "tenant-code" },
+      age1: { type: "numeric", answer: 25, path: "person-1-age" },
+      sex1: { type: "radio", answer: "Female", path: "person-1-gender" },
+      other_hhmemb: { type: "numeric", answer: 2, path: "household-number-of-other-members" },
     }
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "Form Navigation" do
 
   describe "Create new log" do
     it "redirects to the task list for the new log" do
-      visit("/case_logs")
+      visit("/case-logs")
       click_link("Create new log")
       id = CaseLog.order(created_at: :desc).first.id
       expect(page).to have_content("Tasklist for log #{id}")
@@ -37,52 +37,52 @@ RSpec.describe "Form Navigation" do
 
   describe "Viewing a log" do
     it "questions can be accessed by url" do
-      visit("/case_logs/#{id}/person_1_age")
+      visit("/case-logs/#{id}/person-1-age")
       expect(page).to have_field("case-log-age1-field")
     end
 
     it "a question page leads to the next question defined in the form definition" do
       pages = question_answers.map { |_key, val| val[:path] }
       pages[0..-2].each_with_index do |val, index|
-        visit("/case_logs/#{id}/#{val}")
+        visit("/case-logs/#{id}/#{val}")
         click_button("Save and continue")
-        expect(page).to have_current_path("/case_logs/#{id}/#{pages[index + 1]}")
+        expect(page).to have_current_path("/case-logs/#{id}/#{pages[index + 1]}")
       end
     end
 
     describe "Back link directs correctly", js: true do
       it "go back to tasklist page from tenant code" do
-        visit("/case_logs/#{id}")
-        visit("/case_logs/#{id}/tenant_code")
+        visit("/case-logs/#{id}")
+        visit("/case-logs/#{id}/tenant-code")
         click_link(text: "Back")
         expect(page).to have_content("Tasklist for log #{id}")
       end
 
       it "go back to tenant code page from tenant age page", js: true do
-        visit("/case_logs/#{id}/tenant_code")
+        visit("/case-logs/#{id}/tenant-code")
         click_button("Save and continue")
-        visit("/case_logs/#{id}/person_1_age")
+        visit("/case-logs/#{id}/person-1-age")
         click_link(text: "Back")
         expect(page).to have_field("case-log-tenant-code-field")
       end
 
       it "doesn't get stuck in infinite loops", js: true do
-        visit("/case_logs")
-        visit("/case_logs/#{id}/net_income")
+        visit("/case-logs")
+        visit("/case-logs/#{id}/net-income")
         fill_in("case-log-earnings-field", with: 740)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         click_link(text: "Back")
         click_link(text: "Back")
-        expect(page).to have_current_path("/case_logs")
+        expect(page).to have_current_path("/case-logs")
       end
 
       context "when changing an answer from the check answers page", js: true do
         it "the back button routes correctly" do
-          visit("/case_logs/#{id}/household_characteristics/check_answers")
+          visit("/case-logs/#{id}/household-characteristics/check-answers")
           first("a", text: /Answer/).click
           click_link("Back")
-          expect(page).to have_current_path("/case_logs/#{id}/household_characteristics/check_answers")
+          expect(page).to have_current_path("/case-logs/#{id}/household-characteristics/check-answers")
         end
       end
     end

--- a/spec/features/form/helpers.rb
+++ b/spec/features/form/helpers.rb
@@ -1,12 +1,12 @@
 module Helpers
   def fill_in_number_question(case_log_id, question, value, path)
-    visit("/case_logs/#{case_log_id}/#{path}")
+    visit("/case-logs/#{case_log_id}/#{path}")
     fill_in("case-log-#{question.to_s.dasherize}-field", with: value)
     click_button("Save and continue")
   end
 
   def answer_all_questions_in_income_subsection(case_log)
-    visit("/case_logs/#{case_log.id}/net_income")
+    visit("/case-logs/#{case_log.id}/net-income")
     fill_in("case-log-earnings-field", with: 18_000)
     choose("case-log-incfreq-yearly-field")
     click_button("Save and continue")
@@ -17,7 +17,7 @@ module Helpers
   end
 
   def sign_in(user)
-    visit("/case_logs")
+    visit("/case-logs")
     fill_in("user[email]", with: user.email)
     fill_in("user[password]", with: user.password)
     click_button("Sign in")

--- a/spec/features/form/page_routing_spec.rb
+++ b/spec/features/form/page_routing_spec.rb
@@ -20,29 +20,29 @@ RSpec.describe "Form Page Routing" do
   end
 
   it "can route the user to a different page based on their answer on the current page", js: true do
-    visit("case_logs/#{id}/conditional_question")
+    visit("case-logs/#{id}/conditional-question")
     # using a question name that is already in the db to avoid
     # having to add a new column to the db for this test
     choose("case-log-preg-occ-yes-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case_logs/#{id}/conditional_question_yes_page")
+    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-yes-page")
     click_link(text: "Back")
-    expect(page).to have_current_path("/case_logs/#{id}/conditional_question")
+    expect(page).to have_current_path("/case-logs/#{id}/conditional-question")
     choose("case-log-preg-occ-no-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case_logs/#{id}/conditional_question_no_page")
+    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-no-page")
   end
 
   it "can route based on multiple conditions", js: true do
-    visit("/case_logs/#{id}/person_1_gender")
+    visit("/case-logs/#{id}/person-1-gender")
     choose("case-log-sex1-female-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case_logs/#{id}/household_number_of_other_members")
-    visit("/case_logs/#{id}/conditional_question")
+    expect(page).to have_current_path("/case-logs/#{id}/household-number-of-other-members")
+    visit("/case-logs/#{id}/conditional-question")
     choose("case-log-preg-occ-no-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case_logs/#{id}/conditional_question_no_page")
+    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-no-page")
     click_button("Save and continue")
-    expect(page).to have_current_path("/case_logs/#{id}/conditional_question/check_answers")
+    expect(page).to have_current_path("/case-logs/#{id}/conditional-question/check-answers")
   end
 end

--- a/spec/features/form/saving_data_spec.rb
+++ b/spec/features/form/saving_data_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Form Saving Data" do
       answer = hsh[:answer]
       path = hsh[:path]
       original_value = case_log.send(question)
-      visit("/case_logs/#{id}/#{path}")
+      visit("/case-logs/#{id}/#{path.to_s.dasherize}")
       case type
       when "text"
         fill_in("case-log-#{question.to_s.dasherize}-field", with: answer)
@@ -57,7 +57,7 @@ RSpec.describe "Form Saving Data" do
   end
 
   it "updates total value of the rent", js: true do
-    visit("/case_logs/#{id}/rent")
+    visit("/case-logs/#{id}/rent")
 
     fill_in("case-log-brent-field", with: 3)
     expect(page).to have_field("case-log-tcharge-field", with: "3")
@@ -73,17 +73,17 @@ RSpec.describe "Form Saving Data" do
   end
 
   it "displays number answers in inputs if they are already saved" do
-    visit("/case_logs/#{id}/property_postcode")
+    visit("/case-logs/#{id}/property-postcode")
     expect(page).to have_field("case-log-property-postcode-field", with: "P0 5ST")
   end
 
   it "displays text answers in inputs if they are already saved" do
-    visit("/case_logs/#{id}/person_1_age")
+    visit("/case-logs/#{id}/person-1-age")
     expect(page).to have_field("case-log-age1-field", with: "17")
   end
 
   it "displays checkbox answers in inputs if they are already saved" do
-    visit("/case_logs/#{case_log_with_checkbox_questions_answered.id}/accessibility_requirements")
+    visit("/case-logs/#{case_log_with_checkbox_questions_answered.id.to_s.dasherize}/accessibility-requirements")
     # Something about our styling makes the selenium webdriver think the actual radio buttons are not visible so we pass false here
     expect(page).to have_checked_field(
       "case-log-accessibility-requirements-housingneeds-a-field",

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -27,18 +27,18 @@ RSpec.describe "Task List" do
   end
 
   it "skips to the first section if no answers are completed" do
-    visit("/case_logs/#{empty_case_log.id}")
+    visit("/case-logs/#{empty_case_log.id}")
     expect(page).to have_link("Skip to next incomplete section", href: /#household_characteristics/)
   end
 
   it "shows the number of completed sections if no sections are completed" do
-    visit("/case_logs/#{empty_case_log.id}")
+    visit("/case-logs/#{empty_case_log.id}")
     expect(page).to have_content("You’ve completed 0 of 9 sections.")
   end
 
   it "shows the number of completed sections if one section is completed" do
     answer_all_questions_in_income_subsection(empty_case_log)
-    visit("/case_logs/#{empty_case_log.id}")
+    visit("/case-logs/#{empty_case_log.id}")
     expect(page).to have_content("You’ve completed 1 of 9 sections.")
   end
 end

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -28,16 +28,16 @@ RSpec.describe "validations" do
   describe "Question validation" do
     context "given an invalid tenant age" do
       it " of less than 0 it shows validation" do
-        visit("/case_logs/#{id}/person_1_age")
-        fill_in_number_question(empty_case_log.id, "age1", -5, "person_1_age")
+        visit("/case-logs/#{id}/person-1-age")
+        fill_in_number_question(empty_case_log.id, "age1", -5, "person-1-age")
         expect(page).to have_selector("#error-summary-title")
         expect(page).to have_selector("#case-log-age1-error")
         expect(page).to have_selector("#case-log-age1-field-error")
       end
 
       it " of greater than 120 it shows validation" do
-        visit("/case_logs/#{id}/person_1_age")
-        fill_in_number_question(empty_case_log.id, "age1", 121, "person_1_age")
+        visit("/case-logs/#{id}/person-1-age")
+        fill_in_number_question(empty_case_log.id, "age1", 121, "person-1-age")
         expect(page).to have_selector("#error-summary-title")
         expect(page).to have_selector("#case-log-age1-error")
         expect(page).to have_selector("#case-log-age1-field-error")
@@ -47,54 +47,54 @@ RSpec.describe "validations" do
 
   describe "date validation", js: true do
     def fill_in_date(case_log_id, question, day, month, year, path)
-      visit("/case_logs/#{case_log_id}/#{path}")
+      visit("/case-logs/#{case_log_id}/#{path}")
       fill_in("#{question}_1i", with: year)
       fill_in("#{question}_2i", with: month)
       fill_in("#{question}_3i", with: day)
     end
 
     it "does not allow out of range dates to be submitted" do
-      fill_in_date(id, "case_log_mrcdate", 3100, 12, 2000, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 3100, 12, 2000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
 
-      fill_in_date(id, "case_log_mrcdate", 12, 1, 20_000, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 12, 1, 20_000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
 
-      fill_in_date(id, "case_log_mrcdate", 13, 100, 2020, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 13, 100, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
 
-      fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/local_authority/check_answers")
+      expect(page).to have_current_path("/case-logs/#{id}/local-authority/check-answers")
     end
 
     it "does not allow non numeric inputs to be submitted" do
-      fill_in_date(id, "case_log_mrcdate", "abc", "de", "ff", "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", "abc", "de", "ff", "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
     end
 
     it "does not allow partial inputs to be submitted" do
-      fill_in_date(id, "case_log_mrcdate", 21, 12, nil, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 21, 12, nil, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
 
-      fill_in_date(id, "case_log_mrcdate", 12, nil, 2000, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 12, nil, 2000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
 
-      fill_in_date(id, "case_log_mrcdate", nil, 10, 2020, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", nil, 10, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/property_major_repairs")
+      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
     end
 
     it "allows valid inputs to be submitted" do
-      fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property_major_repairs")
+      fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case_logs/#{id}/local_authority/check_answers")
+      expect(page).to have_current_path("/case-logs/#{id}/local-authority/check-answers")
     end
   end
 
@@ -113,30 +113,30 @@ RSpec.describe "validations" do
       let(:income_under_soft_limit) { 700 }
 
       it "prompts the user to confirm the value is correct", js: true do
-        visit("/case_logs/#{case_log.id}/net_income")
+        visit("/case-logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         expect(page).to have_content("Are you sure this is correct?")
         check("case-log-override-net-income-validation-override-net-income-validation-field", allow_label_click: true)
         click_button("Save and continue")
-        expect(page).to have_current_path("/case_logs/#{case_log.id}/net_income_uc_proportion")
+        expect(page).to have_current_path("/case-logs/#{case_log.id}/net-income-uc-proportion")
       end
 
       it "does not require confirming the value if the value is amended" do
-        visit("/case_logs/#{case_log.id}/net_income")
+        visit("/case-logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         fill_in("case-log-earnings-field", with: income_under_soft_limit)
         click_button("Save and continue")
-        expect(page).to have_current_path("/case_logs/#{case_log.id}/net_income_uc_proportion")
+        expect(page).to have_current_path("/case-logs/#{case_log.id}/net-income-uc-proportion")
         case_log.reload
         expect(case_log.override_net_income_validation).to be_nil
       end
 
       it "clears the confirmation question if the amount was amended and the page is returned to using the back button", js: true do
-        visit("/case_logs/#{case_log.id}/net_income")
+        visit("/case-logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
@@ -147,7 +147,7 @@ RSpec.describe "validations" do
       end
 
       it "does not clear the confirmation question if the page is returned to using the back button and the amount is still over the soft limit", js: true do
-        visit("/case_logs/#{case_log.id}/net_income")
+        visit("/case-logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "User Features" do
 
   context "Organisation page" do
     it "default to organisation details" do
-      visit("/case_logs")
+      visit("/case-logs")
       click_link("Your organisation")
       expect(page).to have_content(user.organisation.name)
     end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "User Features" do
   context "A user navigating to case logs" do
     it " is required to log in" do
       visit("/case-logs")
-      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_current_path("/users/sign-in")
     end
 
     it "does not see the default devise error message" do
@@ -150,7 +150,7 @@ RSpec.describe "User Features" do
     end
 
     it "personal details page is present and accessible" do
-      visit("/users/account/personal_details")
+      visit("/users/account/personal-details")
       expect(page).to have_content("Change your personal details")
     end
 

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -3,28 +3,28 @@ RSpec.describe "User Features" do
   let!(:user) { FactoryBot.create(:user) }
   context "A user navigating to case logs" do
     it " is required to log in" do
-      visit("/case_logs")
+      visit("/case-logs")
       expect(page).to have_current_path("/users/sign_in")
     end
 
     it "does not see the default devise error message" do
-      visit("/case_logs")
+      visit("/case-logs")
       expect(page).to have_no_content("You need to sign in or sign up before continuing.")
     end
 
     it " is redirected to case logs after signing in" do
-      visit("/case_logs")
+      visit("/case-logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
-      expect(page).to have_current_path("/case_logs")
+      expect(page).to have_current_path("/case-logs")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
   end
 
   context "A user who has forgotten their password" do
     it " is redirected to the reset password page when they click the reset password link" do
-      visit("/case_logs")
+      visit("/case-logs")
       click_link("reset your password")
       expect(page).to have_current_path("/users/password/new")
     end
@@ -81,7 +81,7 @@ RSpec.describe "User Features" do
 
   context "If user not logged in" do
     it "'Your account' link does not display" do
-      visit("/case_logs")
+      visit("/case-logs")
       expect(page).to have_no_link("Your account")
     end
 
@@ -92,7 +92,7 @@ RSpec.describe "User Features" do
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
-      expect(page).to have_current_path("/case_logs")
+      expect(page).to have_current_path("/case-logs")
     end
 
     it "tries to access account page, redirects to log in page" do
@@ -103,7 +103,7 @@ RSpec.describe "User Features" do
 
   context "Trying to log in with incorrect credentials" do
     it "shows a gov uk error summary and no flash message" do
-      visit("/case_logs")
+      visit("/case-logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "nonsense")
       click_button("Sign in")
@@ -112,7 +112,7 @@ RSpec.describe "User Features" do
     end
 
     it "show specific field error messages if a field was omitted" do
-      visit("/case_logs")
+      visit("/case-logs")
       click_button("Sign in")
       expect(page).to have_selector("#error-summary-title")
       expect(page).to have_selector("#user-email-field-error")
@@ -120,7 +120,7 @@ RSpec.describe "User Features" do
     end
 
     it "show specific field error messages if an invalid email address is entered" do
-      visit("/case_logs")
+      visit("/case-logs")
       fill_in("user[email]", with: "thisisn'tanemail")
       click_button("Sign in")
       expect(page).to have_selector("#error-summary-title")
@@ -131,14 +131,14 @@ RSpec.describe "User Features" do
 
   context "Your Account " do
     before(:each) do
-      visit("/case_logs")
+      visit("/case-logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
     end
 
     it "shows 'Your account' link in navigation if logged in and redirect to correct page" do
-      visit("/case_logs")
+      visit("/case-logs")
       expect(page).to have_link("Your account")
       click_link("Your account")
       expect(page).to have_current_path("/users/account")

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe TasklistHelper do
     let(:subsection) { form.get_subsection("household_characteristics") }
 
     it "returns the check answers page path if the section has been started already" do
-      expect(first_page_or_check_answers(subsection, case_log)).to match(/check_answers/)
+      expect(first_page_or_check_answers(subsection, case_log)).to match(/check-answers/)
     end
 
     it "returns the first question page path for the section if it has not been started yet" do
-      expect(first_page_or_check_answers(subsection, empty_case_log)).to match(/tenant_code/)
+      expect(first_page_or_check_answers(subsection, empty_case_log)).to match(/tenant-code/)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe TasklistHelper do
 
     context "for a subsection that's enabled" do
       it "returns the subsection link url" do
-        expect(subsection_link(subsection, case_log)).to match(/household_characteristics/)
+        expect(subsection_link(subsection, case_log)).to match(/household-characteristics/)
       end
     end
 

--- a/spec/requests/bulk_upload_controller_spec.rb
+++ b/spec/requests/bulk_upload_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe BulkUploadController, type: :request do
-  let(:url) { "/case_logs/bulk_upload" }
+  let(:url) { "/case-logs/bulk-upload" }
   let(:organisation) { FactoryBot.create(:organisation) }
   before do
     allow(Organisation).to receive(:find).with(107_242).and_return(organisation)

--- a/spec/requests/case_log_controller_spec.rb
+++ b/spec/requests/case_log_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CaseLogsController, type: :request do
     end
 
     before do
-      post "/case_logs", headers: headers, params: params.to_json
+      post "/case-logs", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -137,12 +137,12 @@ RSpec.describe CaseLogsController, type: :request do
 
       before do
         sign_in user
-        get "/case_logs", headers: headers, params: {}
+        get "/case-logs", headers: headers, params: {}
       end
 
       it "only shows case logs for your organisation" do
-        expected_case_row_log = "<a class=\"govuk-link\" href=\"/case_logs/#{case_log.id}\">#{case_log.id}</a>"
-        unauthorized_case_row_log = "<a class=\"govuk-link\" href=\"/case_logs/#{unauthorized_case_log.id}\">#{unauthorized_case_log.id}</a>"
+        expected_case_row_log = "<a class=\"govuk-link\" href=\"/case-logs/#{case_log.id}\">#{case_log.id}</a>"
+        unauthorized_case_row_log = "<a class=\"govuk-link\" href=\"/case-logs/#{unauthorized_case_log.id}\">#{unauthorized_case_log.id}</a>"
         expect(CGI.unescape_html(response.body)).to include(expected_case_row_log)
         expect(CGI.unescape_html(response.body)).not_to include(unauthorized_case_row_log)
       end
@@ -153,7 +153,7 @@ RSpec.describe CaseLogsController, type: :request do
       let(:id) { completed_case_log.id }
 
       before do
-        get "/case_logs/#{id}", headers: headers
+        get "/case-logs/#{id}", headers: headers
       end
 
       it "returns http success" do
@@ -183,7 +183,7 @@ RSpec.describe CaseLogsController, type: :request do
         context "case logs that are owned or managed by your organisation" do
           before do
             sign_in user
-            get "/case_logs/#{case_log.id}", headers: headers, params: {}
+            get "/case-logs/#{case_log.id}", headers: headers, params: {}
           end
 
           it "shows the tasklist for case logs you have access to" do
@@ -210,7 +210,7 @@ RSpec.describe CaseLogsController, type: :request do
 
           before do
             sign_in user
-            get "/case_logs/#{section_completed_case_log.id}", headers: headers, params: {}
+            get "/case-logs/#{section_completed_case_log.id}", headers: headers, params: {}
           end
 
           it "displays a section status for a case log" do
@@ -223,7 +223,7 @@ RSpec.describe CaseLogsController, type: :request do
         context "case logs that are not owned or managed by your organisation" do
           before do
             sign_in user
-            get "/case_logs/#{unauthorized_case_log.id}", headers: headers, params: {}
+            get "/case-logs/#{unauthorized_case_log.id}", headers: headers, params: {}
           end
 
           it "does not show the tasklist for case logs you don't have access to" do
@@ -238,7 +238,7 @@ RSpec.describe CaseLogsController, type: :request do
         context "case logs that are not owned or managed by your organisation" do
           before do
             sign_in user
-            get "/case_logs/#{unauthorized_case_log.id}/person_1_age", headers: headers, params: {}
+            get "/case-logs/#{unauthorized_case_log.id}/person-1-age", headers: headers, params: {}
           end
 
           it "does not show form pages for case logs you don't have access to" do
@@ -253,7 +253,7 @@ RSpec.describe CaseLogsController, type: :request do
         context "case logs that are not owned or managed by your organisation" do
           before do
             sign_in user
-            get "/case_logs/#{unauthorized_case_log.id}/household_characteristics/check_answers", headers: headers, params: {}
+            get "/case-logs/#{unauthorized_case_log.id}/household-characteristics/check-answers", headers: headers, params: {}
           end
 
           it "does not show a check answers for case logs you don't have access to" do
@@ -274,7 +274,7 @@ RSpec.describe CaseLogsController, type: :request do
     let(:id) { case_log.id }
 
     before do
-      patch "/case_logs/#{id}", headers: headers, params: params.to_json
+      patch "/case-logs/#{id}", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -332,7 +332,7 @@ RSpec.describe CaseLogsController, type: :request do
     let(:id) { case_log.id }
 
     before do
-      put "/case_logs/#{id}", headers: headers, params: params.to_json
+      put "/case-logs/#{id}", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -372,7 +372,7 @@ RSpec.describe CaseLogsController, type: :request do
 
     context "expected deletion" do
       before do
-        delete "/case_logs/#{id}", headers: headers
+        delete "/case-logs/#{id}", headers: headers
       end
 
       it "returns http success" do
@@ -406,7 +406,7 @@ RSpec.describe CaseLogsController, type: :request do
     context "deletion fails" do
       before do
         allow_any_instance_of(CaseLog).to receive(:discard).and_return(false)
-        delete "/case_logs/#{id}", headers: headers
+        delete "/case-logs/#{id}", headers: headers
       end
 
       it "returns an unprocessable entity 422" do
@@ -440,7 +440,7 @@ RSpec.describe CaseLogsController, type: :request do
     before do
       allow(FormHandler.instance).to receive(:get_form).and_return(form)
       sign_in user
-      post "/case_logs/#{case_log.id}/form", params: params
+      post "/case-logs/#{case_log.id}/form", params: params
     end
 
     context "invalid answers" do
@@ -489,7 +489,7 @@ RSpec.describe CaseLogsController, type: :request do
 
       before do
         sign_in user
-        post "/case_logs/#{unauthorized_case_log.id}/form", params: params
+        post "/case-logs/#{unauthorized_case_log.id}/form", params: params
       end
 
       it "does not let you post form answers to case logs you don't have access to" do

--- a/spec/requests/soft_validations_controller_spec.rb
+++ b/spec/requests/soft_validations_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SoftValidationsController, type: :request do
   let(:params) { { case_log_id: case_log.id } }
-  let(:url) { "/case_logs/#{case_log.id}/net_income/soft_validations" }
+  let(:url) { "/case-logs/#{case_log.id}/net-income/soft-validations" }
 
   before do
     get url, params: {}


### PR DESCRIPTION
The [URL standards for GOV.UK](https://www.gov.uk/guidance/content-design/url-standards-for-gov-uk) state that:

> dashes should be used to separate words within URLs so they are easy to read - for example, <https://www.gov.uk/set-up-business> (this might not apply if the URL is designed to be read aloud)

We should follow the same URL standards as used on GOV.UK and many other government services.