### PR TITLE
Render radio conditional questions inline rather than below

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,11 @@ Assumptions made by the format:
 - All pages have at least 1 question
 - The ActiveRecord case log model has a field for each question name (must match). In the case of checkbox questions it must have one field for every answer option (again names must match).
 - Text not required by a page/question such as a header or hint text should be passed as an empty string
-- For conditionally shown questions conditions that have been implemented and can be used are:
+- For conditionally shown questions, conditions that have been implemented and can be used are:
   - Radio question answer option selected matches one of conditional e.g. ["answer-options-1-string", "answer-option-3-string"]
   - Numeric question value matches condition e.g. [">2"], ["<7"] or ["== 6"]
+- When the top level question is a radio button and the conditional question is a numeric, text or date field then the conditional question is shown inline
+- When the conditional question is a radio, checkbox or select field it should be displayed on it's own page and "depends_on" should be used rather than "conditional_for"
 
   Page routing:
 

--- a/app/helpers/conditional_questions_helper.rb
+++ b/app/helpers/conditional_questions_helper.rb
@@ -3,6 +3,13 @@ module ConditionalQuestionsHelper
     page.questions.map(&:conditional_for).compact.map(&:keys).flatten
   end
 
+  def find_conditional_question(page, conditional_for, answer_value)
+    return if conditional_for.nil?
+
+    conditional_key = conditional_for.find { |_, conditional_value| conditional_value.include? answer_value }&.first
+    page.questions.find { |q| q.id == conditional_key }
+  end
+
   def display_question_key_div(page, question)
     "style='display:none;'".html_safe if conditional_questions_for_page(page).include?(question.id) || question.requires_js
   end

--- a/app/helpers/conditional_questions_helper.rb
+++ b/app/helpers/conditional_questions_helper.rb
@@ -3,10 +3,10 @@ module ConditionalQuestionsHelper
     page.questions.map(&:conditional_for).compact.map(&:keys).flatten
   end
 
-  def find_conditional_question(page, conditional_for, answer_value)
-    return if conditional_for.nil?
+  def find_conditional_question(page, question, answer_value)
+    return if question.conditional_for.nil?
 
-    conditional_key = conditional_for.find { |_, conditional_value| conditional_value.include? answer_value }&.first
+    conditional_key = question.conditional_for.find { |_, conditional_value| conditional_value.include? answer_value }&.first
     page.questions.find { |q| q.id == conditional_key }
   end
 

--- a/app/helpers/question_attribute_helper.rb
+++ b/app/helpers/question_attribute_helper.rb
@@ -1,8 +1,7 @@
 module QuestionAttributeHelper
   def stimulus_html_attributes(question)
     attribs = [
-      numeric_question_html_attributes(question),
-      conditional_html_attributes(question),
+      numeric_question_html_attributes(question)
     ]
     merge_controller_attributes(*attribs)
   end
@@ -18,16 +17,6 @@ private
       "data-action": "numeric-question#calculateFields",
       "data-target": "case-log-#{question.result_field.to_s.dasherize}-field",
       "data-calculated": question.fields_to_add.to_json,
-    }
-  end
-
-  def conditional_html_attributes(question)
-    return {} if question.conditional_for.blank?
-
-    {
-      "data-controller": "conditional-question",
-      "data-action": "conditional-question#displayConditional",
-      "data-info": question.conditional_for.to_json,
     }
   end
 end

--- a/app/helpers/question_attribute_helper.rb
+++ b/app/helpers/question_attribute_helper.rb
@@ -1,7 +1,8 @@
 module QuestionAttributeHelper
   def stimulus_html_attributes(question)
     attribs = [
-      numeric_question_html_attributes(question)
+      numeric_question_html_attributes(question),
+      conditional_html_attributes(question),
     ]
     merge_controller_attributes(*attribs)
   end
@@ -17,6 +18,17 @@ private
       "data-action": "numeric-question#calculateFields",
       "data-target": "case-log-#{question.result_field.to_s.dasherize}-field",
       "data-calculated": question.fields_to_add.to_json,
+    }
+  end
+
+  # TODO: remove this once all conditional questions no longer need JS
+  def conditional_html_attributes(question)
+    return {} if question.conditional_for.blank? || question.type == "radio"
+
+    {
+      "data-controller": "conditional-question",
+      "data-action": "conditional-question#displayConditional",
+      "data-info": question.conditional_for.to_json,
     }
   end
 end

