### PR TITLE
Show correct links in header navigation when signed in/out

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,10 +37,11 @@
         service_url: '/'
       ) do |component|
         if current_user.nil?
-          component.navigation_item(text: 'Case logs', href: case_logs_path)
+          component.navigation_item(text: 'Sign in', href: user_session_path)
         elsif
+          component.navigation_item(text: 'Case logs', href: case_logs_path)
           component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
-          component.navigation_item(text: 'Your account', href: '/users/account')
+          component.navigation_item(text: 'Your account', href: users_account_path)
           component.navigation_item(text: 'Sign out', href: destroy_user_session_path, options: {:method => :delete})
         end
       end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe "User Features" do
 
     it "Can navigate and sign in page with sign in button" do
       visit("/")
-      expect(page).to have_link("Case logs")
-      click_link("Case logs")
+      expect(page).to have_link("Sign in")
+      click_link("Sign in")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
-      expect(page).to have_current_path("/case-logs")
+      expect(page).to have_current_path("/")
     end
 
     it "tries to access account page, redirects to log in page" do


### PR DESCRIPTION
Signed out:

<img width="987" alt="Screenshot 2021-12-01 at 18 55 15" src="https://user-images.githubusercontent.com/813383/144296207-e04efe29-ef9d-445b-81fd-679da76568c4.png">


Signed in:

<img width="991" alt="Screenshot 2021-12-01 at 18 55 07" src="https://user-images.githubusercontent.com/813383/144296225-ddc04d91-a9a0-4899-8910-6156e0727ad7.png">