### PR TITLE
Fix tenancy validations

### DIFF
--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -8,7 +8,7 @@ module Validations::TenancyValidations
     is_ast = record.tenancy == "Assured Shorthold"
     conditions = [
       { condition: !(is_secure || is_ast) && is_present, error: I18n.t("validations.tenancy.length.fixed_term_not_required") },
-      { condition: (is_ast && !is_in_range) && is_present,  error: I18n.t("validations.tenancy.length.shorthold") },
+      { condition: (is_ast && !is_in_range) && is_present, error: I18n.t("validations.tenancy.length.shorthold") },
       { condition: is_secure && (!is_in_range && is_present), error: I18n.t("validations.tenancy.length.secure") },
     ]
 

--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -12,7 +12,12 @@ module Validations::TenancyValidations
       { condition: is_secure && (!is_in_range && is_present), error: I18n.t("validations.tenancy.length.secure") },
     ]
 
-    conditions.each { |condition| condition[:condition] ? (record.errors.add :tenancylength, condition[:error]) : nil }
+    conditions.each do |condition|
+      next unless condition[:condition]
+
+      record.errors.add :tenancylength, condition[:error]
+      record.errors.add :tenancy, condition[:error]
+    end
   end
 
   def validate_other_tenancy_type(record)

--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -8,7 +8,7 @@ module Validations::TenancyValidations
     is_ast = record.tenancy == "Assured Shorthold"
     conditions = [
       { condition: !(is_secure || is_ast) && is_present, error: I18n.t("validations.tenancy.length.fixed_term_not_required") },
-      { condition: is_ast && !is_in_range,  error: I18n.t("validations.tenancy.length.shorthold") },
+      { condition: (is_ast && !is_in_range) && is_present,  error: I18n.t("validations.tenancy.length.shorthold") },
       { condition: is_secure && (!is_in_range && is_present), error: I18n.t("validations.tenancy.length.secure") },
     ]
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe CaseLog do
       end
     end
 
-    context "when validaiting fixed term tenancy" do
+    context "when validating fixed term tenancy" do
       it "Must not be completed if Type of main tenancy is not responded with either Secure or Assured shorthold " do
         expect {
           described_class.create!(tenancy: "Other",
@@ -405,59 +405,6 @@ RSpec.describe CaseLog do
                                   owning_organisation: owning_organisation,
                                   managing_organisation: managing_organisation)
         }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "Must be completed and between 2 and 99 if type of tenancy is Assured shorthold" do
