### PR TITLE
Update CORE helpdesk link in footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,7 +5,7 @@
 
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Online helpdesk</h3>
       <p class="govuk-body govuk-!-font-size-16">
-        <a class="govuk-link govuk-footer__link" href="https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21" target="_blank">CORE helpdesk</a> (opens in a new tab)</p>
+        <a class="govuk-link govuk-footer__link" href="https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21" rel="noreferrer noopener" target="_blank">CORE helpdesk (opens in a new tab)</a></p>
 
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Telephone</h3>
       <ul class="govuk-list govuk-!-font-size-16">


### PR DESCRIPTION
‘Opens in new tab’ should be within link, and link should have `rel="noreferrer noopener"`