### PR TITLE
Update referral validation numbers and clearing of the answers

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -156,7 +156,7 @@ class CaseLog < ApplicationRecord
   end
 
   def is_internal_transfer?
-    !!(referral && referral == 1)
+    referral == 1
   end
 
   def is_relet_to_temp_tenant?

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -156,7 +156,7 @@ class CaseLog < ApplicationRecord
   end
 
   def is_internal_transfer?
-    !!(referral && referral.zero?)
+    !!(referral && referral == 1)
   end
 
   def is_relet_to_temp_tenant?
@@ -233,7 +233,7 @@ private
     form.invalidated_page_questions(self).each do |question|
       enabled = form.enabled_page_questions(self)
       answer_options = enabled.map(&:id).include?(question.id) ? enabled.find { |q| q.id == question.id }.answer_options : []
-      contains_selected_answer_option = answer_options.present? ? answer_options.values.map { |x| x["value"] }.include?(public_send(question.id)) : false
+      contains_selected_answer_option = answer_options.present? ? answer_options.key?(public_send(question.id).to_s) : false
       if !contains_selected_answer_option && respond_to?(question.id.to_s) && (question.type == "radio" || question.type == "checkbox")
         public_send("#{question.id}=", nil)
       end

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -64,7 +64,7 @@ module Validations::PropertyValidations
     end
   end
 
-  REFERRAL_INVALID_TMP = [2, 3, 5, 6, 7, 8].freeze
+  REFERRAL_INVALID_TMP = [8, 10, 12, 13, 14, 15].freeze
   def validate_rsnvac(record)
     if !record.first_time_property_let_as_social_housing? && record.has_first_let_vacancy_reason?
       record.errors.add :rsnvac, I18n.t("validations.property.rsnvac.first_let_not_social")

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3222,37 +3222,37 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Internal transfer"
                     },
