### PR TITLE
Use ‘log‘ not ‘case log’

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register_page "Dashboard" do
   content title: proc { I18n.t("active_admin.dashboard") } do
     columns do
       column do
-        panel "Recent Case Logs" do
+        panel "Recent logs" do
           table_for CaseLog.order(updated_at: :desc).limit(10) do
             column :id
             column :created_at
@@ -17,13 +17,13 @@ ActiveAdmin.register_page "Dashboard" do
       end
 
       column do
-        panel "Total case logs in progress" do
+        panel "Total logs in progress" do
           para CaseLog.in_progress.size
         end
-        panel "Total case logs completed" do
+        panel "Total logs completed" do
           para CaseLog.completed.size
         end
-        panel "Total case logs completed" do
+        panel "Total logs completed" do
           pie_chart CaseLog.group(:status).size
         end
       end

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -31,7 +31,7 @@ class CaseLogsController < ApplicationController
         render json: { errors: @case_log.errors.messages }, status: :unprocessable_entity
       end
     else
-      render_not_found_json("Case log", params[:id])
+      render_not_found_json("Log", params[:id])
     end
   end
 
@@ -43,7 +43,7 @@ class CaseLogsController < ApplicationController
         if @case_log
           render json: @case_log, status: :ok
         else
-          render_not_found_json("Case log", params[:id])
+          render_not_found_json("Log", params[:id])
         end
       end
     end
@@ -67,7 +67,7 @@ class CaseLogsController < ApplicationController
         render json: { errors: @case_log.errors.messages }, status: :unprocessable_entity
       end
     else
-      render_not_found_json("Case log", params[:id])
+      render_not_found_json("Log", params[:id])
     end
   end
 

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -16,7 +16,7 @@ private
 
   def create_next_missing_question_link(subsection, case_log)
     pages_to_fill_in = subsection.unanswered_questions(case_log).map(&:page)
-    url = "/case-logs/#{case_log.id}/#{pages_to_fill_in.first.id.to_s.dasherize}"
+    url = "/logs/#{case_log.id}/#{pages_to_fill_in.first.id.to_s.dasherize}"
     govuk_link_to("Answer the missing questions", url).html_safe
   end
 end

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Case log #{@case_log.id}" %>
+<% content_for :title, "Log #{@case_log.id}" %>
 
 <%= turbo_frame_tag "case_log_form", target: "_top" do %>
   <div class="govuk-grid-row">

--- a/app/views/case_logs/index.html.erb
+++ b/app/views/case_logs/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Case logs" %>
+<% content_for :title, "Your logs" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/form/_check_answers_table.html.erb
+++ b/app/views/form/_check_answers_table.html.erb
@@ -6,6 +6,6 @@
     <%= question.answer_label(@case_log) %>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= govuk_link_to(question.update_answer_link_name(@case_log), "/case-logs/#{@case_log.id}/#{question.page.id.to_s.dasherize}").html_safe %>
+    <%= govuk_link_to(question.update_answer_link_name(@case_log), "/logs/#{@case_log.id}/#{question.page.id.to_s.dasherize}").html_safe %>
   </dd>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
         if current_user.nil?
           component.navigation_item(text: 'Sign in', href: user_session_path)
         elsif
-          component.navigation_item(text: 'Case logs', href: case_logs_path)
+          component.navigation_item(text: 'Your logs', href: case_logs_path)
           component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
           component.navigation_item(text: 'Your account', href: user_path(current_user))
           component.navigation_item(text: 'Sign out', href: destroy_user_session_path, options: {:method => :delete})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   form_handler = FormHandler.instance
   form = form_handler.get_form("2021_2022")
 
-  resources :case_logs, path: "/case-logs" do
+  resources :case_logs, path: "/logs" do
     collection do
       post "bulk-upload", to: "bulk_upload#bulk_upload"
       get "bulk-upload", to: "bulk_upload#show"

