### PR TITLE
Cldc 629 household situation renewal

### DIFF
--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -29,7 +29,8 @@ module TasklistHelper
     path = if subsection.is_started?(case_log)
              "case_log_#{subsection.id}_check_answers_path"
            else
-             "case_log_#{subsection.pages.first.id}_path"
+             next_page = subsection.pages.first.routed_to?(case_log) ? subsection.pages.first.id : case_log.form.next_page(subsection.pages.first, case_log)
+             "case_log_#{next_page}_path"
            end
     send(path, case_log)
   end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -25,7 +25,7 @@ module TasklistHelper
     case_log.form.subsections.count { |subsection| subsection.status(case_log) == status }
   end
 
-  def first_page_or_check_answers(subsection, case_log)
+  def next_page_or_check_answers(subsection, case_log)
     path = if subsection.is_started?(case_log)
              "case_log_#{subsection.id}_check_answers_path"
            else
@@ -37,7 +37,7 @@ module TasklistHelper
 
   def subsection_link(subsection, case_log)
     if subsection.status(case_log) != :cannot_start_yet
-      next_page_path = first_page_or_check_answers(subsection, case_log).to_s
+      next_page_path = next_page_or_check_answers(subsection, case_log).to_s
       govuk_link_to(subsection.label, next_page_path.dasherize, aria: { describedby: subsection.id.dasherize })
     else
       subsection.label

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -100,6 +100,7 @@ class CaseLog < ApplicationRecord
   enum cbl: POLAR, _suffix: true
   enum chr: POLAR, _suffix: true
   enum cap: POLAR, _suffix: true
+  enum letting_allocation_unknown: POLAR, _suffix: true
   enum wchair: POLAR2, _suffix: true
   enum incfreq: INCFREQ, _suffix: true
   enum benefits: BENEFITS, _suffix: true

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -256,7 +256,14 @@ private
     self.nocharge = household_charge == "Yes" ? "No" : "Yes"
     self.layear = "Less than 1 year" if renewal == "Yes"
     self.underoccupation_benefitcap = "No" if renewal == "Yes" && year == 2021
-    self.homeless = "No" if renewal == "Yes"
+    if renewal == "Yes"
+      self.homeless = "No"
+      self.referral = "Internal transfer"
+    end
+    if needstype == "General needs"
+      self.prevten = "Fixed-term private registered provider (PRP) general needs tenancy" if managing_organisation.provider_type == "PRP"
+      self.prevten = "Fixed-term local authority general needs tenancy" if managing_organisation.provider_type == "LA"
+    end
   end
 
   def process_postcode_changes!

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -114,7 +114,7 @@ class Form
   end
 
   def invalidated_page_questions(case_log)
-    #we're already treating address fields as a special case and reset their values upon saving a case_log
+    # we're already treating address fields as a special case and reset their values upon saving a case_log
     address_questions = %w[postcode_known la previous_postcode_known prevloc property_postcode previous_postcode]
     pages_that_are_routed_to = pages.select { |p| p.routed_to?(case_log) }
     enabled_question_ids = pages_that_are_routed_to.flat_map(&:questions).map(&:id) || []

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -114,9 +114,11 @@ class Form
   end
 
   def invalidated_page_questions(case_log)
+    #we're already treating address fields as a special case and reset their values upon saving a case_log
+    address_questions = %w[postcode_known la previous_postcode_known prevloc property_postcode previous_postcode]
     pages_that_are_routed_to = pages.select { |p| p.routed_to?(case_log) }
     enabled_question_ids = pages_that_are_routed_to.flat_map(&:questions).map(&:id) || []
-    invalidated_pages(case_log).flat_map(&:questions).reject { |q| enabled_question_ids.include?(q.id) } || []
+    invalidated_pages(case_log).flat_map(&:questions).reject { |q| enabled_question_ids.include?(q.id) || address_questions.include?(q.id) } || []
   end
 
   def invalidated_conditional_questions(case_log)

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1146,7 +1146,8 @@
                     }
                   }
                 }
-              }
+              },
+              "depends_on":  [{ "renewal": "No" }]
             },
             "time_on_la_waiting_list": {
               "header": "",
@@ -1314,7 +1315,28 @@
                   "hint_text": "",
                   "type": "text"
                 }
-              }
+              },
+              "depends_on": [{ "renewal": "No" }]
+            },
+            "reason_for_leaving_last_settled_home_renewal": {
+              "header": "Leaving their last settled home",
+              "description": "",
+              "questions": {
+                "reason": {
+                  "header": "What is the tenant’s main reason for the household leaving their last settled home?",
+                  "hint_text": "",
+                  "type": "radio",
+                  "answer_options": {
+                    "0": {
+                      "value": "End of fixed term tenancy - no fault"
+                    },
+                    "1": {
+                      "value": "End of assured shorthold tenancy - no fault"
+                    }
+                  }
+                }
+              },
+              "depends_on": [{ "renewal": "Yes" }]
             },
             "previous_housing_situation": {
               "header": "",
@@ -1396,7 +1418,28 @@
                     }
                   }
                 }
