### PR TITLE
Change how we're reseting answers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/tagliala/activeadmin.git
-  revision: a8ce826de172e3604b152d53c41aa68e2015ab80
+  revision: 000dd9425860fbadc72d4e08b893be098f5dff9b
   branch: feature/railties-7
   specs:
     activeadmin (2.10.0)
@@ -111,8 +111,8 @@ GEM
       ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.554.0)
-    aws-sdk-core (3.126.1)
+    aws-partitions (1.556.0)
+    aws-sdk-core (3.126.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -254,11 +254,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.1-arm64-darwin)
+    nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
@@ -274,7 +274,7 @@ GEM
       globalid
       paper_trail (>= 3.0.0)
     parallel (1.21.0)
-    parser (3.1.0.0)
+    parser (3.1.1.0)
       ast (~> 2.4.1)
     pg (1.3.2)
     postcodes_io (0.4.0)
@@ -419,7 +419,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    stimulus-rails (1.0.2)
+    stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.1)
     thor (1.2.1)

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -230,7 +230,7 @@ private
       condition_key = conditions.first[:key]
       condition_value = conditions.first[:value]
       if public_send("#{condition_key}_changed?") && condition_value == public_send(condition_key) && !public_send("#{dependent}_changed?")
-        self.layear = nil
+        self[dependent] = nil
       end
     end
   end

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -219,6 +219,16 @@ private
     form.invalidated_page_questions(self).each do |question|
       public_send("#{question.id}=", nil) if respond_to?(question.id.to_s)
     end
+
+    dependent_questions = { layear: [{ key: :renewal, value: "No" }] }
+
+    dependent_questions.each do |dependent, conditions|
+      condition_key = conditions.first[:key]
+      condition_value = conditions.first[:value]
+      if public_send("#{condition_key}_changed?") && condition_value == public_send(condition_key) && !public_send("#{dependent}_changed?")
+        self.layear = nil
+      end
+    end
   end
 
   def dynamically_not_required
@@ -256,11 +266,11 @@ private
     end
     self.has_benefits = get_has_benefits
     self.nocharge = household_charge == "Yes" ? "No" : "Yes"
-    self.layear = "Less than 1 year" if renewal == "Yes"
     self.underoccupation_benefitcap = "No" if renewal == "Yes" && year == 2021
     if renewal == "Yes"
       self.homeless = "No"
       self.referral = "Internal transfer"
+      self.layear = "Less than 1 year"
     end
     if needstype == "General needs"
       self.prevten = "Fixed-term private registered provider (PRP) general needs tenancy" if managing_organisation.provider_type == "PRP"

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -217,8 +217,8 @@ private
     form.invalidated_page_questions(self).each do |question|
       enabled = form.enabled_page_questions(self)
       contains_selected_answer_option = enabled.map(&:id).include?(question.id) && enabled.find { |q| q.id == question.id }.answer_options.values.map { |x| x["value"] }.include?(public_send(question.id))
-      unless contains_selected_answer_option
-        public_send("#{question.id}=", nil) if respond_to?(question.id.to_s)
+      if !contains_selected_answer_option && respond_to?(question.id.to_s)
+        public_send("#{question.id}=", nil)
       end
     end
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -116,9 +116,12 @@ class Form
   def invalidated_page_questions(case_log)
     # we're already treating address fields as a special case and reset their values upon saving a case_log
     address_questions = %w[postcode_known la previous_postcode_known prevloc property_postcode previous_postcode]
+    invalidated_pages(case_log).flat_map(&:questions).reject { |q| address_questions.include?(q.id) } || []
+  end
+
+  def enabled_page_questions(case_log)
     pages_that_are_routed_to = pages.select { |p| p.routed_to?(case_log) }
-    enabled_question_ids = pages_that_are_routed_to.flat_map(&:questions).map(&:id) || []
-    invalidated_pages(case_log).flat_map(&:questions).reject { |q| enabled_question_ids.include?(q.id) || address_questions.include?(q.id) } || []
+    pages_that_are_routed_to.flat_map(&:questions) || []
   end
 
   def invalidated_conditional_questions(case_log)

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
       net_income_known { "Yes" }
       property_owner_organisation { "Test" }
       property_manager_organisation { "Test" }