--- a/app/helpers/question_attribute_helper.rb
+++ b/app/helpers/question_attribute_helper.rb
@@ -21,9 +21,8 @@ private
     }
   end
 
-  # TODO: remove this once all conditional questions no longer need JS
   def conditional_html_attributes(question)
-    return {} if question.conditional_for.blank? || question.type == "radio"
+    return {} if question.conditional_for.blank?
 
     {
       "data-controller": "conditional-question",

--- a/app/helpers/question_view_helper.rb
+++ b/app/helpers/question_view_helper.rb
@@ -1,0 +1,25 @@
+module QuestionViewHelper
+  def caption(caption, page_header, conditional)
+    return nil unless caption && page_header.blank? && !conditional
+
+    { text: caption.html_safe, size: "l" }
+  end
+
+  def legend(question, page_header, conditional)
+    {
+      text: question.header.html_safe,
+      size: label_size(page_header, conditional),
+      tag: label_tag(page_header, conditional),
+    }
+  end
+
+private
+
+  def label_size(page_header, conditional)
+    page_header.blank? && !conditional ? "l" : "m"
+  end
+
+  def label_tag(page_header, conditional)
+    page_header.blank? && !conditional ? "h1" : "h2"
+  end
+end

--- a/app/helpers/question_view_helper.rb
+++ b/app/helpers/question_view_helper.rb
@@ -1,8 +1,8 @@
 module QuestionViewHelper
-  def caption(caption, page_header, conditional)
-    return nil unless caption && page_header.blank? && !conditional
+  def caption(caption_text, page_header, conditional)
+    return nil unless caption_text && page_header.blank? && !conditional
 
-    { text: caption.html_safe, size: "l" }
+    { text: caption_text.html_safe, size: "l" }
   end
 
   def legend(question, page_header, conditional)

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -27,14 +27,19 @@ class Form::Page
     subsection.enabled?(case_log) && depends_on_met(case_log)
   end
 
-  # We expect to render only one radio question (with conditionals)
-  # def questions_to_render
-  #   if questions.first.type == "radio"
-  #     [questions.first]
-  #   else
-  #     questions
-  #   end
-  # end
+  def non_conditional_questions
+    @non_conditional_questions ||= questions.reject do |q|
+      conditional_questions.include?(q.id)
+    end
+  end
+
+  def conditional_questions
+    @conditional_questions ||= questions.flat_map { |q|
+      next if q.conditional_for.blank?
+
+      q.conditional_for.keys
+    }.compact
+  end
 
 private
 

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -29,11 +29,13 @@ class Form::Page
 
   def non_conditional_questions
     @non_conditional_questions ||= questions.reject do |q|
-      conditional_questions.include?(q.id)
+      conditional_questions_ids.include?(q.id)
     end
   end
 
-  def conditional_questions
+private
+
+  def conditional_questions_ids
     @conditional_questions ||= questions.flat_map { |q|
       next if q.conditional_for.blank?
 
@@ -41,8 +43,6 @@ class Form::Page
       q.conditional_for.keys if q.type == "radio"
     }.compact
   end
-
-private
 
   def depends_on_met(case_log)
     return true unless depends_on

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -27,6 +27,15 @@ class Form::Page
     subsection.enabled?(case_log) && depends_on_met(case_log)
   end
 
+  # We expect to render only one radio question (with conditionals)
+  def questions_to_render
+    if questions.first.type == "radio"
+      [questions.first]
+    else
+      questions
+    end
+  end
+
 private
 
   def depends_on_met(case_log)

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -29,14 +29,14 @@ class Form::Page
 
   def non_conditional_questions
     @non_conditional_questions ||= questions.reject do |q|
-      conditional_questions_ids.include?(q.id)
+      conditional_question_ids.include?(q.id)
     end
   end
 
 private
 
-  def conditional_questions_ids
-    @conditional_questions ||= questions.flat_map { |q|
+  def conditional_question_ids
+    @conditional_question_ids ||= questions.flat_map { |q|
       next if q.conditional_for.blank?
 
       # TODO: remove this condition once all conditional questions no longer need JS

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -28,13 +28,13 @@ class Form::Page
   end
 
   # We expect to render only one radio question (with conditionals)
-  def questions_to_render
-    if questions.first.type == "radio"
-      [questions.first]
-    else
-      questions
-    end
-  end
+  # def questions_to_render
+  #   if questions.first.type == "radio"
+  #     [questions.first]
+  #   else
+  #     questions
+  #   end
+  # end
 
 private
 

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -37,7 +37,8 @@ class Form::Page
     @conditional_questions ||= questions.flat_map { |q|
       next if q.conditional_for.blank?
 
-      q.conditional_for.keys
+      # TODO: remove this condition once all conditional questions no longer need JS
+      q.conditional_for.keys if q.type == "radio"
     }.compact
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -35,7 +35,7 @@ class Form::Question
 
   def answer_label(case_log)
     return checkbox_answer_label(case_log) if type == "checkbox"
-    return case_log[id].to_formatted_s(:govuk_date) if type == "date"
+    return case_log[id]&.to_formatted_s(:govuk_date).to_s if type == "date"
 
     return case_log[id].to_s if case_log[id].present?
 

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -26,20 +26,12 @@ module Validations::HouseholdValidations
   end
 
   def validate_armed_forces_injured(record)
-    if (record.armedforces == "A current or former regular in the UK Armed Forces (excluding National Service)" || record.armedforces == "A current or former reserve in the UK Armed Forces (excluding National Service)") && record.reservist.blank?
-      record.errors.add :reservist, I18n.t("validations.household.reservist.injury_required")
-    end
-
     if (record.armedforces == "No" || record.armedforces == "Prefer not to say") && record.reservist.present?
       record.errors.add :reservist, I18n.t("validations.household.reservist.injury_not_required")
     end
   end
 
   def validate_armed_forces_active_response(record)
-    if record.armedforces == "A current or former regular in the UK Armed Forces (excluding National Service)" && record.leftreg.blank?
-      record.errors.add :leftreg, I18n.t("validations.household.leftreg.question_required")
-    end
-
     if record.armedforces != "A current or former regular in the UK Armed Forces (excluding National Service)" && record.leftreg.present?
       record.errors.add :leftreg, I18n.t("validations.household.leftreg.question_not_required")
     end

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -4,10 +4,6 @@ module Validations::HouseholdValidations
   def validate_reasonable_preference(record)
     if record.homeless == "No" && record.reasonpref == "Yes"
       record.errors.add :reasonpref, I18n.t("validations.household.reasonpref.not_homeless")
-    elsif record.reasonpref == "Yes"
-      if [record.rp_homeless, record.rp_insan_unsat, record.rp_medwel, record.rp_hardship, record.rp_dontknow].none? { |a| a == "Yes" }
-        record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonable_preference_reason.reason_required")
-      end
     elsif record.reasonpref == "No"
       if [record.rp_homeless, record.rp_insan_unsat, record.rp_medwel, record.rp_hardship, record.rp_dontknow].any? { |a| a == "Yes" }
         record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonable_preference_reason.reason_not_required")

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_check_boxes_fieldset question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    legend: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe } do %>
 
     <% question.answer_options.map do |key, val| %>

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_check_boxes_fieldset question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe } do %>
 

--- a/app/views/form/_date_question.html.erb
+++ b/app/views/form/_date_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_date_field question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    legend: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: 20,
     **stimulus_html_attributes(question)

--- a/app/views/form/_date_question.html.erb
+++ b/app/views/form/_date_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_date_field question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: 20,

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_number_field question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    label: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     min: question.min, max: question.max, step: question.step,
     width: question.width, :readonly => question.read_only?,

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_number_field question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     min: question.min, max: question.max, step: question.step,

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_radio_buttons_fieldset question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    legend: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe } do %>
 
     <% question.answer_options.map do |key, val| %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -14,7 +14,13 @@
           <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) %>
         <% else %>
           <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) do %>
