### PR TITLE
Time out logged in devise session after 1 day

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -189,7 +189,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 1.day
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
Caveats: This will affect Admin Users (Internal) and Users (External).