### PR TITLE
Cldc 491 rent and charges validations (part 1)

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -266,6 +266,8 @@ class CaseLog < ApplicationRecord
 
   def benefits_unknown?
     hb == 3
+  end
+
   def this_landlord?
     landlord == 1
   end

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -266,6 +266,8 @@ class CaseLog < ApplicationRecord
 
   def benefits_unknown?
     hb == 3
+  def this_landlord?
+    landlord == 1
   end
 
 private

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -272,6 +272,10 @@ class CaseLog < ApplicationRecord
     landlord == 1
   end
 
+  def other_landlord?
+    landlord == 2
+  end
+
 private
 
   PIO = Postcodes::IO.new

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -40,7 +40,7 @@ class CaseLog < ApplicationRecord
   RENT_TYPE_MAPPING_LABELS = { 1 => "Social Rent", 2 => "Affordable Rent", 3 => "Intermediate Rent" }.freeze
   HAS_BENEFITS_OPTIONS = [1, 6, 8, 7].freeze
   STATUS = { "not_started" => 0, "in_progress" => 1, "completed" => 2 }.freeze
-  NUM_OF_WEEKS_FROM_PERIOD = { 0 => 26, 1 => 13, 2 => 12, 3 => 50, 4 => 49, 5 => 48, 6 => 47, 7 => 46, 8 => 52 }.freeze
+  NUM_OF_WEEKS_FROM_PERIOD = { 2 => 26, 3 => 13, 4 => 12, 5 => 50, 6 => 49, 7 => 48, 8 => 47, 9 => 46, 1 => 52 }.freeze
   enum status: STATUS
 
   def form

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -90,7 +90,7 @@ class CaseLog < ApplicationRecord
     num_of_weeks = NUM_OF_WEEKS_FROM_PERIOD[period]
     return unless field_value && num_of_weeks
 
-    field_value / 52 * num_of_weeks
+    (field_value / 52 * num_of_weeks).round(2)
   end
 
   def applicable_income_range

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -58,4 +58,11 @@ module Validations::FinancialValidations
       record.errors.add :tshortfall, I18n.t("validations.financial.hbrentshortfall.outstanding_no_benefits")
     end
   end
+
+  def validate_rent_amount(record)
+    if record.brent.present? && record.tshortfall.present? && record.brent < record.tshortfall * 2
+      record.errors.add :brent, I18n.t("validations.financial.rent.less_than_double_shortfall", tshortfall: record.tshortfall * 2)
+      record.errors.add :tshortfall, I18n.t("validations.financial.tshortfall.more_than_rent")
+    end
+  end
 end

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -101,6 +101,17 @@ module Validations::FinancialValidations
       record.errors.add :tshortfall, I18n.t("validations.financial.tshortfall.more_than_rent")
     end
 
+    if record.tcharge.present? && weekly_value_in_range(record, "tcharge", 9.99)
+      record.errors.add :tcharge, I18n.t("validations.financial.tcharge.under_10")
+    end
+
+    answered_questions = [record.tcharge, record.chcharge].concat(record.household_charge.zero? ? [record.household_charge] : [])
+    if answered_questions.count(&:present?) > 1
+      record.errors.add :tcharge, I18n.t("validations.financial.tcharge.complete_1_of_3") if record.tcharge.present?
+      record.errors.add :chcharge, I18n.t("validations.financial.chcharge.complete_1_of_3") if record.chcharge.present?
+      record.errors.add :household_charge, I18n.t("validations.financial.household_charge.complete_1_of_3") if record.household_charge.present?
+    end
+
     validate_charges(record)
   end
 

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -69,11 +69,11 @@ module Validations::FinancialValidations
       record.errors.add :tcharge, I18n.t("validations.financial.tcharge.under_10")
     end
 
-    answered_questions = [record.tcharge, record.chcharge].concat(!(record.household_charge && record.household_charge.zero?).nil? ? [record.household_charge] : [])
+    answered_questions = [record.tcharge, record.chcharge].concat(record.household_charge && record.household_charge.zero? ? [record.household_charge] : [])
     if answered_questions.count(&:present?) > 1
-      record.errors.add :tcharge, I18n.t("validations.financial.tcharge.complete_1_of_3") if record.tcharge.present?
-      record.errors.add :chcharge, I18n.t("validations.financial.chcharge.complete_1_of_3") if record.chcharge.present?
-      record.errors.add :household_charge, I18n.t("validations.financial.household_charge.complete_1_of_3") if record.household_charge.present?
+      record.errors.add :tcharge, I18n.t("validations.financial.charges.complete_1_of_3") if record.tcharge.present?
+      record.errors.add :chcharge, I18n.t("validations.financial.charges.complete_1_of_3") if record.chcharge.present?
+      record.errors.add :household_charge, I18n.t("validations.financial.charges.complete_1_of_3") if record.household_charge.present?
     end
 
     validate_charges(record)

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -65,9 +65,12 @@ module Validations::FinancialValidations
       record.errors.add :tshortfall, I18n.t("validations.financial.tshortfall.more_than_rent")
     end
 
-    if record.scharge.present? && record.this_landlord? && record.weekly_value(record.scharge).present? && !record.weekly_value(record.scharge).between?(0, 55)
-      record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.general_needs")
-      record.errors.add :landlord, I18n.t("validations.organisation.landlord.invalid_scharge")
+    if record.scharge.present? && record.this_landlord? && record.weekly_value(record.scharge).present?
+      if !record.weekly_value(record.scharge).between?(0, 55) && record.is_general_needs?
+        record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.general_needs")
+      elsif !record.weekly_value(record.scharge).between?(0, 280) && record.is_supported_housing?
+        record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing")
+      end
     end
   end
 end

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -65,11 +65,19 @@ module Validations::FinancialValidations
       record.errors.add :tshortfall, I18n.t("validations.financial.tshortfall.more_than_rent")
     end
 
-    if record.scharge.present? && record.this_landlord? && record.weekly_value(record.scharge).present?
-      if !record.weekly_value(record.scharge).between?(0, 55) && record.is_general_needs?
-        record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.general_needs")
-      elsif !record.weekly_value(record.scharge).between?(0, 280) && record.is_supported_housing?
-        record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing")
+    if record.scharge.present? && record.weekly_value(record.scharge).present?
+      if record.this_landlord?
+        if !record.weekly_value(record.scharge).between?(0, 55) && record.is_general_needs?
+          record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.general_needs")
+        elsif !record.weekly_value(record.scharge).between?(0, 280) && record.is_supported_housing?
+          record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing")
+        end
+      elsif record.other_landlord?
+        if !record.weekly_value(record.scharge).between?(0, 45) && record.is_general_needs?
+          record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.other_landlord.general_needs")
+        elsif !record.weekly_value(record.scharge).between?(0, 165) && record.is_supported_housing?
+          record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing")
+        end
       end
     end
   end

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -64,5 +64,10 @@ module Validations::FinancialValidations
       record.errors.add :brent, I18n.t("validations.financial.rent.less_than_double_shortfall", tshortfall: record.tshortfall * 2)
       record.errors.add :tshortfall, I18n.t("validations.financial.tshortfall.more_than_rent")
     end
+
+    if record.scharge.present? && record.this_landlord? && record.weekly_value(record.scharge).present? && !record.weekly_value(record.scharge).between?(0, 55)
+      record.errors.add :scharge, I18n.t("validations.financial.rent.scharge.this_landlord.general_needs")
+      record.errors.add :landlord, I18n.t("validations.organisation.landlord.invalid_scharge")
+    end
   end
 end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4702,31 +4702,31 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "2": {
                       "value": "Every 2 weeks"
                     },
