### PR TITLE
Add lint stage to pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,7 +74,22 @@ jobs:
         run: |
           bundle exec rspec
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
+
+      - name: Rubocop
+        run: |
+          bundle exec rubocop
 
   deploy:
     name: Deploy
@@ -82,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: 'sandbox'
     if: github.ref == 'refs/heads/main'
-    needs: test
+    needs: [lint, test]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Help ensure Rubocop violations aren't merged so linting the codebase happens automatically and stays easy.