### PR TITLE
CLDC-791: Rename ‘About this log‘ section

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3,11 +3,11 @@
   "start_year": 2021,
   "end_year": 2022,
   "sections": {
-    "about_this_log": {
-      "label": "About this log",
+    "setup": {
+      "label": "Before you start",
       "subsections": {
-        "about_this_log": {
-          "label": "About this log",
+        "setup": {
+          "label": "Set up your lettings log",
           "pages": {
             "gdpr_acceptance": {
               "header": "",
@@ -230,7 +230,7 @@
       "subsections": {
         "household_characteristics": {
           "label": "Household characteristics",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "person_1_age": {
               "header": "",
@@ -779,7 +779,7 @@
         },
         "household_situation": {
           "label": "Household situation",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "previous_housing_situation": {
               "header": "",
@@ -907,7 +907,7 @@
         },
         "household_needs": {
           "label": "Household needs",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "armed_forces": {
               "header": "Experience of the UK Armed Forces",
@@ -1051,7 +1051,7 @@
       "subsections": {
         "tenancy_information": {
           "label": "Tenancy information",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "starter_tenancy": {
               "header": "",
@@ -1165,7 +1165,7 @@
         },
         "property_information": {
           "label": "Property information",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "property_postcode": {
               "header": "",
@@ -1831,7 +1831,7 @@
       "subsections": {
         "income_and_benefits": {
           "label": "Income, benefits and outgoings",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "net_income_known": {
               "header": "Household’s combined income",
@@ -2710,7 +2710,7 @@
       "subsections": {
         "local_authority": {
           "label": "Local authority",
-          "depends_on": [{ "about_this_log": "completed" }],
+          "depends_on": [{ "setup": "completed" }],
           "pages": {
             "time_lived_in_la": {
               "header": "",
@@ -3280,7 +3280,7 @@
         "declaration": {
           "label": "Declaration",
           "depends_on": [{
-            "about_this_log": "completed",
+            "setup": "completed",
             "household_characteristics": "completed",
             "household_situation": "completed",
             "household_needs": "completed",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -60,23 +60,6 @@
               },
               "depends_on": [{ "gdpr_acceptance": "Yes" }]
             },
-            "sale_or_letting": {
-              "header": "",
-              "description": "",
-              "questions": {
-                "sale_or_letting": {
-                  "check_answer_label": "Letting or sale",
-                  "header": "Is this a letting or sale?",
-                  "hint_text": "",
-                  "type": "radio",
-                  "answer_options": {
-                    "1": "Letting",
-                    "0": "Sale"
-                  }
-                }
-              },
-              "depends_on": [{ "gdpr_acceptance": "Yes" }]
-            },
             "tenant_same_property_renewal": {
               "header": "",
               "description": "",
@@ -93,8 +76,7 @@
                 }
               },
               "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Letting"
+                "gdpr_acceptance": "Yes"
               }]
             },
             "startdate": {
@@ -109,8 +91,7 @@
                 }
               },
               "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Letting"
+                "gdpr_acceptance": "Yes"
               }]
             },
             "about_this_letting": {
@@ -153,8 +134,7 @@
                 }
               },
               "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Letting"
+                "gdpr_acceptance": "Yes"
               }]
             },
             "tenant_code": {
@@ -170,8 +150,7 @@
                 }
               },
               "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Letting"
+                "gdpr_acceptance": "Yes"
               }]
             },
             "property_reference": {
@@ -187,39 +166,6 @@
                 }
               },
               "depends_on": [{ "gdpr_acceptance": "Yes" }]
-            },
-            "sale_completion_date": {
-              "header": "",
-              "description": "",
-              "questions": {
-                "sale_completion_date": {
-                  "check_answer_label": "Sale completion date",
-                  "header": "What is the sale completion date?",
-                  "hint_text": "For example, 27 3 2021.",
-                  "type": "date"
-                }
-              },
-              "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Sale"
-              }]
-            },
-            "purchaser_code": {
-              "header": "",
-              "description": "",
-              "questions": {
-                "purchaser_code": {
-                  "check_answer_label": "Purchaser code",
-                  "header": "What is the purchaser code?",
-                  "hint_text": "",
-                  "type": "text",
-                  "width": 10
-                }
-              },
-              "depends_on": [{
-                "gdpr_acceptance": "Yes",
-                "sale_or_letting": "Sale"
-              }]
             }
           }
         }

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     managing_organisation { FactoryBot.create(:organisation) }
     trait :about_completed do
       gdpr_acceptance { "Yes" }
-      sale_or_letting { "Letting" }
       tenant_same_property_renewal { "No" }
       needstype { 1 }
       rent_type { 1 }
@@ -117,7 +116,6 @@ FactoryBot.define do
       gdpr_declined { "No" }
       property_owner_organisation { "Test" }
       property_manager_organisation { "Test" }
-      sale_or_letting { "Letting" }
       tenant_same_property_renewal { 1 }
       rent_type { 1 }
       intermediate_rent_product_name { 2 }

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -126,7 +126,6 @@
     "gdpr_declined": "",
     "property_owner_organisation": "",
     "property_manager_organisation": "",
-    "sale_or_letting": "",
     "rent_type": "Social Rent",
     "intermediate_rent_product_name": "",
     "needstype": "General needs",

--- a/spec/fixtures/forms/2022_2023.json
+++ b/spec/fixtures/forms/2022_2023.json
@@ -31,23 +31,6 @@
                 },
                 "depends_on": [{ "gdpr_acceptance": "No" }]
               },
-              "sale_or_letting": {
-                "header": "",
-                "description": "",
-                "questions": {
-                  "sale_or_letting": {
-                    "check_answer_label": "Letting or sale",
-                    "header": "Is this a letting or sale?",
-                    "hint_text": "",
-                    "type": "radio",
-                    "answer_options": {
-                      "1": "Letting",
-                      "0": "Sale"
-                    }
-                  }
-                },
-                "depends_on": [{ "gdpr_acceptance": "Yes" }]
-              },
               "tenant_same_property_renewal": {
                 "header": "",
                 "description": "",
@@ -63,7 +46,9 @@
                     }
                   }
                 },