-                    "1": {
+                    "3": {
                       "value": "Every 4 weeks"
                     },
-                    "2": {
+                    "4": {
                       "value": "Every calendar month"
                     },
-                    "3": {
+                    "5": {
                       "value": "Weekly for 50 weeks"
                     },
-                    "4": {
+                    "6": {
                       "value": "Weekly for 49 weeks"
                     },
-                    "5": {
+                    "7": {
                       "value": "Weekly for 48 weeks"
                     },
-                    "6": {
+                    "8": {
                       "value": "Weekly for 47 weeks"
                     },
-                    "7": {
+                    "9": {
                       "value": "Weekly for 46 weeks"
                     },
-                    "8": {
+                    "1": {
                       "value": "Weekly for 52 weeks"
                     }
                   }
@@ -4777,32 +4777,12 @@
               },
               "depends_on": [
                 {
-                  "period": 8,
+                  "period": 1,
                   "needstype": 0,
                   "household_charge": 0
                 },
                 {
-                  "period": 8,
-                  "needstype": 0,
-                  "household_charge": null
-                },
-                {
-                  "period": 3,
-                  "needstype": 0,
-                  "household_charge": 0
-                },
-                {
-                  "period": 3,
-                  "needstype": 0,
-                  "household_charge": null
-                },
-                {
-                  "period": 4,
-                  "needstype": 0,
-                  "household_charge": 0
-                },
-                {
-                  "period": 4,
+                  "period": 1,
                   "needstype": 0,
                   "household_charge": null
                 },
@@ -4833,6 +4813,26 @@
                 },
                 {
                   "period": 7,
+                  "needstype": 0,
+                  "household_charge": null
+                },
+                {
+                  "period": 8,
+                  "needstype": 0,
+                  "household_charge": 0
+                },
+                {
+                  "period": 8,
+                  "needstype": 0,
+                  "household_charge": null
+                },
+                {
+                  "period": 9,
+                  "needstype": 0,
+                  "household_charge": 0
+                },
+                {
+                  "period": 9,
                   "needstype": 0,
                   "household_charge": null
                 }
@@ -4874,12 +4874,12 @@
               },
               "depends_on": [
                 {
-                  "period": 0,
+                  "period": 2,
                   "needstype": 0,
                   "household_charge": 0
                 },
                 {
-                  "period": 0,
+                  "period": 2,
                   "needstype": 0,
                   "household_charge": null
                 }
@@ -4921,12 +4921,12 @@
               },
               "depends_on": [
                 {
-                  "period": 1,
+                  "period": 3,
                   "needstype": 0,
                   "household_charge": 0
                 },
                 {
-                  "period": 1,
+                  "period": 3,
                   "needstype": 0,
                   "household_charge": null
                 }
@@ -4968,12 +4968,12 @@
               },
               "depends_on": [
                 {
-                  "period": 2,
+                  "period": 4,
                   "needstype": 0,
                   "household_charge": 0
                 },
                 {
-                  "period": 2,
+                  "period": 4,
                   "needstype": 0,
                   "household_charge": null
                 }
@@ -5081,32 +5081,12 @@
               },
               "depends_on": [
                 {
-                  "period": 8,
+                  "period": 1,
                   "household_charge": 0,
                   "is_carehome": 0
                 },
                 {
-                  "period": 8,
-                  "household_charge": null,
-                  "is_carehome": 0
-                },
-                {
-                  "period": 3,
-                  "household_charge": 0,
-                  "is_carehome": 0
-                },
-                {
-                  "period": 3,
-                  "household_charge": null,
-                  "is_carehome": 0
-                },
-                {
-                  "period": 4,
-                  "household_charge": 0,
-                  "is_carehome": 0
-                },
-                {
-                  "period": 4,
+                  "period": 1,
                   "household_charge": null,
                   "is_carehome": 0
                 },
@@ -5143,6 +5123,66 @@
                 {
                   "period": 8,
                   "household_charge": 0,
+                  "is_carehome": 0
+                },
+                {
+                  "period": 8,
+                  "household_charge": null,
+                  "is_carehome": 0
+                },
+                {
+                  "period": 9,
+                  "household_charge": 0,
+                  "is_carehome": 0
+                },
+                {
+                  "period": 9,
+                  "household_charge": null,
+                  "is_carehome": 0
+                },
+                {
+                  "period": 1,
+                  "household_charge": 0,
+                  "is_carehome": null
+                },
+                {
+                  "period": 1,
+                  "household_charge": null,
+                  "is_carehome": null
+                },
+                {
+                  "period": 5,
+                  "household_charge": 0,
+                  "is_carehome": null
+                },
+                {
+                  "period": 5,
+                  "household_charge": null,
+                  "is_carehome": null
+                },
+                {
+                  "period": 6,
+                  "household_charge": 0,
+                  "is_carehome": null
+                },
+                {
+                  "period": 6,
+                  "household_charge": null,
+                  "is_carehome": null
+                },
+                {
+                  "period": 7,
+                  "household_charge": 0,
+                  "is_carehome": null
+                },
+                {
+                  "period": 7,
+                  "household_charge": null,
+                  "is_carehome": null
+                },
+                {
+                  "period": 8,
+                  "household_charge": 0,
                   "is_carehome": null
                 },
                 {
@@ -5151,52 +5191,12 @@
                   "is_carehome": null
                 },
                 {
-                  "period": 3,
+                  "period": 9,
                   "household_charge": 0,
                   "is_carehome": null
                 },
                 {
-                  "period": 3,
-                  "household_charge": null,
-                  "is_carehome": null
-                },
-                {
-                  "period": 4,
-                  "household_charge": 0,
-                  "is_carehome": null
-                },
-                {
-                  "period": 4,
-                  "household_charge": null,
-                  "is_carehome": null
-                },
-                {
-                  "period": 5,
-                  "household_charge": 0,
-                  "is_carehome": null
-                },
-                {
-                  "period": 5,
-                  "household_charge": null,
-                  "is_carehome": null
-                },
-                {
-                  "period": 6,
-                  "household_charge": 0,
-                  "is_carehome": null
-                },
-                {
-                  "period": 6,
-                  "household_charge": null,
-                  "is_carehome": null
-                },
-                {
-                  "period": 7,
-                  "household_charge": 0,
-                  "is_carehome": null
-                },
-                {
-                  "period": 7,
+                  "period": 9,
                   "household_charge": null,
                   "is_carehome": null
                 }
@@ -5305,22 +5305,22 @@
               "depends_on": [
                 {
                   "household_charge": 0,
-                  "period": 0,
+                  "period": 2,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": null,
-                  "period": 0,
+                  "period": 2,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": 0,
-                  "period": 0,
+                  "period": 2,
                   "is_carehome": null
                 },
                 {
                   "household_charge": null,
-                  "period": 0,
+                  "period": 2,
                   "is_carehome": null
                 }
               ]
@@ -5428,22 +5428,22 @@
               "depends_on": [
                 {
                   "household_charge": 0,
-                  "period": 1,
+                  "period": 3,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": null,
-                  "period": 1,
+                  "period": 3,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": 0,
-                  "period": 1,
+                  "period": 3,
                   "is_carehome": null
                 },
                 {
                   "household_charge": null,
-                  "period": 1,
+                  "period": 3,
                   "is_carehome": null
                 }
               ]
@@ -5551,22 +5551,22 @@
               "depends_on": [
                 {
                   "household_charge": 0,
-                  "period": 2,
+                  "period": 4,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": null,
-                  "period": 2,
+                  "period": 4,
                   "is_carehome": 0
                 },
                 {
                   "household_charge": 0,
-                  "period": 2,
+                  "period": 4,
                   "is_carehome": null
                 },
                 {
                   "household_charge": null,
-                  "period": 2,
+                  "period": 4,
                   "is_carehome": null
                 }
               ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,8 @@ en:
         less_than_double_shortfall: "Answer must be more than double the shortfall in basic rent"
         scharge:
           this_landlord:
-            general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord"
+            general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord and it is a general needs letting"
+            supported_housing: "Service charge must be between 0 and 280 per week if the landlord is this landlord and it is a suported housing letting"
 
     household:
       reasonpref:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,11 +94,29 @@ en:
         less_than_double_shortfall: "Answer must be more than double the shortfall in basic rent"
         scharge:
           this_landlord:
-            general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord and it is a general needs letting"
-            supported_housing: "Service charge must be between 0 and 280 per week if the landlord is this landlord and it is a suported housing letting"
+            general_needs: "Service charge must be between £0 and £55 per week if the landlord is this landlord and it is a general needs letting"
+            supported_housing: "Service charge must be between £0 and £280 per week if the landlord is this landlord and it is a suported housing letting"
           other_landlord:
-            general_needs: "Service charge must be between 0 and 45 per week if the landlord is another RP and it is a general needs letting"
-            supported_housing: "Service charge must be between 0 and 165 per week if the landlord is another RP and it is a suported housing letting"
+            general_needs: "Service charge must be between £0 and £45 per week if the landlord is another RP and it is a general needs letting"
+            supported_housing: "Service charge must be between £0 and £165 per week if the landlord is another RP and it is a suported housing letting"
+        pscharge:
+          this_landlord:
+            general_needs: "Personal service charge must be between £0 and £30 per week if the landlord is this landlord and it is a general needs letting"
+            supported_housing: "Personal service charge must be between £0 and £200 per week if the landlord is this landlord and it is a suported housing letting"
+          other_landlord:
+            general_needs: "Personal service charge must be between £0 and £35 per week if the landlord is another RP and it is a general needs letting"
+            supported_housing: "Personal service charge must be between £0 and £75 per week if the landlord is another RP and it is a suported housing letting"
+        supcharg:
+          this_landlord:
+            general_needs: "Support charge must be between £0 and £40 per week if the landlord is this landlord and it is a general needs letting"
+            supported_housing: "Support charge must be between £0 and £465 per week if the landlord is this landlord and it is a suported housing letting"
+          other_landlord:
+            general_needs: "Support charge must be between £0 and £60 per week if the landlord is another RP and it is a general needs letting"
+            supported_housing: "Support charge must be between £0 and £120 per week if the landlord is another RP and it is a suported housing letting"
+      charges:
+        complete_1_of_3: 'Only one question out of "Total charge", "Charges for carehomes" and "Does the household pay rent or charges?" needs to be selected and completed'
+      tcharge:
+        under_10: "Total charge must be at least £10 per week"
 
     household:
       reasonpref:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
     financial:
       tshortfall:
         outstanding_amount_not_required: "You must not answer the outstanding amount question if you don’t have outstanding rent or charges"
-        more_than_rent: "Answer cannot be more than half of the basic rent amount"
+        more_than_rent: "Answer must be less than half of the basic rent amount"
       hbrentshortfall:
         outstanding_no_benefits: "Outstanding amount for basic rent and/or benefit eligible charges cannot be 'Yes' if tenant is not in receipt of housing benefit or universal benefit or if benefit is unknown"
       benefits:
@@ -91,7 +91,7 @@ en:
         earnings_missing: "Enter how much income the household has in total"
       negative_currency: "Enter an amount above 0"
       rent:
-        less_than_double_shortfall: "Answer cannot be less than double shortfall in basic rent"
+        less_than_double_shortfall: "Answer must be more than double the shortfall in basic rent"
         scharge:
           this_landlord:
             general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
       negative_currency: "Enter an amount above 0"
       rent:
         less_than_double_shortfall: "Answer cannot be less than double shortfall in basic rent"
+        scharge:
+          this_landlord:
+            general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord"
 
     household:
       reasonpref:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,9 @@ en:
           this_landlord:
             general_needs: "Service charge must be between 0 and 55 per week if the landlord is this landlord and it is a general needs letting"
             supported_housing: "Service charge must be between 0 and 280 per week if the landlord is this landlord and it is a suported housing letting"
+          other_landlord:
+            general_needs: "Service charge must be between 0 and 45 per week if the landlord is another RP and it is a general needs letting"
+            supported_housing: "Service charge must be between 0 and 165 per week if the landlord is another RP and it is a suported housing letting"
 
     household:
       reasonpref:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,8 @@ en:
 
     financial:
       tshortfall:
-        outstanding_amount_not_required: "You must not answer the outstanding amount question if you don’t have outstanding rent or charges."
+        outstanding_amount_not_required: "You must not answer the outstanding amount question if you don’t have outstanding rent or charges"
+        more_than_rent: "Answer cannot be more than half of the basic rent amount"
       hbrentshortfall:
         outstanding_no_benefits: "Outstanding amount for basic rent and/or benefit eligible charges cannot be 'Yes' if tenant is not in receipt of housing benefit or universal benefit or if benefit is unknown"
       benefits:
@@ -89,6 +90,8 @@ en:
         freq_missing: "Select how often the household receives income"
         earnings_missing: "Enter how much income the household has in total"
       negative_currency: "Enter an amount above 0"
+      rent:
+        less_than_double_shortfall: "Answer cannot be less than double shortfall in basic rent"
 
     household:
       reasonpref:

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
       earnings { 68 }
       incfreq { 0 }
       benefits { 1 }
-      period { 0 }
+      period { 2 }
       brent { 200 }
       scharge { 50 }
       pscharge { 40 }

--- a/spec/factories/case_log.rb
+++ b/spec/factories/case_log.rb
@@ -139,10 +139,8 @@ FactoryBot.define do
       armedforces { 0 }
       builtype { 1 }
       unitletas { 2 }
-      household_charge { 1 }
       has_benefits { 1 }
       is_carehome { 0 }
-      chcharge { 7 }
       letting_in_sheltered_accommodation { 0 }
       la_known { 1 }
       declaration { 1 }

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -141,7 +141,6 @@
     "has_benefits": 1,
     "household_charge": 1,
     "is_carehome": 1,
-    "chcharge": 6,
     "letting_in_sheltered_accommodation": 0,
     "declaration": 1,
     "referral": 1

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -76,7 +76,7 @@
     "incfreq": 0,
     "benefits": 1,
     "hb": 1,
-    "period": 0,
+    "period": 2,
     "brent": 200,
     "scharge": 50,
     "pscharge": 40,

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -135,7 +135,7 @@
     <nocharge>0</nocharge>
     <is_carehome>0</is_carehome>
     <letting_in_sheltered_accommodation>0</letting_in_sheltered_accommodation>
-    <household_charge>1</household_charge>
+    <household_charge/>
     <referral/>
     <brent>200.0</brent>
     <scharge>50.0</scharge>
@@ -143,7 +143,7 @@
     <supcharg>35.0</supcharg>
     <tcharge>325.0</tcharge>
     <tshortfall>12.0</tshortfall>
-    <chcharge>7.0</chcharge>
+    <chcharge/>
     <declaration>1</declaration>
     <previous_postcode_known>1</previous_postcode_known>
     <previous_la_known/>

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -54,7 +54,7 @@
     <earnings>68</earnings>
     <incfreq>0</incfreq>
     <benefits>1</benefits>
-    <period>0</period>
+    <period>2</period>
     <layear>2</layear>
     <lawaitlist>1</lawaitlist>
     <property_postcode>NW1 5TY</property_postcode>

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -641,10 +641,10 @@
                     "header": "Which period are rent and other charges due?",
                     "type": "radio",
                     "answer_options": {
-                      "0": {
+                      "2": {
                         "value": "Weekly for 52 weeks"
                       },
-                      "1": {
+                      "3": {
                         "value": "Every 2 weeks"
                       }
                     }

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -310,35 +310,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid bi-weekly" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 100, period: 0)
+            case_log.update!(brent: 100, period: 2)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(50.0)
             expect(record_from_db["wrent"]).to eq(50.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 100, period: 0)
+            case_log.update!(scharge: 100, period: 2)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(50.0)
             expect(record_from_db["wscharge"]).to eq(50.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 100, period: 0)
+            case_log.update!(pscharge: 100, period: 2)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(50.0)
             expect(record_from_db["wpschrge"]).to eq(50.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 100, period: 0)
+            case_log.update!(supcharg: 100, period: 2)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(50.0)
             expect(record_from_db["wsupchrg"]).to eq(50.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 100, period: 0)
+            case_log.update!(tcharge: 100, period: 2)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(50.0)
             expect(record_from_db["wtcharge"]).to eq(50.0)
@@ -347,7 +347,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 2, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(50.0)
                 expect(record_from_db["wtshortfall"]).to eq(50.0)
@@ -356,7 +356,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 2, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(50.0)
                 expect(record_from_db["wtshortfall"]).to eq(50.0)
@@ -365,7 +365,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 0, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 100, period: 2, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(50.0)
                 expect(record_from_db["wtshortfall"]).to eq(50.0)
@@ -376,35 +376,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid every 4 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 120, period: 1)
+            case_log.update!(brent: 120, period: 3)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(30.0)
             expect(record_from_db["wrent"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 120, period: 1)
+            case_log.update!(scharge: 120, period: 3)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(30.0)
             expect(record_from_db["wscharge"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 120, period: 1)
+            case_log.update!(pscharge: 120, period: 3)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(30.0)
             expect(record_from_db["wpschrge"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 120, period: 1)
+            case_log.update!(supcharg: 120, period: 3)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(30.0)
             expect(record_from_db["wsupchrg"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 120, period: 1)
+            case_log.update!(tcharge: 120, period: 3)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(30.0)
             expect(record_from_db["wtcharge"]).to eq(30.0)
@@ -413,7 +413,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 3, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -422,7 +422,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 3, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -431,7 +431,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 1, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 120, period: 3, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -442,35 +442,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid every calendar month" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 2)
+            case_log.update!(brent: 130, period: 4)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(30.0)
             expect(record_from_db["wrent"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 2)
+            case_log.update!(scharge: 130, period: 4)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(30.0)
             expect(record_from_db["wscharge"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 2)
+            case_log.update!(pscharge: 130, period: 4)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(30.0)
             expect(record_from_db["wpschrge"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 2)
+            case_log.update!(supcharg: 130, period: 4)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(30.0)
             expect(record_from_db["wsupchrg"]).to eq(30.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 2)
+            case_log.update!(tcharge: 130, period: 4)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(30.0)
             expect(record_from_db["wtcharge"]).to eq(30.0)
@@ -479,7 +479,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -488,7 +488,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -497,7 +497,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 2, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(30.0)
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
@@ -508,35 +508,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 50 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 3)
+            case_log.update!(brent: 130, period: 5)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(125.0)
             expect(record_from_db["wrent"]).to eq(125.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 3)
+            case_log.update!(scharge: 130, period: 5)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(125.0)
             expect(record_from_db["wscharge"]).to eq(125.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 3)
+            case_log.update!(pscharge: 130, period: 5)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(125.0)
             expect(record_from_db["wpschrge"]).to eq(125.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 3)
+            case_log.update!(supcharg: 130, period: 5)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(125.0)
             expect(record_from_db["wsupchrg"]).to eq(125.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 3)
+            case_log.update!(tcharge: 130, period: 5)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(125.0)
             expect(record_from_db["wtcharge"]).to eq(125.0)
@@ -545,7 +545,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(125.0)
                 expect(record_from_db["wtshortfall"]).to eq(125.0)
@@ -554,7 +554,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(125.0)
                 expect(record_from_db["wtshortfall"]).to eq(125.0)
@@ -563,7 +563,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 3, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(125.0)
                 expect(record_from_db["wtshortfall"]).to eq(125.0)
@@ -574,35 +574,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 49 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 4)
+            case_log.update!(brent: 130, period: 6)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(122.5)
             expect(record_from_db["wrent"]).to eq(122.5)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 4)
+            case_log.update!(scharge: 130, period: 6)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(122.5)
             expect(record_from_db["wscharge"]).to eq(122.5)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 4)
+            case_log.update!(pscharge: 130, period: 6)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(122.5)
             expect(record_from_db["wpschrge"]).to eq(122.5)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 4)
+            case_log.update!(supcharg: 130, period: 6)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(122.5)
             expect(record_from_db["wsupchrg"]).to eq(122.5)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 4)
+            case_log.update!(tcharge: 130, period: 6)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(122.5)
             expect(record_from_db["wtcharge"]).to eq(122.5)
@@ -611,7 +611,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(122.5)
                 expect(record_from_db["wtshortfall"]).to eq(122.5)
@@ -620,7 +620,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(122.5)
                 expect(record_from_db["wtshortfall"]).to eq(122.5)
@@ -629,7 +629,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 4, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(122.5)
                 expect(record_from_db["wtshortfall"]).to eq(122.5)
@@ -640,35 +640,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 48 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 5)
+            case_log.update!(brent: 130, period: 7)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(120.0)
             expect(record_from_db["wrent"]).to eq(120.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 5)
+            case_log.update!(scharge: 130, period: 7)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(120.0)
             expect(record_from_db["wscharge"]).to eq(120.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 5)
+            case_log.update!(pscharge: 130, period: 7)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(120.0)
             expect(record_from_db["wpschrge"]).to eq(120.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 5)
+            case_log.update!(supcharg: 130, period: 7)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(120.0)
             expect(record_from_db["wsupchrg"]).to eq(120.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 5)
+            case_log.update!(tcharge: 130, period: 7)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(120.0)
             expect(record_from_db["wtcharge"]).to eq(120.0)
@@ -677,7 +677,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(120.0)
                 expect(record_from_db["wtshortfall"]).to eq(120.0)
@@ -686,7 +686,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(120.0)
                 expect(record_from_db["wtshortfall"]).to eq(120.0)
@@ -695,7 +695,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 5, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(120.0)
                 expect(record_from_db["wtshortfall"]).to eq(120.0)
@@ -706,35 +706,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 47 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 6)
+            case_log.update!(brent: 130, period: 8)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(117.5)
             expect(record_from_db["wrent"]).to eq(117.5)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 6)
+            case_log.update!(scharge: 130, period: 8)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(117.5)
             expect(record_from_db["wscharge"]).to eq(117.5)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 6)
+            case_log.update!(pscharge: 130, period: 8)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(117.5)
             expect(record_from_db["wpschrge"]).to eq(117.5)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 6)
+            case_log.update!(supcharg: 130, period: 8)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(117.5)
             expect(record_from_db["wsupchrg"]).to eq(117.5)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 6)
+            case_log.update!(tcharge: 130, period: 8)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(117.5)
             expect(record_from_db["wtcharge"]).to eq(117.5)
@@ -743,7 +743,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(117.5)
                 expect(record_from_db["wtshortfall"]).to eq(117.5)
@@ -752,7 +752,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(117.5)
                 expect(record_from_db["wtshortfall"]).to eq(117.5)
@@ -761,7 +761,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 6, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(117.5)
                 expect(record_from_db["wtshortfall"]).to eq(117.5)
@@ -772,35 +772,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 46 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 7)
+            case_log.update!(brent: 130, period: 9)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(115.0)
             expect(record_from_db["wrent"]).to eq(115.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 7)
+            case_log.update!(scharge: 130, period: 9)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(115.0)
             expect(record_from_db["wscharge"]).to eq(115.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 7)
+            case_log.update!(pscharge: 130, period: 9)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(115.0)
             expect(record_from_db["wpschrge"]).to eq(115.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 7)
+            case_log.update!(supcharg: 130, period: 9)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(115.0)
             expect(record_from_db["wsupchrg"]).to eq(115.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 7)
+            case_log.update!(tcharge: 130, period: 9)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(115.0)
             expect(record_from_db["wtcharge"]).to eq(115.0)
@@ -809,7 +809,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 9, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(115.0)
                 expect(record_from_db["wtshortfall"]).to eq(115.0)
@@ -818,7 +818,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 9, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(115.0)
                 expect(record_from_db["wtshortfall"]).to eq(115.0)
@@ -827,7 +827,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 7, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 9, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(115.0)
                 expect(record_from_db["wtshortfall"]).to eq(115.0)
@@ -838,35 +838,35 @@ RSpec.describe CaseLog do
 
         context "when rent is paid weekly for 52 weeks" do
           it "correctly derives and saves weekly rent" do
-            case_log.update!(brent: 130, period: 8)
+            case_log.update!(brent: 130, period: 1)
             record_from_db = ActiveRecord::Base.connection.execute("select wrent from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wrent).to eq(130.0)
             expect(record_from_db["wrent"]).to eq(130.0)
           end
 
           it "correctly derives and saves weekly service charge" do
-            case_log.update!(scharge: 130, period: 8)
+            case_log.update!(scharge: 130, period: 1)
             record_from_db = ActiveRecord::Base.connection.execute("select wscharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wscharge).to eq(130.0)
             expect(record_from_db["wscharge"]).to eq(130.0)
           end
 
           it "correctly derives and saves weekly personal service charge" do
-            case_log.update!(pscharge: 130, period: 8)
+            case_log.update!(pscharge: 130, period: 1)
             record_from_db = ActiveRecord::Base.connection.execute("select wpschrge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wpschrge).to eq(130.0)
             expect(record_from_db["wpschrge"]).to eq(130.0)
           end
 
           it "correctly derives and saves weekly support charge" do
-            case_log.update!(supcharg: 130, period: 8)
+            case_log.update!(supcharg: 130, period: 1)
             record_from_db = ActiveRecord::Base.connection.execute("select wsupchrg from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wsupchrg).to eq(130.0)
             expect(record_from_db["wsupchrg"]).to eq(130.0)
           end
 
           it "correctly derives and saves weekly total charge" do
-            case_log.update!(tcharge: 130, period: 8)
+            case_log.update!(tcharge: 130, period: 1)
             record_from_db = ActiveRecord::Base.connection.execute("select wtcharge from case_logs where id=#{case_log.id}").to_a[0]
             expect(case_log.wtcharge).to eq(130.0)
             expect(record_from_db["wtcharge"]).to eq(130.0)
@@ -875,7 +875,7 @@ RSpec.describe CaseLog do
           context "when the tenant has an outstanding amount after benefits" do
             context "when tenant is in receipt of housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 1)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 1, hb: 1)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(130.0)
                 expect(record_from_db["wtshortfall"]).to eq(130.0)
@@ -884,7 +884,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of universal credit with housing element exc. housing benefit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 6)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 1, hb: 6)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(130.0)
                 expect(record_from_db["wtshortfall"]).to eq(130.0)
@@ -893,7 +893,7 @@ RSpec.describe CaseLog do
 
             context "when tenant is in receipt of housing benefit and universal credit" do
               it "correctly derives and saves weekly total shortfall" do
-                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 8, hb: 8)
+                case_log.update!(hbrentshortfall: 0, tshortfall: 130, period: 1, hb: 8)
                 record_from_db = ActiveRecord::Base.connection.execute("select wtshortfall from case_logs where id=#{case_log.id}").to_a[0]
                 expect(case_log.wtshortfall).to eq(130.0)
                 expect(record_from_db["wtshortfall"]).to eq(130.0)

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -372,6 +372,21 @@ RSpec.describe CaseLog do
               end
             end
           end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 2)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(50.06)
+            expect(case_log.wpschrge).to eq(50.07)
+            expect(case_log.wscharge).to eq(50.49)
+            expect(case_log.wrent).to eq(50.49)
+            expect(case_log.wtcharge).to eq(201.1)
+            expect(record_from_db["wsupchrg"]).to eq(50.06)
+            expect(record_from_db["wpschrge"]).to eq(50.07)
+            expect(record_from_db["wscharge"]).to eq(50.49)
+            expect(record_from_db["wrent"]).to eq(50.49)
+            expect(record_from_db["wtcharge"]).to eq(201.1)
+          end
         end
 
         context "when rent is paid every 4 weeks" do
@@ -437,6 +452,21 @@ RSpec.describe CaseLog do
                 expect(record_from_db["wtshortfall"]).to eq(30.0)
               end
             end
+          end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 3)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(25.03)
+            expect(case_log.wpschrge).to eq(25.03)
+            expect(case_log.wscharge).to eq(25.24)
+            expect(case_log.wrent).to eq(25.24)
+            expect(case_log.wtcharge).to eq(100.55)
+            expect(record_from_db["wsupchrg"]).to eq(25.03)
+            expect(record_from_db["wpschrge"]).to eq(25.03)
+            expect(record_from_db["wscharge"]).to eq(25.24)
+            expect(record_from_db["wrent"]).to eq(25.24)
+            expect(record_from_db["wtcharge"]).to eq(100.55)
           end
         end
 
@@ -504,6 +534,21 @@ RSpec.describe CaseLog do
               end
             end
           end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 4)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(23.10)