-            <%= render partial: "#{conditional_question.type}_question", locals: { question: conditional_question, caption: caption, page_header: page_header, f: f } %>
+            <%= render partial: "#{conditional_question.type}_question", locals: {
+              question: conditional_question,
+              caption: caption,
+              page_header: page_header,
+              f: f,
+              conditional: true
+            } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -9,7 +9,7 @@
       <% if key.starts_with?("divider") %>
         <%= f.govuk_radio_divider %>
       <% else %>
-        <% conditional_question = find_conditional_question(@page, question.conditional_for, val) %>
+        <% conditional_question = find_conditional_question(@page, question, val) %>
         <% if conditional_question.nil? %>
           <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) %>
         <% else %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -9,10 +9,11 @@
       <% if key.starts_with?("divider") %>
         <%= f.govuk_radio_divider %>
       <% else %>
-        <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) do %>
-          <% conditional_key = question.conditional_for&.find { |_, cval| cval.include? val }&.first %>
-          <% if conditional_key %>
-            <% conditional_question = @page.questions.find { |q| q.id == conditional_key } %>
+        <% conditional_question = find_conditional_question(@page, question.conditional_for, val) %>
+        <% if conditional_question.nil? %>
+          <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) %>
+        <% else %>
+          <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) do %>
             <%= render partial: "#{conditional_question.type}_question", locals: { question: conditional_question, caption: caption, page_header: page_header, f: f } %>
           <% end %>
         <% end %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -9,7 +9,13 @@
       <% if key.starts_with?("divider") %>
         <%= f.govuk_radio_divider %>
       <% else %>
