### PR TITLE
Refactor validation specs

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -6,6 +6,7 @@ module Validations::HouseholdValidations
   def validate_reasonable_preference(record)
     if record.homeless == "No" && record.reasonpref == "Yes"
       record.errors.add :reasonpref, I18n.t("validations.household.reasonpref.not_homeless")
+      record.errors.add :homeless, I18n.t("validations.household.reasonpref.not_homeless")
     elsif record.reasonpref == "No"
       if [record.rp_homeless, record.rp_insan_unsat, record.rp_medwel, record.rp_hardship, record.rp_dontknow].any? { |a| a == "Yes" }
         record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonable_preference_reason.reason_not_required")

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe CaseLog do
   end
 
   describe "#new" do
+    context "when creating a record" do
+      let(:case_log) do
+        described_class.create(
+          owning_organisation: owning_organisation,
+          managing_organisation: managing_organisation,
+        )
+      end
+
+      it "attaches the correct custom validator" do
+        expect(case_log._validators.values.flatten.map(&:class))
+          .to include(CaseLogValidator)
+      end
+    end
+
     # TODO: replace these with validator specs and checks for method call here
     context "when a reasonable preference is set to yes" do
       it "validates that previously homeless should be selected" do

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -33,43 +33,6 @@ RSpec.describe CaseLog do
     end
 
     # TODO: replace these with validator specs and checks for method call here