+            expect(case_log.wpschrge).to eq(23.11)
+            expect(case_log.wscharge).to eq(23.30)
+            expect(case_log.wrent).to eq(23.30)
+            expect(case_log.wtcharge).to eq(92.82)
+            expect(record_from_db["wsupchrg"]).to eq(23.10)
+            expect(record_from_db["wpschrge"]).to eq(23.11)
+            expect(record_from_db["wscharge"]).to eq(23.30)
+            expect(record_from_db["wrent"]).to eq(23.30)
+            expect(record_from_db["wtcharge"]).to eq(92.82)
+          end
         end
 
         context "when rent is paid weekly for 50 weeks" do
@@ -569,6 +614,21 @@ RSpec.describe CaseLog do
                 expect(record_from_db["wtshortfall"]).to eq(125.0)
               end
             end
+          end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 5)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(96.27)
+            expect(case_log.wpschrge).to eq(96.28)
+            expect(case_log.wscharge).to eq(97.1)
+            expect(case_log.wrent).to eq(97.09)
+            expect(case_log.wtcharge).to eq(386.73)
+            expect(record_from_db["wsupchrg"]).to eq(96.27)
+            expect(record_from_db["wpschrge"]).to eq(96.28)
+            expect(record_from_db["wscharge"]).to eq(97.1)
+            expect(record_from_db["wrent"]).to eq(97.09)
+            expect(record_from_db["wtcharge"]).to eq(386.73)
           end
         end
 
