### PR TITLE
Accessible autocomplete: Only enhance select element once

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -5,14 +5,14 @@ class FormController < ApplicationController
 
   def submit_form
     if @case_log
-      page = @case_log.form.get_page(params[:case_log][:page])
-      responses_for_page = responses_for_page(page)
+      @page = @case_log.form.get_page(params[:case_log][:page])
+      responses_for_page = responses_for_page(@page)
       if @case_log.update(responses_for_page) && @case_log.has_no_unresolved_soft_errors?
-        redirect_path = @case_log.form.next_page_redirect_path(page, @case_log)
+        redirect_path = @case_log.form.next_page_redirect_path(@page, @case_log)
         redirect_to(send(redirect_path, @case_log))
       else
-        subsection = @case_log.form.subsection_for_page(page)
-        render "form/page", locals: { page: page, subsection: subsection.label }, status: :unprocessable_entity
+        @subsection = @case_log.form.subsection_for_page(@page)
+        render "form/page", status: :unprocessable_entity
       end
     else
       render_not_found
@@ -33,9 +33,9 @@ class FormController < ApplicationController
     form.pages.map do |page|
       define_method(page.id) do |_errors = {}|
         if @case_log
-          subsection = @case_log.form.subsection_for_page(page)
-          case_log_form_page = @case_log.form.get_page(page.id)
-          render "form/page", locals: { page: case_log_form_page, subsection: subsection.label }
+          @subsection = @case_log.form.subsection_for_page(page)
+          @page = @case_log.form.get_page(page.id)
+          render "form/page"
         else
           render_not_found
         end

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -1,3 +1,4 @@
+<% selected = CaseLog::UK_LA[@case_log.public_send(question.id)] || "" %>
 <%= answers = question.answer_options.map { |key, value| OpenStruct.new(id: key, name: value) }
  f.govuk_collection_select question.id.to_sym,
     answers,
@@ -6,6 +7,6 @@
     caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
     label: { text: question.header, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
     hint: { text: question.hint_text&.html_safe },
-    options: { disabled: [""], selected: @case_log.public_send(question.id) || "" },
+    options: { disabled: [""], selected: selected },
     "data-controller": "accessible-autocomplete"
  %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <% content_for :title, @page.header.present? ? @page.header : @page.questions.first().header.html_safe %>
 
 <% content_for :before_content do %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, page.header.present? ? page.header : page.questions.first().header.html_safe %>
+<% content_for :title, @page.header.present? ? @page.header : @page.questions.first().header.html_safe %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
@@ -10,26 +10,26 @@
 <%= turbo_frame_tag "case_log_form", target: "_top" do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% if page.header.present? %>
+      <% if @page.header.present? %>
         <h1 class="govuk-heading-l">
-          <span class="govuk-caption-l"><%= subsection %></span>
-          <%= page.header %>
+          <span class="govuk-caption-l"><%= @subsection.label %></span>
+          <%= @page.header %>
         </h1>
       <% end %>
 
       <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
         <%= f.govuk_error_summary %>
-        <% page.questions.map do |question| %>
-          <div id=<%= question.id + "_div " %><%= display_question_key_div(page, question) %> >
-            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption: subsection, page_header: page.header, f: f } %>
+        <% @page.questions.map do |question| %>
+          <div id=<%= question.id + "_div " %><%= display_question_key_div(@page, question) %> >
+            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption: @subsection.label, page_header: @page.header, f: f } %>
           </div>
         <% end %>
 
-        <% if page.has_soft_validations? %>
-          <%= render partial: "form/validation_override_question", locals: { f: f, page: page } %>
+        <% if @page.has_soft_validations? %>
+          <%= render partial: "form/validation_override_question", locals: { f: f, page: @page } %>
         <% end %>
 
-        <%= f.hidden_field :page, value: page.id %>
+        <%= f.hidden_field :page, value: @page.id %>
         <%= f.govuk_submit "Save and continue"  %>
       <% end %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,10 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', defer: true %>
+
+    <% if content_for?(:head) %>
+      <%= yield(:head) %>
+    <% end %>
     <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
 
     <% if Rails.env.development? %>