-    context "when a reasonable preference is set to yes" do
-      it "validates that previously homeless should be selected" do
-        expect {
-          described_class.create!(
-            homeless: "No",
-            reasonpref: "Yes",
-            owning_organisation: owning_organisation,
-            managing_organisation: managing_organisation,
-          )
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when a reasonable preference is set to no" do
-      it "validates no reason is needed" do
-        expect {
-          described_class.create!(
-            reasonpref: "No",
-            rp_homeless: "No",
-            owning_organisation: owning_organisation,
-            managing_organisation: managing_organisation,
-          )
-        }.not_to raise_error
-      end
-
-      it "validates that no reason has been provided" do
-        expect {
-          described_class.create!(
-            reasonpref: "No",
-            rp_medwel: "Yes",
-            owning_organisation: owning_organisation,
-            managing_organisation: managing_organisation,
-          )
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
     context "with a reason for leaving last settled home validation" do
       it "checks the reason for leaving must be don’t know if reason for leaving settled home (Q9a) is don’t know." do
         expect {
@@ -756,6 +719,10 @@ RSpec.describe CaseLog do
 
     it "validates the net income" do
       expect(validator).to receive(:validate_net_income)
+    end
+
+    it "validates reasonable preference" do
+      expect(validator).to receive(:validate_reasonable_preference)
     end
   end
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -76,46 +76,6 @@ RSpec.describe CaseLog do
     end
 
     context "when validating pregnancy questions" do
-      it "Cannot answer yes if no female tenants" do
-        expect {
-          described_class.create!(preg_occ: "Yes",
-                                  sex1: "Male",
-                                  age1: 20,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "Cannot answer yes if no female tenants within age range" do
-        expect {
-          described_class.create!(preg_occ: "Yes",
-                                  sex1: "Female",
-                                  age1: 51,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "Cannot answer prefer not to say if no valid tenants" do
-        expect {
-          described_class.create!(preg_occ: "Prefer not to say",
-                                  sex1: "Male",
-                                  age1: 20,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "Can answer yes if valid tenants" do
-        expect {
-          described_class.create!(preg_occ: "Yes",
-                                  sex1: "Female",
-                                  age1: 20,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
-        }.not_to raise_error
-      end
-
       it "Can answer yes if valid second tenant" do
         expect {
           described_class.create!(preg_occ: "Yes",

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CaseLog do
   end
 
   describe "#new" do
+    # TODO: replace these with validator specs and checks for method call here
     context "when a reasonable preference is set to yes" do
       it "validates that previously homeless should be selected" do
         expect {
@@ -707,6 +708,7 @@ RSpec.describe CaseLog do
         check_rsnvac_referral_validation("Health service")
       end
     end
+    # END TODO
   end
 
   describe "#update" do

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -18,26 +18,6 @@ RSpec.describe CaseLog do
   end
 
   describe "#new" do
-    it "raises an error when offered is present and invalid" do
-      expect {
-        described_class.create!(
-          offered: "random",
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it "raises an error when previous_postcode is present and invalid" do
-      expect {
-        described_class.create!(
-          previous_postcode: "invalid_postcode",
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid, /#{I18n.t("validations.postcode")}/)
-    end
-
     it "validates age is a number" do
       expect {
         described_class.create!(
@@ -86,15 +66,6 @@ RSpec.describe CaseLog do
           owning_organisation: owning_organisation,
           managing_organisation: managing_organisation,
         )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it "validates bedroom number" do
-      expect {
-        described_class.create!(unittype_gn: "Shared house",
-                                beds: 0,
-                                owning_organisation: owning_organisation,
-                                managing_organisation: managing_organisation)
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
@@ -353,17 +324,6 @@ RSpec.describe CaseLog do
             owning_organisation: owning_organisation,
             managing_organisation: managing_organisation,
           )
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when validating fixed term tenancy" do
-      it "Must not be completed if Type of main tenancy is not responded with either Secure or Assured shorthold " do
-        expect {
-          described_class.create!(tenancy: "Other",
-                                  tenancylength: 10,
-                                  owning_organisation: owning_organisation,
-                                  managing_organisation: managing_organisation)
         }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
@@ -797,6 +757,35 @@ RSpec.describe CaseLog do
         check_rsnvac_referral_validation("Community mental health team")
         check_rsnvac_referral_validation("Health service")
       end
+    end
+  end
+
+  describe "#update" do
+    let(:case_log) { FactoryBot.create(:case_log) }
+    let(:validator) { case_log._validators[nil].first }
+
+    after do
+      case_log.update(age1: 25)
+    end
+
+    it "validates bedroom number" do
+      expect(validator).to receive(:validate_shared_housing_rooms)
+    end
+
+    it "validates number of times the property has been relet" do
+      expect(validator).to receive(:validate_property_number_of_times_relet)
+    end
+
+    it "validates tenancy length for tenancy type" do
+      expect(validator).to receive(:validate_fixed_term_tenancy)
+    end
+
+    it "validates the previous postcode" do
+      expect(validator).to receive(:validate_previous_accommodation_postcode)
+    end
+
+    it "validates the net income" do
+      expect(validator).to receive(:validate_net_income)
     end
   end
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -18,57 +18,6 @@ RSpec.describe CaseLog do
   end
 
   describe "#new" do
-    it "validates age is a number" do
-      expect {
-        described_class.create!(
-          age1: "random",
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-      expect {
-        described_class.create!(
-          age3: "random",
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it "validates age is under 120" do
-      expect {
-        described_class.create!(
-          age1: 121,
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-      expect {
-        described_class.create!(
-          age3: 121,
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it "validates age is over 0" do
-      expect {
-        described_class.create!(
-          age1: 0,
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-      expect {
-        described_class.create!(
-          age3: 0,
-          owning_organisation: owning_organisation,
-          managing_organisation: managing_organisation,
-        )
-      }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
     context "when a reasonable preference is set to yes" do
       it "validates that previously homeless should be selected" do
         expect {
@@ -766,6 +715,11 @@ RSpec.describe CaseLog do
 
     after do
       case_log.update(age1: 25)
+    end
+
+    it "validates ages" do
+      expect(validator).to receive(:validate_person_1_age)
+      expect(validator).to receive(:validate_household_number_of_other_members)
     end
 
     it "validates bedroom number" do

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Validations::HouseholdValidations do
       context "when reasonable preference is given" do
         context "when the tenant was previously homeless" do
           it "does not add an error" do
-            record.homeless = "Yes - other homelessness"
+            record.homeless = "Other homeless - not found statutorily homeless but considered homeless by landlord"
             record.reasonpref = "Yes"
             household_validator.validate_reasonable_preference(record)
             expect(record.errors["reasonpref"]).to be_empty

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Validations::HouseholdValidations do
+  subject(:household_validator) { validator_class.new }
+
+  let(:validator_class) { Class.new { include Validations::HouseholdValidations } }
+  let(:record) { FactoryBot.create(:case_log) }
+
+  describe "age validations" do
+    it "validates that person 1's age is a number" do
+      record.age1 = "random"
+      household_validator.validate_person_1_age(record)
+      expect(record.errors["age1"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 16))
+    end
+
+    it "validates that other household member ages are a number" do
+      record.age3 = "random"
+      household_validator.validate_household_number_of_other_members(record)
+      expect(record.errors["age3"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 1))
+    end
+
+    it "validates that person 1's age is greater than 16" do
+      record.age1 = 15
+      household_validator.validate_person_1_age(record)
+      expect(record.errors["age1"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 16))
+    end
+
+    it "validates that other household member ages are greater than 1" do
+      record.age4 = 0
+      household_validator.validate_household_number_of_other_members(record)
+      expect(record.errors["age4"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 1))
+    end
+
+    it "validates that person 1's age is less than 121" do
+      record.age1 = 121
+      household_validator.validate_person_1_age(record)
+      expect(record.errors["age1"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 16))
+    end
+
+    it "validates that other household member ages are greater than 121" do
+      record.age4 = 123
+      household_validator.validate_household_number_of_other_members(record)
+      expect(record.errors["age4"])
+        .to include(match I18n.t("validations.household.age.must_be_valid", lower_bound: 1))
+    end
+  end
+end

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -110,4 +110,59 @@ RSpec.describe Validations::HouseholdValidations do
       end
     end
   end
+
+  describe "pregnancy validations" do
+    context "when there are no female tenants" do
+      it "validates that pregnancy cannot be yes" do
+        record.preg_occ = "Yes"
+        record.sex1 = "Male"
+        household_validator.validate_pregnancy(record)
+        expect(record.errors["preg_occ"])
+          .to include(match I18n.t("validations.household.preg_occ.no_female"))
+      end
+
+      it "validates that pregnancy cannot be prefer not to say" do
+        record.preg_occ = "Prefer not to say"
+        record.sex1 = "Male"
+        household_validator.validate_pregnancy(record)
+        expect(record.errors["preg_occ"])
+          .to include(match I18n.t("validations.household.preg_occ.no_female"))
+      end
+    end
+
+    context "when there are female tenants" do
+      context "but they are older than 50" do
+        it "validates that pregnancy cannot be yes" do
+          record.preg_occ = "Yes"
+          record.sex1 = "Female"
+          record.age1 = "51"
+          household_validator.validate_pregnancy(record)
+          expect(record.errors["preg_occ"])
+            .to include(match I18n.t("validations.household.preg_occ.no_female"))
+        end
+      end
+
+      context "and they are the main tenant and under 51" do
+        it "pregnancy can be yes" do
+          record.preg_occ = "Yes"
+          record.sex1 = "Female"
+          record.age1 = "32"
+          household_validator.validate_pregnancy(record)
+          expect(record.errors["preg_occ"]).to be_empty
+        end
+      end
+
+      context "and they are another household member and under 51" do
+        it "pregnancy can be yes" do
+          record.preg_occ = "Yes"
+          record.sex1 = "Male"
+          record.age1 = 25
+          record.sex3 = "Female"
+          record.age3 = "32"
+          household_validator.validate_pregnancy(record)
+          expect(record.errors["preg_occ"]).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Validations::HouseholdValidations do
             household_validator.validate_reasonable_preference(record)
             expect(record.errors["reasonpref"]).to be_empty
             expect(record.errors["homeless"]).to be_empty
-            record.homeless = "Yes - assessed as homeless by a local authority and owed a homelessness duty. Including if threatened with homelessness within 56 days"
+            record.homeless = "Assessed as homeless (or threatened with homelessness within 56 days) by a local authority and owed a homelessness duty"
             household_validator.validate_reasonable_preference(record)
             expect(record.errors["reasonpref"]).to be_empty
             expect(record.errors["homeless"]).to be_empty


### PR DESCRIPTION
The idea here is to make the tests smaller units since the Case Log spec at the moment does a lot and is large. 

This would mean that when testing validations, the case log spec is only responsible for checking that the correct validation methods are called while the individual Validator class specs are responsible for testing the actual logic and edge cases of those validations.