@@ -636,6 +696,21 @@ RSpec.describe CaseLog do
               end
             end
           end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 6)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(94.34)
+            expect(case_log.wpschrge).to eq(94.35)
+            expect(case_log.wscharge).to eq(95.15)
+            expect(case_log.wrent).to eq(95.14)
+            expect(case_log.wtcharge).to eq(379)
+            expect(record_from_db["wsupchrg"]).to eq(94.34)
+            expect(record_from_db["wpschrge"]).to eq(94.35)
+            expect(record_from_db["wscharge"]).to eq(95.15)
+            expect(record_from_db["wrent"]).to eq(95.14)
+            expect(record_from_db["wtcharge"]).to eq(379)
+          end
         end
 
         context "when rent is paid weekly for 48 weeks" do
@@ -701,6 +776,21 @@ RSpec.describe CaseLog do
                 expect(record_from_db["wtshortfall"]).to eq(120.0)
               end
             end
+          end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 7)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(92.42)
+            expect(case_log.wpschrge).to eq(92.43)
+            expect(case_log.wscharge).to eq(93.21)
+            expect(case_log.wrent).to eq(93.20)
+            expect(case_log.wtcharge).to eq(371.26)
+            expect(record_from_db["wsupchrg"]).to eq(92.42)
+            expect(record_from_db["wpschrge"]).to eq(92.43)
+            expect(record_from_db["wscharge"]).to eq(93.21)
+            expect(record_from_db["wrent"]).to eq(93.20)
+            expect(record_from_db["wtcharge"]).to eq(371.26)
           end
         end
 
