### PR TITLE
Use Notify rather than Gmail for devise emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "govuk-components"
 # GOV UK component form builder DSL
 gem "govuk_design_system_formbuilder"
+# GOV UK Notify
+gem "notifications-ruby-client"
 # Turbo and Stimulus
 gem "hotwire-rails"
 # Soft delete ActiveRecords objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/activeadmin/arbre.git
-  revision: e4970e683c81c99432b73f0ceb5dff7d3fe50413
+  revision: 305c221a2131be8dd0d96955f9b0a328dfa4beba
   specs:
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 7.1)
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/tagliala/activeadmin.git
-  revision: 8ccc35b8144482284c90b0af74a01e940765f7a6
+  revision: f4fc57251399c0ed452d72ac4b07d0bdd3d047c6
   branch: feature/railties-7
   specs:
     activeadmin (2.9.0)
@@ -106,7 +106,7 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    bootsnap (1.10.1)
+    bootsnap (1.10.2)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -158,7 +158,7 @@ GEM
       activemodel (>= 6.1)
       railties (>= 6.1)
       view_component (~> 2.47.0)
-    govuk_design_system_formbuilder (3.0.0)
+    govuk_design_system_formbuilder (3.0.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -186,6 +186,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jwt (2.3.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -211,7 +212,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    msgpack (1.4.3)
+    msgpack (1.4.4)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -234,6 +235,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     overcommit (0.58.0)
       childprocess (>= 0.6.3, < 5)
@@ -242,7 +245,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
+    pg (1.3.0)
     postcodes_io (0.4.0)
       excon (~> 0.39)
     pry (0.13.1)
@@ -435,6 +438,7 @@ DEPENDENCIES
   hotwire-rails
   json-schema
   listen (~> 3.3)
+  notifications-ruby-client
   overcommit (>= 0.37.0)
   pg (~> 1.1)
   postcodes_io

--- a/app/mailers/devise_notify_mailer.rb
+++ b/app/mailers/devise_notify_mailer.rb
@@ -1,0 +1,49 @@
+class DeviseNotifyMailer < Devise::Mailer
+  require "notifications/client"
+
+  RESET_PASSWORD_TEMPLATE_ID = "4593417c-500f-452c-8111-0f9d311aad0e".freeze
+  SET_PASSWORD_TEMPLATE_ID   = "00cd7163-4213-4596-b4f9-9e72796e0d76".freeze
+
+  def notify_client
+    @notify_client ||= ::Notifications::Client.new(ENV["GOVUK_NOTIFY_API_KEY"])
+  end
+
+  def host
+    @host ||= ENV["APP_HOST"]
+  end
+
+  def send_email(email, template_id, personalisation)
+    notify_client.send_email(
+      email_address: email,
+      template_id: template_id,
+      personalisation: personalisation,
+    )
+  end
+
+  def reset_password_instructions(record, token, _opts = {})
+    template_id = record.last_sign_in_at ? RESET_PASSWORD_TEMPLATE_ID : SET_PASSWORD_TEMPLATE_ID
+    personalisation = {
+      name: record.name,
+      email: record.email,
+      organisation: record.organisation.name,
+      link: "https://#{host}/users/password/edit?reset_password_token=#{token}",
+    }
+    send_email(record.email, template_id, personalisation)
+  end
+
+  # def confirmation_instructions(record, token, _opts = {})
+  #   super
+  # end
+  #
+  # def unlock_instructions(record, token, opts = {})
+  #   super
+  # end
+  #
+  # def email_changed(record, opts = {})
+  #   super
+  # end
+  #
+  # def password_change(record, opts = {})
+  #   super
+  # end
+end

--- a/app/mailers/devise_notify_mailer.rb
+++ b/app/mailers/devise_notify_mailer.rb
@@ -1,8 +1,8 @@
 class DeviseNotifyMailer < Devise::Mailer
   require "notifications/client"
 
-  RESET_PASSWORD_TEMPLATE_ID = "4593417c-500f-452c-8111-0f9d311aad0e".freeze
-  SET_PASSWORD_TEMPLATE_ID   = "00cd7163-4213-4596-b4f9-9e72796e0d76".freeze
+  RESET_PASSWORD_TEMPLATE_ID = "2c410c19-80a7-481c-a531-2bcb3264f8e6".freeze
+  SET_PASSWORD_TEMPLATE_ID   = "257460a6-6616-4640-a3f9-17c3d73d9e91".freeze
 
   def notify_client
     @notify_client ||= ::Notifications::Client.new(ENV["GOVUK_NOTIFY_API_KEY"])

--- a/app/views/devise/mailer/_password_change_forgotten.html.erb
+++ b/app/views/devise/mailer/_password_change_forgotten.html.erb
@@ -1,8 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= govuk_link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/_password_change_initial.html.erb
+++ b/app/views/devise/mailer/_password_change_initial.html.erb
@@ -1,6 +1,0 @@
-<p>Hello <%= @resource.name %>!</p>
-
-<p>An account has been created for you to submit CORE data on behalf of <%= @resource.organisation.name %>.</p>
-
-<p>Your username is <%= @resource.email %>, use the link below to set your password.
-<p><%= govuk_link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,0 @@
-<p>Welcome <%= @email %>!</p>
-
-<p>You can confirm your account email through the link below:</p>
-
-<p><%= govuk_link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,0 @@
-<p>Hello <%= @email %>!</p>
-
-<% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
-<% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
-<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,0 @@
-<% if @resource.last_sign_in_at.nil? %>
-  <%= render partial: "password_change_initial" %>
-<% else %>
-  <%= render partial: "password_change_forgotten" %>
-<% end %>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
-
-<p>Click the link below to unlock your account:</p>
-
-<p><%= govuk_link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,10 +24,11 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV["CORE_EMAIL_USERNAME"]
+  # config.mailer_sender = ENV["CORE_EMAIL_USERNAME"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
+  config.mailer = "DeviseNotifyMailer"
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/spec/request_helper.rb
+++ b/spec/request_helper.rb
@@ -5,5 +5,7 @@ module RequestHelper
     WebMock.disable_net_connect!(allow_localhost: true)
     WebMock.stub_request(:get, /api.postcodes.io/)
       .to_return(status: 200, body: "{\"status\":404,\"error\":\"Postcode not found\"}", headers: {})
+    WebMock.stub_request(:post, /api.notifications.service.gov.uk\/v2\/notifications\/email/)
+      .to_return(status: 200, body: "", headers: {})
   end
 end

--- a/spec/requests/auth/passwords_controller_spec.rb
+++ b/spec/requests/auth/passwords_controller_spec.rb
@@ -4,6 +4,12 @@ require_relative "../../support/devise"
 RSpec.describe Auth::PasswordsController, type: :request do
   let(:params) { { user: { email: email } } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
+  let(:notify_client) { double(Notifications::Client) }
+
+  before do
+    allow_any_instance_of(DeviseNotifyMailer).to receive(:notify_client).and_return(notify_client)
+    allow(notify_client).to receive(:send_email).and_return(true)
+  end
 
   context "when a password reset is requested for a valid email" do
     let(:user) { FactoryBot.create(:user) }
@@ -29,19 +35,6 @@ RSpec.describe Auth::PasswordsController, type: :request do
       expect(response).to have_http_status(:redirect)
       follow_redirect!
       expect(response.body).to match(/Check your email/)
-    end
-  end
-
-  context "when a password reset is requested the email" do
-    let(:user) { FactoryBot.create(:user, last_sign_in_at: Time.zone.now) }
-    let(:email) { user.email }
-
-    it "should contain the correct email" do
-      post "/users/password", params: params
-      follow_redirect!
-      email_ascii_content = ActionMailer::Base.deliveries.last.body.raw_source
-      email_content = email_ascii_content.encode("ASCII", "UTF-8", undef: :replace)
-      expect(email_content).to match(email)
     end
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,12 +1,18 @@
 require "rails_helper"
 
-RSpec.describe "password_reset", type: :request do
+RSpec.describe UsersController, type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:unauthorised_user) { FactoryBot.create(:user) }
   let(:headers) { { "Accept" => "text/html" } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
   let(:new_value) { "new test name" }
   let(:params) { { id: user.id, user: { name: new_value } } }
+  let(:notify_client) { double(Notifications::Client) }
+
+  before do
+    allow_any_instance_of(DeviseNotifyMailer).to receive(:notify_client).and_return(notify_client)
+    allow(notify_client).to receive(:send_email).and_return(true)
+  end
 
   context "a not signed in user" do
     describe "#show" do


### PR DESCRIPTION
This PR switches Devise from using Gmail SMTP via ActionMailer to Gov UK Notify to send emails for password resets and user confirmations.

- [x] Use Notify for new user emails
- [x] Use Notify for password reset emails
- [x] Create templates in Notify account
- [x] Remove no longer needed Devise mailer templates since the templates now live in Notify
- [x] Set API key env var in secret store

![image](https://user-images.githubusercontent.com/5101747/150791998-f390b054-21c0-4062-8ff2-dc99feb6bf1f.png)
![image](https://user-images.githubusercontent.com/5101747/150792705-02dc891c-4c8d-4419-8f74-395225f35f87.png)

