### PR TITLE
CLDC-891: Add hidden text to change links (and answer links)

### DIFF
--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -70,9 +70,9 @@ class Form::Question
 
   def update_answer_link_name(case_log)
     if type == "checkbox"
-      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change" : "Answer"
+      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change <span class=\"govuk-visually-hidden\">#{check_answer_label.to_s.downcase}</span>".html_safe : "Answer"
     else
-      case_log[id].blank? ? "Answer" : "Change"
+      case_log[id].blank? ? "Answer" : "Change <span class=\"govuk-visually-hidden\">#{check_answer_label.to_s.downcase}</span>".html_safe
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -72,7 +72,7 @@ class Form::Question
     if type == "checkbox"
       answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer"
     else
-      case_log[id].blank? ? "Answer" : "Change <span class=\"govuk-visually-hidden\">#{check_answer_label.to_s.downcase}</span>".html_safe
+      case_log[id].blank? ? "Answer" : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -70,7 +70,7 @@ class Form::Question
 
   def update_answer_link_name(case_log)
     if type == "checkbox"
-      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change <span class=\"govuk-visually-hidden\">#{check_answer_label.to_s.downcase}</span>".html_safe : "Answer"
+      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer"
     else
       case_log[id].blank? ? "Answer" : "Change <span class=\"govuk-visually-hidden\">#{check_answer_label.to_s.downcase}</span>".html_safe
     end

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -70,9 +70,9 @@ class Form::Question
 
   def update_answer_link_name(case_log)
     if type == "checkbox"
-      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>"
+      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
     else
-      case_log[id].blank? ? "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>" : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
+      case_log[id].blank? ? "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -70,9 +70,9 @@ class Form::Question
 
   def update_answer_link_name(case_log)
     if type == "checkbox"
-      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer"
+      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>"
     else
-      case_log[id].blank? ? "Answer" : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
+      case_log[id].blank? ? "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>" : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -69,11 +69,12 @@ class Form::Question
   end
 
   def update_answer_link_name(case_log)
-    if type == "checkbox"
-      answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
-    else
-      case_log[id].blank? ? "Answer<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe : "Change<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
-    end
+    link_type = if type == "checkbox"
+                  answer_options.keys.any? { |key| case_log[key] == "Yes" } ? "Change" : "Answer"
+                else
+                  case_log[id].blank? ? "Answer" : "Change"
+                end
+    "#{link_type}<span class=\"govuk-visually-hidden\"> #{check_answer_label.to_s.downcase}</span>".html_safe
   end
 
   def completed?(case_log)

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -59,9 +59,11 @@ RSpec.describe "Form Check Answers Page" do
       expect(page).to have_content("Non-binary")
     end
 
+    # Regex explanation: match the string "Answer" but not if it's follow by "the missing questions"
+    # This way only the links in the table will get picked up
     it "should have an answer link for questions missing an answer" do
       visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
-      assert_selector "a", text: /Answer\z/, count: 4
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 4
       assert_selector "a", text: "Change", count: 0
       expect(page).to have_link("Answer", href: "/logs/#{empty_case_log.id}/person-1-age")
     end
@@ -69,20 +71,20 @@ RSpec.describe "Form Check Answers Page" do
     it "should have a change link for answered questions" do
       fill_in_number_question(empty_case_log.id, "age1", 28, "person-1-age")
       visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
-      assert_selector "a", text: /Answer\z/, count: 3
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 3
       assert_selector "a", text: "Change", count: 1
       expect(page).to have_link("Change", href: "/logs/#{empty_case_log.id}/person-1-age")
     end
 
     it "should have a change link for answered questions" do
       visit("/logs/#{empty_case_log.id}/household-needs/check-answers")
-      assert_selector "a", text: /Answer\z/, count: 5
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 5
       assert_selector "a", text: "Change", count: 0
       visit("/logs/#{empty_case_log.id}/accessibility-requirements")
       check("case-log-accessibility-requirements-housingneeds-c-field")
       click_button("Save and continue")
       visit("/logs/#{empty_case_log.id}/household-needs/check-answers")
-      assert_selector "a", text: /Answer\z/, count: 4
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 4
       assert_selector "a", text: "Change", count: 1
       expect(page).to have_link("Change", href: "/logs/#{empty_case_log.id}/accessibility-requirements")
     end

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Form::Question, type: :model do
     it "has an update answer link text helper" do
       expect(subject.update_answer_link_name(case_log)).to eq("Answer")
       case_log[question_id] = 5
-      expect(subject.update_answer_link_name(case_log)).to eq("Change")
+      expect(subject.update_answer_link_name(case_log)).to include("Change")
     end
 
     context "when type is date" do

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Form::Question, type: :model do
     end
 
     it "has an update answer link text helper" do
-      expect(subject.update_answer_link_name(case_log)).to eq("Answer")
+      expect(subject.update_answer_link_name(case_log)).to eq("Answer<span class=\"govuk-visually-hidden\"> income</span>")
       case_log[question_id] = 5
       expect(subject.update_answer_link_name(case_log)).to eq("Change<span class=\"govuk-visually-hidden\"> income</span>")
     end

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Form::Question, type: :model do
     it "has an update answer link text helper" do
       expect(subject.update_answer_link_name(case_log)).to eq("Answer")
       case_log[question_id] = 5
-      expect(subject.update_answer_link_name(case_log)).to include("Change")
+      expect(subject.update_answer_link_name(case_log)).to eq("Change<span class=\"govuk-visually-hidden\"> income</span>")
     end
 
     context "when type is date" do


### PR DESCRIPTION
**Hidden text element in the check answers page HMTL**
<img width="520" alt="Screenshot 2022-01-17 at 11 56 25" src="https://user-images.githubusercontent.com/47317567/149765622-e9e6fdd8-c75c-4295-b75a-29b3aa0223ce.png">

**Check answers page with styles turned off now has change links with text that matches the check answer label**
<img width="497" alt="Screenshot 2022-01-17 at 11 56 54" src="https://user-images.githubusercontent.com/47317567/149765615-0bd246d6-d521-432e-a74d-a46fd94fe405.png">

**Hidden text element in the check answers page HMTL for answer links**
<img width="688" alt="Screenshot 2022-01-17 at 14 12 19" src="https://user-images.githubusercontent.com/47317567/149785538-c81a66b4-22d5-4d16-8734-4c91f546ec2e.png">

**Check answers page with styles turned off now has answer links with text that matches the check answer label**
<img width="446" alt="Screenshot 2022-01-17 at 14 11 15" src="https://user-images.githubusercontent.com/47317567/149785564-599d3267-9164-44bc-8b6b-bfb6cb2ef96d.png">

