### PR TITLE
CLDC-961: Model data versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,6 @@ gem "govuk_design_system_formbuilder"
 gem "notifications-ruby-client"
 # Turbo and Stimulus
 gem "hotwire-rails"
-# Soft delete ActiveRecords objects
-gem "discard"
 # Administration framework
 gem "activeadmin", git: "https://github.com/tagliala/activeadmin.git", branch: "feature/railties-7"
 # Admin charts
@@ -47,6 +45,8 @@ gem "postcodes_io"
 gem "view_component"
 # Use the AWS S3 SDK as storage mechanism
 gem "aws-sdk-s3"
+# Track changes to models for auditing or versioning.
+gem "paper_trail"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem "view_component"
 gem "aws-sdk-s3"
 # Track changes to models for auditing or versioning.
 gem "paper_trail"
+# Store active record objects in version whodunnits
+gem "paper_trail-globalid"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,8 +156,6 @@ GEM
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     digest (3.1.0)
-    discard (1.2.1)
-      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -266,6 +264,9 @@ GEM
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
       rexml (~> 3.2)
+    paper_trail (12.2.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -326,6 +327,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -456,7 +459,6 @@ DEPENDENCIES
   capybara-lockstep
   chartkick
   devise!
-  discard
   dotenv-rails
   factory_bot_rails
   govuk-components
@@ -466,6 +468,7 @@ DEPENDENCIES
   listen (~> 3.3)
   notifications-ruby-client
   overcommit (>= 0.37.0)
+  paper_trail
   pg (~> 1.1)
   postcodes_io
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,9 @@ GEM
     paper_trail (12.2.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
+    paper_trail-globalid (0.2.0)
+      globalid
+      paper_trail (>= 3.0.0)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -469,6 +472,7 @@ DEPENDENCIES
   notifications-ruby-client
   overcommit (>= 0.37.0)
   paper_trail
+  paper_trail-globalid
   pg (~> 1.1)
   postcodes_io
   pry-byebug

--- a/app/concerns/admin/paper_trail.rb
+++ b/app/concerns/admin/paper_trail.rb
@@ -1,0 +1,15 @@
+module Admin
+  module PaperTrail
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :set_paper_trail_whodunnit
+    end
+
+  protected
+
+    def user_for_paper_trail
+      current_admin_user
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,17 @@
 class ApplicationController < ActionController::Base
+  before_action :set_paper_trail_whodunnit
+
   def render_not_found
     render "errors/not_found", status: :not_found
   end
 
   def render_not_found_json(class_name, id)
     render json: { error: "#{class_name} #{id} not found" }, status: :not_found
+  end
+
+protected
+
+  def user_for_paper_trail
+    current_user
   end
 end

--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -60,7 +60,7 @@ class CaseLogsController < ApplicationController
 
   def destroy
     if @case_log
-      if @case_log.discard
+      if @case_log.delete
         head :no_content
       else
         render json: { errors: @case_log.errors.messages }, status: :unprocessable_entity

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -6,6 +6,8 @@ class AdminUser < ApplicationRecord
 
   has_one_time_password(encrypted: true)
 
+  has_paper_trail
+
   validates :phone, presence: true, numericality: true
 
   MFA_SMS_TEMPLATE_ID = "bf309d93-804e-4f95-b1f4-bd513c48ecb0".freeze

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -30,11 +30,11 @@ private
 end
 
 class CaseLog < ApplicationRecord
-  include Discard::Model
   include Validations::SoftValidations
   include Constants::CaseLog
   include Constants::IncomeRanges
-  default_scope -> { kept }
+
+  has_paper_trail
 
   validates_with CaseLogValidator
   before_validation :process_postcode_changes!, if: :property_postcode_changed?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,7 +3,10 @@ class Organisation < ApplicationRecord
   has_many :owned_case_logs, class_name: "CaseLog", foreign_key: "owning_organisation_id"
   has_many :managed_case_logs, class_name: "CaseLog", foreign_key: "managing_organisation_id"
 
+  has_paper_trail
+
   include Constants::Organisation
+
   enum provider_type: PROVIDER_TYPE
 
   def case_logs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :owned_case_logs, through: :organisation
   has_many :managed_case_logs, through: :organisation
 
+  has_paper_trail
+
   enum role: ROLES
 
   def case_logs

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -340,3 +340,7 @@ end
 Rails.application.config.after_initialize do
   ActiveAdmin.application.stylesheets.delete("active_admin/print.css")
 end
+
+Rails.application.config.after_initialize do
+  ActiveAdmin::BaseController.include Admin::PaperTrail
+end

--- a/db/migrate/20220207151239_create_versions.rb
+++ b/db/migrate/20220207151239_create_versions.rb
@@ -1,0 +1,22 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false, limit: 191
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20220207151312_remove_discarded_at_from_case_logs.rb
+++ b/db/migrate/20220207151312_remove_discarded_at_from_case_logs.rb
@@ -1,0 +1,11 @@
+class RemoveDiscardedAtFromCaseLogs < ActiveRecord::Migration[7.0]
+  def up
+    remove_index :case_logs, :discarded_at
+    remove_column :case_logs, :discarded_at
+  end
+
+  def down
+    add_column :case_logs, :discarded_at, :datetime
+    add_index :case_logs, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 202202071123100) do
     t.integer "beds"
     t.integer "offered"
     t.integer "wchair"
+    t.integer "earnings"
     t.integer "incfreq"
     t.integer "benefits"
     t.integer "period"
@@ -127,7 +128,6 @@ ActiveRecord::Schema.define(version: 202202071123100) do
     t.integer "rp_medwel"
     t.integer "rp_hardship"
     t.integer "rp_dontknow"
-    t.datetime "discarded_at"
     t.string "tenancyother"
     t.integer "override_net_income_validation"
     t.string "property_owner_organisation"
@@ -182,7 +182,6 @@ ActiveRecord::Schema.define(version: 202202071123100) do
     t.integer "is_carehome"
     t.integer "letting_in_sheltered_accomodation"
     t.integer "household_charge"
-    t.integer "earnings"
     t.integer "referral"
     t.decimal "brent", precision: 10, scale: 2
     t.decimal "scharge", precision: 10, scale: 2
@@ -192,7 +191,6 @@ ActiveRecord::Schema.define(version: 202202071123100) do
     t.decimal "tshortfall", precision: 10, scale: 2
     t.decimal "chcharge", precision: 10, scale: 2
     t.integer "declaration"
-    t.index ["discarded_at"], name: "index_case_logs_on_discarded_at"
     t.index ["managing_organisation_id"], name: "index_case_logs_on_managing_organisation_id"
     t.index ["owning_organisation_id"], name: "index_case_logs_on_owning_organisation_id"
   end
@@ -250,6 +248,16 @@ ActiveRecord::Schema.define(version: 202202071123100) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", limit: 191, null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at", precision: 6
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
 end

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -6,8 +6,11 @@ describe Admin::AdminUsersController, type: :controller do
   let(:page) { Capybara::Node::Simple.new(response.body) }
   let(:resource_title) { "Admin Users" }
   let(:valid_session) { {} }
+  let(:signed_in_admin_user) { FactoryBot.create(:admin_user) }
 
-  login_admin_user
+  before do
+    sign_in signed_in_admin_user
+  end
 
   describe "Get admin users" do
     before do
@@ -27,22 +30,30 @@ describe Admin::AdminUsersController, type: :controller do
     it "creates a new admin user" do
       expect { post :create, session: valid_session, params: params }.to change(AdminUser, :count).by(1)
     end
+
+    it "tracks who created the record" do
+      post :create, session: valid_session, params: params
+      created_id = response.location.match(/[0-9]+/)[0]
+      whodunnit_actor = AdminUser.find_by(id: created_id).versions.last.actor
+      expect(whodunnit_actor).to be_a(AdminUser)
+      expect(whodunnit_actor.id).to eq(signed_in_admin_user.id)
+    end
   end
 
   describe "Update admin users" do
-    context "when editing the form" do
+    context "when viewing the form" do
       before do
         get :edit, session: valid_session, params: { id: AdminUser.first.id }
       end
 
-      it "shows an edit form" do
+      it "shows the correct fields" do
         expect(page).to have_field("admin_user_email")
         expect(page).to have_field("admin_user_password")
         expect(page).to have_field("admin_user_password_confirmation")
       end
     end
 
-    context "when updating the form" do
+    context "when updating an admin user" do
       let(:admin_user) { FactoryBot.create(:admin_user) }
       let(:email) { "new_email@example.com" }
       let(:params) { { id: admin_user.id, admin_user: { email: email } } }
@@ -54,6 +65,13 @@ describe Admin::AdminUsersController, type: :controller do
       it "updates the user without needing to input a password" do
         admin_user.reload
         expect(admin_user.email).to eq(email)
+      end
+
+      it "tracks who updated the record" do
+        admin_user.reload
+        whodunnit_actor = admin_user.versions.last.actor
+        expect(whodunnit_actor).to be_a(AdminUser)
+        expect(whodunnit_actor.id).to eq(signed_in_admin_user.id)
       end
     end
   end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -5,14 +5,14 @@ require_relative "../../request_helper"
 describe Admin::DashboardController, type: :controller do
   before do
     RequestHelper.stub_http_requests
+    sign_in admin_user
   end
 
   render_views
   let(:page) { Capybara::Node::Simple.new(response.body) }
   let(:resource_title) { "Dashboard" }
   let(:valid_session) { {} }
-
-  login_admin_user
+  let(:admin_user) { FactoryBot.create(:admin_user) }
 
   describe "Get case logs" do
     before do

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -108,7 +108,6 @@ FactoryBot.define do
       rp_medwel { "No" }
       rp_hardship { "No" }
       rp_dontknow { "No" }
-      discarded_at { nil }
       tenancyother { nil }
       override_net_income_validation { nil }
       net_income_known { "Yes" }

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -20,33 +20,46 @@ RSpec.describe AdminUser, type: :model do
         )
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
+
+    it "requires an email" do
+      expect {
+        described_class.create!(
+          password: "password123",
+          phone: "075752137",
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "requires a password" do
+      expect {
+        described_class.create!(
+          email: "admin_test@example.com",
+          phone: "075752137",
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "can be created" do
+      expect {
+        described_class.create!(
+          email: "admin_test@example.com",
+          password: "password123",
+          phone: "075752137",
+        )
+      }.to change(described_class, :count).by(1)
+    end
   end
 
-  it "requires an email" do
-    expect {
-      described_class.create!(
-        password: "password123",
-        phone: "075752137",
-      )
-    }.to raise_error(ActiveRecord::RecordInvalid)
-  end
+  describe "paper trail" do
+    let(:admin_user) { FactoryBot.create(:admin_user) }
 
-  it "requires a password" do
-    expect {
-      described_class.create!(
-        email: "admin_test@example.com",
-        phone: "075752137",
-      )
-    }.to raise_error(ActiveRecord::RecordInvalid)
-  end
+    it "creates a record of changes to a log" do
+      expect { admin_user.update!(phone: "09673867853") }.to change(admin_user.versions, :count).by(1)
+    end
 
-  it "can be created" do
-    expect {
-      described_class.create!(
-        email: "admin_test@example.com",
-        password: "password123",
-        phone: "075752137",
-      )
-    }.to change(described_class, :count).by(1)
+    it "allows case logs to be restored to a previous version" do
+      admin_user.update!(phone: "09673867853")
+      expect(admin_user.paper_trail.previous_version.phone).to eq("07563867654")
+    end
   end
 end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1172,4 +1172,17 @@ RSpec.describe CaseLog do
       end
     end
   end
+
+  describe "paper trail" do
+    let(:case_log) { FactoryBot.create(:case_log, :in_progress) }
+
+    it "creates a record of changes to a log" do
+      expect { case_log.update!(age1: 64) }.to change(case_log.versions, :count).by(1)
+    end
+
+    it "allows case logs to be restored to a previous version" do
+      case_log.update!(age1: 63)
+      expect(case_log.paper_trail.previous_version.age1).to eq(17)
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe Organisation, type: :model do
       end
     end
   end
+
+  describe "paper trail" do
+    let(:organisation) { FactoryBot.create(:organisation) }
+
+    it "creates a record of changes to a log" do
+      expect { organisation.update!(name: "new test name") }.to change(organisation.versions, :count).by(1)
+    end
+
+    it "allows case logs to be restored to a previous version" do
+      organisation.update!(name: "new test name")
+      expect(organisation.paper_trail.previous_version.name).to eq("DLUHC")
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,4 +52,17 @@ RSpec.describe User, type: :model do
       expect(user.data_coordinator?).to be false
     end
   end
+
+  describe "paper trail" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "creates a record of changes to a log" do
+      expect { user.update!(name: "new test name") }.to change(user.versions, :count).by(1)
+    end
+
+    it "allows case logs to be restored to a previous version" do
+      user.update!(name: "new test name")
+      expect(user.paper_trail.previous_version.name).to eq("Danny Rojas")
+    end
+  end
 end

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -401,9 +401,8 @@ RSpec.describe CaseLogsController, type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      it "soft deletes the case log" do
+      it "deletes the case log" do
         expect { CaseLog.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(CaseLog.with_discarded.find(id)).to be_a(CaseLog)
       end
 
       context "with an invalid case log id" do
@@ -428,7 +427,7 @@ RSpec.describe CaseLogsController, type: :request do
     context "when a case log deletion fails" do
       before do
         allow(CaseLog).to receive(:find_by).and_return(case_log)
-        allow(case_log).to receive(:discard).and_return(false)
+        allow(case_log).to receive(:delete).and_return(false)
         delete "/logs/#{id}", headers: headers
       end
 

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CaseLogsController, type: :request do
       end
 
       it "tracks who created the record" do
-        created_id = response.location.match(/[1-9]+/)[0]
+        created_id = response.location.match(/[0-9]+/)[0]
         whodunnit_actor = CaseLog.find_by(id: created_id).versions.last.actor
         expect(whodunnit_actor).to be_a(User)
         expect(whodunnit_actor.id).to eq(user.id)

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -155,6 +155,13 @@ RSpec.describe FormController, type: :request do
             expect(case_log.age1).to eq(answer)
             expect(case_log.age2).to be nil
           end
+
+          it "tracks who updated the record" do
+            case_log.reload
+            whodunnit_actor = case_log.versions.last.actor
+            expect(whodunnit_actor).to be_a(User)
+            expect(whodunnit_actor.id).to eq(user.id)
+          end
         end
       end
 

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -185,6 +185,13 @@ RSpec.describe OrganisationsController, type: :request do
             follow_redirect!
             expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
           end
+
+          it "tracks who updated the record" do
+            organisation.reload
+            whodunnit_actor = organisation.versions.last.actor
+            expect(whodunnit_actor).to be_a(User)
+            expect(whodunnit_actor.id).to eq(user.id)
+          end
         end
 
         context "with an organisation that the user does not belong to" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -196,6 +196,13 @@ RSpec.describe UsersController, type: :request do
         user.reload
         expect(user.name).to eq(new_value)
       end
+
+      it "tracks who updated the record" do
+        user.reload
+        whodunnit_actor = user.versions.last.actor
+        expect(whodunnit_actor).to be_a(User)
+        expect(whodunnit_actor.id).to eq(user.id)
+      end
     end
 
     context "when the update fails to persist" do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -6,12 +6,4 @@ module ControllerMacros
       sign_in user
     end
   end
-
-  def login_admin_user
-    before do
-      @request.env["devise.mapping"] = Devise.mappings[:admin_user]
-      admin_user = FactoryBot.create(:admin_user)
-      sign_in admin_user
-    end
-  end
 end


### PR DESCRIPTION
This creates a new record in the Versions table every time a model with `has_paper_trail` is updated. https://github.com/paper-trail-gem/paper_trail.

This does potential mean an explosion in data size since CaseLog is updated every time a form question is submitted. Given the form currently has ~70 pages, assuming some question are amended - we're likely to see ~100 records (tracking each change) for each case log where previously we only had 1. Worth considering whether we want to track this aggressively or whether we should be more selective on versioning. For example we could choose to only version if the change is >24 hours after the last version was created or only version on specific field etc. Alternatively we could only keep x number of version per model, or versions up to a certain age.

This PR removes Discard (gem for soft delete functionality), as we don't really need it any more now that deletes are versioned and can be restored from Paper Trail.

- [x] Use PaperTrail to version data models (User, Admin User, Organisation, Case Log)
- [x] Track whodunnit on form UI changes
- [x] Track whodunnit on Admin Panel changes

Out of scope: 
1. Track whodunnit on API changes (since we don't have individual API users yet)
2. Tracking whodunnit on changes made from Rails console or via Rake tasks
3. Display versions in Active Admin (Subsequent PR if required to keep this small and atomic)