### PR TITLE
Remove tenancy/referral validations

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -67,11 +67,6 @@ module Validations::HouseholdValidations
   end
 
   def validate_referral(record)
-    if record.referral.present? && record.tenancy.present? && !record.is_internal_transfer? && record.is_secure_tenancy?
-      record.errors.add :referral, I18n.t("validations.household.referral.secure_tenancy")
-      record.errors.add :tenancy, I18n.t("validations.tenancy.cannot_be_internal_transfer")
-    end
-
     if record.is_internal_transfer? && record.is_assessed_homeless?
       record.errors.add :referral, I18n.t("validations.household.referral.assessed_homeless")
       record.errors.add :homeless, I18n.t("validations.household.homeless.assessed.internal_transfer")

--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -32,11 +32,4 @@ module Validations::TenancyValidations
   def validate_other_tenancy_type(record)
     validate_other_field(record, 4, :tenancy, :tenancyother)
   end
-
-  def validate_tenancy_type(record)
-    if record.tenancy.present? && !record.is_secure_tenancy? && record.is_internal_transfer?
-      record.errors.add :tenancy, I18n.t("validations.tenancy.internal_transfer")
-      record.errors.add :referral, I18n.t("validations.household.referral.cannot_be_secure_tenancy")
-    end
-  end
 end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe CaseLog do
     it "validates tenancy type" do
       expect(validator).to receive(:validate_fixed_term_tenancy)
       expect(validator).to receive(:validate_other_tenancy_type)
-      expect(validator).to receive(:validate_tenancy_type)
     end
 
     it "validates the previous postcode" do

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -499,23 +499,6 @@ RSpec.describe Validations::HouseholdValidations do
   end
 
   describe "referral validations" do
-    context "when type of tenancy is not secure" do
-      it "cannot be not internal transfer" do
-        record.tenancy = 3
-        record.referral = 3
-        household_validator.validate_referral(record)
-        expect(record.errors["referral"])
-          .to include(match I18n.t("validations.household.referral.secure_tenancy"))
-      end
-
-      it "can be internal transfer" do
-        record.tenancy = 3
-        record.referral = 1
-        household_validator.validate_referral(record)
-        expect(record.errors["referral"]).to be_empty
-      end
-    end
-
     context "when homelessness is assessed" do
       it "cannot be internal transfer" do
         record.homeless = 11

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -106,25 +106,6 @@ RSpec.describe Validations::TenancyValidations do
             expect(record.errors["tenancy"]).to be_empty
           end
         end
-
-        context "when referral is not internal transfer" do
-          it "adds an error" do
-            record.tenancy = 0
-            record.referral = 1
-            tenancy_validator.validate_tenancy_type(record)
-            expect(record.errors["tenancy"])
-              .to include(match I18n.t("validations.tenancy.internal_transfer"))
-          end
-        end
-
-        context "when referral is internal transfer" do
-          it "does not add an error" do
-            record.tenancy = 3
-            record.referral = 1
-            tenancy_validator.validate_tenancy_type(record)
-            expect(record.errors["tenancy"]).to be_empty
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
Remove validations that only let internal referral to be selected for secure tenancy and vice versa. This validation seemed to be created by mistake and could not be located in the validations sheet