### PR TITLE
Reset more values

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -227,7 +227,7 @@ private
   def reset_derived_questions
     dependent_questions = { layear: [{ key: :renewal, value: "No" }],
                             homeless: [{ key: :renewal, value: "No" }],
-                            referral: [{ key: :renewal, value: "No" }]}
+                            referral: [{ key: :renewal, value: "No" }] }
 
     dependent_questions.each do |dependent, conditions|
       condition_key = conditions.first[:key]

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -225,7 +225,9 @@ private
   end
 
   def reset_derived_questions
-    dependent_questions = { layear: [{ key: :renewal, value: "No" }], homeless: [{ key: :renewal, value: "No" }] }
+    dependent_questions = { layear: [{ key: :renewal, value: "No" }],
+                            homeless: [{ key: :renewal, value: "No" }],
+                            referral: [{ key: :renewal, value: "No" }]}
 
     dependent_questions.each do |dependent, conditions|
       condition_key = conditions.first[:key]
@@ -283,6 +285,7 @@ private
       self.homeless = "No"
       self.referral = "Internal transfer"
       self.layear = "Less than 1 year"
+      self.reasonpref = nil if reasonpref == "Yes"
     end
     if needstype == "General needs"
       self.prevten = "Fixed-term private registered provider (PRP) general needs tenancy" if managing_organisation.provider_type == "PRP"

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -531,6 +531,29 @@ RSpec.describe CaseLog do
         expect(case_log["referral"]).to eq("Internal transfer")
       end
     end
+
+    context "when it is not a renewal" do
+      let!(:case_log) do
+        described_class.create({
+          managing_organisation: organisation,
+          owning_organisation: organisation,
+          renewal: "No",
+          year: 2021,
+        })
+      end
+
+      it "correctly derives and saves reasonpref when changed to renewal" do
+        case_log.update!({ reasonpref: "Yes" })
+        record_from_db = ActiveRecord::Base.connection.execute("select reasonpref from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["reasonpref"]).to eq(1)
+        expect(case_log["reasonpref"]).to eq("Yes")
+
+        case_log.update!({ renewal: "Yes" })
+        record_from_db = ActiveRecord::Base.connection.execute("select reasonpref from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["reasonpref"]).to eq(nil)
+        expect(case_log["reasonpref"]).to eq(nil)
+      end
+    end
   end
 
   describe "resetting invalidated fields" do


### PR DESCRIPTION
When we select non renewal and select reasonable preference as "Yes"
Then when we try to select renewal
It tries to set homeless to No which doesn't pass the validation as reasonable preference cannot be yes anymore.

This PR resets resonablepref if it's yes and it's a renewal and also resets referral