### PR TITLE
Dates and times should follow GDS style guide

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/activeadmin/arbre.git
-  revision: e4970e683c81c99432b73f0ceb5dff7d3fe50413
+  revision: 305c221a2131be8dd0d96955f9b0a328dfa4beba
   specs:
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 7.1)
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/tagliala/activeadmin.git
-  revision: 8ccc35b8144482284c90b0af74a01e940765f7a6
+  revision: f4fc57251399c0ed452d72ac4b07d0bdd3d047c6
   branch: feature/railties-7
   specs:
     activeadmin (2.9.0)
@@ -106,7 +106,7 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    bootsnap (1.10.1)
+    bootsnap (1.10.2)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -158,7 +158,7 @@ GEM
       activemodel (>= 6.1)
       railties (>= 6.1)
       view_component (~> 2.47.0)
-    govuk_design_system_formbuilder (3.0.0)
+    govuk_design_system_formbuilder (3.0.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -211,7 +211,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    msgpack (1.4.3)
+    msgpack (1.4.4)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -242,7 +242,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
+    pg (1.3.0)
     postcodes_io (0.4.0)
       excon (~> 0.39)
     pry (0.13.1)
@@ -461,4 +461,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.3
+   2.3.4

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -35,7 +35,7 @@ class Form::Question
 
   def answer_label(case_log)
     return checkbox_answer_label(case_log) if type == "checkbox"
-    return case_log[id].strftime("%d %b %Y") if type == "date"
+    return case_log[id].to_formatted_s(:govuk_date) if type == "date"
 
     return case_log[id].to_s if case_log[id].present?
 

--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -21,7 +21,7 @@
         <%= log.tenant_code %>
       </td>
       <td id="last-changed" class="govuk-table__cell">
-        <%= log.updated_at.strftime("%d %b %Y") %>
+        <%= log.updated_at.to_formatted_s(:govuk_date) %>
       </td>
     </tr>
     <% end %>

--- a/app/views/organisations/users.html.erb
+++ b/app/views/organisations/users.html.erb
@@ -18,7 +18,7 @@
       <%= body.row do |row|
         row.cell(text: simple_format(user_cell(user), {}, wrapper_tag: "div"))
         row.cell(text: simple_format(org_cell(user), {}, wrapper_tag: "div"))
-        row.cell(text: user.last_sign_in_at&.strftime("%d %b %Y") )
+        row.cell(text: user.last_sign_in_at&.to_formatted_s(:govuk_date) )
       end %>
     <% end %>
   <% end %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,41 @@
+Time::DATE_FORMATS[:govuk_date] = "%-d %B %Y"
+Time::DATE_FORMATS[:govuk_date_short_month] = "%-d %b %Y"
+Date::DATE_FORMATS[:govuk_date] = "%-d %B %Y"
+Date::DATE_FORMATS[:govuk_date_short_month] = "%-d %b %Y"
+
+Time::DATE_FORMATS[:month_and_year] = "%B %Y"
+Date::DATE_FORMATS[:month_and_year] = "%B %Y"
+
+Time::DATE_FORMATS[:short_month_and_year] = "%b %Y"
+Date::DATE_FORMATS[:short_month_and_year] = "%b %Y"
+
+Time::DATE_FORMATS[:day_and_month] = "%-d %B"
+Date::DATE_FORMATS[:day_and_month] = "%-d %B"
+
+Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
+  format = if time >= time.midday && time <= time.midday.end_of_minute
+             "%e %B %Y at %l%P (midday)"
+           elsif time >= time.midnight && time <= time.midnight.end_of_minute
+             "%e %B %Y at %l%P (midnight)"
+           elsif time.min.zero?
+             "%e %B %Y at %l%P"
+           else
+             "%e %B %Y at %l:%M%P"
+           end
+
+  time.strftime(format).squish
+end
+
+Time::DATE_FORMATS[:govuk_time] = lambda do |time|
+  format = if time >= time.midday && time <= time.midday.end_of_minute
+             "%l%P (midday)"
+           elsif time >= time.midnight && time <= time.midnight.end_of_minute
+             "%l%P (midnight)"
+           elsif time.min.zero?
+             "%l%P"
+           else
+             "%l:%M%P"
+           end
+
+  time.strftime(format).squish
+end

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Time::DATE_FORMATS" do
+  describe ":govuk_date_and_time, :govuk_time formats" do
+    it "formats time to indicate midday" do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 0, 59)
+      expect(date_and_time.to_formatted_s(:govuk_date_and_time)).to eq("25 December 2020 at 12pm (midday)")
+      expect(date_and_time.to_formatted_s(:govuk_time)).to eq("12pm (midday)")
+    end
+
+    it "formats time to indicate midnight" do
+      date_and_time = Time.zone.local(2020, 12, 25, 0, 0, 59)
+      expect(date_and_time.to_formatted_s(:govuk_date_and_time)).to eq("25 December 2020 at 12am (midnight)")
+      expect(date_and_time.to_formatted_s(:govuk_time)).to eq("12am (midnight)")
+    end
+
+    it "formats time with minutes if the time is not on the hour" do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 1, 0)
+      expect(date_and_time.to_formatted_s(:govuk_date_and_time)).to eq("25 December 2020 at 12:01pm")
+      expect(date_and_time.to_formatted_s(:govuk_time)).to eq("12:01pm")
+    end
+
+    it "formats time without minutes if the time is on the hour" do
+      date_and_time = Time.zone.local(2020, 12, 25, 15)
+      expect(date_and_time.to_formatted_s(:govuk_date_and_time)).to eq("25 December 2020 at 3pm")
+      expect(date_and_time.to_formatted_s(:govuk_time)).to eq("3pm")
+    end
+
+    it "does not pad single-digit day and hour with whitespace" do
+      date_and_time = Time.zone.local(2020, 12, 5, 6, 10, 0)
+      expect(date_and_time.to_formatted_s(:govuk_date_and_time)).to eq("5 December 2020 at 6:10am")
+      expect(date_and_time.to_formatted_s(:govuk_time)).to eq("6:10am")
+    end
+  end
+end

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Form::Question, type: :model do
 
       it "displays a formatted answer label" do
         case_log.mrcdate = Time.zone.local(2021, 10, 11)
-        expect(subject.answer_label(case_log)).to eq("11 Oct 2021")
+        expect(subject.answer_label(case_log)).to eq("11 October 2021")
       end
     end
 


### PR DESCRIPTION
[Dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [times](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times) should follow the GDS style guide.

This PR adds a date formatter that can be called with `.to_formatted_s(:govuk_date)` and `.to_formatted_s(:govuk_time)`, amongst other common options.