### PR TITLE
Don’t require JS to create new log

### DIFF
--- a/app/views/case_logs/index.html.erb
+++ b/app/views/case_logs/index.html.erb
@@ -6,7 +6,7 @@
       <%= content_for(:title) %>
     </h1>
 
-    <%= govuk_button_link_to "Create new log", case_logs_path, method: :post %>
+    <%= govuk_button_to "Create new log", case_logs_path %>
 
     <% if @in_progress_case_logs.present? %>
       <%= render partial: "log_list", locals: { case_logs: @in_progress_case_logs, title: "Logs you need to complete", date_title: "Last Changed" } %>

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Form Navigation" do
   describe "Create new log" do
     it "redirects to the task list for the new log" do
       visit("/logs")
-      click_link("Create new log")
+      click_button("Create new log")
       id = CaseLog.order(created_at: :desc).first.id
       expect(page).to have_content("Log #{id}")
     end


### PR DESCRIPTION
Use `govuk_button_to` to use form submission rather than rely on a link which uses Turbolinks.