### PR TITLE
CLDC-831: Remove link to complete all answers from check your answers page

### DIFF
--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -5,10 +5,9 @@ module CheckAnswersHelper
     total = subsection.applicable_questions_count(case_log)
     answered = subsection.answered_questions_count(case_log)
     if total == answered
-      '<p class="govuk-body govuk-!-margin-bottom-7">You answered all the questions</p>'.html_safe
+      '<p class="govuk-body">You answered all the questions.</p>'.html_safe
     else
-      "<p class=\"govuk-body govuk-!-margin-bottom-7\">You answered #{answered} of #{total} questions</p>
-      #{create_next_missing_question_link(subsection, case_log)}".html_safe
+      "<p class=\"govuk-body\">You have answered #{answered} of #{total} questions.</p>".html_safe
     end
   end
 
@@ -20,13 +19,5 @@ module CheckAnswersHelper
     else
       "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe
     end
-  end
-
-private
-
-  def create_next_missing_question_link(subsection, case_log)
-    pages_to_fill_in = subsection.unanswered_questions(case_log).map(&:page)
-    url = "/logs/#{case_log.id}/#{pages_to_fill_in.first.id.to_s.dasherize}"
-    govuk_link_to("Answer the missing questions", url).html_safe
   end
 end

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -15,7 +15,7 @@
 
       <%= display_answered_questions_summary(subsection, @case_log) %>
 
-      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <dl class="govuk-summary-list">
         <% subsection.applicable_questions(@case_log).each do |question| %>
           <%= render partial: 'form/check_answers_table', locals: { question: question, case_log: @case_log } %>
         <% end %>

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -89,26 +89,6 @@ RSpec.describe "Form Check Answers Page" do
       expect(page).to have_link("Change", href: "/logs/#{empty_case_log.id}/accessibility-requirements")
     end
 
-    it "should have a link pointing to the first question if no questions are answered" do
-      visit("/logs/#{empty_case_log.id}/#{subsection}/check-answers")
-      expect(page).to have_content("You answered 0 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/logs/#{empty_case_log.id}/tenant-code")
-    end
-
-    it "should have a link pointing to the next empty question if some questions are answered" do
-      fill_in_number_question(empty_case_log.id, "earnings", 18_000, "net-income")
-
-      visit("/logs/#{empty_case_log.id}/income-and-benefits/check-answers")
-      expect(page).to have_content("You answered 1 of 4 questions")
-      expect(page).to have_link("Answer the missing questions", href: "/logs/#{empty_case_log.id}/net-income")
-    end
-
-    it "should not display the missing answer questions link if all questions are answered" do
-      answer_all_questions_in_income_subsection(empty_case_log)
-      expect(page).to have_content("You answered all the questions")
-      assert_selector "a", text: "Answer the missing questions", count: 0
-    end
-
     it "does not display conditional questions that were not visited" do
       visit("/logs/#{id}/#{conditional_subsection}/check-answers")
       question_labels = ["Has the condition been met?"]

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -8,11 +8,9 @@ RSpec.describe CheckAnswersHelper do
 
   describe "display_answered_questions_summary" do
     context "given a section that hasn't been completed yet" do
-      it "returns a link to the next unanswered question" do
+      it "returns that you have unanswered questions" do
         expect(display_answered_questions_summary(subsection, case_log))
-          .to match(/You answered 2 of 4 questions/)
-        expect(display_answered_questions_summary(subsection, case_log))
-          .to match(/href/)
+          .to match(/You have answered 2 of 4 questions./)
       end
     end
 
@@ -21,7 +19,7 @@ RSpec.describe CheckAnswersHelper do
         case_log.sex1 = "F"
         case_log.other_hhmemb = 0
         expect(display_answered_questions_summary(subsection, case_log))
-          .to match(/You answered all the questions/)
+          .to match(/You answered all the questions./)
         expect(display_answered_questions_summary(subsection, case_log))
           .not_to match(/href/)
       end


### PR DESCRIPTION
This link is not in the prototype, and we have not observed a need for it so far. We can revisit this feature should we have evidence for it.

| Before | After |
| - | - |
| <img width="761" alt="Screenshot 2022-01-19 at 17 23 20" src="https://user-images.githubusercontent.com/813383/150182730-2f2c9fdd-d85f-43d4-be03-7e6d28b3b86a.png"> | <img width="760" alt="Screenshot 2022-01-19 at 17 23 33" src="https://user-images.githubusercontent.com/813383/150182753-3c3055f2-707b-4f0d-80e5-a069d429a061.png"> |
