### PR TITLE
Don't validate bedroom number if not answered yet

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -70,22 +70,6 @@ module Validations::HouseholdValidations
     end
   end
 
-  def validate_shared_housing_rooms(record)
-    unless record.unittype_gn.nil?
-      if record.unittype_gn == "Bedsit" && record.beds != 1 && record.beds.present?
-        record.errors.add :unittype_gn, I18n.t("validations.household.unittype_gn.one_bedroom_bedsit")
-      end
-
-      if !record.other_hhmemb.nil? && record.other_hhmemb.positive? && (record.unittype_gn.include?("Shared") && !record.beds.to_i.between?(1, 7))
-        record.errors.add :unittype_gn, I18n.t("validations.household.unittype_gn.one_seven_bedroom_shared")
-      end
-
-      if record.unittype_gn.include?("Shared") && !record.beds.to_i.between?(1, 3) && record.beds.present?
-        record.errors.add :unittype_gn, I18n.t("validations.household.unittype_gn.one_three_bedroom_single_tenant_shared")
-      end
-    end
-  end
-
   def validate_previous_housing_situation(record)
     if record.rsnvac == "Relet to tenant who occupied same property as temporary accommodation" && NON_TEMP_ACCOMMODATION.include?(record.prevten)
       record.errors.add :prevten, I18n.t("validations.household.prevten.non_temp_accommodation")

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -63,4 +63,19 @@ module Validations::PropertyValidations
       record.errors.add :property_postcode, error_message
     end
   end
+
+  def validate_shared_housing_rooms(record)
+    unless record.unittype_gn.nil?
+      if record.unittype_gn == "Bedsit" && record.beds != 1 && record.beds.present?
+        record.errors.add :unittype_gn, I18n.t("validations.property.unittype_gn.one_bedroom_bedsit")
+      end
+
+      if record.other_hhmemb&.zero? && record.unittype_gn.include?("Shared") &&
+          !record.beds.to_i.between?(1, 3) && record.beds.present?
+        record.errors.add :unittype_gn, I18n.t("validations.property.unittype_gn.one_three_bedroom_single_tenant_shared")
+      elsif record.unittype_gn.include?("Shared") && record.beds.present? && !record.beds.to_i.between?(1, 7)
+        record.errors.add :unittype_gn, I18n.t("validations.property.unittype_gn.one_seven_bedroom_shared")
+      end
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,10 @@ en:
         previous_let_social: "Property cannot have a previous let type if it is being let as social housing for the first time"
         non_temp_accommodation: "Answer cannot be re-let to tenant who occupied the same property as temporary accommodation as you already told us this accommodation is not temporary"
         referral_invalid: "Answer cannot be re-let to tenant who occupied the same property as temporary accommodation as you already told us a different source of referral for this letting"
+      unittype_gn:
+        one_bedroom_bedsit: "A bedsit can only have one bedroom"
+        one_seven_bedroom_shared: "A shared house must have 1 to 7 bedrooms"
+        one_three_bedroom_single_tenant_shared: "A shared house with less than two tenants must have 1 to 3 bedrooms"
 
     financial:
       tshortfall:
@@ -100,10 +104,6 @@ en:
         one_partner: "Number of partners cannot be greater than 1"
       housingneeds_a:
         one_or_two_choices: "Only one box must be ticked or 'other disabilities' plus one of mobility disabilities"