-        <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) %>
+        <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) do %>
+          <% conditional_key = question.conditional_for&.find { |_, cval| cval.include? val }&.first %>
+          <% if conditional_key %>
+            <% conditional_question = @page.questions.find { |q| q.id == conditional_key } %>
+            <%= render partial: "#{conditional_question.type}_question", locals: { question: conditional_question, caption: caption, page_header: page_header, f: f } %>
+          <% end %>
+        <% end %>
       <% end %>
     <% end %>
 <% end %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_radio_buttons_fieldset question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     legend: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe } do %>
 
@@ -16,7 +16,7 @@
           <%= f.govuk_radio_button question.id, val, label: { text: val }, **stimulus_html_attributes(question) do %>
             <%= render partial: "#{conditional_question.type}_question", locals: {
               question: conditional_question,
-              caption: caption,
+              caption_text: caption_text,
               page_header: page_header,
               f: f,
               conditional: true

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -6,7 +6,7 @@
     answers,
     :id,
     :name,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     options: { disabled: [""], selected: selected },

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -6,8 +6,8 @@
     answers,
     :id,
     :name,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    label: { text: question.header, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     options: { disabled: [""], selected: selected },
     "data-controller": "accessible-autocomplete"

--- a/app/views/form/_text_question.html.erb
+++ b/app/views/form/_text_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_field question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: question.width ? question.width : nil,

--- a/app/views/form/_text_question.html.erb
+++ b/app/views/form/_text_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_field question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    label: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: question.width ? question.width : nil,
     **stimulus_html_attributes(question)

--- a/app/views/form/_textarea_question.html.erb
+++ b/app/views/form/_textarea_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_area question.id.to_sym,
-    caption: caption(caption, page_header, conditional),
+    caption: caption(caption_text, page_header, conditional),
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: question.width ? question.width : nil,

--- a/app/views/form/_textarea_question.html.erb
+++ b/app/views/form/_textarea_question.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_area question.id.to_sym,
-    caption: caption && !page_header.present? ? { text: caption.html_safe, size: "l" } : nil,
-    label: { text: question.header.html_safe, size: !page_header.present? ? "l" : "m", tag: !page_header.present? ? "h1" : "h2" },
+    caption: caption(caption, page_header, conditional),
+    label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     width: question.width ? question.width : nil,
     **stimulus_html_attributes(question)

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -36,7 +36,7 @@
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             <% end %>
-            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption: @subsection.label, page_header: @page.header, f: f } %>
+            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption: @subsection.label, page_header: @page.header, f: f, conditional: false } %>
           </div>
         <% end %>
 

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -11,6 +11,8 @@
   ) %>
 <% end %>
 
+<div data-controller="govukfrontend"></div>
+
 <%= turbo_frame_tag "case_log_form", target: "_top" do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -29,7 +31,7 @@
 
       <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
         <%= f.govuk_error_summary %>
-        <% @page.questions_to_render.map do |question| %>
+        <% @page.questions.map do |question| %>
           <div id=<%= question.id + "_div " %> >
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -29,8 +29,8 @@
 
       <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
         <%= f.govuk_error_summary %>
-        <% @page.questions.map do |question| %>
-          <div id=<%= question.id + "_div " %><%= display_question_key_div(@page, question) %> >
+        <% @page.questions_to_render.map do |question| %>
+          <div id=<%= question.id + "_div " %> >
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             <% end %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -36,7 +36,7 @@
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             <% end %>
-            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption: @subsection.label, page_header: @page.header, f: f, conditional: false } %>
+            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption_text: @subsection.label, page_header: @page.header, f: f, conditional: false } %>
           </div>
         <% end %>
 

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -32,7 +32,7 @@
       <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
         <%= f.govuk_error_summary %>
         <% @page.non_conditional_questions.map do |question| %>