@@ -768,6 +858,21 @@ RSpec.describe CaseLog do
               end
             end
           end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 8)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(90.49)
+            expect(case_log.wpschrge).to eq(90.50)
+            expect(case_log.wscharge).to eq(91.27)
+            expect(case_log.wrent).to eq(91.26)
+            expect(case_log.wtcharge).to eq(363.53)
+            expect(record_from_db["wsupchrg"]).to eq(90.49)
+            expect(record_from_db["wpschrge"]).to eq(90.50)
+            expect(record_from_db["wscharge"]).to eq(91.27)
+            expect(record_from_db["wrent"]).to eq(91.26)
+            expect(record_from_db["wtcharge"]).to eq(363.53)
+          end
         end
 
         context "when rent is paid weekly for 46 weeks" do
@@ -834,6 +939,21 @@ RSpec.describe CaseLog do
               end
             end
           end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 9)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(88.57)
+            expect(case_log.wpschrge).to eq(88.58)
+            expect(case_log.wscharge).to eq(89.33)
+            expect(case_log.wrent).to eq(89.32)
+            expect(case_log.wtcharge).to eq(355.79)
+            expect(record_from_db["wsupchrg"]).to eq(88.57)
+            expect(record_from_db["wpschrge"]).to eq(88.58)
+            expect(record_from_db["wscharge"]).to eq(89.33)
+            expect(record_from_db["wrent"]).to eq(89.32)
+            expect(record_from_db["wtcharge"]).to eq(355.79)
+          end
         end
 
         context "when rent is paid weekly for 52 weeks" do
@@ -899,6 +1019,21 @@ RSpec.describe CaseLog do
                 expect(record_from_db["wtshortfall"]).to eq(130.0)
               end
             end
