### PR TITLE
Add errors controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
-  def render_not_found_html
-    render file: Rails.root.join("public/404.html"), status: :not_found
+  def render_not_found
+    render "errors/not_found", status: :not_found
   end
 
   def render_not_found_json(class_name, id)

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -55,7 +55,7 @@ class CaseLogsController < ApplicationController
     if @case_log
       render :edit
     else
-      render_not_found_html
+      render_not_found
     end
   end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,25 @@
+class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def not_found
+    respond_to do |format|
+      format.html { render status: :not_found }
+      format.json { render json: { error: "Resource not found" }, status: :not_found }
+      format.all { render status: :not_found, body: nil }
+    end
+  end
+
+  def internal_server_error
+    respond_to do |format|
+      format.html { render status: :internal_server_error }
+      format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
+    end
+  end
+
+  def unprocessable_entity
+    respond_to do |format|
+      format.html { render status: :unprocessable_entity }
+      format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
+    end
+  end
+end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -16,7 +16,7 @@ class FormController < ApplicationController
         render "form/page", locals: { form: form, page: page, subsection: subsection.label }, status: :unprocessable_entity
       end
     else
-      render_not_found_html
+      render_not_found
     end
   end
 
@@ -27,7 +27,7 @@ class FormController < ApplicationController
       subsection = form.get_subsection(current_url.split("/")[-2])
       render "form/check_answers", locals: { subsection: subsection, form: form }
     else
-      render_not_found_html
+      render_not_found
     end
   end
 
@@ -38,7 +38,7 @@ class FormController < ApplicationController
         subsection = form.subsection_for_page(page)
         render "form/page", locals: { form: form, page: page, subsection: subsection.label }
       else
-        render_not_found_html
+        render_not_found
       end
     end
   end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,6 +1,8 @@
+<% content_for :title, "Sorry, there is a problem with the service" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <h1 class="govuk-heading-l"><%= content_for(:title) %></h1>
     <p class="govuk-body">Try again later.</p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,6 +1,8 @@
+<% content_for :title, "Page not found" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Page not found</h1>
+    <h1 class="govuk-heading-l"><%= content_for(:title) %></h1>
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
     <p class="govuk-body"><a class="govuk-link" href="https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21">Get help</a> if the web address is correct and not working.</p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,6 +1,8 @@
+<% content_for :title, "Sorry, there is a problem with the service" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <h1 class="govuk-heading-l"><%= content_for(:title) %></h1>
     <p class="govuk-body">Try again later.</p>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module DataCollector
     #
     config.time_zone = "London"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.exceptions_app = routes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,4 +50,10 @@ Rails.application.routes.draw do
       get "#{subsection.id.to_s.dasherize}/check-answers", to: "form#check_answers"
     end
   end
+
+  scope via: :all do
+    match "/404", to: "errors#not_found"
+    match "/422", to: "errors#unprocessable_entity"
+    match "/500", to: "errors#internal_server_error"
+  end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ErrorsController, type: :controller do
+  describe "GET #not_found" do
+    it "returns not found" do
+      get :not_found
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET #internal_server_error" do
+    it "returns internal_server_error" do
+      get :internal_server_error
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
+
+  describe "GET #unprocessable_entity" do
+    it "returns unprocessable_entity" do
+      get :unprocessable_entity
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
Inspired by [govuk-rails-boilerplate](https://github.com/DFE-Digital/govuk-rails-boilerplate/), moves errors from `public` folder and instead uses an error controller.