### PR TITLE
Set sign in and sign out messages to empty strings

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,6 +45,10 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: ""
+      signed_out: ""
+      already_signed_out: ""
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "User Features" do
       fill_in("user[password]", with: "pAssword1")
       click_button("Sign in")
       expect(page).to have_current_path("/logs")
-      expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
     end
   end
 


### PR DESCRIPTION
Removing them completely made device gem revert to defaults by the looks of it.
Setting flash notice values to empty strings doesn't show the banner anymore.