+          end
+
+          it "correctly derives floats" do
+            case_log.update!(supcharg: 100.12, pscharge: 100.13, scharge: 100.98, brent: 100.97, period: 1)
+            record_from_db = ActiveRecord::Base.connection.execute("select wtcharge, wsupchrg, wpschrge, wscharge, wrent from case_logs where id=#{case_log.id}").to_a[0]
+            expect(case_log.wsupchrg).to eq(100.12)
+            expect(case_log.wpschrge).to eq(100.13)
+            expect(case_log.wscharge).to eq(100.98)
+            expect(case_log.wrent).to eq(100.97)
+            expect(case_log.wtcharge).to eq(402.2)
+            expect(record_from_db["wsupchrg"]).to eq(100.12)
+            expect(record_from_db["wpschrge"]).to eq(100.13)
+            expect(record_from_db["wscharge"]).to eq(100.98)
+            expect(record_from_db["wrent"]).to eq(100.97)
+            expect(record_from_db["wtcharge"]).to eq(402.2)
           end
         end
       end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -591,6 +591,128 @@ RSpec.describe Validations::FinancialValidations do
           end
         end
       end
+
+      context "when period is weekly" do
+        it "validates that total charge is at least 10 per week" do
+          record.period = 1
+          record.tcharge = 9
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+                .to include(match I18n.t("validations.financial.tcharge.under_10"))
+        end
+
+        it "allows the total charge to be over 10 per week" do
+          record.period = 1
+          record.tcharge = 10
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+                .to be_empty
+        end
+      end
+
+      context "when period is every 2 weeks" do
+        it "validates that total charge is at least 10 per week" do
+          record.period = 2
+          record.tcharge = 19.99
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+                .to include(match I18n.t("validations.financial.tcharge.under_10"))
+        end
+
+        it "allows the total charge to be over 10 per week" do
+          record.period = 2
+          record.tcharge = 20
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+                .to be_empty
+        end
+      end
+
+      context "when entering charges" do
+        it "returns an error for 3 charge types selected" do
+          record.tcharge = 19.99
+          record.chcharge = 20
+          record.household_charge = 0
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+          expect(record.errors["household_charge"])
+            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+        end
+
+        it "returns an error for tcharge and chcharge types selected" do
+          record.tcharge = 19.99
+          record.chcharge = 20
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["household_charge"])
+            .to be_empty
+          expect(record.errors["tcharge"])
+            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+        end
+
+        it "returns an error for tcharge and household_charge types selected" do
+          record.tcharge = 19.99
+          record.household_charge = 0
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["chcharge"])
+            .to be_empty
+          expect(record.errors["tcharge"])
+            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+          expect(record.errors["household_charge"])
+            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+        end
+
+        it "returns an error for chcharge and household_charge types selected" do
+          record.chcharge = 20
+          record.household_charge = 0
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["tcharge"])
+            .to be_empty
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+          expect(record.errors["household_charge"])
+            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+        end
+      end
+
+      it "does not return an error for household_charge being yes" do
+        record.household_charge = 0
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["tcharge"])
+          .to be_empty
+        expect(record.errors["chcharge"])
+          .to be_empty
+        expect(record.errors["household_charge"])
+          .to be_empty
+      end
+
+      it "does not return an error for chcharge being selected" do
+        record.household_charge = 1
+        record.chcharge = 20
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["tcharge"])
+          .to be_empty
+        expect(record.errors["chcharge"])
+          .to be_empty
+        expect(record.errors["household_charge"])
+          .to be_empty
+      end
+
+      it "does not return an error for tcharge being selected" do
+        record.household_charge = 1
+        record.tcharge = 19.99
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["tcharge"])
+          .to be_empty
+        expect(record.errors["chcharge"])
+          .to be_empty
+        expect(record.errors["household_charge"])
+          .to be_empty
+      end
     end
   end
 end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -186,4 +186,19 @@ RSpec.describe Validations::FinancialValidations do
       end
     end
   end
+
+  describe "rent and charges validations" do
+    context "when shortfall amount is provided" do
+      it "validates that basic rent is no less than double the shortfall" do
+        record.hbrentshortfall = 1
+        record.tshortfall = 99.50
+        record.brent = 198
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["brent"])
+          .to include(match I18n.t("validations.financial.rent.less_than_double_shortfall", shortfall: 198))
+        expect(record.errors["tshortfall"])
+          .to include(match I18n.t("validations.financial.tshortfall.more_than_rent"))
+      end
+    end
+  end
 end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -203,252 +203,296 @@ RSpec.describe Validations::FinancialValidations do
 
     context "when the landlord is this landlord" do
       context "when needstype is general needs" do
-        it "does not allow the scharge to be outside of 0 and 55 range per week when period is weekly" do
+        before do
           record.needstype = 1
           record.landlord = 1
-          record.period = 1
-          record.scharge = 56
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
         end
 
-        it "does allow the scharge to be between of 0 and 55 per week when period is weekly" do
-          record.needstype = 1
-          record.landlord = 1
-          record.period = 1
-          record.scharge = 54
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 56 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 300 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 111 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 31 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 150 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 61 },
+         }].each do |test_case|
+          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to include(match I18n.t("validations.financial.rent.#{test_case[:charge][:field]}.this_landlord.general_needs"))
+          end
         end
 
-        it "does not allow the scharge to be outside of 0 and 55 range per week when period is monthly" do
-          record.needstype = 1
-          record.landlord = 1
-          record.period = 4
-          record.scharge = 300
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
-        end
-
-        it "does allow the scharge to be between of 0 and 55 per week when period is monthly" do
-          record.needstype = 1
-          record.landlord = 1
-          record.period = 4
-          record.scharge = 220
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
-        end
-
-        it "does not allow the scharge to be outside of 0 and 55 range per week when period is every 2 weeks" do
-          record.needstype = 1
-          record.landlord = 1
-          record.period = 2
-          record.scharge = 111
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
-        end
-
-        it "does allow the scharge to be between of 0 and 55 per week when period is every 2 weeks" do
-          record.needstype = 1
-          record.landlord = 1
-          record.period = 2
-          record.scharge = 109
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 54 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 220 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 109 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 30 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 120 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 59 },
+         }].each do |test_case|
+          it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to be_empty
+          end
         end
       end
 
       context "when needstype is supported housing" do
-        it "does not allow the scharge to be outside of 0 and 280 range per week when period is weekly" do
+        before do
           record.needstype = 0
           record.landlord = 1
-          record.period = 1
-          record.scharge = 281
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
         end
 
-        it "does allow the scharge to be between of 0 and 280 per week when period is weekly" do
-          record.needstype = 0
-          record.landlord = 1
-          record.period = 1
-          record.scharge = 280
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 281 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 1225 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 561 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 201 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 1000 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 400.80 },
+         }].each do |test_case|
+          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to include(match I18n.t("validations.financial.rent.#{test_case[:charge][:field]}.this_landlord.supported_housing"))
+          end
         end
 
-        it "does not allow the scharge to be outside of 0 and 280 range per week when period is monthly" do
-          record.needstype = 0
-          record.landlord = 1
-          record.period = 4
-          record.scharge = 1225
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
-        end
-
-        it "does allow the scharge to be between of 0 and 280 per week when period is monthly" do
-          record.needstype = 0
-          record.landlord = 1
-          record.period = 4
-          record.scharge = 1200
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
-        end
-
-        it "does not allow the scharge to be outside of 0 and 280 range per week when period is every 2 weeks" do
-          record.needstype = 0
-          record.landlord = 1
-          record.period = 2
-          record.scharge = 561
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
-        end
-
-        it "does allow the scharge to be between of 0 and 280 per week when period is every 2 weeks" do
-          record.needstype = 0
-          record.landlord = 1
-          record.period = 2
-          record.scharge = 559
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 280 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 1200 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 559 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 199.99 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 800 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 400 },
+         }].each do |test_case|
+          it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to be_empty
+          end
         end
       end
     end
 
     context "when the landlord is another RP" do
       context "when needstype is general needs" do
-        it "does not allow the scharge to be outside of 0 and 45 range per week when period is weekly" do
+        before do
           record.needstype = 1
           record.landlord = 2
-          record.period = 1
-          record.scharge = 46
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
         end
 
-        it "does allow the scharge to be between of 0 and 45 per week when period is weekly" do
-          record.needstype = 1
-          record.landlord = 2
-          record.period = 1
-          record.scharge = 44
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 46 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 200 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 91 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 36 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 190 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 71 },
+         }].each do |test_case|
+          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to include(match I18n.t("validations.financial.rent.#{test_case[:charge][:field]}.other_landlord.general_needs"))
+          end
         end
 
