### PR TITLE
Enable section descriptions and add note about privacy notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The JSON should follow the structure:
   "sections": {
     "[snake_case_section_name_string]": {
       "label": String,
+      "description": String,
       "subsections": {
         "[snake_case_subsection_name_string]": {
           "label": String,

--- a/app/models/form/section.rb
+++ b/app/models/form/section.rb
@@ -1,9 +1,10 @@
 class Form::Section
-  attr_accessor :id, :label, :subsections, :form
+  attr_accessor :id, :label, :description, :subsections, :form
 
   def initialize(id, hsh, form)
     @id = id
     @label = hsh["label"]
+    @description = hsh["description"]
     @form = form
     @subsections = hsh["subsections"].map { |s_id, s| Form::Subsection.new(s_id, s, self) }
   end

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -6,6 +6,9 @@
           <%= section.label %>
         </span>
       </h2>
+      <% if section.description %>
+        <p class="govuk-body"><%= section.description.html_safe %></p>
+      <% end %>
       <ul class="app-task-list__items">
         <% section.subsections.map do |subsection| %>
           <% subsection_status = subsection.status(@case_log) %>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -173,6 +173,7 @@
     },
     "household": {
       "label": "About the household",
+      "description": "Make sure the tenant has seen <a class=\"govuk-link\" href=\"/files/privacy-notice.pdf\">the Department for Levelling Up, Housing & Communities (DLUHC) privacy notice</a> before completing this section.",
       "subsections": {
         "household_characteristics": {
           "label": "Household characteristics",

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -3,6 +3,7 @@
     "sections": {
       "household": {
         "label": "About the household",
+        "description": "Make sure the tenant has seen the privacy notice.",
         "subsections": {
           "household_characteristics": {
             "label": "Household characteristics",

--- a/spec/models/form/section_spec.rb
+++ b/spec/models/form/section_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Form::Section, type: :model do
     expect(section.label).to eq("About the household")
   end
 
+  it "has a description" do
+    expect(section.description).to eq("Make sure the tenant has seen the privacy notice.")
+  end
+
   it "has subsections" do
     expected_subsections = %w[household_characteristics household_needs]
     expect(section.subsections.map(&:id)).to eq(expected_subsections)


### PR DESCRIPTION
* Adds a new field for a section: `description` – this is shown under the respective section label in the task list
* Adds test for the above
* Adds description for the ‘About the household’ section which shows a note about the tenant needing to see the privacy notice.

<img width="675" alt="Screenshot 2022-02-03 at 15 46 29" src="https://user-images.githubusercontent.com/813383/152377036-eeb17209-b891-4bfb-8194-0741c113b406.png">