-      unittype_gn:
-        one_bedroom_bedsit: "A bedsit can only have one bedroom"
-        one_seven_bedroom_shared: "A shared house must have 1 to 7 bedrooms"
-        one_three_bedroom_single_tenant_shared: "A shared house with less than two tenants must have 1 to 3 bedrooms"
       prevten:
         non_temp_accommodation: "Answer cannot be non-temporary accommodation as you already told us this is a re-let to tenant who occupied the same property as temporary accommodation"
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe CaseLog do
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
+    it "validates bedroom number" do
+      expect {
+        described_class.create!(unittype_gn: "Shared house",
+                                beds: 0,
+                                owning_organisation: owning_organisation,
+                                managing_organisation: managing_organisation)
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     context "when a reasonable preference is set to yes" do
       it "validates that previously homeless should be selected" do
         expect {
@@ -297,55 +306,6 @@ RSpec.describe CaseLog do
             owning_organisation: owning_organisation,
             managing_organisation: managing_organisation,
           )
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when validating shared accommodation bedrooms" do
-      it "checks you must have more than zero bedrooms" do
-        expect {
-          described_class.create!(unittype_gn: "Shared house",
-                                  beds: 0,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "checks you must answer less than 8 bedrooms" do
-        expect {
-          described_class.create!(unittype_gn: "Shared bungalow",
-                                  beds: 8,
-                                  other_hhmemb: 1,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "checks you must answer less than 4 bedrooms" do
-        expect {
-          described_class.create!(unittype_gn: "Shared bungalow",
-                                  beds: 4,
-                                  other_hhmemb: 0,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "checks a bedsit cannot have more than one room" do
-        expect {
-          described_class.create!(unittype_gn: "Bedsit",
-                                  beds: 2,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "checks a bedsit cannot be less than one room" do
-        expect {
-          described_class.create!(unittype_gn: "Bedsit",
-                                  beds: 0,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
         }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
@@ -779,24 +739,6 @@ RSpec.describe CaseLog do
             managing_organisation: managing_organisation,
           )
         }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when validating type of unit" do
-      it "Cannot be bedsit if no of bedrooms is greater than 1" do
-        expect {
-          described_class.create!(unittype_gn: "Bedsit",
-                                  beds: 2,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect {
-          described_class.create!(unittype_gn: "Bedsit",
-                                  beds: 1,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.not_to raise_error
       end
     end
 

--- a/spec/models/validations/property_validations_spec.rb
+++ b/spec/models/validations/property_validations_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe Validations::PropertyValidations do
 
   let(:property_validator_class) { Class.new { include Validations::PropertyValidations } }
   let(:record) { FactoryBot.create(:case_log) }
-  let(:expected_error) { I18n.t("validations.property.offered.relet_number") }
 
   describe "#validate_property_number_of_times_relet" do
+    let(:expected_error) { I18n.t("validations.property.offered.relet_number") }
+
     it "does not add an error if the record offered is missing" do
       record.offered = nil
       property_validator.validate_property_number_of_times_relet(record)
@@ -35,6 +36,93 @@ RSpec.describe Validations::PropertyValidations do
       property_validator.validate_property_number_of_times_relet(record)
       expect(record.errors).not_to be_empty
       expect(record.errors["offered"]).to include(match(expected_error))
+    end
+  end
+
+  describe "#validate_shared_housing_rooms" do
+    context "when number of bedrooms has not been answered" do
+      it "does not add an error" do
+        record.beds = nil
+        record.unittype_gn = "Bedsit"
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context "when unit type is shared and number of bedrooms has not been answered" do
+      it "does not add an error" do
+        record.beds = nil
+        record.unittype_gn = "Shared bungalow"
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context "when unit type has not been answered" do
+      it "does not add an error" do
+        record.beds = 2
+        record.unittype_gn = nil
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context "when a bedsit has more than 1 bedroom" do
+      let(:expected_error) { I18n.t("validations.property.unittype_gn.one_bedroom_bedsit") }
+
+      it "adds an error" do
+        record.beds = 2
+        record.unittype_gn = "Bedsit"
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors["unittype_gn"]).to include(match(expected_error))
+      end
+    end
+
+    context "when a bedsit has less than 1 bedroom" do
+      let(:expected_error) { I18n.t("validations.property.unittype_gn.one_bedroom_bedsit") }
+
+      it "adds an error" do
+        record.beds = 0
+        record.unittype_gn = "Bedsit"
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors["unittype_gn"]).to include(match(expected_error))
+      end
+    end
+
+    context "when shared housing has more than 7 bedrooms" do
+      let(:expected_error) { I18n.t("validations.property.unittype_gn.one_seven_bedroom_shared") }
+
+      it "adds an error if the number of bedrooms is not between 1 and 7" do
+        record.beds = 8
+        record.unittype_gn = "Shared house"
+        record.other_hhmemb = 2
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors["unittype_gn"]).to include(match(expected_error))
+      end
+    end
+
+    context "when shared housing has less than 1 bedrooms" do
+      let(:expected_error) { I18n.t("validations.property.unittype_gn.one_seven_bedroom_shared") }
+
+      it "adds an error if the number of bedrooms is not between 1 and 7" do
+        record.beds = 0
+        record.unittype_gn = "Shared house"
+        record.other_hhmemb = 2
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors["unittype_gn"]).to include(match(expected_error))
+      end
+    end
+
+    context "when there are too many bedrooms for the number of household members and unit type" do
+      let(:expected_error) { I18n.t("validations.property.unittype_gn.one_three_bedroom_single_tenant_shared") }
+
+      it "adds an error" do
+        record.beds = 4
+        record.unittype_gn = "Shared house"
+        record.other_hhmemb = 0
+        property_validator.validate_shared_housing_rooms(record)
+        expect(record.errors["unittype_gn"]).to include(match(expected_error))
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes bug where if you select Shared house or Shared bungalow you can't progress because it expects a bedroom number between 1 and 7 and you haven't answered that question yet.