-          <div id=<%= question.id + "_div " %> >
+          <div id=<%= question.id + "_div " %><%= display_question_key_div(@page, question) %> >
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             <% end %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -31,7 +31,7 @@
 
       <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
         <%= f.govuk_error_summary %>
-        <% @page.questions.map do |question| %>
+        <% @page.non_conditional_questions.map do |question| %>
           <div id=<%= question.id + "_div " %> >
             <% if question.read_only? %>
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/webpacker/controllers/conditional_question_controller.js
+++ b/app/webpacker/controllers/conditional_question_controller.js
@@ -16,15 +16,30 @@ export default class extends Controller {
     }
   }
 
+  clearTextNumericInput(input) {
+    input.value = ""
+  }
+
+  clearDateInputs(inputs) {
+    inputs.forEach((input) => { input.value = "" })
+  }
+
   displayConditionalRadio() {
     if(this.element.checked) {
       let selectedValue = this.element.value
       let conditional_for = JSON.parse(this.element.dataset.info)
       Object.entries(conditional_for).map(([targetQuestion, conditions]) => {
-        let input = document.getElementById(`case-log-${targetQuestion.replaceAll("_","-")}-field`)
-        if(conditions.includes(selectedValue)) {
-        } else {
-          input.value = ""
+          if(conditions.includes(selectedValue)) {
+          } else {
+            const textNumericInput = document.getElementById(`case-log-${targetQuestion.replaceAll("_","-")}-field`)
+            if (textNumericInput == null) {
+              const dateInputs = [1,2,3].map((idx) => {
+                return document.getElementById(`case_log_${targetQuestion}_${idx}i`)
+              })
+              this.clearDateInputs(dateInputs)
+            } else {
+              this.clearTextNumericInput(textNumericInput)
+          }
         }
       })
     }

--- a/app/webpacker/controllers/conditional_question_controller.js
+++ b/app/webpacker/controllers/conditional_question_controller.js
@@ -23,6 +23,7 @@ export default class extends Controller {
 
       Object.entries(conditional_for).map(([targetQuestion, conditions]) => {
         let div = document.getElementById(targetQuestion + "_div")
+        if (div == null) return;
         if(conditions.includes(selectedValue)) {
           div.style.display = "block"
         } else {

--- a/app/webpacker/controllers/conditional_question_controller.js
+++ b/app/webpacker/controllers/conditional_question_controller.js
@@ -20,21 +20,11 @@ export default class extends Controller {
     if(this.element.checked) {
       let selectedValue = this.element.value
       let conditional_for = JSON.parse(this.element.dataset.info)
-
       Object.entries(conditional_for).map(([targetQuestion, conditions]) => {
-        let div = document.getElementById(targetQuestion + "_div")
-        if (div == null) return;
+        let input = document.getElementById(`case-log-${targetQuestion.replaceAll("_","-")}-field`)
         if(conditions.includes(selectedValue)) {
-          div.style.display = "block"
         } else {
-          div.style.display = "none"
-          let buttons = document.getElementsByName(`case_log[${targetQuestion}]`);
-          if (buttons.length == 0){
-            buttons = document.getElementsByName(`case_log[${targetQuestion}][]`);
-          }
-          Object.entries(buttons).map(([idx, button]) => {
-            button.checked = false;
-          })
+          input.value = ""
         }
       })
     }

--- a/app/webpacker/controllers/govukfrontend_controller.js
+++ b/app/webpacker/controllers/govukfrontend_controller.js
@@ -1,0 +1,8 @@
+import {initAll} from "govuk-frontend";
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    initAll()
+  }
+}

--- a/app/webpacker/controllers/govukfrontend_controller.js
+++ b/app/webpacker/controllers/govukfrontend_controller.js
@@ -1,5 +1,5 @@
-import {initAll} from "govuk-frontend";
-import {Controller} from "@hotwired/stimulus";
+import { initAll } from "govuk-frontend";
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -5,15 +5,11 @@
 require.context('govuk-frontend/govuk/assets')
 
 import '../styles/application.scss'
-import Rails from "@rails/ujs"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
-import { initAll } from 'govuk-frontend'
+import "controllers"
 import "@hotwired/turbo-rails"
+import { initAll } from 'govuk-frontend'
 
-
-Rails.start()
 ActiveStorage.start()
 initAll()
-
-import "controllers"

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,5 @@ module DataCollector
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.exceptions_app = routes
-
-    config.action_view.form_with_generates_remote_forms = false
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module DataCollector
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.exceptions_app = routes
+
+    config.action_view.form_with_generates_remote_forms = false
   end
 end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -924,16 +924,15 @@
                     "2": "A spouse / civil partner of a UK Armed Forces member who has separated or been bereaved within the last 2 years",
                     "3": "No",
                     "4": "Tenant prefers not to say"
-                  },
-                  "conditional_for": {
-                    "leftreg": [
-                      "A current or former regular in the UK Armed Forces (excluding National Service)"
-                    ],
-                    "reservist": [
-                      "A current or former regular in the UK Armed Forces (excluding National Service)"
-                    ]
                   }
-                },
+                }
+              }
+            },
+            "armed_forces_member": {
+              "header": "Experience of the UK Armed Forces",
+              "description": "",
+              "depends_on": [{ "armedforces": "A current or former regular in the UK Armed Forces (excluding National Service)" }],
+              "questions": {
                 "leftreg": {
                   "header": "Are they still serving?",
                   "hint_text": "",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -827,7 +827,7 @@
                   "type": "radio",
                   "answer_options": {
                     "0": "Yes - assessed as homeless by a local authority and owed a homelessness duty. Including if threatened with homelessness within 56 days",
-                    "1": "Yes - other homelessness ",
+                    "1": "Yes - other homelessness",
                     "2": "No"
                   }
                 }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3185,11 +3185,15 @@
                     "1": "No",
                     "divider": true,
                     "2": "Don’t know"
-                  },
-                  "conditional_for": {
-                    "reasonable_preference_reason": ["Yes"]
                   }
-                },
+                }
+              }
+            },
+            "reasonable_preference_reason": {
+              "header": "Reason for reasonable preference being given",
+              "description": "",
+              "depends_on": [{ "reasonpref": "Yes" }],
+              "questions": {
                 "reasonable_preference_reason": {
                   "check_answer_label": "Reason for reasonable preference",
                   "header": "Why were they given reasonable preference?",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@hotwired/turbo-rails": "^7.1.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
-    "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
     "accessible-autocomplete": "^2.0.3",
     "chart.js": "^3.6.0",

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Form Conditional Questions" do
       choose("case-log-armedforces-no-field", allow_label_click: true)
       expect(page).not_to have_field("case-log-leftreg-field")
       choose("case-log-armedforces-a-current-or-former-regular-in-the-uk-armed-forces-excluding-national-service-field", allow_label_click: true)
-      expect(page).to have_css("#case-log-leftreg-field", text: "")
+      expect(page).to have_field("case-log-leftreg-field", with: "")
     end
   end
 end

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -30,13 +30,11 @@ RSpec.describe "Form Conditional Questions" do
       visit("/logs/#{id}/armed-forces")
       # Something about our styling makes the selenium webdriver think the actual radio buttons are not visible so we allow label click here
       choose("case-log-armedforces-a-current-or-former-regular-in-the-uk-armed-forces-excluding-national-service-field", allow_label_click: true)
-      expect(page).to have_selector("#reservist_div")
-      choose("case-log-reservist-no-field", allow_label_click: true)
-      expect(page).to have_checked_field("case-log-reservist-no-field", visible: false)
+      fill_in("case-log-leftreg-field", with: "text")
       choose("case-log-armedforces-no-field", allow_label_click: true)
-      expect(page).not_to have_selector("#reservist_div")
+      expect(page).not_to have_field("case-log-leftreg-field")
       choose("case-log-armedforces-a-current-or-former-regular-in-the-uk-armed-forces-excluding-national-service-field", allow_label_click: true)
-      expect(page).to have_unchecked_field("case-log-reservist-no-field", visible: false)
+      expect(page).to have_css("#case-log-leftreg-field", text: "")
     end
   end
 end

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -124,32 +124,14 @@
                       "4": "Tenant prefers not to say"
                     },
                     "conditional_for": {
-                      "leftreg": ["A current or former regular in the UK Armed Forces (excluding National Service)"],
-                      "reservist": ["A current or former regular in the UK Armed Forces (excluding National Service)"]
+                      "leftreg": ["A current or former regular in the UK Armed Forces (excluding National Service)"]
                     }
                   },
                   "leftreg": {
                     "header": "Are they still serving?",
                     "hint_text": "",
-                    "type": "radio",
-                    "check_answer_label": "When did they leave the Armed Forces?",
-                    "answer_options": {
-                      "0": "Yes",
-                      "1": "No - they left up to 5 years ago",
-                      "2": "No - they left more than 5 years ago",
-                      "3": "Prefer not to say"
-                    }
-                  },
-                  "reservist": {
-                    "header": "Were they seriously injured or ill as a result of their service?",
-                    "hint_text": "",
-                    "type": "radio",
-                    "check_answer_label": "Has anyone in the household been seriously injured or ill as a result of their service in the armed forces?",
-                    "answer_options": {
-                      "0": "Yes",
-                      "1": "No",
-                      "2": "Prefer not to say"
-                    }
+                    "type": "text",
+                    "check_answer_label": "When did they leave the Armed Forces?"
                   }
                 }
               },

