### PR TITLE
Update validation and db mapping for homeless

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -208,7 +208,7 @@ class CaseLog < ApplicationRecord
   end
 
   def is_not_homeless?
-    homeless == 2
+    homeless == 1
   end
 
   def is_london_rent?

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -4,13 +4,12 @@ module Validations::HouseholdValidations
   # Validations methods need to be called 'validate_<page_name>' to run on model save
   # or 'validate_' to run on submit as well
   def validate_reasonable_preference(record)
-    if record.is_not_homeless? && record.given_reasonable_preference?
-      record.errors.add :reasonpref, I18n.t("validations.household.reasonpref.not_homeless")
+    if record.is_not_homeless? && record.rp_homeless == 1
+      record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonpref.not_homeless")
       record.errors.add :homeless, I18n.t("validations.household.homeless.reasonpref.not_homeless")
-    elsif !record.given_reasonable_preference?
-      if [record.rp_homeless, record.rp_insan_unsat, record.rp_medwel, record.rp_hardship, record.rp_dontknow].any? { |a| a == 1 }
-        record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonable_preference_reason.reason_not_required")
-      end
+    end
+    if !record.given_reasonable_preference? && [record.rp_homeless, record.rp_insan_unsat, record.rp_medwel, record.rp_hardship, record.rp_dontknow].any? { |a| a == 1 }
+      record.errors.add :reasonable_preference_reason, I18n.t("validations.household.reasonable_preference_reason.reason_not_required")
     end
   end
 

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -2656,13 +2656,13 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "11": {
                       "value": "Assessed as homeless (or threatened with homelessness within 56 days) by a local authority and owed a homelessness duty"
                     },
-                    "1": {
+                    "7": {
                       "value": "Other homeless - not found statutorily homeless but considered homeless by landlord"
                     },
-                    "2": {
+                    "1": {
                       "value": "No"
                     }
                   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,7 +86,7 @@ en:
 
     household:
       reasonpref:
-        not_homeless: "Can not be Yes if Not Homeless immediately prior to this letting has been selected"
+        not_homeless: "Can not be \"They were homeless or about to lose their home\" if Not Homeless immediately prior to this letting has been selected"
       reasonable_preference_reason:
         reason_required: "If reasonable preference is \"Yes\", a reason must be given"
         reason_not_required: "If reasonable preference is \"No\", no reasons should be given"
@@ -127,7 +127,7 @@ en:
         other:
           internal_transfer: "Answer cannot be other homelessness as you already told us this tenancy was an internal transfer"
         reasonpref:
-          not_homeless: "Can not be No if household was given reasonable preference"
+          not_homeless: "Can not be No if \"They were homeless or about to lose their home\" was selected as reasonable preference reason"
       previous_la_known: "Enter a local authority"
 
 

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -99,8 +99,8 @@ FactoryBot.define do
       illness_type_7 { 0 }
       illness_type_9 { 0 }
       illness_type_10 { 0 }
-      rp_homeless { 1 }
-      rp_insan_unsat { 0 }
+      rp_homeless { 0 }
+      rp_insan_unsat { 1 }
       rp_medwel { 0 }
       rp_hardship { 0 }
       rp_dontknow { 0 }

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -72,8 +72,8 @@
     <illness_type_7>0</illness_type_7>
     <illness_type_9>0</illness_type_9>
     <illness_type_10>0</illness_type_10>
-    <rp_homeless>1</rp_homeless>
-    <rp_insan_unsat>0</rp_insan_unsat>
+    <rp_homeless>0</rp_homeless>
+    <rp_insan_unsat>1</rp_insan_unsat>
     <rp_medwel>0</rp_medwel>
     <rp_hardship>0</rp_hardship>
     <rp_dontknow>0</rp_dontknow>

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe Validations::HouseholdValidations do
   end
 
   describe "reasonable preference validations" do
-    context "when reasonable preference is given" do
+    context "when reasonable preference is homeless" do
       context "when the tenant was not previously homeless" do
         it "adds an error" do
-          record.homeless = 2
-          record.reasonpref = 0
+          record.homeless = 1
+          record.rp_homeless = 1
           household_validator.validate_reasonable_preference(record)
-          expect(record.errors["reasonpref"])
+          expect(record.errors["reasonable_preference_reason"])
             .to include(match I18n.t("validations.household.reasonpref.not_homeless"))
           expect(record.errors["homeless"])
             .to include(match I18n.t("validations.household.homeless.reasonpref.not_homeless"))


### PR DESCRIPTION
Fixes the validation for reasonable preference (CLDC-487)
Previously reasonpref wouldn't be allowed to be selected if homeless is selected as No
Now we can select a reasonable preference as Yes but cannot select `Homeless...` as the reason