### PR TITLE
CLDC-786: Add hint text for tenant code

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -164,7 +164,7 @@
                 "tenant_code": {
                   "check_answer_label": "Tenant code",
                   "header": "What is the tenant code?",
-                  "hint_text": "",
+                  "hint_text": "This is how you usually refer to this tenancy on your own systems.",
                   "type": "text",
                   "width": 10
                 }
@@ -181,7 +181,7 @@
                 "propcode": {
                   "check_answer_label": "Property reference",
                   "header": "What is the property reference?",
-                  "hint_text": "This is how you refer to the property in your own systems",
+                  "hint_text": "This is how you usually refer to this property on your own systems.",
                   "type": "text",
                   "width": 10
                 }

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -12,6 +12,7 @@
                   "tenant_code": {
                     "check_answer_label": "Tenant code",
                     "header": "What is the tenant code?",
+                    "hint_text": "This is how you usually refer to this tenancy on your own systems.",
                     "type": "text",
                     "width": 10
                   }


### PR DESCRIPTION
Does what it says on the tin. Also updates hint text for Property reference. 