--- a/app/webpacker/controllers/accessible_autocomplete_controller.js
+++ b/app/webpacker/controllers/accessible_autocomplete_controller.js
@@ -3,10 +3,15 @@ import accessibleAutocomplete from "accessible-autocomplete"
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 
 export default class extends Controller {
+  static values = { enhanced: Boolean, default: false }
+
   connect() {
-    accessibleAutocomplete.enhanceSelectElement({
-      defaultValue: '',
-      selectElement: this.element
-    })
+    if(!this.enhancedValue){
+      accessibleAutocomplete.enhanceSelectElement({
+        defaultValue: '',
+        selectElement: this.element
+      })
+      this.enhancedValue = true
+    }
   }
 }

--- a/app/webpacker/controllers/accessible_autocomplete_controller.js
+++ b/app/webpacker/controllers/accessible_autocomplete_controller.js
@@ -3,15 +3,11 @@ import accessibleAutocomplete from "accessible-autocomplete"
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 
 export default class extends Controller {
-  static values = { enhanced: Boolean, default: false }
 
   connect() {
-    if(!this.enhancedValue){
-      accessibleAutocomplete.enhanceSelectElement({
-        defaultValue: '',
-        selectElement: this.element
-      })
-      this.enhancedValue = true
-    }
+    accessibleAutocomplete.enhanceSelectElement({
+      defaultValue: '',
+      selectElement: this.element
+    })
   }
 }

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -24,4 +24,12 @@ RSpec.describe "Accessible Automcomplete" do
     find("#case-log-la-field").click.native.send_keys("T", "h", "a", "n", :down, :enter)
     expect(find("#case-log-la-field").value).to eq("Thanet")
   end
+
+  it "maintains enhancement state across back navigation", js: true do
+    visit("/logs/#{case_log.id}/accessible-select")
+    find("#case-log-la-field").click.native.send_keys("T", "h", "a", "n", :down, :enter)
+    click_button("Save and continue")
+    click_link(text: "Back")
+    expect(page).to have_selector("input", class: "autocomplete__input", count: 1)
+  end
 end

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe "Accessible Automcomplete" do
     visit("/logs/#{case_log.id}/accessible-select")
     expect(page).to have_select("case-log-la-field", disabled_options: ["Select an option"])
   end
+
+  it "has the correct option selected if one has been saved" do
+    case_log.update(property_postcode: nil, la: "Oxford")
+    visit("/logs/#{case_log.id}/accessible-select")
+    expect(page).to have_select("case-log-la-field", selected: ["Oxford"])
+  end
 end

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe "Accessible Automcomplete" do
   end
 
   it "has the correct option selected if one has been saved" do
-    case_log.update(property_postcode: nil, la: "Oxford")
+    case_log.update!(property_postcode: nil, la: "Oxford")
     visit("/logs/#{case_log.id}/accessible-select")
-    expect(page).to have_select("case-log-la-field", selected: ["Oxford"])
+    expect(page).to have_select("case-log-la-field", selected: %w[Oxford])
   end
 end

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -32,4 +32,9 @@ RSpec.describe "Accessible Automcomplete" do
     click_link(text: "Back")
     expect(page).to have_selector("input", class: "autocomplete__input", count: 1)
   end
+
+  it "has a disabled null option" do
+    visit("/logs/#{case_log.id}/accessible-select")
+    expect(page).to have_select("case-log-la-field", disabled_options: ["Select an option"])
+  end
 end

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -193,11 +193,12 @@
                     "type": "select",
                     "check_answer_label": "Accessible Select",
                     "answer_options": {
-                      "0": "Adur",
-                      "1": "Lewisham",
-                      "2": "Oxford",
-                      "3": "Thanet",
-                      "4": "York"
+                      "" : "Select an option",
+                      "E07000223": "Adur",
+                      "E09000023": "Lewisham",
+                      "E07000178": "Oxford",
+                      "E07000114": "Thanet",
+                      "E06000014": "York"
                     }
                   }
                 }


### PR DESCRIPTION
We set turbo to not cache the form page so that it gets reloaded when using the back link. This has minimal if any performance impact as each form page loads fast anyway and has the benefit of meaning our stimulus controllers don't need to consider state at all.

Primarily this means we can always call progressive enhance on select options without  needing to check if they've already been enhanced. It also means error messages properly reevaluate when using the back button rather than preserving error messages that no longer apply.