### PR TITLE
Point to custom devise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "roo"
 gem "json-schema"
 # Authentication
 # Point at branch until devise is compatible with Turbo, see https://github.com/heartcombo/devise/pull/5340
-gem "devise", github: "ghiculescu/devise", branch: "error-code-422"
+gem "devise", github: "baarkerlounger/devise", branch: "dluhc-fixes"
 # UK postcode parsing and validation
 gem "uk_postcode"
 # Get rich data from postcode lookups. Wraps postcodes.io

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,11 @@ GIT
       responders (>= 2, < 4)
 
 GIT
-  remote: https://github.com/ghiculescu/devise.git
-  revision: 3b2d9ae3d47be5c9228c4446119b04b0e98917c1
-  branch: error-code-422
+  remote: https://github.com/baarkerlounger/devise.git
+  revision: 0f585ea6683a06858863597628b48610731c2613
+  branch: dluhc-fixes
   specs:
-    devise (4.8.0)
+    devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)


### PR DESCRIPTION
<img width="248" alt="Screenshot 2022-01-11 at 16 43 40" src="https://user-images.githubusercontent.com/5101747/149134593-b7428af6-b312-4222-8268-d3714b87fa24.png">

Upstream devise currently has this incorrectly capitalised string in it's error messages. A fix was previously merged into a V5 release candidate branch (https://github.com/heartcombo/devise/pull/4834) but development on that branch appears to have stalled in 2019 and doesn't look likely to be picked up again. A new PR has been opened for it against current main: https://github.com/heartcombo/devise/pull/5454.

Since we were already pointing to a fork of Devise to make it compatible with Turbo until upstream has full support (see https://github.com/heartcombo/devise/pull/5340) we may as well point to a fork that contains both fixes. Which is what this PR does. This also means we can ensure the fork branch stays up to date with upstream.