### PR TITLE
Add timeout for postcode lookup

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -190,10 +190,6 @@ private
   end
 
   def set_derived_fields
-    if property_postcode.present?
-      self.postcode = UKPostcode.parse(property_postcode).outcode
-      self.postcod2 = UKPostcode.parse(property_postcode).incode
-    end
     if previous_postcode.present?
       self.ppostc1 = UKPostcode.parse(previous_postcode).outcode
       self.ppostc2 = UKPostcode.parse(previous_postcode).incode
@@ -218,7 +214,12 @@ private
     else
       self.la = get_la(property_postcode)
     end
-
+    if property_postcode.present?
+      self.postcode = UKPostcode.parse(property_postcode).outcode
+      self.postcod2 = UKPostcode.parse(property_postcode).incode
+    else
+      self.postcode = self.postcod2 = nil
+    end
     self.totchild = get_totchild
     self.totelder = get_totelder
     self.totadult = get_totadult

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -1,4 +1,5 @@
 require "postcodes_io"
+require "timeout"
 
 class CaseLogValidator < ActiveModel::Validator
   # Validations methods need to be called 'validate_' to run on model save
@@ -241,7 +242,8 @@ private
 
   def get_la(postcode)
     if postcode.present?
-      postcode_lookup = PIO.lookup(postcode)
+      postcode_lookup = nil
+      Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) }
       if postcode_lookup && postcode_lookup.info.present?
         self.is_la_inferred = true
         return postcode_lookup.admin_district

--- a/app/models/constants/case_log.rb
+++ b/app/models/constants/case_log.rb
@@ -489,7 +489,7 @@ module Constants::CaseLog
     "Tewkesbury" => "E07000083",
     "Basingstoke and Deane" => "E07000084",
     "East Hampshire" => "E07000085",
-    "King’s Lynn and West Norfolk" => "E07000146",
+    "King's Lynn and West Norfolk" => "E07000146",
     "Eastleigh" => "E07000086",
     "North Norfolk" => "E07000147",
     "Norwich" => "E07000148",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1294,7 +1294,7 @@
                     "133": "Isles of Scilly",
                     "134": "Islington",
                     "135": "Kensington & Chelsea",
-                    "136": "Kings Lynn & West Norfolk",
+                    "136": "King's Lynn and West Norfolk",
                     "137": "Kingston-upon-Hull",
                     "138": "Kingston-upon-Thames",
                     "139": "Kirklees",

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1031,6 +1031,7 @@ RSpec.describe Form, type: :model do
         CaseLog.create({
           managing_organisation: organisation,
           owning_organisation: organisation,
+          postcode_known: "Yes",
           property_postcode: "M1 1AE",
         })
       end
@@ -1054,7 +1055,7 @@ RSpec.describe Form, type: :model do
         address_case_log.reload
 
         record_from_db = ActiveRecord::Base.connection.execute("select la, property_postcode from case_logs where id=#{address_case_log.id}").to_a[0]
-        expect(record_from_db["property_postcode"]).to eq("")
+        expect(record_from_db["property_postcode"]).to eq(nil)
         expect(address_case_log.la).to eq(nil)
         expect(record_from_db["la"]).to eq(nil)
       end


### PR DESCRIPTION
Add a timeout of 5 seconds when looking up the postcode using postcodes.io
Such long request should rarely happen and if it does 5 seconds doesn't look too long when the screen is loading
Reset location fields if postcode not known (CLDC-782)