--- a/docs/api/DLUHC-CORE-Data.v1.json
+++ b/docs/api/DLUHC-CORE-Data.v1.json
@@ -12,7 +12,7 @@
     }
   ],
   "paths": {
-    "/case-logs/:id": {
+    "/logs/:id": {
       "parameters": [],
       "get": {
         "summary": "Get Case Log Info by Case Log ID",
@@ -180,7 +180,7 @@
         ]
       }
     },
-    "/case-logs": {
+    "/logs": {
       "post": {
         "summary": "Create New Case Log",
         "operationId": "post-caselog",

--- a/spec/controllers/admin/case_logs_controller_spec.rb
+++ b/spec/controllers/admin/case_logs_controller_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../support/devise"
 describe Admin::CaseLogsController, type: :controller do
   render_views
   let(:page) { Capybara::Node::Simple.new(response.body) }
-  let(:resource_title) { "Case Logs" }
+  let(:resource_title) { "Logs" }
   let(:valid_session) { {} }
   login_admin_user
 

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -21,18 +21,18 @@ describe Admin::DashboardController, type: :controller do
     end
 
     it "returns a panel of recent case logs" do
-      expect(page).to have_xpath("//div[contains(@class, 'panel') and contains(//h3, 'Recent Case Logs')]")
+      expect(page).to have_xpath("//div[contains(@class, 'panel') and contains(//h3, 'Recent logs')]")
     end
 
     it "returns a panel of in progress case logs" do
-      panel_xpath = "//div[@class='panel' and .//h3[contains(., 'Total case logs in progress')]]"
+      panel_xpath = "//div[@class='panel' and .//h3[contains(., 'Total logs in progress')]]"
       panel_content_xpath = "#{panel_xpath}//div[@class='panel_contents' and .//p[contains(., 2)]]"
       expect(page).to have_xpath(panel_xpath)
       expect(page).to have_xpath(panel_content_xpath)
     end
 
     it "returns a panel of completed case logs" do
-      panel_xpath = "//div[@class='panel' and .//h3[contains(., 'Total case logs completed')]]"
+      panel_xpath = "//div[@class='panel' and .//h3[contains(., 'Total logs completed')]]"
       panel_content_xpath = "#{panel_xpath}//div[@class='panel_contents' and .//p[contains(., 1)]]"
       expect(page).to have_xpath(panel_xpath)
       expect(page).to have_xpath(panel_content_xpath)

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -30,18 +30,18 @@ RSpec.describe "Form Check Answers Page" do
 
   context "when the user needs to check their answers for a subsection" do
     it "can be visited by URL" do
-      visit("case-logs/#{id}/#{subsection}/check-answers")
+      visit("/logs/#{id}/#{subsection}/check-answers")
       expect(page).to have_content("#{subsection.tr('-', ' ').humanize} Check your answers")
     end
 
     let(:last_question_for_subsection) { "household-number-of-other-members" }
     it "redirects to the check answers page when answering the last question and clicking save and continue" do
       fill_in_number_question(id, "other_hhmemb", 0, last_question_for_subsection)
-      expect(page).to have_current_path("/case-logs/#{id}/#{subsection}/check-answers")
+      expect(page).to have_current_path("/logs/#{id}/#{subsection}/check-answers")
     end
 
     it "has question headings based on the subsection" do
-      visit("case-logs/#{id}/#{subsection}/check-answers")
+      visit("/logs/#{id}/#{subsection}/check-answers")
       question_labels = ["Tenant code", "Tenant's age", "Tenant's gender", "Number of Other Household Members"]
       question_labels.each do |label|
         expect(page).to have_content(label)
@@ -52,51 +52,51 @@ RSpec.describe "Form Check Answers Page" do
       fill_in_number_question(empty_case_log.id, "age1", 28, "person-1-age")
       choose("case-log-sex1-non-binary-field")
       click_button("Save and continue")
-      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
+      visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
       expect(page).to have_content("28")
       expect(page).to have_content("Non-binary")
     end
 
     it "should have an answer link for questions missing an answer" do
-      visit("case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
+      visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
       assert_selector "a", text: /Answer\z/, count: 4
       assert_selector "a", text: "Change", count: 0
-      expect(page).to have_link("Answer", href: "/case-logs/#{empty_case_log.id}/person-1-age")
+      expect(page).to have_link("Answer", href: "/logs/#{empty_case_log.id}/person-1-age")
     end
 
     it "should have a change link for answered questions" do
       fill_in_number_question(empty_case_log.id, "age1", 28, "person-1-age")
-      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
+      visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
       assert_selector "a", text: /Answer\z/, count: 3
       assert_selector "a", text: "Change", count: 1
-      expect(page).to have_link("Change", href: "/case-logs/#{empty_case_log.id}/person-1-age")
+      expect(page).to have_link("Change", href: "/logs/#{empty_case_log.id}/person-1-age")
     end
 
     it "should have a change link for answered questions" do
-      visit("/case-logs/#{empty_case_log.id}/household-needs/check-answers")
+      visit("/logs/#{empty_case_log.id}/household-needs/check-answers")
       assert_selector "a", text: /Answer\z/, count: 4
       assert_selector "a", text: "Change", count: 0
-      visit("/case-logs/#{empty_case_log.id}/accessibility-requirements")
+      visit("/logs/#{empty_case_log.id}/accessibility-requirements")
       check("case-log-accessibility-requirements-housingneeds-c-field")
       click_button("Save and continue")
-      visit("/case-logs/#{empty_case_log.id}/household-needs/check-answers")
+      visit("/logs/#{empty_case_log.id}/household-needs/check-answers")
       assert_selector "a", text: /Answer\z/, count: 3
       assert_selector "a", text: "Change", count: 1
-      expect(page).to have_link("Change", href: "/case-logs/#{empty_case_log.id}/accessibility-requirements")
+      expect(page).to have_link("Change", href: "/logs/#{empty_case_log.id}/accessibility-requirements")
     end
 
     it "should have a link pointing to the first question if no questions are answered" do
-      visit("/case-logs/#{empty_case_log.id}/#{subsection}/check-answers")
+      visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
       expect(page).to have_content("You answered 0 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/case-logs/#{empty_case_log.id}/tenant-code")
+      expect(page).to have_link("Answer the missing questions", href: "/logs/#{empty_case_log.id}/tenant-code")
     end
 
     it "should have a link pointing to the next empty question if some questions are answered" do
       fill_in_number_question(empty_case_log.id, "earnings", 18_000, "net-income")
 
-      visit("/case-logs/#{empty_case_log.id}/income-and-benefits/check-answers")
+      visit("/logs/#{empty_case_log.id}/income-and-benefits/check-answers")
       expect(page).to have_content("You answered 1 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/case-logs/#{empty_case_log.id}/net-income")
+      expect(page).to have_link("Answer the missing questions", href: "/logs/#{empty_case_log.id}/net-income")
     end
 
     it "should not display the missing answer questions link if all questions are answered" do
@@ -106,7 +106,7 @@ RSpec.describe "Form Check Answers Page" do
     end
 
     it "does not display conditional questions that were not visited" do
-      visit("case-logs/#{id}/#{conditional_subsection}/check-answers")
+      visit("/logs/#{id}/#{conditional_subsection}/check-answers")
       question_labels = ["Has the condition been met?"]
       question_labels.each do |label|
         expect(page).to have_content(label)
@@ -119,10 +119,10 @@ RSpec.describe "Form Check Answers Page" do
     end
 
     it "displays conditional question that were visited" do
-      visit("/case-logs/#{id}/conditional-question")
+      visit("/logs/#{id}/conditional-question")
       choose("case-log-preg-occ-no-field")
       click_button("Save and continue")
-      visit("/case-logs/#{id}/#{conditional_subsection}/check-answers")
+      visit("/logs/#{id}/#{conditional_subsection}/check-answers")
       question_labels = ["Has the condition been met?", "Has the condition not been met?"]
       question_labels.each do |label|
         expect(page).to have_content(label)

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe "Form Conditional Questions" do
 
   context "given a page where some questions are only conditionally shown, depending on how you answer the first question" do
     it "initially hides conditional questions" do
-      visit("/case-logs/#{id}/armed-forces")
+      visit("/logs/#{id}/armed-forces")
       expect(page).not_to have_selector("#armed_forces_injured_div")
     end
 
     it "shows conditional questions if the required answer is selected and hides it again when a different answer option is selected", js: true do
-      visit("/case-logs/#{id}/armed-forces")
+      visit("/logs/#{id}/armed-forces")
       # Something about our styling makes the selenium webdriver think the actual radio buttons are not visible so we allow label click here
       choose("case-log-armedforces-a-current-or-former-regular-in-the-uk-armed-forces-exc-national-service-field", allow_label_click: true)
       expect(page).to have_selector("#reservist_div")

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Form Navigation" do
       visit("/logs")
       click_link("Create new log")
       id = CaseLog.order(created_at: :desc).first.id
-      expect(page).to have_content("Case log #{id}")
+      expect(page).to have_content("Log #{id}")
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe "Form Navigation" do
         visit("/logs/#{id}")
         visit("/logs/#{id}/tenant-code")
         click_link(text: "Back")
-        expect(page).to have_content("Case log #{id}")
+        expect(page).to have_content("Log #{id}")
       end
 
       it "go back to tenant code page from tenant age page", js: true do

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Form Navigation" do
 
   describe "Create new log" do
     it "redirects to the task list for the new log" do
-      visit("/case-logs")
+      visit("/logs")
       click_link("Create new log")
       id = CaseLog.order(created_at: :desc).first.id
       expect(page).to have_content("Case log #{id}")
@@ -37,52 +37,52 @@ RSpec.describe "Form Navigation" do
 
   describe "Viewing a log" do
     it "questions can be accessed by url" do
-      visit("/case-logs/#{id}/person-1-age")
+      visit("/logs/#{id}/person-1-age")
       expect(page).to have_field("case-log-age1-field")
     end
 
     it "a question page leads to the next question defined in the form definition" do
       pages = question_answers.map { |_key, val| val[:path] }
       pages[0..-2].each_with_index do |val, index|
-        visit("/case-logs/#{id}/#{val}")
+        visit("/logs/#{id}/#{val}")
         click_button("Save and continue")
-        expect(page).to have_current_path("/case-logs/#{id}/#{pages[index + 1]}")
+        expect(page).to have_current_path("/logs/#{id}/#{pages[index + 1]}")
       end
     end
 
     describe "Back link directs correctly", js: true do
       it "go back to tasklist page from tenant code" do
-        visit("/case-logs/#{id}")
-        visit("/case-logs/#{id}/tenant-code")
+        visit("/logs/#{id}")
+        visit("/logs/#{id}/tenant-code")
         click_link(text: "Back")
         expect(page).to have_content("Case log #{id}")
       end
 
       it "go back to tenant code page from tenant age page", js: true do
-        visit("/case-logs/#{id}/tenant-code")
+        visit("/logs/#{id}/tenant-code")
         click_button("Save and continue")
-        visit("/case-logs/#{id}/person-1-age")
+        visit("/logs/#{id}/person-1-age")
         click_link(text: "Back")
         expect(page).to have_field("case-log-tenant-code-field")
       end
 
       it "doesn't get stuck in infinite loops", js: true do
-        visit("/case-logs")
-        visit("/case-logs/#{id}/net-income")
+        visit("/logs")
+        visit("/logs/#{id}/net-income")
         fill_in("case-log-earnings-field", with: 740)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         click_link(text: "Back")
         click_link(text: "Back")
-        expect(page).to have_current_path("/case-logs")
+        expect(page).to have_current_path("/logs")
       end
 
       context "when changing an answer from the check answers page", js: true do
         it "the back button routes correctly" do
-          visit("/case-logs/#{id}/household-characteristics/check-answers")
+          visit("/logs/#{id}/household-characteristics/check-answers")
           first("a", text: /Answer/).click
           click_link("Back")
-          expect(page).to have_current_path("/case-logs/#{id}/household-characteristics/check-answers")
+          expect(page).to have_current_path("/logs/#{id}/household-characteristics/check-answers")
         end
       end
     end

--- a/spec/features/form/helpers.rb
+++ b/spec/features/form/helpers.rb
@@ -1,12 +1,12 @@
 module Helpers
   def fill_in_number_question(case_log_id, question, value, path)
-    visit("/case-logs/#{case_log_id}/#{path}")
+    visit("/logs/#{case_log_id}/#{path}")
     fill_in("case-log-#{question.to_s.dasherize}-field", with: value)
     click_button("Save and continue")
   end
 
   def answer_all_questions_in_income_subsection(case_log)
-    visit("/case-logs/#{case_log.id}/net-income")
+    visit("/logs/#{case_log.id}/net-income")
     fill_in("case-log-earnings-field", with: 18_000)
     choose("case-log-incfreq-yearly-field")
     click_button("Save and continue")
@@ -17,7 +17,7 @@ module Helpers
   end
 
   def sign_in(user)
-    visit("/case-logs")
+    visit("/logs")
     fill_in("user[email]", with: user.email)
     fill_in("user[password]", with: user.password)
     click_button("Sign in")

--- a/spec/features/form/page_routing_spec.rb
+++ b/spec/features/form/page_routing_spec.rb
@@ -20,29 +20,29 @@ RSpec.describe "Form Page Routing" do
   end
 
   it "can route the user to a different page based on their answer on the current page", js: true do
-    visit("case-logs/#{id}/conditional-question")
+    visit("/logs/#{id}/conditional-question")
     # using a question name that is already in the db to avoid
     # having to add a new column to the db for this test
     choose("case-log-preg-occ-yes-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-yes-page")
+    expect(page).to have_current_path("/logs/#{id}/conditional-question-yes-page")
     click_link(text: "Back")
-    expect(page).to have_current_path("/case-logs/#{id}/conditional-question")
+    expect(page).to have_current_path("/logs/#{id}/conditional-question")
     choose("case-log-preg-occ-no-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-no-page")
+    expect(page).to have_current_path("/logs/#{id}/conditional-question-no-page")
   end
 
   it "can route based on multiple conditions", js: true do
-    visit("/case-logs/#{id}/person-1-gender")
+    visit("/logs/#{id}/person-1-gender")
     choose("case-log-sex1-female-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case-logs/#{id}/household-number-of-other-members")
-    visit("/case-logs/#{id}/conditional-question")
+    expect(page).to have_current_path("/logs/#{id}/household-number-of-other-members")
+    visit("/logs/#{id}/conditional-question")
     choose("case-log-preg-occ-no-field", allow_label_click: true)
     click_button("Save and continue")
-    expect(page).to have_current_path("/case-logs/#{id}/conditional-question-no-page")
+    expect(page).to have_current_path("/logs/#{id}/conditional-question-no-page")
     click_button("Save and continue")
-    expect(page).to have_current_path("/case-logs/#{id}/conditional-question/check-answers")
+    expect(page).to have_current_path("/logs/#{id}/conditional-question/check-answers")
   end
 end

--- a/spec/features/form/saving_data_spec.rb
+++ b/spec/features/form/saving_data_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Form Saving Data" do
       answer = hsh[:answer]
       path = hsh[:path]
       original_value = case_log.send(question)
-      visit("/case-logs/#{id}/#{path.to_s.dasherize}")
+      visit("/logs/#{id}/#{path.to_s.dasherize}")
       case type
       when "text"
         fill_in("case-log-#{question.to_s.dasherize}-field", with: answer)
@@ -57,7 +57,7 @@ RSpec.describe "Form Saving Data" do
   end
 
   it "updates total value of the rent", js: true do
-    visit("/case-logs/#{id}/rent")
+    visit("/logs/#{id}/rent")
 
     fill_in("case-log-brent-field", with: 3)
     expect(page).to have_field("case-log-tcharge-field", with: "3")
@@ -73,17 +73,17 @@ RSpec.describe "Form Saving Data" do
   end
 
   it "displays number answers in inputs if they are already saved" do
-    visit("/case-logs/#{id}/property-postcode")
+    visit("/logs/#{id}/property-postcode")
     expect(page).to have_field("case-log-property-postcode-field", with: "P0 5ST")
   end
 
   it "displays text answers in inputs if they are already saved" do
-    visit("/case-logs/#{id}/person-1-age")
+    visit("/logs/#{id}/person-1-age")
     expect(page).to have_field("case-log-age1-field", with: "17")
   end
 
   it "displays checkbox answers in inputs if they are already saved" do
-    visit("/case-logs/#{case_log_with_checkbox_questions_answered.id.to_s.dasherize}/accessibility-requirements")
+    visit("/logs/#{case_log_with_checkbox_questions_answered.id.to_s.dasherize}/accessibility-requirements")
     # Something about our styling makes the selenium webdriver think the actual radio buttons are not visible so we pass false here
     expect(page).to have_checked_field(
       "case-log-accessibility-requirements-housingneeds-a-field",

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -27,18 +27,18 @@ RSpec.describe "Task List" do
   end
 
   it "skips to the first section if no answers are completed" do
-    visit("/case-logs/#{empty_case_log.id}")
+    visit("/logs/#{empty_case_log.id}")
     expect(page).to have_link("Skip to next incomplete section", href: /#household_characteristics/)
   end
 
   it "shows the number of completed sections if no sections are completed" do
-    visit("/case-logs/#{empty_case_log.id}")
+    visit("/logs/#{empty_case_log.id}")
     expect(page).to have_content("You’ve completed 0 of 9 sections.")
   end
 
   it "shows the number of completed sections if one section is completed" do
     answer_all_questions_in_income_subsection(empty_case_log)
-    visit("/case-logs/#{empty_case_log.id}")
+    visit("/logs/#{empty_case_log.id}")
     expect(page).to have_content("You’ve completed 1 of 9 sections.")
   end
 end

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "validations" do
   describe "Question validation" do
     context "given an invalid tenant age" do
       it " of less than 0 it shows validation" do
-        visit("/case-logs/#{id}/person-1-age")
+        visit("/logs/#{id}/person-1-age")
         fill_in_number_question(empty_case_log.id, "age1", -5, "person-1-age")
         expect(page).to have_selector("#error-summary-title")
         expect(page).to have_selector("#case-log-age1-error")
@@ -37,7 +37,7 @@ RSpec.describe "validations" do
       end
 
       it " of greater than 120 it shows validation" do
-        visit("/case-logs/#{id}/person-1-age")
+        visit("/logs/#{id}/person-1-age")
         fill_in_number_question(empty_case_log.id, "age1", 121, "person-1-age")
         expect(page).to have_selector("#error-summary-title")
         expect(page).to have_selector("#case-log-age1-error")
@@ -49,7 +49,7 @@ RSpec.describe "validations" do
 
   describe "date validation", js: true do
     def fill_in_date(case_log_id, question, day, month, year, path)
-      visit("/case-logs/#{case_log_id}/#{path}")
+      visit("/logs/#{case_log_id}/#{path}")
       fill_in("#{question}_1i", with: year)
       fill_in("#{question}_2i", with: month)
       fill_in("#{question}_3i", with: day)
@@ -58,45 +58,45 @@ RSpec.describe "validations" do
     it "does not allow out of range dates to be submitted" do
       fill_in_date(id, "case_log_mrcdate", 3100, 12, 2000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
 
       fill_in_date(id, "case_log_mrcdate", 12, 1, 20_000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
 
       fill_in_date(id, "case_log_mrcdate", 13, 100, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
 
       fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/local-authority/check-answers")
+      expect(page).to have_current_path("/logs/#{id}/local-authority/check-answers")
     end
 
     it "does not allow non numeric inputs to be submitted" do
       fill_in_date(id, "case_log_mrcdate", "abc", "de", "ff", "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
     end
 
     it "does not allow partial inputs to be submitted" do
       fill_in_date(id, "case_log_mrcdate", 21, 12, nil, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
 
       fill_in_date(id, "case_log_mrcdate", 12, nil, 2000, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
 
       fill_in_date(id, "case_log_mrcdate", nil, 10, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/property-major-repairs")
+      expect(page).to have_current_path("/logs/#{id}/property-major-repairs")
     end
 
     it "allows valid inputs to be submitted" do
       fill_in_date(id, "case_log_mrcdate", 21, 11, 2020, "property-major-repairs")
       click_button("Save and continue")
-      expect(page).to have_current_path("/case-logs/#{id}/local-authority/check-answers")
+      expect(page).to have_current_path("/logs/#{id}/local-authority/check-answers")
     end
   end
 
@@ -115,30 +115,30 @@ RSpec.describe "validations" do
       let(:income_under_soft_limit) { 700 }
 
       it "prompts the user to confirm the value is correct", js: true do
-        visit("/case-logs/#{case_log.id}/net-income")
+        visit("/logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         expect(page).to have_content("Are you sure this is correct?")
         check("case-log-override-net-income-validation-override-net-income-validation-field", allow_label_click: true)
         click_button("Save and continue")
-        expect(page).to have_current_path("/case-logs/#{case_log.id}/net-income-uc-proportion")
+        expect(page).to have_current_path("/logs/#{case_log.id}/net-income-uc-proportion")
       end
 
       it "does not require confirming the value if the value is amended" do
-        visit("/case-logs/#{case_log.id}/net-income")
+        visit("/logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
         fill_in("case-log-earnings-field", with: income_under_soft_limit)
         click_button("Save and continue")
-        expect(page).to have_current_path("/case-logs/#{case_log.id}/net-income-uc-proportion")
+        expect(page).to have_current_path("/logs/#{case_log.id}/net-income-uc-proportion")
         case_log.reload
         expect(case_log.override_net_income_validation).to be_nil
       end
 
       it "clears the confirmation question if the amount was amended and the page is returned to using the back button", js: true do
-        visit("/case-logs/#{case_log.id}/net-income")
+        visit("/logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")
@@ -149,7 +149,7 @@ RSpec.describe "validations" do
       end
 
       it "does not clear the confirmation question if the page is returned to using the back button and the amount is still over the soft limit", js: true do
-        visit("/case-logs/#{case_log.id}/net-income")
+        visit("/logs/#{case_log.id}/net-income")
         fill_in("case-log-earnings-field", with: income_over_soft_limit)
         choose("case-log-incfreq-weekly-field", allow_label_click: true)
         click_button("Save and continue")

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "User Features" do
 
     context "Organisation page" do
       it "defaults to organisation details" do
-        visit("/case-logs")
+        visit("/logs")
         click_link("Your organisation")
         expect(page).to have_content(user.organisation.name)
       end
@@ -51,7 +51,7 @@ RSpec.describe "User Features" do
 
     context "Organisation page" do
       it "can only see the details tab" do
-        visit("/case-logs")
+        visit("/logs")
         click_link("Your organisation")
         expect(page).to have_current_path("/organisations/#{org_id}/details")
         expect(page).to have_no_link("Users")

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -3,28 +3,28 @@ RSpec.describe "User Features" do
   let!(:user) { FactoryBot.create(:user) }
   context "A user navigating to case logs" do
     it " is required to log in" do
-      visit("/case-logs")
+      visit("/logs")
       expect(page).to have_current_path("/users/sign-in")
     end
 
     it "does not see the default devise error message" do
-      visit("/case-logs")
+      visit("/logs")
       expect(page).to have_no_content("You need to sign in or sign up before continuing.")
     end
 
     it " is redirected to case logs after signing in" do
-      visit("/case-logs")
+      visit("/logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
-      expect(page).to have_current_path("/case-logs")
+      expect(page).to have_current_path("/logs")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
   end
 
   context "A user who has forgotten their password" do
     it " is redirected to the reset password page when they click the reset password link" do
-      visit("/case-logs")
+      visit("/logs")
       click_link("reset your password")
       expect(page).to have_current_path("/users/password/new")
     end
@@ -76,7 +76,7 @@ RSpec.describe "User Features" do
 
   context "If user not logged in" do
     it "'Your account' link does not display" do
-      visit("/case-logs")
+      visit("/logs")
       expect(page).to have_no_link("Your account")
     end
 
@@ -98,7 +98,7 @@ RSpec.describe "User Features" do
 
   context "Trying to log in with incorrect credentials" do
     it "shows a gov uk error summary and no flash message" do
-      visit("/case-logs")
+      visit("/logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "nonsense")
       click_button("Sign in")
@@ -108,7 +108,7 @@ RSpec.describe "User Features" do
     end
 
     it "show specific field error messages if a field was omitted" do
-      visit("/case-logs")
+      visit("/logs")
       click_button("Sign in")
       expect(page).to have_selector("#error-summary-title")
       expect(page).to have_selector("#user-email-field-error")
@@ -117,7 +117,7 @@ RSpec.describe "User Features" do
     end
 
     it "show specific field error messages if an invalid email address is entered" do
-      visit("/case-logs")
+      visit("/logs")
       fill_in("user[email]", with: "thisisn'tanemail")
       click_button("Sign in")
       expect(page).to have_selector("#error-summary-title")
@@ -129,14 +129,14 @@ RSpec.describe "User Features" do
 
   context "Your Account " do
     before(:each) do
-      visit("/case-logs")
+      visit("/logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
     end
 
     it "shows 'Your account' link in navigation if logged in and redirect to correct page" do
-      visit("/case-logs")
+      visit("/logs")
       expect(page).to have_link("Your account")
       click_link("Your account")
       expect(page).to have_current_path("/users/#{user.id}")
@@ -165,7 +165,7 @@ RSpec.describe "User Features" do
 
   context "Adding a new user" do
     before(:each) do
-      visit("/case-logs")
+      visit("/logs")
       fill_in("user[email]", with: user.email)
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")

--- a/spec/requests/bulk_upload_controller_spec.rb
+++ b/spec/requests/bulk_upload_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe BulkUploadController, type: :request do
-  let(:url) { "/case-logs/bulk-upload" }
+  let(:url) { "/logs/bulk-upload" }
   let(:user) { FactoryBot.create(:user) }
   let(:organisation) { user.organisation }
   before do

--- a/spec/requests/case_log_controller_spec.rb
+++ b/spec/requests/case_log_controller_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe CaseLogsController, type: :request do
             end
 
             it "shows the tasklist for case logs you have access to" do
-              expect(response.body).to match("Case log")
+              expect(response.body).to match("Log")
               expect(response.body).to match(case_log.id.to_s)
             end
 

--- a/spec/requests/case_log_controller_spec.rb
+++ b/spec/requests/case_log_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CaseLogsController, type: :request do
     end
 
     before do
-      post "/case-logs", headers: headers, params: params.to_json
+      post "/logs", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -137,12 +137,12 @@ RSpec.describe CaseLogsController, type: :request do
 
       before do
         sign_in user
-        get "/case-logs", headers: headers, params: {}
+        get "/logs", headers: headers, params: {}
       end
 
       it "only shows case logs for your organisation" do
-        expected_case_row_log = "<a class=\"govuk-link\" href=\"/case-logs/#{case_log.id}\">#{case_log.id}</a>"
-        unauthorized_case_row_log = "<a class=\"govuk-link\" href=\"/case-logs/#{unauthorized_case_log.id}\">#{unauthorized_case_log.id}</a>"
+        expected_case_row_log = "<a class=\"govuk-link\" href=\"/logs/#{case_log.id}\">#{case_log.id}</a>"
+        unauthorized_case_row_log = "<a class=\"govuk-link\" href=\"/logs/#{unauthorized_case_log.id}\">#{unauthorized_case_log.id}</a>"
         expect(CGI.unescape_html(response.body)).to include(expected_case_row_log)
         expect(CGI.unescape_html(response.body)).not_to include(unauthorized_case_row_log)
       end
@@ -153,7 +153,7 @@ RSpec.describe CaseLogsController, type: :request do
       let(:id) { completed_case_log.id }
 
       before do
-        get "/case-logs/#{id}", headers: headers
+        get "/logs/#{id}", headers: headers
       end
 
       it "returns http success" do
@@ -182,7 +182,7 @@ RSpec.describe CaseLogsController, type: :request do
 
         context "a user that is not signed in" do
           it "does not let the user get case log tasklist pages they don't have access to" do
-            get "/case-logs/#{case_log.id}", headers: headers, params: {}
+            get "/logs/#{case_log.id}", headers: headers, params: {}
             expect(response).to redirect_to("/users/sign-in")
           end
         end
@@ -191,7 +191,7 @@ RSpec.describe CaseLogsController, type: :request do
           context "case logs that are owned or managed by your organisation" do
             before do
               sign_in user
-              get "/case-logs/#{case_log.id}", headers: headers, params: {}
+              get "/logs/#{case_log.id}", headers: headers, params: {}
             end
 
             it "shows the tasklist for case logs you have access to" do
@@ -218,7 +218,7 @@ RSpec.describe CaseLogsController, type: :request do
 
             before do
               sign_in user
-              get "/case-logs/#{section_completed_case_log.id}", headers: headers, params: {}
+              get "/logs/#{section_completed_case_log.id}", headers: headers, params: {}
             end
 
             it "displays a section status for a case log" do
@@ -231,7 +231,7 @@ RSpec.describe CaseLogsController, type: :request do
           context "case logs that are not owned or managed by your organisation" do
             before do
               sign_in user
-              get "/case-logs/#{unauthorized_case_log.id}", headers: headers, params: {}
+              get "/logs/#{unauthorized_case_log.id}", headers: headers, params: {}
             end
 
             it "does not show the tasklist for case logs you don't have access to" do
@@ -253,7 +253,7 @@ RSpec.describe CaseLogsController, type: :request do
     let(:id) { case_log.id }
 
     before do
-      patch "/case-logs/#{id}", headers: headers, params: params.to_json
+      patch "/logs/#{id}", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -311,7 +311,7 @@ RSpec.describe CaseLogsController, type: :request do
     let(:id) { case_log.id }
 
     before do
-      put "/case-logs/#{id}", headers: headers, params: params.to_json
+      put "/logs/#{id}", headers: headers, params: params.to_json
     end
 
     it "returns http success" do
@@ -351,7 +351,7 @@ RSpec.describe CaseLogsController, type: :request do
 
     context "expected deletion" do
       before do
-        delete "/case-logs/#{id}", headers: headers
+        delete "/logs/#{id}", headers: headers
       end
 
       it "returns http success" do
@@ -385,7 +385,7 @@ RSpec.describe CaseLogsController, type: :request do
     context "deletion fails" do
       before do
         allow_any_instance_of(CaseLog).to receive(:discard).and_return(false)
-        delete "/case-logs/#{id}", headers: headers
+        delete "/logs/#{id}", headers: headers
       end
 
       it "returns an unprocessable entity 422" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -23,19 +23,19 @@ RSpec.describe FormController, type: :request do
   context "a not signed in user" do
     describe "GET" do
       it "does not let you get case logs pages you don't have access to" do
-        get "/case-logs/#{case_log.id}/person-1-age", headers: headers, params: {}
+        get "/logs/#{case_log.id}/person-1-age", headers: headers, params: {}
         expect(response).to redirect_to("/users/sign-in")
       end
 
       it "does not let you get case log check answer pages you don't have access to" do
-        get "/case-logs/#{case_log.id}/household-characteristics/check-answers", headers: headers, params: {}
+        get "/logs/#{case_log.id}/household-characteristics/check-answers", headers: headers, params: {}
         expect(response).to redirect_to("/users/sign-in")
       end
     end
 
     describe "POST" do
       it "does not let you post form answers to case logs you don't have access to" do
-        post "/case-logs/#{case_log.id}/form", params: {}
+        post "/logs/#{case_log.id}/form", params: {}
         expect(response).to redirect_to("/users/sign-in")
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe FormController, type: :request do
       context "form pages" do
         context "case logs that are not owned or managed by your organisation" do
           it "does not show form pages for case logs you don't have access to" do
-            get "/case-logs/#{unauthorized_case_log.id}/person-1-age", headers: headers, params: {}
+            get "/logs/#{unauthorized_case_log.id}/person-1-age", headers: headers, params: {}
             expect(response).to have_http_status(:not_found)
           end
         end
@@ -59,7 +59,7 @@ RSpec.describe FormController, type: :request do
       context "check answers pages" do
         context "case logs that are not owned or managed by your organisation" do
           it "does not show a check answers for case logs you don't have access to" do
-            get "/case-logs/#{unauthorized_case_log.id}/household-characteristics/check-answers", headers: headers, params: {}
+            get "/logs/#{unauthorized_case_log.id}/household-characteristics/check-answers", headers: headers, params: {}
             expect(response).to have_http_status(:not_found)
           end
         end
@@ -91,7 +91,7 @@ RSpec.describe FormController, type: :request do
 
         before do
           allow(FormHandler.instance).to receive(:get_form).and_return(form)
-          post "/case-logs/#{case_log.id}/form", params: params
+          post "/logs/#{case_log.id}/form", params: params
         end
 
         context "invalid answers" do
@@ -153,7 +153,7 @@ RSpec.describe FormController, type: :request do
         end
 
         it "sets checked items to true" do
-          post "/case-logs/#{case_log.id}/form", params: case_log_form_params
+          post "/logs/#{case_log.id}/form", params: case_log_form_params
           case_log.reload
 
           expect(case_log.housingneeds_a).to eq("Yes")
@@ -162,7 +162,7 @@ RSpec.describe FormController, type: :request do
         end
 
         it "sets previously submitted items to false when resubmitted with new values" do
-          post "/case-logs/#{case_log.id}/form", params: new_case_log_form_params
+          post "/logs/#{case_log.id}/form", params: new_case_log_form_params
           case_log.reload
 
           expect(case_log.housingneeds_a).to eq("No")
@@ -209,7 +209,7 @@ RSpec.describe FormController, type: :request do
 
           it "updates both question fields" do
             allow_any_instance_of(Form::Page).to receive(:expected_responses).and_return(questions_for_page)
-            post "/case-logs/#{case_log.id}/form", params: case_log_form_params
+            post "/logs/#{case_log.id}/form", params: case_log_form_params
             case_log.reload
 
             expect(case_log.housingneeds_a).to eq("Yes")
@@ -246,11 +246,11 @@ RSpec.describe FormController, type: :request do
         end
 
         it "routes to the appropriate conditional page based on the question answer of the current page" do
-          post "/case-logs/#{case_log.id}/form", params: case_log_form_conditional_question_yes_params
-          expect(response).to redirect_to("/case-logs/#{case_log.id}/conditional-question-yes-page")
+          post "/logs/#{case_log.id}/form", params: case_log_form_conditional_question_yes_params
+          expect(response).to redirect_to("/logs/#{case_log.id}/conditional-question-yes-page")
 
-          post "/case-logs/#{case_log.id}/form", params: case_log_form_conditional_question_no_params
-          expect(response).to redirect_to("/case-logs/#{case_log.id}/conditional-question-no-page")
+          post "/logs/#{case_log.id}/form", params: case_log_form_conditional_question_no_params
+          expect(response).to redirect_to("/logs/#{case_log.id}/conditional-question-no-page")
         end
       end
 
@@ -266,7 +266,7 @@ RSpec.describe FormController, type: :request do
         end
 
         before do
-          post "/case-logs/#{unauthorized_case_log.id}/form", params: {}
+          post "/logs/#{unauthorized_case_log.id}/form", params: {}
         end
 
         it "does not let you post form answers to case logs you don't have access to" do

--- a/spec/requests/soft_validations_controller_spec.rb
+++ b/spec/requests/soft_validations_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SoftValidationsController, type: :request do
   let(:params) { { case_log_id: case_log.id } }
-  let(:url) { "/case-logs/#{case_log.id}/net-income/soft-validations" }
+  let(:url) { "/logs/#{case_log.id}/net-income/soft-validations" }
   let(:user) { FactoryBot.create(:user) }
 
   context "a not signed in user" do

--- a/spec/requests/user_controller_spec.rb
+++ b/spec/requests/user_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UsersController, type: :request do
 
     describe "#patch" do
       it "does not let you update user details" do
-        patch "/case-logs/#{user.id}", params: {}
+        patch "/logs/#{user.id}", params: {}
         expect(response).to redirect_to("/users/sign-in")
       end
     end


### PR DESCRIPTION
Removes ‘case logs’ from user-visible parts of the site:

* Updates `/case-logs/*` routes to use `/logs/*`
* Changes references to ‘case log(s)’ to ‘log(s)’

Lots of mention of case logs in the code, comments and API spec, but can decide if we want to address that later.