-              }
+              },
+              "depends_on": [{ "renewal": "No" }]
+            },
+            "previous_housing_situation_renewal": {
+              "header": "",
+              "description": "",
+              "questions": {
+                "prevten": {
+                  "header": "Where was the household immediately before this letting?",
+                  "hint_text": "",
+                  "type": "radio",
+                  "answer_options": {
+                    "0": {
+                      "value": "Supported housing"
+                    },
+                    "1": {
+                      "value": "Sheltered accommodation"
+                    }
+                  }
+                }
+              },
+              "depends_on": [{ "renewal": "Yes", "needstype": "Supported housing" }]
             },
             "underoccupation_benefitcap": {
               "header": "",
@@ -1427,7 +1470,8 @@
                     }
                   }
                 }
-              }
+              },
+              "depends_on": [{ "renewal": "No" }]
             },
             "homelessness": {
               "header": "",
@@ -1449,7 +1493,8 @@
                     }
                   }
                 }
-              }
+              },
+              "depends_on": [{ "renewal": "No" }]
             },
             "previous_postcode": {
               "header": "",
@@ -2044,7 +2089,8 @@
               "depends_on": [
                 {
                   "managing_organisation.provider_type": "LA",
-                  "needstype": "General needs"
+                  "needstype": "General needs",
+                  "referral": "No"
                 }
               ]
             },
@@ -2100,7 +2146,8 @@
               "depends_on": [
                 {
                   "managing_organisation.provider_type": "PRP",
-                  "needstype": "General needs"
+                  "needstype": "General needs",
+                  "referral": "No"
                 }
               ]
             },
@@ -2156,7 +2203,8 @@
               "depends_on": [
                 {
                   "managing_organisation.provider_type": "LA",
-                  "needstype": "Supported housing"
+                  "needstype": "Supported housing",
+                  "referral": "No"
                 }
               ]
             },
@@ -2215,7 +2263,8 @@
               "depends_on": [
                 {
                   "managing_organisation.provider_type": "PRP",
-                  "needstype": "Supported housing"
+                  "needstype": "Supported housing",
+                  "referral": "No"
                 }
               ]
             }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -2095,7 +2095,7 @@
                 {
                   "managing_organisation.provider_type": "LA",
                   "needstype": "General needs",
-                  "referral": "No"
+                  "renewal": "No"
                 }
               ]
             },
@@ -2152,7 +2152,7 @@
                 {
                   "managing_organisation.provider_type": "PRP",
                   "needstype": "General needs",
-                  "referral": "No"
+                  "renewal": "No"
                 }
               ]
             },
@@ -2209,7 +2209,7 @@
                 {
                   "managing_organisation.provider_type": "LA",
                   "needstype": "Supported housing",
-                  "referral": "No"
+                  "renewal": "No"
                 }
               ]
             },