-                "depends_on": [{ "gdpr_acceptance": "Yes", "sale_or_letting": "Letting" }]
+                "depends_on": [{
+                  "gdpr_acceptance": "Yes"
+                }]
               },
               "startdate": {
                 "header": "",
@@ -76,7 +61,9 @@
                     "type": "date"
                   }
                 },
-                "depends_on": [{ "gdpr_acceptance": "Yes", "sale_or_letting": "Letting" }]
+                "depends_on": [{
+                  "gdpr_acceptance": "Yes"
+                }]
               },
               "about_this_letting": {
                 "header": "Tell us about this letting",
@@ -115,34 +102,9 @@
                     }
                   }
                 },
-                "depends_on": [{ "gdpr_acceptance": "Yes", "sale_or_letting": "Letting" }]
-              },
-              "sale_completion_date": {
-                "header": "",
-                "description": "",
-                "questions": {
-                  "sale_completion_date": {
-                    "check_answer_label": "Sale completion date",
-                    "header": "What is the sale completion date?",
-                    "hint_text": "For example, 27 3 2007",
-                    "type": "date"
-                  }
-                },
-                "depends_on": [{ "gdpr_acceptance": "Yes", "sale_or_letting": "Sale" }]
-              },
-              "purchaser_code": {
-                "header": "",
-                "description": "",
-                "questions": {
-                  "purchaser_code": {
-                    "check_answer_label": "Purchaser code",
-                    "header": "What is the purchaser code?",
-                    "hint_text": "",
-                    "type": "text",
-                    "width": 10
-                  }
-                },
-                "depends_on": [{ "gdpr_acceptance": "Yes", "sale_or_letting": "Sale" }]
+                "depends_on": [{
+                  "gdpr_acceptance": "Yes"
+                }]
               }
             }
           }

--- a/spec/fixtures/forms/2022_2023.json
+++ b/spec/fixtures/forms/2022_2023.json
@@ -1,11 +1,11 @@
 {
     "form_type": "lettings",
     "sections": {
-      "about_this_log": {
-        "label": "About this log",
+      "setup": {
+        "label": "Before you start",
         "subsections": {
-          "about_this_log": {
-            "label": "About this log",
+          "setup": {
+            "label": "Set up your lettings log",
             "pages": {
               "gdpr_acceptance": {
                 "header": "",

--- a/spec/models/form/subsection_spec.rb
+++ b/spec/models/form/subsection_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Form::Subsection, type: :model do
   end
 
   context "the privacy notice has not been shown" do
-    let(:section_id) { "about_this_log" }
-    let(:subsection_id) { "about_this_log" }
+    let(:section_id) { "setup" }
+    let(:subsection_id) { "setup" }
     let(:case_log) { FactoryBot.build(:case_log, :about_completed, gdpr_acceptance: "No") }
 
     it "does not mark the section as completed" do


### PR DESCRIPTION
After testing ‘Tailor your log’, we’re going to use ‘Set up your [lettings|sales] log’.