-        expect {
-          described_class.create!(tenancy: "Assured Shorthold",
-                                  tenancylength: 1,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect {
-          described_class.create!(tenancy: "Assured Shorthold",
-                                  tenancylength: nil,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect {
-          described_class.create!(tenancy: "Assured Shorthold",
-                                  tenancylength: 2,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.not_to raise_error
-      end
-
-      it "Must be empty or between 2 and 99 if type of tenancy is Secure" do
-        expect {
-          described_class.create!(tenancy: "Secure (including flexible)",
-                                  tenancylength: 1,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect {
-          described_class.create!(tenancy: "Secure (including flexible)",
-                                  tenancylength: 100,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect {
-          described_class.create!(tenancy: "Secure (including flexible)",
-                                  tenancylength: nil,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.not_to raise_error
-
-        expect {
-          described_class.create!(tenancy: "Secure (including flexible)",
-                                  tenancylength: 2,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.not_to raise_error
       end
     end
 

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Validations::TenancyValidations do
         it "tenancy length should not be present" do
           record.tenancy = "Other"
           record.tenancylength = 10
-          subject.validate_fixed_term_tenancy(record)
+          tenancy_validator.validate_fixed_term_tenancy(record)
           expect(record.errors["tenancylength"]).to include(match(expected_error))
           expect(record.errors["tenancy"]).to include(match(expected_error))
         end
@@ -27,7 +27,7 @@ RSpec.describe Validations::TenancyValidations do
           it "adds an error" do
             record.tenancy = "Assured Shorthold"
             record.tenancylength = 1
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end
@@ -37,7 +37,7 @@ RSpec.describe Validations::TenancyValidations do
           it "adds an error" do
             record.tenancy = "Assured Shorthold"
             record.tenancylength = 100
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end
@@ -47,7 +47,7 @@ RSpec.describe Validations::TenancyValidations do
           it "does not add an error" do
             record.tenancy = "Assured Shorthold"
             record.tenancylength = 3
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty
           end
@@ -57,7 +57,7 @@ RSpec.describe Validations::TenancyValidations do
           it "does not add an error" do
             record.tenancy = "Assured Shorthold"
             record.tenancylength = nil
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty
           end
@@ -71,7 +71,7 @@ RSpec.describe Validations::TenancyValidations do
           it "adds an error" do
             record.tenancy = "Secure (including flexible)"
             record.tenancylength = 1
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end
@@ -81,7 +81,7 @@ RSpec.describe Validations::TenancyValidations do
           it "adds an error" do
             record.tenancy = "Secure (including flexible)"
             record.tenancylength = 100
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end
@@ -91,7 +91,7 @@ RSpec.describe Validations::TenancyValidations do
           it "does not add an error" do
             record.tenancy = "Secure (including flexible)"
             record.tenancylength = 3
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty
           end
@@ -101,7 +101,7 @@ RSpec.describe Validations::TenancyValidations do
           it "does not add an error" do
             record.tenancy = "Secure (including flexible)"
             record.tenancylength = nil
-            subject.validate_fixed_term_tenancy(record)
+            tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty
           end

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -44,9 +44,19 @@ RSpec.describe Validations::TenancyValidations do
         end
 
         context "when tenancy length is between 2-99" do
-          it "adds an error" do
+          it "does not add an error" do
             record.tenancy = "Assured Shorthold"
             record.tenancylength = 3
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to be_empty
+            expect(record.errors["tenancy"]).to be_empty
+          end
+        end
+
+        context "when tenancy length has not been answered" do
+          it "does not add an error" do
+            record.tenancy = "Assured Shorthold"
+            record.tenancylength = nil
             subject.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty
@@ -78,9 +88,19 @@ RSpec.describe Validations::TenancyValidations do
         end
 
         context "when tenancy length is between 2-99" do
-          it "adds an error" do
+          it "does not add an error" do
             record.tenancy = "Secure (including flexible)"
             record.tenancylength = 3
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to be_empty
+            expect(record.errors["tenancy"]).to be_empty
+          end
+        end
+
+        context "when tenancy length has not been answered" do
+          it "does not add an error" do
+            record.tenancy = "Secure (including flexible)"
+            record.tenancylength = nil
             subject.validate_fixed_term_tenancy(record)
             expect(record.errors["tenancylength"]).to be_empty
             expect(record.errors["tenancy"]).to be_empty

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe Validations::TenancyValidations do
+  subject(:tenancy_validator) { validator_class.new }
+
+  let(:validator_class) { Class.new { include Validations::TenancyValidations } }
+  let(:record) { FactoryBot.create(:case_log) }
+
+  describe "#validate_fixed_term_tenancy" do
+    context "when fixed term tenancy" do
+      context "when type of tenancy is not assured or assured shorthold" do
+        let(:expected_error) { I18n.t("validations.tenancy.length.fixed_term_not_required") }
+
+        it "tenancy length should not be present" do
+          record.tenancy = "Other"
+          record.tenancylength = 10
+          subject.validate_fixed_term_tenancy(record)
+          expect(record.errors["tenancylength"]).to include(match(expected_error))
+          expect(record.errors["tenancy"]).to include(match(expected_error))
+        end
+      end
+
+      context "when type of tenancy is assured shorthold" do
+        let(:expected_error) { I18n.t("validations.tenancy.length.shorthold") }
+
+        context "when tenancy length is greater than 1" do
+          it "adds an error" do
+            record.tenancy = "Assured Shorthold"
+            record.tenancylength = 1
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to include(match(expected_error))
+            expect(record.errors["tenancy"]).to include(match(expected_error))
+          end
+        end
+
+        context "when tenancy length is less than 100" do
+          it "adds an error" do
+            record.tenancy = "Assured Shorthold"
+            record.tenancylength = 100
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to include(match(expected_error))
+            expect(record.errors["tenancy"]).to include(match(expected_error))
+          end
+        end
+
+        context "when tenancy length is between 2-99" do
+          it "adds an error" do
+            record.tenancy = "Assured Shorthold"
+            record.tenancylength = 3
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to be_empty
+            expect(record.errors["tenancy"]).to be_empty
+          end
+        end
+      end
+
+      context "when type of tenancy is secure" do
+        let(:expected_error) { I18n.t("validations.tenancy.length.secure") }
+
+        context "when tenancy length is greater than 1" do
+          it "adds an error" do
+            record.tenancy = "Secure (including flexible)"
+            record.tenancylength = 1
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to include(match(expected_error))
+            expect(record.errors["tenancy"]).to include(match(expected_error))
+          end
+        end
+
+        context "when tenancy length is less than 100" do
+          it "adds an error" do
+            record.tenancy = "Secure (including flexible)"
+            record.tenancylength = 100
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to include(match(expected_error))
+            expect(record.errors["tenancy"]).to include(match(expected_error))
+          end
+        end
+
+        context "when tenancy length is between 2-99" do
+          it "adds an error" do
+            record.tenancy = "Secure (including flexible)"
+            record.tenancylength = 3
+            subject.validate_fixed_term_tenancy(record)
+            expect(record.errors["tenancylength"]).to be_empty
+            expect(record.errors["tenancy"]).to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes two bugs:

1. Tenancy validation is a compound validation - it validates that the tenancy type and tenancy length are valid together but we were only adding the error to the length field so if you made the incompatible change on the tenancy type page you wouldn't see the error. This PR adds it to both.

2. For assured shorthold tenancy it was trying to validate the length before you answered length (meaning if you picked assured shorthold you couldn't click save and continue to progress to the next question). This PR fixes that.