### PR TITLE
Bugfix: Default charge values to 0

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -249,7 +249,13 @@ private
     self.totchild = get_totchild
     self.totelder = get_totelder
     self.totadult = get_totadult
-    self.tcharge = brent.to_f + scharge.to_f + pscharge.to_f + supcharg.to_f
+    if %i[brent scharge pscharge supcharg].any? { |f| public_send(f).present? }
+      self.brent ||= 0
+      self.scharge ||= 0
+      self.pscharge ||= 0
+      self.supcharg ||= 0
+      self.tcharge = brent.to_f + scharge.to_f + pscharge.to_f + supcharg.to_f
+    end
     self.has_benefits = get_has_benefits
     self.nocharge = household_charge == "Yes" ? "No" : "Yes"
     self.layear = "Less than 1 year" if renewal == "Yes"

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -956,7 +956,6 @@ RSpec.describe CaseLog do
   end
 
   describe "derived variables" do
-    require "date"
     let(:organisation) { FactoryBot.create(:organisation, provider_type: "PRP") }
     let!(:case_log) do
       described_class.create({
@@ -1027,6 +1026,18 @@ RSpec.describe CaseLog do
       expect(record_from_db["day"]).to eq(10)
       expect(record_from_db["month"]).to eq(10)
       expect(record_from_db["year"]).to eq(2021)
+    end
+
+    context "when any charge field is set" do
+      before do
+        case_log.update!(pscharge: 10)
+      end
+
+      it "derives that any blank ones are 0" do
+        record_from_db = ActiveRecord::Base.connection.execute("select supcharg, scharge from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["supcharg"].to_f).to eq(0.0)
+        expect(record_from_db["scharge"].to_f).to eq(0.0)
+      end
     end
 
     context "when saving addresses" do


### PR DESCRIPTION
Currently if you answer any of the charge fields the subsection assumes you've answered that question and marks it as complete but the form doesn't. This defaults all unanswered values on that page to 0 if any have been answered so that the behaviour is consistent. i.e. so that you don't get all sections complete but form incomplete because it thinks those fields still need answering.