-                    "1": {
+                    "2": {
                       "value": "Tenant applied directly (no referral or nomination)"
                     },
-                    "2": {
+                    "8": {
                       "value": "Re-located through official housing mobility scheme"
                     },
-                    "3": {
+                    "10": {
                       "value": "Other social landlord"
                     },
-                    "4": {
+                    "9": {
                       "value": "Community learning disability team"
                     },
-                    "5": {
+                    "14": {
                       "value": "Community mental health team"
                     },
-                    "6": {
+                    "15": {
                       "value": "Health service"
                     },
-                    "7": {
+                    "12": {
                       "value": "Police, probation or prison"
                     },
-                    "8": {
+                    "13": {
                       "value": "Youth offending team"
                     },
-                    "9": {
+                    "7": {
                       "value": "Voluntary agency"
                     },
-                    "10": {
+                    "16": {
                       "value": "Other"
                     }
                   }
@@ -3276,40 +3276,40 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Internal transfer"
                     },
-                    "1": {
+                    "2": {
                       "value": "Tenant applied directly (no referral or nomination)"
                     },
-                    "2": {
+                    "3": {
                       "value": "Private registered provider (PRP) lettings only - nominated by a local housing authority"
                     },
-                    "3": {
+                    "8": {
                       "value": "Re-located through official housing mobility scheme"
                     },
-                    "4": {
+                    "10": {
                       "value": "Other social landlord"
                     },
-                    "5": {
+                    "9": {
                       "value": "Community learning disability team"
                     },
-                    "6": {
+                    "14": {
                       "value": "Community mental health team"
                     },
-                    "7": {
+                    "15": {
                       "value": "Health service"
                     },
-                    "8": {
+                    "12": {
                       "value": "Police, probation or prison"
                     },
-                    "9": {
+                    "13": {
                       "value": "Youth offending team"
                     },
-                    "10": {
+                    "7": {
                       "value": "Voluntary agency"
                     },
-                    "11": {
+                    "16": {
                       "value": "Other"
                     }
                   }
@@ -3333,40 +3333,40 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Internal transfer"
                     },
-                    "1": {
+                    "2": {
                       "value": "Tenant applied directly (no referral or nomination)"
                     },
-                    "2": {
+                    "3": {
                       "value": "Private registered provider (PRP) supported lettings only - referred by local authority housing department"
                     },
-                    "3": {
+                    "8": {
                       "value": "Re-located through official housing mobility scheme"
                     },
-                    "4": {
+                    "10": {
                       "value": "Other social landlord"
                     },
-                    "5": {
+                    "9": {
                       "value": "Community learning disability team"
                     },
-                    "6": {
+                    "14": {
                       "value": "Community mental health team"
                     },
-                    "7": {
+                    "15": {
                       "value": "Health service"
                     },
-                    "8": {
+                    "12": {
                       "value": "Police, probation or prison"
                     },
-                    "9": {
+                    "13": {
                       "value": "Youth offending team"
                     },
-                    "10": {
+                    "7": {
                       "value": "Voluntary agency"
                     },
-                    "11": {
+                    "16": {
                       "value": "Other"
                     }
                   }
@@ -3390,43 +3390,43 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Internal transfer"
                     },
-                    "1": {
+                    "2": {
                       "value": "Tenant applied directly (no referral or nomination)"
                     },
-                    "2": {
+                    "3": {
                       "value": "Private registered provider (PRP) lettings only - nominated by a local housing authority"
                     },
-                    "3": {
+                    "4": {
                       "value": "Private registered provider (PRP) supported lettings only - referred by local authority housing department"
                     },
-                    "4": {
+                    "8": {
                       "value": "Re-located through official housing mobility scheme"
                     },
-                    "5": {
+                    "10": {
                       "value": "Other social landlord"
                     },
-                    "6": {
+                    "9": {
                       "value": "Community learning disability team"
                     },
-                    "7": {
+                    "14": {
                       "value": "Community mental health team"
                     },
-                    "8": {
+                    "15": {
                       "value": "Health service"
                     },
-                    "9": {
+                    "12": {
                       "value": "Police, probation or prison"
                     },
-                    "10": {
+                    "13": {
                       "value": "Youth offending team"
                     },
-                    "11": {
+                    "7": {
                       "value": "Voluntary agency"
                     },
-                    "12": {
+                    "16": {
                       "value": "Other"
                     }
                   }

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -136,13 +136,14 @@
     "builtype": 0,
     "property_wheelchair_accessible": 1,
     "void_or_renewal_date": "05/05/2020",
-    "renewal": 1,
+    "renewal": 0,
     "new_build_handover_date": "01/01/2019",
     "has_benefits": 1,
     "household_charge": 1,
     "is_carehome": 1,
     "chcharge":  6,
     "letting_in_sheltered_accommodation": 0,
-    "declaration": 1
+    "declaration": 1,
+    "referral": 1
   }
 }

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -688,7 +688,7 @@ RSpec.describe CaseLog do
 
       it "does clear the value for answers that do not apply for invalidated page" do
         case_log.update!({ wchair: 1, sex2: "F", age2: 33 })
-        case_log.update!({ cbl: 0 })
+        case_log.update!({ cbl: 1 })
         case_log.update!({ preg_occ: 0 })
 
         expect(case_log.cbl).to eq(nil)

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -490,7 +490,7 @@ RSpec.describe Validations::HouseholdValidations do
 
       it "can be internal transfer" do
         record.tenancy = 3
-        record.referral = 0
+        record.referral = 1
         household_validator.validate_referral(record)
         expect(record.errors["referral"]).to be_empty
       end
@@ -499,7 +499,7 @@ RSpec.describe Validations::HouseholdValidations do
     context "when homelessness is assessed" do
       it "cannot be internal transfer" do
         record.homeless = 0
-        record.referral = 0
+        record.referral = 1
         household_validator.validate_referral(record)
         expect(record.errors["referral"])
           .to include(match I18n.t("validations.household.referral.assessed_homeless"))
@@ -518,7 +518,7 @@ RSpec.describe Validations::HouseholdValidations do
 
     context "when homelessness is other" do
       it "cannot be internal transfer" do
-        record.referral = 0
+        record.referral = 1
         record.homeless = 1
         household_validator.validate_referral(record)
         expect(record.errors["referral"])

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Validations::TenancyValidations do
         context "when referral is not internal transfer" do
           it "adds an error" do
             record.tenancy = 0
-            record.referral = 0
+            record.referral = 1
             tenancy_validator.validate_tenancy_type(record)
             expect(record.errors["tenancy"])
               .to include(match I18n.t("validations.tenancy.internal_transfer"))
@@ -120,7 +120,7 @@ RSpec.describe Validations::TenancyValidations do
         context "when referral is internal transfer" do
           it "does not add an error" do
             record.tenancy = 3
-            record.referral = 0
+            record.referral = 1
             tenancy_validator.validate_tenancy_type(record)
             expect(record.errors["tenancy"]).to be_empty
           end


### PR DESCRIPTION
We were clearing out the answers we didn't want to clear upon routing changes because of the enum update