### PR TITLE
Rake task to export routes as CSV

### DIFF
--- a/lib/tasks/routes_export.rake
+++ b/lib/tasks/routes_export.rake
@@ -1,0 +1,35 @@
+namespace :route_formatter do
+  desc "Export routes as CSV"
+  task csv: :environment do |t|
+    class CSVFormatter
+      def initialize
+        @buffer= []
+      end
+
+      def result
+        @buffer.join("\n")
+      end
+
+      def section_title(title)
+      end
+
+      def section(routes)
+        routes.each do |r|
+          @buffer << [r[:name], r[:verb], r[:path], r[:reqs]].join(",")
+        end
+      end
+
+      def header(routes)
+        @buffer << %w"Prefix Verb URI_Pattern Controller#Action".join(",")
+      end
+
+      def no_routes
+        @buffer << ""
+      end
+    end
+    require "action_dispatch/routing/inspector"
+    all_routes = Rails.application.routes.routes
+    inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
+    puts inspector.format(CSVFormatter.new)
+  end
+end


### PR DESCRIPTION
Useful Rake task to export all routes to CSV; useful for auditing URLs used by the service.

```bash
bin/rails route_formatter:csv

# Or run task and copy to clipboard, and you can paste to csv file
bin/rails route_formatter:csv | pbcopy
```