### PR TITLE
CLDC-815-long-term-vision-validation

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -65,6 +65,13 @@ module Validations::HouseholdValidations
     end
   end
 
+  def validate_condition_effects(record)
+    all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
+    if all_options.count(1) >= 1 && record.illness != 0
+      record.errors.add :condition_effects, I18n.t("validations.household.condition_effects.no_choices")
+    end   
+  end
+
   def validate_previous_housing_situation(record)
     if record.is_relet_to_temp_tenant? && !record.previous_tenancy_was_temporary?
       record.errors.add :prevten, I18n.t("validations.household.prevten.non_temp_accommodation")

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -115,7 +115,7 @@ private
 
   def has_illness?(record)
     all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
-    return all_options.count(1) >= 1
+    all_options.count(1) >= 1
   end
 
   def women_of_child_bearing_age_in_household(record)

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -66,8 +66,7 @@ module Validations::HouseholdValidations
   end
 
   def validate_condition_effects(record)
-    all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
-    if all_options.count(1) >= 1 && record.illness != 0
+    if has_illness?(record) && record.illness != 0
       record.errors.add :condition_effects, I18n.t("validations.household.condition_effects.no_choices")
     end
   end
@@ -113,6 +112,11 @@ module Validations::HouseholdValidations
   end
 
 private
+
+  def has_illness?(record)
+    all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
+    return all_options.count(1) >= 1
+  end
 
   def women_of_child_bearing_age_in_household(record)
     (1..8).any? do |n|

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -66,7 +66,8 @@ module Validations::HouseholdValidations
   end
 
   def validate_condition_effects(record)
-    if has_illness?(record) && record.illness != 0
+    all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
+    if all_options.count(1) >= 1 && household_no_illness?(record)
       record.errors.add :condition_effects, I18n.t("validations.household.condition_effects.no_choices")
     end
   end
@@ -113,9 +114,8 @@ module Validations::HouseholdValidations
 
 private
 
-  def has_illness?(record)
-    all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
-    all_options.count(1) >= 1
+  def household_no_illness?(record)
+    record.illness != 0
   end
 
   def women_of_child_bearing_age_in_household(record)

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -69,7 +69,7 @@ module Validations::HouseholdValidations
     all_options = [record.illness_type_1, record.illness_type_2, record.illness_type_3, record.illness_type_4, record.illness_type_5, record.illness_type_6, record.illness_type_7, record.illness_type_8, record.illness_type_9, record.illness_type_10]
     if all_options.count(1) >= 1 && record.illness != 0
       record.errors.add :condition_effects, I18n.t("validations.household.condition_effects.no_choices")
-    end   
+    end
   end
 
   def validate_previous_housing_situation(record)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
         male_refuge: "Answer cannot be male as you told us their housing situation immediately before this letting was a refuge"
       reason:
         not_internal_transfer: "Answer cannot be permanently decanted from another property owned by this landlord as you told us the source of referral for this tenancy was not an internal transfer"
+      condition_effects:
+        no_choices: "You can not provide details about effects of conditions on any of the household members if you have not answered yes to the any of the household having a physical or mental health condition (or other illness) expected to last 12 months or more"
 
     tenancy:
       length:

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -51,7 +51,7 @@ FactoryBot.define do
       underoccupation_benefitcap { 0 }
       leftreg { 1 }
       reservist { 0 }
-      illness { 1 }
+      illness { 0 }
       preg_occ { 1 }
       tenancy_code { "BZ757" }
       startertenancy { 0 }

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -44,7 +44,7 @@
     "underoccupation_benefitcap": 0,
     "leftreg": 1,
     "reservist": 0,
-    "illness": 1,
+    "illness": 0,
     "preg_occ": 0,
     "tenancy_code": "BZ757",
     "startdate": "12/12/2021",

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -38,7 +38,7 @@
     <underoccupation_benefitcap>0</underoccupation_benefitcap>
     <leftreg>1</leftreg>
     <reservist>0</reservist>
-    <illness>1</illness>
+    <illness>0</illness>
     <preg_occ>1</preg_occ>
     <tenancy_code>BZ757</tenancy_code>
     <startertenancy>0</startertenancy>

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -562,6 +562,15 @@ RSpec.describe Validations::HouseholdValidations do
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
     end
+
+    it "expects that an illness can be selected if answer to anyone in household with health condition is yes " do
+      record.illness = 0
+      record.illness_type_1 = 1
+      record.illness_type_2 = 1
+      record.illness_type_3 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"]).to be_empty
+    end
   end
 
   describe "accessibility requirement validations" do

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates hearing can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -497,7 +497,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates mobility can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -505,7 +505,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates dexterity can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -513,7 +513,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates learning or understanding or concentrating can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -521,7 +521,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates memory can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -529,7 +529,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates mental health can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -537,15 +537,15 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
-    
+    end
+
     it "validates stamina or breathing or fatigue can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
       record.illness_type_8 = 1
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates socially or behaviourally can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -553,7 +553,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
 
     it "validates other can't be selected if answer to anyone in household with health condition is not yes" do
       record.illness = 1
@@ -561,7 +561,7 @@ RSpec.describe Validations::HouseholdValidations do
       household_validator.validate_condition_effects(record)
       expect(record.errors["condition_effects"])
         .to include(match I18n.t("validations.household.condition_effects.no_choices"))
-    end 
+    end
   end
 
   describe "accessibility requirement validations" do

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -482,6 +482,88 @@ RSpec.describe Validations::HouseholdValidations do
     end
   end
 
+  describe "condition effects validation" do
+    it "validates vision can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_1 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates hearing can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_2 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates mobility can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_3 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates dexterity can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_4 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates learning or understanding or concentrating can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_5 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates memory can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_6 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates mental health can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_7 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+    
+    it "validates stamina or breathing or fatigue can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_8 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates socially or behaviourally can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_9 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+
+    it "validates other can't be selected if answer to anyone in household with health condition is not yes" do
+      record.illness = 1
+      record.illness_type_10 = 1
+      household_validator.validate_condition_effects(record)
+      expect(record.errors["condition_effects"])
+        .to include(match I18n.t("validations.household.condition_effects.no_choices"))
+    end 
+  end
+
   describe "accessibility requirement validations" do
     it "validates that mutually exclusive options can't be selected together" do
       record.housingneeds_a = 1


### PR DESCRIPTION
Prevents a submission if a condition effect has been selected but the answer to anyone in the household having a health condition is not yes. This validation might not have been necessary for the online form since the routing for the section is set up to prevent the condition effects question page from being visited is the answer to the previous question was not yes