### PR TITLE
CLDC-902: London location validation

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -385,7 +385,10 @@ private
 
   def get_inferred_la(postcode)
     postcode_lookup = nil
-    Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) } rescue Timeout::Error
+    begin
+      Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) }
+    rescue Timeout::Error
+    end
     if postcode_lookup && postcode_lookup.info.present?
       postcode_lookup.codes["admin_district"]
     end

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -388,6 +388,7 @@ private
     begin
       Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) }
     rescue Timeout::Error
+      Rails.logger.warn("Postcodes.io lookup timed out")
     end
     if postcode_lookup && postcode_lookup.info.present?
       postcode_lookup.codes["admin_district"]

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -385,7 +385,7 @@ private
 
   def get_inferred_la(postcode)
     postcode_lookup = nil
-    Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) }
+    Timeout.timeout(5) { postcode_lookup = PIO.lookup(postcode) } rescue Timeout::Error
     if postcode_lookup && postcode_lookup.info.present?
       postcode_lookup.codes["admin_district"]
     end

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -57,6 +57,9 @@ module Validations::PropertyValidations
   def validate_la(record)
     if record.la.present? && !LONDON_BOROUGHS.include?(record.la) && record.is_london_rent?
       record.errors.add :la, I18n.t("validations.property.la.london_rent")
+      if record.postcode_known? && record.property_postcode.present?
+        record.errors.add :property_postcode, I18n.t("validations.property.la.london_rent")
+      end
     end
 
     if record.la_known? && record.la.blank?

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -412,6 +412,17 @@ RSpec.describe CaseLog do
           .to raise_error(ActiveRecord::RecordInvalid, /#{I18n.t("validations.postcode")}/)
       end
 
+      context "when the local authority lookup times out" do
+        before do
+          allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+        end
+
+        it "logs a warning" do
+          expect(Rails.logger).to receive(:warn).with("Postcodes.io lookup timed out")
+          address_case_log.update!({ postcode_known: 1, property_postcode: "M1 1AD" })
+        end
+      end
+
       it "correctly resets all fields if property postcode not known" do
         address_case_log.update!({ postcode_known: 0 })
 

--- a/spec/models/validations/property_validations_spec.rb
+++ b/spec/models/validations/property_validations_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe Validations::PropertyValidations do
         record.rent_type = 2
         property_validator.validate_la(record)
         expect(record.errors["la"]).to include(match(expected_error))
+        expect(record.errors["property_postcode"]).to be_empty
       end
 
       it "expects that the local authority is in London" do
@@ -163,6 +164,17 @@ RSpec.describe Validations::PropertyValidations do
         record.rent_type = 2
         property_validator.validate_la(record)
         expect(record.errors["la"]).to be_empty
+      end
+
+      context "when the la has been derived from a known postcode" do
+        it "also adds an error to the postcode field" do
+          record.la = "E07000105"
+          record.rent_type = 2
+          record.postcode_known = 1
+          record.property_postcode = "BN18 7TR"
+          property_validator.validate_la(record)
+          expect(record.errors["property_postcode"]).to include(match(expected_error))
+        end
       end
     end
 


### PR DESCRIPTION
Also add london borough error message to postcode field so you're not blocked on that page if the LA has been derived from postcode.

https://digital.dclg.gov.uk/jira/browse/CLDC-902