### PR TITLE
Fix some inferred variables

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -243,7 +243,8 @@ private
   def reset_derived_questions
     dependent_questions = { layear: [{ key: :renewal, value: 0 }],
                             homeless: [{ key: :renewal, value: 0 }],
-                            referral: [{ key: :renewal, value: 0 }] }
+                            referral: [{ key: :renewal, value: 0 }],
+                            underoccupation_benefitcap: [{ key: :renewal, value: 0 }] }
 
     dependent_questions.each do |dependent, conditions|
       condition_key = conditions.first[:key]
@@ -299,13 +300,14 @@ private
     self.underoccupation_benefitcap = 3 if renewal == 1 && year == 2021
     self.ethnic = ethnic || ethnic_group
     if is_renewal?
+      self.underoccupation_benefitcap = 2 if year == 2021
       self.homeless = 2
       self.referral = 0
       self.layear = 1
-    end
-    if is_general_needs?
-      self.prevten = 32 if managing_organisation.provider_type == "PRP"
-      self.prevten = 30 if managing_organisation.provider_type == "LA"
+      if is_general_needs?
+        self.prevten = 32 if managing_organisation.provider_type == "PRP"
+        self.prevten = 30 if managing_organisation.provider_type == "LA"
+      end
     end
   end
 

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -10,7 +10,7 @@
     <sex1>F</sex1>
     <ethnic>2</ethnic>
     <national>4</national>
-    <prevten>32</prevten>
+    <prevten>6</prevten>
     <ecstat1>0</ecstat1>
     <hhmemb>2</hhmemb>
     <age2>32</age2>

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -623,8 +623,8 @@ RSpec.describe CaseLog do
 
       it "correctly derives and saves underoccupation_benefitcap if year is 2021" do
         record_from_db = ActiveRecord::Base.connection.execute("select underoccupation_benefitcap from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["underoccupation_benefitcap"]).to eq(3)
-        expect(case_log["underoccupation_benefitcap"]).to eq(3)
+        expect(record_from_db["underoccupation_benefitcap"]).to eq(2)
+        expect(case_log["underoccupation_benefitcap"]).to eq(2)
       end
 
       it "correctly derives and saves prevten" do


### PR DESCRIPTION
reset underoccupation benefitcap if it's not a renewal. 
Only set underoccupation benefitcap and prevten if it is a renewal