### PR TITLE
Correct logic for void/renewal/handover dates

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -73,11 +73,11 @@
                   "hint_text": "A renewal is a letting to the same tenant in the same property.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
-                      "value": "No"
-                    },
                     "1": {
                       "value": "Yes"
+                    },
+                    "0": {
+                      "value": "No"
                     }
                   }
                 }
@@ -883,8 +883,11 @@
               },
               "depends_on": [
                 {
-                  "rsnvac": "First let of new-build property",
-                  "renewal": "No"
+                  "renewal": "No",
+                  "rsnvac": [
+                    "First let of conversion, rehabilitation or acquired property",
+                    "First let of leased property"
+                  ]
                 }
               ]
             },
@@ -902,10 +905,7 @@
               "depends_on": [
                 {
                   "renewal": "No",
-                  "rsnvac": [
-                    "First let of conversion, rehabilitation or acquired property?",
-                    "First let of leased property"
-                  ]
+                  "rsnvac": "First let of new-build property"
                 }
               ]
             },
@@ -919,11 +919,11 @@
                   "hint_text": "Major repairs are works that could not be reasonably carried out with a tenant living at the property. For example, structural repairs.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
-                      "value": "No"
-                    },
                     "1": {
                       "value": "Yes"
+                    },
+                    "0": {
+                      "value": "No"
                     }
                   },
                   "conditional_for": {
@@ -939,8 +939,11 @@
               },
               "depends_on": [
                 {
-                  "rsnvac": "First let of new-build property",
-                  "renewal": "No"
+                  "renewal": "No",
+                  "rsnvac": [
+                    "First let of conversion, rehabilitation or acquired property",
+                    "First let of leased property"
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
* Correct Yes/No order for renewal question
* Fixes void/renewal/new-build question not being asked
* Shows the new-build handover date question if reason for vacancy is ‘First let of new-build property’
* Shows the void/renewal date and major repairs questions if reason for vacancy is NOT ‘First let of new-build property’

<img width="680" alt="Screenshot 2022-02-17 at 14 56 09" src="https://user-images.githubusercontent.com/813383/154508068-0d99a8ed-dc0c-4045-a222-ec70030ad4f9.png">
