### PR TITLE
Remove back link from organisation page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,9 +52,7 @@
         text: "This is a new service – #{govuk_mail_to("test@mhclg.gov.uk", "give feedback or report a problem", subject: "Feedback about Lettings and Sales of Social Housing in England Data Collection")}".html_safe
       ) %>
 
-      <div role="navigation">
-        <%= content_for(:before_content) %>
-      </div>
+      <%= content_for(:before_content) %>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if flash.notice %>

--- a/app/views/layouts/organisations.html.erb
+++ b/app/views/layouts/organisations.html.erb
@@ -1,10 +1,3 @@
-<% content_for :before_content do %>
-  <%= govuk_back_link(
-    text: 'Back',
-    href: :back,
-  ) %>
-<% end %>
-
 <% content_for :content do %>
   <h1 class="govuk-heading-l">
     Your organisation


### PR DESCRIPTION
* Remove `div` with `role="navigation` from application layout – this appears on all pages, even if they have no navigation. Also, it’s up to the component within `before_content` to determine if they have a `navigation` role.
* Remove back link from organisation page, as it it not needed.