### PR TITLE
CLDC-663: Weekly total shortfall derived variable

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -38,7 +38,7 @@ class CaseLog < ApplicationRecord
   OPTIONAL_FIELDS = %w[postcode_known la_known first_time_property_let_as_social_housing tenant_code propcode].freeze
   RENT_TYPE_MAPPING = { 0 => 1, 1 => 2, 2 => 2, 3 => 3, 4 => 3, 5 => 3 }.freeze
   RENT_TYPE_MAPPING_LABELS = { 1 => "Social Rent", 2 => "Affordable Rent", 3 => "Intermediate Rent" }.freeze
-  HAS_BENEFITS_OPTIONS = [0, 1, 2, 3].freeze
+  HAS_BENEFITS_OPTIONS = [1, 6, 8, 7].freeze
   STATUS = { "not_started" => 0, "in_progress" => 1, "completed" => 2 }.freeze
   NUM_OF_WEEKS_FROM_PERIOD = { 0 => 26, 1 => 13, 2 => 12, 3 => 50, 4 => 49, 5 => 48, 6 => 47, 7 => 46, 8 => 52 }.freeze
   enum status: STATUS

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -239,6 +239,30 @@ class CaseLog < ApplicationRecord
     reason == 1
   end
 
+  def receives_housing_benefit_only?
+    hb == 1
+  end
+
+  def receives_housing_benefit_and_universal_credit?
+    hb == 8
+  end
+
+  def receives_uc_with_housing_element_excl_housing_benefit?
+    hb == 6
+  end
+
+  def receives_no_benefits?
+    hb == 9
+  end
+
+  def receives_universal_credit_but_no_housing_benefit?
+    hb == 7
+  end
+
+  def benefits_unknown?
+    hb == 3
+  end
+
 private
 
   PIO = Postcodes::IO.new
@@ -327,6 +351,11 @@ private
       self.wtcharge = weekly_value(tcharge) if tcharge.present?
     end
     self.has_benefits = get_has_benefits
+    if tshortfall && (receives_housing_benefit_only? ||
+        receives_housing_benefit_and_universal_credit? ||
+          receives_uc_with_housing_element_excl_housing_benefit?)
+      self.wtshortfall = weekly_value(tshortfall)
+    end
     self.nocharge = household_charge&.zero? ? 1 : 0
     self.underoccupation_benefitcap = 3 if renewal == 1 && year == 2021
     self.ethnic = ethnic || ethnic_group

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -259,6 +259,11 @@ class CaseLog < ApplicationRecord
     hb == 7
   end
 
+  def receives_housing_related_benefits?
+    receives_housing_benefit_only? || receives_uc_with_housing_element_excl_housing_benefit? ||
+      receives_housing_benefit_and_universal_credit?
+  end
+
   def benefits_unknown?
     hb == 3
   end
@@ -351,11 +356,9 @@ private
       self.wtcharge = weekly_value(tcharge) if tcharge.present?
     end
     self.has_benefits = get_has_benefits
-    if tshortfall && (receives_housing_benefit_only? ||
-        receives_housing_benefit_and_universal_credit? ||
-          receives_uc_with_housing_element_excl_housing_benefit?)
-      self.wtshortfall = weekly_value(tshortfall)
-    end
+    self.wtshortfall = if tshortfall && receives_housing_related_benefits?
+                         weekly_value(tshortfall)
+                       end
     self.nocharge = household_charge&.zero? ? 1 : 0
     self.underoccupation_benefitcap = 3 if renewal == 1 && year == 2021
     self.ethnic = ethnic || ethnic_group

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -51,9 +51,9 @@ module Validations::FinancialValidations
   end
 
   def validate_tshortfall(record)
-    hb_donotknow = record.hb == 5
-    hb_none = record.hb == 4
-    hb_uc_no_hb = record.hb == 3
+    hb_donotknow = record.hb == 3
+    hb_none = record.hb == 9
+    hb_uc_no_hb = record.hb == 7
 
     if record.has_hbrentshortfall? && (hb_donotknow || hb_none || hb_uc_no_hb)
       record.errors.add :tshortfall, I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits")

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -51,11 +51,10 @@ module Validations::FinancialValidations
   end
 
   def validate_tshortfall(record)
-    hb_donotknow = record.hb == 3
-    hb_none = record.hb == 9
-    hb_uc_no_hb = record.hb == 7
-
-    if record.has_hbrentshortfall? && (hb_donotknow || hb_none || hb_uc_no_hb)
+    if record.has_hbrentshortfall? &&
+        (record.benefits_unknown? ||
+          record.receives_no_benefits? ||
+            record.receives_universal_credit_but_no_housing_benefit?)
       record.errors.add :tshortfall, I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits")
     end
   end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4610,25 +4610,25 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Housing benefit"
                     },