--- a/spec/helpers/conditional_questions_helper_spec.rb
+++ b/spec/helpers/conditional_questions_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ConditionalQuestionsHelper do
   let(:page) { case_log.form.get_page("armed_forces") }
 
   describe "conditional questions for page" do
-    let(:conditional_pages) { %w[leftreg reservist] }
+    let(:conditional_pages) { %w[leftreg] }
 
     it "returns the question keys of all conditional questions on the given page" do
       expect(conditional_questions_for_page(page)).to eq(conditional_pages)
@@ -13,7 +13,7 @@ RSpec.describe ConditionalQuestionsHelper do
   end
 
   describe "display question key div" do
-    let(:conditional_question) { page.questions.find { |q| q.id == "reservist" } }
+    let(:conditional_question) { page.questions.find { |q| q.id == "leftreg" } }
 
     it "returns a non visible div for conditional questions" do
       expect(display_question_key_div(page, conditional_question)).to match("style='display:none;'")

--- a/spec/helpers/conditional_questions_helper_spec.rb
+++ b/spec/helpers/conditional_questions_helper_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe ConditionalQuestionsHelper do
     end
   end
 
+  describe "find conditional question" do
+    let(:question) { page.questions.find { |q| q.id == "armedforces" } }
+    let(:answer_value) { "A current or former regular in the UK Armed Forces (excluding National Service)" }
+    it "returns the conditional question for a given answer option" do
+      expect(find_conditional_question(page, question, answer_value))
+    end
+  end
+
   describe "display question key div" do
     let(:conditional_question) { page.questions.find { |q| q.id == "leftreg" } }
 