-        it "does not allow the scharge to be outside of 0 and 45 range per week when period is monthly" do
-          record.needstype = 1
-          record.landlord = 2
-          record.period = 4
-          record.scharge = 200
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
-        end
-
-        it "does allow the scharge to be between of 0 and 45 per week when period is monthly" do
-          record.needstype = 1
-          record.landlord = 2
-          record.period = 4
-          record.scharge = 160
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
-        end
-
-        it "does not allow the scharge to be outside of 0 and 45 range per week when period is every 2 weeks" do
-          record.needstype = 1
-          record.landlord = 2
-          record.period = 2
-          record.scharge = 91
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
-        end
-
-        it "does allow the scharge to be between of 0 and 45 per week when period is every 2 weeks" do
-          record.needstype = 1
-          record.landlord = 2
-          record.period = 2
-          record.scharge = 89
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 44 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 160 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 89 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 34 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 140 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 69 },
+         }].each do |test_case|
+          it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to be_empty
+          end
         end
       end
 
       context "when needstype is supported housing" do
-        it "does not allow the scharge to be outside of 0 and 165 range per week when period is weekly" do
+        before do
           record.needstype = 0
           record.landlord = 2
-          record.period = 1
-          record.scharge = 165.90
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
         end
 
-        it "does allow the scharge to be between of 0 and 165 per week when period is weekly" do
-          record.needstype = 0
-          record.landlord = 2
-          record.period = 1
-          record.scharge = 120.88
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 165.90 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 750 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 330.50 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 76 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 400 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 151 },
+         }].each do |test_case|
+          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to include(match I18n.t("validations.financial.rent.#{test_case[:charge][:field]}.other_landlord.supported_housing"))
+          end
         end
 
-        it "does not allow the scharge to be outside of 0 and 165 range per week when period is monthly" do
-          record.needstype = 0
-          record.landlord = 2
-          record.period = 4
-          record.scharge = 750
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
-        end
-
-        it "does allow the scharge to be between of 0 and 165 per week when period is monthly" do
-          record.needstype = 0
-          record.landlord = 2
-          record.period = 4
-          record.scharge = 608
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
-        end
-
-        it "does not allow the scharge to be outside of 0 and 165 range per week when period is every 2 weeks" do
-          record.needstype = 0
-          record.landlord = 2
-          record.period = 2
-          record.scharge = 330.50
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
-        end
-
-        it "does allow the scharge to be between of 0 and 165 per week when period is every 2 weeks" do
-          record.needstype = 0
-          record.landlord = 2
-          record.period = 2
-          record.scharge = 329.99
-          financial_validator.validate_rent_amount(record)
-          expect(record.errors["scharge"])
-            .to be_empty
+        [{
+          period: { label: "weekly", value: 1 },
+          charge: { field: "scharge", value: 120.88 },
+        },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "scharge", value: 608 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "scharge", value: 329.99 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "pscharge", value: 74 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "pscharge", value: 210 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "pscharge", value: 149 },
+         }].each do |test_case|
+          it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
+            record.period = test_case[:period][:value]
+            record[test_case[:charge][:field]] = test_case[:charge][:value]
+            financial_validator.validate_rent_amount(record)
+            expect(record.errors[test_case[:charge][:field]])
+              .to be_empty
+          end
         end
       end
     end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Validations::FinancialValidations do
       it "does not allow the scharge to be outside of 0 and 55 range per week when period is weekly" do
         record.needstype = 1
         record.landlord = 1
-        record.period = 7
+        record.period = 1
         record.scharge = 56
         financial_validator.validate_rent_amount(record)
         expect(record.errors["scharge"])
@@ -215,7 +215,7 @@ RSpec.describe Validations::FinancialValidations do
       it "does allow the scharge to be between of 0 and 55 per week when period is weekly" do
         record.needstype = 1
         record.landlord = 1
-        record.period = 7
+        record.period = 1
         record.scharge = 54
         financial_validator.validate_rent_amount(record)
         expect(record.errors["scharge"])

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -231,6 +231,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 61 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 41 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 200 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 81 },
          }].each do |test_case|
           it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -264,6 +276,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 59 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 39 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 120 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 79 },
          }].each do |test_case|
           it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -304,6 +328,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 400.80 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 466 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 3100 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 990 },
          }].each do |test_case|
           it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -337,6 +373,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 400 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 464 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 2000 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 880 },
          }].each do |test_case|
           it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -379,6 +427,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 71 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 61 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 300 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 122 },
          }].each do |test_case|
           it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -412,6 +472,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 69 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 59.99 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 240 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 119 },
          }].each do |test_case|
           it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -452,6 +524,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 151 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 121 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 620 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 241 },
          }].each do |test_case|
           it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
@@ -485,6 +569,18 @@ RSpec.describe Validations::FinancialValidations do
          {
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "pscharge", value: 149 },
+         },
+         {
+           period: { label: "weekly", value: 1 },
+           charge: { field: "supcharg", value: 119 },
+         },
+         {
+           period: { label: "monthly", value: 4 },
+           charge: { field: "supcharg", value: 480 },
+         },
+         {
+           period: { label: "every 2 weeks", value: 2 },
+           charge: { field: "supcharg", value: 239 },
          }].each do |test_case|
           it "does allow charges inside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -201,65 +201,129 @@ RSpec.describe Validations::FinancialValidations do
       end
     end
 
-    context "when the landlord is this landlord and needstype is general needs" do
-      it "does not allow the scharge to be outside of 0 and 55 range per week when period is weekly" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 1
-        record.scharge = 56
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+    context "when the landlord is this landlord" do
+      context "when needstype is general needs" do
+        it "does not allow the scharge to be outside of 0 and 55 range per week when period is weekly" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 1
+          record.scharge = 56
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 55 per week when period is weekly" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 1
+          record.scharge = 54
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 55 range per week when period is monthly" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 4
+          record.scharge = 300
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 55 per week when period is monthly" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 4
+          record.scharge = 220
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 55 range per week when period is every 2 weeks" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 2
+          record.scharge = 111
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 55 per week when period is every 2 weeks" do
+          record.needstype = 1
+          record.landlord = 1
+          record.period = 2
+          record.scharge = 109
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
       end
 
-      it "does allow the scharge to be between of 0 and 55 per week when period is weekly" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 1
-        record.scharge = 54
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to be_empty
-      end
+      context "when needstype is supported housing" do
+        it "does not allow the scharge to be outside of 0 and 280 range per week when period is weekly" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 1
+          record.scharge = 281
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
+        end
 
-      it "does not allow the scharge to be outside of 0 and 55 range per week when period is monthly" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 4
-        record.scharge = 300
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
-      end
+        it "does allow the scharge to be between of 0 and 280 per week when period is weekly" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 1
+          record.scharge = 280
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
 
-      it "does allow the scharge to be between of 0 and 55 per week when period is monthly" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 4
-        record.scharge = 220
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to be_empty
-      end
+        it "does not allow the scharge to be outside of 0 and 280 range per week when period is monthly" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 4
+          record.scharge = 1225
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
+        end
 
-      it "does not allow the scharge to be outside of 0 and 55 range per week when period is every 2 weeks" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 2
-        record.scharge = 111
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
-      end
+        it "does allow the scharge to be between of 0 and 280 per week when period is monthly" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 4
+          record.scharge = 1200
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
 
-      it "does allow the scharge to be between of 0 and 55 per week when period is every 2 weeks" do
-        record.needstype = 1
-        record.landlord = 1
-        record.period = 2
-        record.scharge = 109
-        financial_validator.validate_rent_amount(record)
-        expect(record.errors["scharge"])
-          .to be_empty
+        it "does not allow the scharge to be outside of 0 and 280 range per week when period is every 2 weeks" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 2
+          record.scharge = 561
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.supported_housing"))
+        end
+
+        it "does allow the scharge to be between of 0 and 280 per week when period is every 2 weeks" do
+          record.needstype = 0
+          record.landlord = 1
+          record.period = 2
+          record.scharge = 559
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
       end
     end
   end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -635,11 +635,11 @@ RSpec.describe Validations::FinancialValidations do
           record.household_charge = 0
           financial_validator.validate_rent_amount(record)
           expect(record.errors["tcharge"])
-            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
           expect(record.errors["household_charge"])
-            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
 
         it "returns an error for tcharge and chcharge types selected" do