@@ -2269,7 +2269,7 @@
                 {
                   "managing_organisation.provider_type": "PRP",
                   "needstype": "Supported housing",
-                  "referral": "No"
+                  "renewal": "No"
                 }
               ]
             }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1112,7 +1112,7 @@
               "description": "",
               "questions": {
                 "layear": {
-                  "check_answer_label": "How long has the household continuously lived in the local authority area where the new letting is located?",
+                  "check_answer_label": "Length of time in local authority area",
                   "header": "How long has the household continuously lived in the local authority area of the new letting?",
                   "hint_text": "",
                   "type": "radio",
@@ -1154,7 +1154,7 @@
               "description": "",
               "questions": {
                 "lawaitlist": {
-                  "check_answer_label": "How long has the household been on the local authority waiting list where the new letting is located?",
+                  "check_answer_label": "Length of time on local authority waiting list",
                   "header": "How long has the household been on the local authority waiting list for the new letting?",
                   "hint_text": "",
                   "type": "radio",
@@ -1196,6 +1196,7 @@
               "description": "",
               "questions": {
                 "reason": {
+                  "check_answer_label": "Reason for leaving last settled home",
                   "header": "What is the tenant’s main reason for the household leaving their last settled home?",
                   "hint_text": "The tenant’s ’last settled home’ is their last long-standing home. For tenants who were in temporary accommodation or sleeping rough, their last settled home is where they were living previously.",
                   "type": "radio",
@@ -1323,6 +1324,7 @@
               "description": "",
               "questions": {
                 "reason": {
+                  "check_answer_label": "Reason for leaving last settled home",
                   "header": "What is the tenant’s main reason for the household leaving their last settled home?",
                   "hint_text": "",
                   "type": "radio",
@@ -1343,6 +1345,7 @@
               "description": "",
               "questions": {
                 "prevten": {
+                  "check_answer_label": "Where was the household immediately before this letting?",
                   "header": "Where was the household immediately before this letting?",
                   "hint_text": "This is where the household was the night before they moved.",
                   "type": "radio",
@@ -1426,6 +1429,7 @@
               "description": "",
               "questions": {
                 "prevten": {
+                  "check_answer_label": "Where was the household immediately before this letting?",
                   "header": "Where was the household immediately before this letting?",
                   "hint_text": "",
                   "type": "radio",
@@ -1446,6 +1450,7 @@
               "description": "",
               "questions": {
                 "underoccupation_benefitcap": {
+                  "check_answer_label": "Removal of spare room subsidy or benefit cap",
                   "header": "Was the reason for leaving a direct result of the removal of the spare room subsidy or benefit cap introduced from 2013?",
                   "hint_text": "",
                   "type": "radio",
@@ -1478,6 +1483,7 @@
               "description": "",
               "questions": {
                 "homeless": {
+                  "check_answer_label": "Household homeless immediately before letting",
                   "header": "Did the household experience homelessness immediately before this letting?",
                   "hint_text": "",
                   "type": "radio",
@@ -1501,7 +1507,6 @@
               "description": "",
               "questions": {
                 "previous_postcode_known": {
-                  "check_answer_label": "Do you know the postcode of the household’s last settled accommodation?",
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "This is also known as the household’s ’last settled home’.",
                   "type": "radio",
@@ -1515,7 +1520,7 @@
                   "hidden_in_check_answers": true
                 },
                 "previous_postcode": {
-                  "check_answer_label": "Postcode of previous accommodation if the household has moved from settled accommodation",
+                  "check_answer_label": "Postcode of household’s last settled accommodation",
                   "header": "Postcode for the previous accommodation",
                   "hint_text": "",
                   "type": "text",
@@ -1552,7 +1557,7 @@
               "description": "",
               "questions": {
                 "prevloc": {
-                  "check_answer_label": "The LA in which household lived immediately before this letting\t",
+                  "check_answer_label": "Location of household’s last settled accommodation",
                   "header": "Which local authority area did the household live in immediately before this letting?",
                   "hint_text": "Includes temporary accommodation.",
                   "type": "select",
@@ -1953,7 +1958,7 @@
               "description": "",
               "questions": {
                 "reasonpref": {
-                  "check_answer_label": "Was the household given ‘reasonable preference’ by the local authority?",
+                  "check_answer_label": "Household given reasonable preference",
                   "header": "Was the household given ‘reasonable preference’ by the local authority?",
                   "hint_text": "Households may be given ‘reasonable preference’ for social housing, also known as ‘priority need’, by the local authority.",
                   "type": "radio",
@@ -2016,7 +2021,7 @@
               "description": "",
               "questions": {
                 "letting_allocation": {
-                  "check_answer_label": "How was this letting allocated?",
+                  "check_answer_label": "Allocation system",
                   "header": "How was this letting allocated?",
                   "hint_text": "Select all that apply.",
                   "type": "checkbox",

--- a/db/migrate/20220210132254_remove_checkbox_parent_fields.rb
+++ b/db/migrate/20220210132254_remove_checkbox_parent_fields.rb
@@ -11,7 +11,7 @@ class RemoveCheckboxParentFields < ActiveRecord::Migration[7.0]
     change_table :case_logs, bulk: true do |t|
       t.column :accessibility_requirements, :string
       t.column :condition_effects, :string
-      t.remove :reasonable_preference_reason, :string
+      t.column :reasonable_preference_reason, :string
     end
   end
 end

--- a/db/migrate/20220216094400_change_unknown_letting_allocation_type.rb
+++ b/db/migrate/20220216094400_change_unknown_letting_allocation_type.rb
@@ -1,0 +1,15 @@
+class ChangeUnknownLettingAllocationType < ActiveRecord::Migration[7.0]
+  def up
+    change_table :case_logs, bulk: true do |t|
+      t.remove :letting_allocation_unknown
+      t.column :letting_allocation_unknown, :integer
+    end
+  end
+
+  def down
+    change_table :case_logs, bulk: true do |t|
+      t.remove :letting_allocation_unknown
+      t.column :letting_allocation_unknown, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,7 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 202202071123100) do
     t.integer "previous_postcode_known"
     t.integer "previous_la_known"
     t.boolean "is_previous_la_inferred"
-    t.boolean "letting_allocation_unknown"
+    t.integer "letting_allocation_unknown"
     t.index ["managing_organisation_id"], name: "index_case_logs_on_managing_organisation_id"
     t.index ["owning_organisation_id"], name: "index_case_logs_on_owning_organisation_id"
   end

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "Accessible Automcomplete" do
     FactoryBot.create(
       :case_log,
       :in_progress,
+      la_known: "Yes",
+      is_la_inferred: false,
       owning_organisation: user.organisation,
       managing_organisation: user.organisation,
     )

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe "Form Check Answers Page" do
   let(:empty_case_log) do
     FactoryBot.create(
       :case_log,
+      la_known: "Yes",
+      is_la_inferred: false,
       owning_organisation: user.organisation,
       managing_organisation: user.organisation,
     )

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -251,7 +251,13 @@
                       "E06000014": "York"
                     }
                   }
-                }
+                },
+                "depends_on": [
+                  {
+                    "la_known": "Yes",
+                    "is_la_inferred": false
+                  }
+                ]
               },
               "condition_effects": {
                 "questions": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -19,8 +19,15 @@
                     "type": "text",
                     "width": 10
                   }
-                }
-              },
+                },
+                "depends_on": [
+                  {
+                    "housingneeds_a": "Yes"
+                  },
+                  {
+                    "housingneeds_a": null
+                  }
+                ]              },
               "person_1_age": {
                 "questions": {
                   "age1": {

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -37,15 +37,20 @@ RSpec.describe TasklistHelper do
     end
   end
 
-  describe "get_first_page_or_check_answers" do
+  describe "get_next_page_or_check_answers" do
     let(:subsection) { case_log.form.get_subsection("household_characteristics") }
 
     it "returns the check answers page path if the section has been started already" do
-      expect(first_page_or_check_answers(subsection, case_log)).to match(/check-answers/)
+      expect(next_page_or_check_answers(subsection, case_log)).to match(/check-answers/)
     end
 
     it "returns the first question page path for the section if it has not been started yet" do
-      expect(first_page_or_check_answers(subsection, empty_case_log)).to match(/tenant-code/)
+      expect(next_page_or_check_answers(subsection, empty_case_log)).to match(/tenant-code/)
+    end
+
+    it "when first question being not routed to returns the second question link" do
+      empty_case_log.housingneeds_a = "No"
+      expect(next_page_or_check_answers(subsection, empty_case_log)).to match(/person-1-age/)
     end
   end
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -582,10 +582,25 @@ RSpec.describe CaseLog do
         expect(case_log["underoccupation_benefitcap"]).to eq("No")
       end
 
-      it "correctly derives and saves homeless" do
-        record_from_db = ActiveRecord::Base.connection.execute("select homeless from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["homeless"]).to eq(1)
-        expect(case_log["homeless"]).to eq("No")
+      it "correctly derives and saves prevten" do
+        case_log.update!({ needstype: "General needs" })
+
+        record_from_db = ActiveRecord::Base.connection.execute("select prevten from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["prevten"]).to eq(32)
+        expect(case_log["prevten"]).to eq("Fixed-term private registered provider (PRP) general needs tenancy")
+
+        case_log.managing_organisation.update!({ provider_type: "LA" })
+        case_log.update!({ needstype: "General needs" })
+
+        record_from_db = ActiveRecord::Base.connection.execute("select prevten from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["prevten"]).to eq(30)
+        expect(case_log["prevten"]).to eq("Fixed-term local authority general needs tenancy")
+      end
+
+      it "correctly derives and saves referral" do
+        record_from_db = ActiveRecord::Base.connection.execute("select referral from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["referral"]).to eq(1)
+        expect(case_log["referral"]).to eq("Internal transfer")
       end
     end
   end

--- a/spec/models/form/subsection_spec.rb
+++ b/spec/models/form/subsection_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe Form::Subsection, type: :model do
       case_log.armedforces = "No"
       case_log.illness = "No"
       case_log.housingneeds_a = "Yes"
+      case_log.la_known = "Yes"
+      case_log.is_la_inferred = false
       case_log.la = "York"
       case_log.illness_type_1 = "Yes"
       expect(sub_section.answered_questions(case_log).map(&:id)).to eq(expected_questions)

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -278,6 +278,8 @@ RSpec.describe CaseLogsController, type: :request do
         case_log = FactoryBot.create(:case_log,
                                      owning_organisation: organisation,
                                      managing_organisation: organisation,
+                                     la_known: "Yes",
+                                     is_la_inferred: true,
                                      postcode_known: "Yes",
                                      property_postcode: "PO5 3TE")
         id = case_log.id


### PR DESCRIPTION
Implement routing for household situation section
Fix inferring local authority (previously was cleared by `reset_invalidated_dependent_fields`)
Infer relevant fields for the subsection and update the content