--- a/spec/helpers/question_view_helper.rb
+++ b/spec/helpers/question_view_helper.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe QuestionViewHelper do
+  let(:page_header) { "Some Page Header" }
+  let(:conditional) { false }
+
+  describe "caption" do
+    let(:subject) { caption(caption_text, page_header, conditional) }
+    let(:caption_text) { "Some text" }
+    let(:caption_options_hash) { { text: caption_text.html_safe, size: "l" } }
+
+    context "a page without a header" do
+      let(:page_header) { nil }
+
+      it "returns an options hash" do
+        expect(subject).to eq(caption_options_hash)
+      end
+    end
+
+    context "a page with a header" do
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "a conditional question" do
+      let(:conditional) { true }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "a question without a caption" do
+      let(:caption_text) { nil }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe "legend" do
+    let(:question) { OpenStruct.new(header: "Some question header") }
+    let(:subject) { legend(question, page_header, conditional) }
+    let(:size) { "m" }
+    let(:tag) { "h2" }
+    let(:legend_options_hash) do
+      { text: "Some question header".html_safe, size: size, tag: tag }
+    end
+
+    context "a page with a header" do
+      it "returns an options hash with a medium question header" do
+        expect(subject).to eq(legend_options_hash)
+      end
+    end
+
+    context "a page without a header" do
+      let(:page_header) { nil }
+      let(:size) { "l" }
+      let(:tag) { "h1" }
+
+      it "returns an options hash with a large question header" do
+        expect(subject).to eq(legend_options_hash)
+      end
+    end
+
+    context "a conditional question" do
+      let(:conditional) { true }
+
+      it "returns an options hash with a medium question header" do
+        expect(subject).to eq(legend_options_hash)
+      end
+    end
+  end
+end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -73,19 +73,6 @@ RSpec.describe Form, type: :model do
     end
 
     context "reasonable preference is yes" do
