### PR TITLE
Redirect to logs if they clicked start now

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -17,4 +17,10 @@ class Auth::SessionsController < Devise::SessionsController
       super
     end
   end
+
+private
+
+  def after_sign_in_path_for(resource)
+    params.dig("user", "start").present? ? case_logs_path : super
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,6 +19,7 @@
         autocomplete: "current-password"
       %>
 
+      <%= f.hidden_field :start, value: request["start"] %>
       <%= f.govuk_submit "Sign in" %>
     </div>
   </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -16,9 +16,10 @@
     <p class="govuk-body">The data will be used to update the national record for social housing. It will also help to inform policy about the cost of social housing and what type of housing needs to be built.</p>
     <p class="govuk-body">This service is only for social housing in England.</p>
 
+    <% start_path = current_user ? case_logs_path : (user_session_path + "?start=true") %>
     <%= govuk_start_button(
       text: 'Start now',
-      href: user_session_path
+      href: start_path
     ) %>
 
     <h2 class="govuk-heading-m">Before you start</h2>

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# Test Controller intital test
 RSpec.describe StartController, type: :controller do
   let(:valid_session) { {} }
 

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require_relative "form/helpers"
+
+RSpec.describe "Start Page Features" do
+  include Helpers
+  let(:user) { FactoryBot.create(:user) }
+
+  context "a signed in user" do
+    before do
+      sign_in user
+    end
+
+    it "takes you to your logs" do
+      visit("/")
+      click_link("Start now")
+      expect(page).to have_current_path("/logs")
+    end
+  end
+
+  context "a not signed in user" do
+    it "takes you to sign in and then to your logs" do
+      visit("/")
+      click_link("Start now")
+      expect(page).to have_current_path("/users/sign-in?start=true")
+      fill_in("user[email]", with: user.email)
+      fill_in("user[password]", with: user.password)
+      click_button("Sign in")
+      expect(page).to have_current_path("/logs")
+    end
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5101747/146773587-3c4e1943-24dd-4359-a542-ad64b8ce1c2e.png)

Expected flow for Start now button that this PR implements:

1. If the user is already signed in, "Start now" takes the to the logs index page (list of logs)
2. If the user is not signed in, it takes them to the sign in page, and then to the logs index page following successful sign in (as opposed to back to the start page after sign in, as currently)