-      renewal { 1 }
+      renewal { "No" }
       rent_type { 1 }
       intermediate_rent_product_name { 2 }
       needstype { 1 }

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -97,7 +97,7 @@
     <property_owner_organisation>Test</property_owner_organisation>
     <property_manager_organisation>Test</property_manager_organisation>
     <sale_or_letting/>
-    <renewal>1</renewal>
+    <renewal>No</renewal>
     <rent_type>1</rent_type>
     <intermediate_rent_product_name>2</intermediate_rent_product_name>
     <purchaser_code>798794</purchaser_code>

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -725,7 +725,8 @@
                       }
                     }
                   }
-                }
+                },
+                "depends_on":  [{ "renewal": "No" }]
               },
               "time_on_la_waiting_list": {
                 "questions": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -396,9 +396,6 @@
                     "answer_options": {
                       "0": {
                         "value": "Yes"
-                      },
-                      "1": {
-                        "value": "No"
                       }
                     }
                   }

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -532,8 +532,16 @@ RSpec.describe CaseLog do
     context "with two pages having the same question key, only one's dependency is met" do
       let(:case_log) { FactoryBot.create(:case_log, :in_progress, cbl: "Yes", preg_occ: "No") }
 
-      it "does not clear the answer" do
+      it "does not clear the value for answers that apply to both pages" do
         expect(case_log.cbl).to eq("Yes")
+      end
+
+      it "does clear the value for answers that do not apply for invalidated page" do
+        case_log.update!({ wchair: "Yes", sex2: "Female", age2: 33 })
+        case_log.update!({ cbl: "No"  })
+        case_log.update!({ preg_occ: "Yes" })
+
+        expect(case_log.cbl).to eq(nil)
       end
     end
 
@@ -573,6 +581,7 @@ RSpec.describe CaseLog do
         expect(case_log["layear"]).to eq("1 year but under 2 years")
       end
     end
+
   end
 
   describe "paper trail" do

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe CaseLog do
 
       it "does clear the value for answers that do not apply for invalidated page" do
         case_log.update!({ wchair: "Yes", sex2: "Female", age2: 33 })
-        case_log.update!({ cbl: "No"  })
+        case_log.update!({ cbl: "No" })
         case_log.update!({ preg_occ: "Yes" })
 
         expect(case_log.cbl).to eq(nil)
@@ -581,7 +581,6 @@ RSpec.describe CaseLog do
         expect(case_log["layear"]).to eq("1 year but under 2 years")
       end
     end
-
   end
 
   describe "paper trail" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Form, type: :model do
     end
 
     context "with two pages having the same question and only one has dependencies met" do
-      let(:expected_invalid) { %w[la_known conditional_question_no_second_question dependent_question layear declaration] }
+      let(:expected_invalid) { %w[la_known cbl conditional_question_no_second_question dependent_question layear declaration] }
 
       it "returns an array of question keys whose pages conditions are not met" do
         case_log["preg_occ"] = "No"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Form, type: :model do
 
   describe "invalidated_page_questions" do
     context "when dependencies are not met" do
-      let(:expected_invalid) { %w[la_known cbl conditional_question_no_second_question dependent_question declaration] }
+      let(:expected_invalid) { %w[la_known cbl conditional_question_no_second_question dependent_question layear declaration] }
 
       it "returns an array of question keys whose pages conditions are not met" do
         expect(form.invalidated_page_questions(case_log).map(&:id).uniq).to eq(expected_invalid)
@@ -139,7 +139,7 @@ RSpec.describe Form, type: :model do
     end
 
     context "with two pages having the same question and only one has dependencies met" do
-      let(:expected_invalid) { %w[la_known conditional_question_no_second_question dependent_question declaration] }
+      let(:expected_invalid) { %w[la_known conditional_question_no_second_question dependent_question layear declaration] }
 
       it "returns an array of question keys whose pages conditions are not met" do
         case_log["preg_occ"] = "No"


### PR DESCRIPTION
Reset values for dependant derived questions
Only reset question values if the selected answer is not present in the answer options