@@ -649,9 +649,9 @@ RSpec.describe Validations::FinancialValidations do
           expect(record.errors["household_charge"])
             .to be_empty
           expect(record.errors["tcharge"])
-            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
 
         it "returns an error for tcharge and household_charge types selected" do
@@ -661,9 +661,9 @@ RSpec.describe Validations::FinancialValidations do
           expect(record.errors["chcharge"])
             .to be_empty
           expect(record.errors["tcharge"])
-            .to include(match I18n.t("validations.financial.tcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
           expect(record.errors["household_charge"])
-            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
 
         it "returns an error for chcharge and household_charge types selected" do
@@ -673,9 +673,9 @@ RSpec.describe Validations::FinancialValidations do
           expect(record.errors["tcharge"])
             .to be_empty
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.chcharge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
           expect(record.errors["household_charge"])
-            .to include(match I18n.t("validations.financial.household_charge.complete_1_of_3"))
+            .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
       end
 

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -200,5 +200,67 @@ RSpec.describe Validations::FinancialValidations do
           .to include(match I18n.t("validations.financial.tshortfall.more_than_rent"))
       end
     end
+
+    context "when the landlord is this landlord and needstype is general needs" do
+      it "does not allow the scharge to be outside of 0 and 55 range per week when period is weekly" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 7
+        record.scharge = 56
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+      end
+
+      it "does allow the scharge to be between of 0 and 55 per week when period is weekly" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 7
+        record.scharge = 54
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to be_empty
+      end
+
+      it "does not allow the scharge to be outside of 0 and 55 range per week when period is monthly" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 4
+        record.scharge = 300
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+      end
+
+      it "does allow the scharge to be between of 0 and 55 per week when period is monthly" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 4
+        record.scharge = 220
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to be_empty
+      end
+
+      it "does not allow the scharge to be outside of 0 and 55 range per week when period is every 2 weeks" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 2
+        record.scharge = 111
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to include(match I18n.t("validations.financial.rent.scharge.this_landlord.general_needs"))
+      end
+
+      it "does allow the scharge to be between of 0 and 55 per week when period is every 2 weeks" do
+        record.needstype = 1
+        record.landlord = 1
+        record.period = 2
+        record.scharge = 109
+        financial_validator.validate_rent_amount(record)
+        expect(record.errors["scharge"])
+          .to be_empty
+      end
+    end
   end
 end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -326,5 +326,131 @@ RSpec.describe Validations::FinancialValidations do
         end
       end
     end
+
+    context "when the landlord is another RP" do
+      context "when needstype is general needs" do
+        it "does not allow the scharge to be outside of 0 and 45 range per week when period is weekly" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 1
+          record.scharge = 46
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 45 per week when period is weekly" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 1
+          record.scharge = 44
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 45 range per week when period is monthly" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 4
+          record.scharge = 200
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 45 per week when period is monthly" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 4
+          record.scharge = 160
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 45 range per week when period is every 2 weeks" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 2
+          record.scharge = 91
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.general_needs"))
+        end
+
+        it "does allow the scharge to be between of 0 and 45 per week when period is every 2 weeks" do
+          record.needstype = 1
+          record.landlord = 2
+          record.period = 2
+          record.scharge = 89
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+      end
+
+      context "when needstype is supported housing" do
+        it "does not allow the scharge to be outside of 0 and 165 range per week when period is weekly" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 1
+          record.scharge = 165.90
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
+        end
+
+        it "does allow the scharge to be between of 0 and 165 per week when period is weekly" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 1
+          record.scharge = 120.88
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 165 range per week when period is monthly" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 4
+          record.scharge = 750
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
+        end
+
+        it "does allow the scharge to be between of 0 and 165 per week when period is monthly" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 4
+          record.scharge = 608
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+
+        it "does not allow the scharge to be outside of 0 and 165 range per week when period is every 2 weeks" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 2
+          record.scharge = 330.50
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to include(match I18n.t("validations.financial.rent.scharge.other_landlord.supported_housing"))
+        end
+
+        it "does allow the scharge to be between of 0 and 165 per week when period is every 2 weeks" do
+          record.needstype = 0
+          record.landlord = 2
+          record.period = 2
+          record.scharge = 329.99
+          financial_validator.validate_rent_amount(record)
+          expect(record.errors["scharge"])
+            .to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -6,62 +6,6 @@ RSpec.describe Validations::HouseholdValidations do
   let(:validator_class) { Class.new { include Validations::HouseholdValidations } }
   let(:record) { FactoryBot.create(:case_log) }
 
-  describe "age validations" do
-    it "validates that person 1's age is a number" do
-      record.age1 = "random"
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age1"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
-    end
-
-    it "validates that other household member ages are a number" do
-      record.age2 = "random"
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age2"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
-    end
-
-    it "validates that person 1's age is greater than 16" do
-      record.age1 = 15
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age1"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
-    end
-
-    it "validates that other household member ages are greater than 1" do
-      record.age2 = 0
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age2"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
-    end
-
-    it "validates that person 1's age is less than 121" do
-      record.age1 = 121
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age1"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
-    end
-
-    it "validates that other household member ages are greater than 121" do
-      record.age2 = 123
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age2"])
-        .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
-    end
-
-    it "validates that person 1's age is between 16 and 120" do
-      record.age1 = 63
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age1"]).to be_empty
-    end
-
-    it "validates that other household member ages are between 1 and 120" do
-      record.age6 = 45
-      household_validator.validate_numeric_min_max(record)
-      expect(record.errors["age6"]).to be_empty
-    end
-  end
-
   describe "reasonable preference validations" do
     context "when reasonable preference is homeless" do
       context "when the tenant was not previously homeless" do

--- a/spec/models/validations/shared_validations_spec.rb
+++ b/spec/models/validations/shared_validations_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe Validations::HouseholdValidations do
+RSpec.describe Validations::SharedValidations do
   subject(:household_validator) { validator_class.new }
 
-  let(:validator_class) { Class.new { include Validations::HouseholdValidations } }
+  let(:validator_class) { Class.new { include Validations::SharedValidations } }
   let(:record) { FactoryBot.create(:case_log) }
 
   describe "numeric min max validations" do

--- a/spec/models/validations/shared_validations_spec.rb
+++ b/spec/models/validations/shared_validations_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Validations::HouseholdValidations do
+  subject(:household_validator) { validator_class.new }
+
+  let(:validator_class) { Class.new { include Validations::HouseholdValidations } }
+  let(:record) { FactoryBot.create(:case_log) }
+
+  describe "numeric min max validations" do
+    context "when validating age" do
+      it "validates that person 1's age is a number" do
+        record.age1 = "random"
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age1"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
+      end
+
+      it "validates that other household member ages are a number" do
+        record.age2 = "random"
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
+      end
+
+      it "validates that person 1's age is greater than 16" do
+        record.age1 = 15
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age1"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
+      end
+
+      it "validates that other household member ages are greater than 1" do
+        record.age2 = 0
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
+      end
+
+      it "validates that person 1's age is less than 121" do
+        record.age1 = 121
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age1"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Lead tenant’s age", min: 16, max: 120))
+      end
+
+      it "validates that other household member ages are greater than 121" do
+        record.age2 = 123
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Person 2’s age", min: 1, max: 120))
+      end
+
+      it "validates that person 1's age is between 16 and 120" do
+        record.age1 = 63
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age1"]).to be_empty
+      end
+
+      it "validates that other household member ages are between 1 and 120" do
+        record.age6 = 45
+        household_validator.validate_numeric_min_max(record)
+        expect(record.errors["age6"]).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Move age validation tests to shared validation spec file

- Add `brent`/`tshortfall` validation: 
_Basic rent cannot be less than shortfall in basic rent
Basic rent cannot be less than double shortfall in basic rent_

- Update `period` mappings

- Add `scharge` validation for `this landlord`
_If Landlord is 1 This Landlord, this must be between 0 and 55 per week (GN only)_
_If Landlord is 1 This Landlord, this must be between 0 and 280 per week (SH only)_

- Add tests for float values in `weekly_value`

Error message content TBC
<img width="793" alt="image" src="https://user-images.githubusercontent.com/54268893/158377991-079394ab-cb3e-4841-bf46-096d33e26475.png">
<img width="846" alt="image" src="https://user-images.githubusercontent.com/54268893/158378081-dfd7c50e-9834-4ef5-b450-90154c87c745.png">