-                    "1": {
+                    "6": {
                       "value": "Universal Credit with housing element (excluding housing benefit)"
                     },
-                    "2": {
+                    "8": {
                       "value": "Housing benefit and Universal Credit (without housing element)"
                     },
-                    "3": {
+                    "7": {
                       "value": "Universal Credit (without housing element)"
                     },
-                    "4": {
+                    "9": {
                       "value": "None"
                     },
                     "divider": {
                       "value": true
                     },
-                    "5": {
+                    "3": {
                       "value": "Don’t know"
                     },
                     "6": {

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -119,7 +119,7 @@ FactoryBot.define do
       majorrepairs { 1 }
       la { "E09000003" }
       prevloc { "E07000105" }
-      hb { 1 }
+      hb { 6 }
       hbrentshortfall { 0 }
       tshortfall { 12 }
       postcod2 { "w3" }

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -97,7 +97,7 @@
     <majorrepairs>1</majorrepairs>
     <la>E09000003</la>
     <prevloc>E07000105</prevloc>
-    <hb>1</hb>
+    <hb>6</hb>
     <hbrentshortfall>0</hbrentshortfall>
     <postcode>NW1</postcode>
     <postcod2>5TY</postcod2>

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -165,6 +165,6 @@
     <wpschrge>20.0</wpschrge>
     <wsupchrg>17.5</wsupchrg>
     <wtcharge>162.5</wtcharge>
-    <wtshortfall/>
+    <wtshortfall>6.0</wtshortfall>
   </form>
 </forms>

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -299,6 +299,15 @@ RSpec.describe CaseLog do
           end
         end
 
+        context "when the tenant is not in receipt of applicable benefits" do
+          it "correctly resets total shortfall" do
+            case_log.update!(wtshortfall: 100, hb: 9)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wtshortfall).to be_nil
+            expect(record_from_db["wtshortfall"]).to be_nil
+          end
+        end
+
         context "when rent is paid bi-weekly" do
           it "correctly derives and saves weekly rent" do
             case_log.update!(brent: 100, period: 0)

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -334,6 +334,35 @@ RSpec.describe CaseLog do
             expect(case_log.wtcharge).to eq(50.0)
             expect(record_from_db["wtcharge"]).to eq(50.0)
           end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(50.0)
+                expect(record_from_db["wtshortfall"]).to eq(50.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(50.0)
+                expect(record_from_db["wtshortfall"]).to eq(50.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(50.0)
+                expect(record_from_db["wtshortfall"]).to eq(50.0)
+              end
+            end
+          end
         end
 
         context "when rent is paid every 4 weeks" do
@@ -370,6 +399,35 @@ RSpec.describe CaseLog do
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(30.0)
             expect(record_from_db["wtcharge"]).to eq(30.0)
+          end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
           end
         end
 
@@ -408,6 +466,35 @@ RSpec.describe CaseLog do
             expect(case_log.wtcharge).to eq(30.0)
             expect(record_from_db["wtcharge"]).to eq(30.0)
           end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(30.0)
+                expect(record_from_db["wtshortfall"]).to eq(30.0)
+              end
+            end
+          end
         end
 
         context "when rent is paid weekly for 50 weeks" do
@@ -444,6 +531,35 @@ RSpec.describe CaseLog do
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(125.0)
             expect(record_from_db["wtcharge"]).to eq(125.0)
+          end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(125.0)
+                expect(record_from_db["wtshortfall"]).to eq(125.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(125.0)
+                expect(record_from_db["wtshortfall"]).to eq(125.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(125.0)
+                expect(record_from_db["wtshortfall"]).to eq(125.0)
+              end
+            end
           end
         end
 
@@ -482,6 +598,35 @@ RSpec.describe CaseLog do
             expect(case_log.wtcharge).to eq(122.5)
             expect(record_from_db["wtcharge"]).to eq(122.5)
           end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(122.5)
+                expect(record_from_db["wtshortfall"]).to eq(122.5)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(122.5)
+                expect(record_from_db["wtshortfall"]).to eq(122.5)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(122.5)
+                expect(record_from_db["wtshortfall"]).to eq(122.5)
+              end
+            end
+          end
         end
 
         context "when rent is paid weekly for 48 weeks" do
@@ -518,6 +663,35 @@ RSpec.describe CaseLog do
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(120.0)
             expect(record_from_db["wtcharge"]).to eq(120.0)
+          end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(120.0)
+                expect(record_from_db["wtshortfall"]).to eq(120.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(120.0)
+                expect(record_from_db["wtshortfall"]).to eq(120.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(120.0)
+                expect(record_from_db["wtshortfall"]).to eq(120.0)
+              end
+            end
           end
         end
 
@@ -556,6 +730,35 @@ RSpec.describe CaseLog do
             expect(case_log.wtcharge).to eq(117.5)
             expect(record_from_db["wtcharge"]).to eq(117.5)
           end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(117.5)
+                expect(record_from_db["wtshortfall"]).to eq(117.5)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(117.5)
+                expect(record_from_db["wtshortfall"]).to eq(117.5)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(117.5)
+                expect(record_from_db["wtshortfall"]).to eq(117.5)
+              end
+            end
+          end
         end
 
         context "when rent is paid weekly for 46 weeks" do
@@ -593,6 +796,35 @@ RSpec.describe CaseLog do
             expect(case_log.wtcharge).to eq(115.0)
             expect(record_from_db["wtcharge"]).to eq(115.0)
           end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(115.0)
+                expect(record_from_db["wtshortfall"]).to eq(115.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(115.0)
+                expect(record_from_db["wtshortfall"]).to eq(115.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(115.0)
+                expect(record_from_db["wtshortfall"]).to eq(115.0)
+              end
+            end
+          end
         end
 
         context "when rent is paid weekly for 52 weeks" do
@@ -629,6 +861,35 @@ RSpec.describe CaseLog do
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(130.0)
             expect(record_from_db["wtcharge"]).to eq(130.0)
+          end
+
+          context "when the tenant has an outstanding amount after benefits" do
+            context "when tenant is in receipt of housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 1)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(130.0)
+                expect(record_from_db["wtshortfall"]).to eq(130.0)
+              end
+            end
+
+            context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 6)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(130.0)
+                expect(record_from_db["wtshortfall"]).to eq(130.0)
+              end
+            end
+
+            context "when tenant is in receipt of housing benefit and universal credit" do
+              it "correctly derives and saves weekly total shortfall" do
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 8)
+                record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
+                expect(case_log.wtshortfall).to eq(130.0)
+                expect(record_from_db["wtshortfall"]).to eq(130.0)
+              end
+            end
           end
         end
       end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe CaseLog do
         other_hhmemb: 6,
         rent_type: 4,
         needstype: 1,
-        hb: 0,
+        hb: 1,
         hbrentshortfall: 1,
       })
     end
@@ -910,8 +910,6 @@ RSpec.describe CaseLog do
     end
 
     it "correctly derives and saves has_benefits" do
-      case_log.reload
-
       record_from_db = ActiveRecord::Base.connection.execute("select has_benefits from case_logs where id=#{case_log.id}").to_a[0]
       expect(record_from_db["has_benefits"]).to eq(1)
     end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Validations::FinancialValidations do
     context "when shortfall is yes" do
       it "validates that housing benefit is not none" do
         record.hbrentshortfall = 0
-        record.hb = 4
+        record.hb = 9
         financial_validator.validate_tshortfall(record)
         expect(record.errors["tshortfall"])
           .to include(match I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits"))
@@ -98,7 +98,7 @@ RSpec.describe Validations::FinancialValidations do
 
       it "validates that housing benefit is not don't know" do
         record.hbrentshortfall = 0
-        record.hb = 5
+        record.hb = 3
         financial_validator.validate_tshortfall(record)
         expect(record.errors["tshortfall"])
           .to include(match I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits"))
@@ -106,7 +106,7 @@ RSpec.describe Validations::FinancialValidations do
 
       it "validates that housing benefit is not Universal Credit without housing benefit" do
         record.hbrentshortfall = 0
-        record.hb = 3
+        record.hb = 7
         financial_validator.validate_tshortfall(record)
         expect(record.errors["tshortfall"])
           .to include(match I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits"))
@@ -114,7 +114,7 @@ RSpec.describe Validations::FinancialValidations do
 
       it "validates that housing benefit is provided" do
         record.hbrentshortfall = 0
-        record.hb = 0
+        record.hb = 1
         financial_validator.validate_tshortfall(record)
         expect(record.errors["tshortfall"]).to be_empty
       end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-663

WTSHORTFALL is the weekly total shortfall between housing-related benefits and the rent and charges combined.

WTSHORTFALL should only be calculated if HB=1 or HB=6 or HB=8 (note these categories will be changing in the 22/23 forms). WTSHORTFALL should be blank in all other situations, even if the user has submitted a value for TSHORTFALL.

TSHORTFALL = Total rent shortfall charge

PERIOD = Rent and other charge period

WTSHORTFALL = (TSHORTFALL / 52) x (no. of weeks from PERIOD)