### PR TITLE
Fix prevten inferred values, revert routing change for prevten

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -304,8 +304,8 @@ private
       self.layear = 1
     end
     if is_general_needs?
-      self.prevten = 2 if managing_organisation.provider_type == "PRP"
-      self.prevten = 0 if managing_organisation.provider_type == "LA"
+      self.prevten = 32 if managing_organisation.provider_type == "PRP"
+      self.prevten = 30 if managing_organisation.provider_type == "LA"
     end
   end
 

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3598,7 +3598,7 @@
               "depends_on": [
                 {
                   "renewal": 0,
-                  "needstype": 1
+                  "needstype": 0
                 }
               ]
             },
@@ -3624,7 +3624,7 @@
               "depends_on": [
                 {
                   "renewal": 1,
-                  "needstype": 1
+                  "needstype": 0
                 }
               ]
             },

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -10,7 +10,7 @@
     <sex1>F</sex1>
     <ethnic>2</ethnic>
     <national>4</national>
-    <prevten>2</prevten>
+    <prevten>32</prevten>
     <ecstat1>0</ecstat1>
     <hhmemb>2</hhmemb>
     <age2>32</age2>

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -631,15 +631,15 @@ RSpec.describe CaseLog do
         case_log.update!({ needstype: 1 })
 
         record_from_db = ActiveRecord::Base.connection.execute("select prevten from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["prevten"]).to eq(2)
-        expect(case_log["prevten"]).to eq(2)
+        expect(record_from_db["prevten"]).to eq(32)
+        expect(case_log["prevten"]).to eq(32)
 
         case_log.managing_organisation.update!({ provider_type: "LA" })
         case_log.update!({ needstype: 1 })
 
         record_from_db = ActiveRecord::Base.connection.execute("select prevten from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["prevten"]).to eq(0)
-        expect(case_log["prevten"]).to eq(0)
+        expect(record_from_db["prevten"]).to eq(30)
+        expect(case_log["prevten"]).to eq(30)
       end
 
       it "correctly derives and saves referral" do


### PR DESCRIPTION
We actually don’t want to see “Where was the household immediately before this letting?” if it’s general needs because we can infer it
It should only show up if it’s supported housing after all so reverting that routing change.
prevten was being inferred to incorrect values that don't exist in JSON