-      it "validates a reason must be selected" do
-        expect {
-          CaseLog.create!(reasonpref: "Yes",
-                          rp_homeless: nil,
-                          rp_insan_unsat: nil,
-                          rp_medwel: nil,
-                          rp_hardship: nil,
-                          rp_dontknow: nil,
-                          owning_organisation: owning_organisation,
-                          managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
       it "validates that previously homeless should be selected" do
         expect {
           CaseLog.create!(

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -153,16 +153,7 @@ RSpec.describe Form, type: :model do
     end
 
     context "armed forces injured validation" do
-      it "must be answered if tenant was a regular or reserve in armed forces" do
-        expect {
-          CaseLog.create!(armedforces: "A current or former regular in the UK Armed Forces (excluding National Service)",
-                          reservist: nil,
-                          owning_organisation: owning_organisation,
-                          managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "must be answered if tenant was not a regular or reserve in armed forces" do
+      it "must not be answered if tenant was not a regular or reserve in armed forces" do
         expect {
           CaseLog.create!(armedforces: "No",
                           reservist: "Yes",
@@ -466,15 +457,6 @@ RSpec.describe Form, type: :model do
     end
 
     context "armed forces active validation" do
-      it "must be answered if ever served in the forces as a regular" do
-        expect {
-          CaseLog.create!(armedforces: "A current or former regular in the UK Armed Forces (excluding National Service)",
-                          leftreg: nil,
-                          owning_organisation: owning_organisation,
-                          managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
       it "must not be answered if not ever served as a regular" do
         expect {
           CaseLog.create!(armedforces: "No",

--- a/spec/models/form/page_spec.rb
+++ b/spec/models/form/page_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Form::Page, type: :model do
     expect(subject.expected_responses.map(&:id)).to eq(expected_responses)
   end
 
+  context "page with conditional questions" do
+    let(:page_id) { "housing_benefit" }
+
+    it "knows which questions are not conditional" do
+      expected_non_conditional_questions = %w[hb]
+      expect(subject.non_conditional_questions.map(&:id))
+        .to eq(expected_non_conditional_questions)
+    end
+  end
+
   context "for a given case log" do
     let(:case_log) { FactoryBot.build(:case_log, :in_progress) }
 

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -120,6 +120,11 @@ RSpec.describe Form::Question, type: :model do
         case_log.mrcdate = Time.zone.local(2021, 10, 11)
         expect(subject.answer_label(case_log)).to eq("11 October 2021")
       end
+
+      it "can handle nils" do
+        case_log.mrcdate = nil
+        expect(subject.answer_label(case_log)).to eq("")
+      end
     end
 
     context "when type is checkbox" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,11 +970,6 @@
   dependencies:
     spark-md5 "^3.0.0"
 
-"@rails/ujs@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.4.tgz#093d5341595a02089ed309dec40f3c37da7b1b10"
-  integrity sha512-O3lEzL5DYbxppMdsFSw36e4BHIlfz/xusynwXGv3l2lhSlvah41qviRpsoAlKXxl37nZAqK+UUF5cnGGK45Mfw==
-
 "@rails/webpacker@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.4.0.tgz#2c64a9ea7e85d2a33e50e86319fe6751df0c47e8"


### PR DESCRIPTION
After this PR:

- When the top level question is a radio button and the conditional question is a text, numeric or date field
   - Then the conditional question is shown inline
- When the top level question is a radio button and the conditional question is a checkbox, select or radio button
  -  Then the conditional question is shown on a new page (not enforced by code)

- When the top level question is a numeric or text question for now the behaviour is unchanged (other household members)



**When the top level question is a radio question**

Before:
![image](https://user-images.githubusercontent.com/5101747/150514443-4ad8faa0-b43d-450b-8e05-98ce6fa6ffd9.png)


After:
![image](https://user-images.githubusercontent.com/5101747/150841529-21891144-8c3a-4968-9152-b89695c962e1.png)

When conditional is not a text box:

![image](https://user-images.githubusercontent.com/5101747/150849658-c23ae740-b2eb-4fad-9cc9-25cef890b540.png)

--------------------------------------------------------------------------------------------------------------------------------------------------------------

**When the top level question is not a radio type the behaviour remain unchanged for now:**
![image](https://user-images.githubusercontent.com/5101747/150818674-2b1796c2-bdcc-49f5-b613-dad712eb5cf3.png)

Radios with further conditional radio should now be on there own page:
![image](https://user-images.githubusercontent.com/5101747/150818803-f7694fd3-ef22-41f4-98a2-9ce28e80d8d6.png)

![image](https://user-images.githubusercontent.com/5101747/150818841-1898f514-4c4a-441b-9202-13388681728f.png)

![image](https://user-images.githubusercontent.com/5101747/150818876-7b70d89f-bbfe-43e8-8cdd-3cb1249e5f0d.png)

![image](https://user-images.githubusercontent.com/5101747/150818923-320155c3-00be-44c6-b194-d58e3a04c104.png)
