### PR TITLE
CDLC-783: Errors when a postcode is known but not provided

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -222,7 +222,9 @@ private
     if property_postcode.blank? || postcode_known == "No"
       reset_location_fields
     else
-      self.la = get_la(property_postcode)
+      inferred_la = get_inferred_la(property_postcode)
+      self.is_la_inferred = inferred_la.present?
+      self.la = inferred_la if inferred_la.present?
     end
     if property_postcode.present?
       self.postcode = UKPostcode.parse(property_postcode).outcode
@@ -254,15 +256,12 @@ private
     end
   end
 
-  def get_la(postcode)
+  def get_inferred_la(postcode)
     postcode_lookup = nil
     Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) }
     if postcode_lookup && postcode_lookup.info.present?
-      self.is_la_inferred = true
-      return postcode_lookup.admin_district
+      postcode_lookup.admin_district
     end
-    self.la = nil
-    self.is_la_inferred = false
   end
 
   def reset_location_fields

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -33,4 +33,10 @@ module Validations::PropertyValidations
       record.errors.add :unitletas, "Property cannot have a previous let type if it is being let as social housing for the first time"
     end
   end
+
+  def validate_property_postcode(record)
+    if record.postcode_known == "Yes" && record.property_postcode.blank?
+      record.errors.add :property_postcode, "Enter a postcode in the correct format, for example AA1 1AA"
+    end
+  end
 end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1125,7 +1125,7 @@
                 },
                 "property_postcode": {
                   "check_answer_label": "Postcode",
-                  "header": "",
+                  "header": "What is the property's postcode?",
                   "hint_text": "",
                   "type": "text",
                   "width": 5

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1134,14 +1134,9 @@ RSpec.describe Form, type: :model do
         expect(record_from_db["la"]).to eq("E08000003")
       end
 
-      it "correctly resets all fields if property postcode is empty" do
-        address_case_log.update!({ property_postcode: "" })
-        address_case_log.reload
-
-        record_from_db = ActiveRecord::Base.connection.execute("select la, property_postcode from case_logs where id=#{address_case_log.id}").to_a[0]
-        expect(record_from_db["property_postcode"]).to eq(nil)
-        expect(address_case_log.la).to eq(nil)
-        expect(record_from_db["la"]).to eq(nil)
+      it "errors if the property postcode is emptied" do
+        expect { address_case_log.update!({ property_postcode: "" }) }
+          .to raise_error(ActiveRecord::RecordInvalid, /Enter a postcode in the correct format/)
       end
 
       it "correctly resets all fields if property postcode not known" do
@@ -1154,7 +1149,7 @@ RSpec.describe Form, type: :model do
         expect(record_from_db["la"]).to eq(nil)
       end
 
-      it "keeps the LA if property postcode changes from not known to known and not provided" do
+      it "changes the LA if property postcode changes from not known to known and provided" do
         address_case_log.update!({ postcode_known: "No" })
         address_case_log.update!({ la: "Westminster" })
         address_case_log.reload
@@ -1164,13 +1159,13 @@ RSpec.describe Form, type: :model do
         expect(address_case_log.la).to eq("Westminster")
         expect(record_from_db["la"]).to eq("E09000033")
 
-        address_case_log.update!({ postcode_known: "Yes" })
+        address_case_log.update!({ postcode_known: "Yes", property_postcode: "M1 1AD" })
         address_case_log.reload
 
         record_from_db = ActiveRecord::Base.connection.execute("select la, property_postcode from case_logs where id=#{address_case_log.id}").to_a[0]
-        expect(record_from_db["property_postcode"]).to eq(nil)
-        expect(address_case_log.la).to eq("Westminster")
-        expect(record_from_db["la"]).to eq("E09000033")
+        expect(record_from_db["property_postcode"]).to eq("M1 1AD")
+        expect(address_case_log.la).to eq("Manchester")
+        expect(record_from_db["la"]).to eq("E08000003")
       end
     end
 


### PR DESCRIPTION
The scope of this change is to add a validation to prevent a property postcode to be saved empty when the "postcode is known" question is answered with "Yes".

* Add a validation with an error message
* Add a header for the postcode field
* Update the related tests
* Do not clear the LA when the postcode lookup hasn't returned any data