### PR TITLE
CLDC-810: Add outside England options to past LA question

### DIFF
--- a/app/models/constants/case_log.rb
+++ b/app/models/constants/case_log.rb
@@ -974,6 +974,10 @@ module Constants::CaseLog
     "Wyre" => "E07000128",
     "Wyre Forest" => "E07000239",
     "York" => "E06000014",
+    "Northern Ireland" => "N92000002",
+    "Scotland" => "S92000003",
+    "Wales" => "W92000004",
+    "Outside UK" => "9300000XX",
   }.freeze
 
   ARMED_FORCES = {

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -2394,7 +2394,11 @@
                     "E07000238": "Wychavon",
                     "E07000128": "Wyre",
                     "E07000239": "Wyre Forest",
-                    "E06000014": "York"
+                    "E06000014": "York",
+                    "N92000002": "Northern Ireland",
+                    "S92000003": "Scotland",
+                    "W92000004": "Wales",
+                    "9300000XX": "Outside UK"
                   }
                 }
               }


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-810

Current Local Authority must be in England but previous one can be outside. This PR adds the required options. Currently at the bottom but design likely to be reviewed anyway.