### PR TITLE
Ensure error summary on question pages appears above the page title

### DIFF
--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -14,24 +14,25 @@
 <div data-controller="govukfrontend"></div>
 
 <%= turbo_frame_tag "case_log_form", target: "_top" do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% if @page.header.present? %>
-        <h1 class="govuk-heading-l">
-          <% if !@page.hide_subsection_label %>
-            <span class="govuk-caption-l"><%= @subsection.label %></span>
-          <% end %>
-          <%= @page.header %>
-        </h1>
-      <% end %>
-
-      <% if @page.description.present? %>
-        <p class="govuk-body govuk-body-m"><%= @page.description.html_safe %></p>
-      <% end %>
-
-      <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
+  <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post" do |f| %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
         <% remove_other_page_errors(@case_log, @page) %>
         <%= f.govuk_error_summary %>
+
+        <% if @page.header.present? %>
+          <h1 class="govuk-heading-l">
+            <% if !@page.hide_subsection_label %>
+              <span class="govuk-caption-l"><%= @subsection.label %></span>
+            <% end %>
+            <%= @page.header %>
+          </h1>
+        <% end %>
+
+        <% if @page.description.present? %>
+          <p class="govuk-body govuk-body-m"><%= @page.description.html_safe %></p>
+        <% end %>
+
         <% @page.non_conditional_questions.map do |question| %>
           <div id=<%= question.id + "_div " %><%= display_question_key_div(@page, question) %> >
             <% if question.read_only? %>
@@ -47,7 +48,7 @@
 
         <%= f.hidden_field :page, value: @page.id %>
         <%= f.govuk_submit "Save and continue"  %>
-      <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
<img width="700" alt="Screenshot 2022-02-07 at 17 18 42" src="https://user-images.githubusercontent.com/813383/152838682-2d3091d6-ae42-4beb-a049-ed8df76d968b.png">

See: https://design-system.service.gov.uk/components/error-summary/#where-to-put-the-error-summary