### PR TITLE
Only route to prevten if it's supported housing

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -2590,7 +2590,7 @@
                   }
                 }
               },
-              "depends_on": [{ "renewal": 0 }]
+              "depends_on": [{ "renewal": 0, "needstype": 0 }]
             },
             "previous_housing_situation_renewal": {
               "header": "",


### PR DESCRIPTION
Only route to prevten if it's supported housing because we infer the answer if the needs type is general needs