### PR TITLE
Use Adminterface theme for ActiveAdmin and adjust to match main service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,9 @@ gem "govuk_markdown"
 gem "notifications-ruby-client"
 # Turbo and Stimulus
 gem "hotwire-rails"
-# Administration framework
+# Administration interface
 gem "activeadmin"
+gem "adminterface"
 # Admin charts
 gem "chartkick"
 # Spreadsheet parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,12 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    adminterface (0.3.0)
+      activeadmin (~> 2.9)
+      httparty (>= 0.18)
+      image_processing (~> 1.0)
+      rails (>= 6.0)
+      rainbow (~> 3.0)
     arbre (1.5.0)
       activesupport (>= 3.0.0, < 7.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -192,8 +198,14 @@ GEM
       rails (>= 6.0.0)
       stimulus-rails
       turbo-rails
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)
       has_scope (~> 0.6)
@@ -232,9 +244,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.5)
+    multi_xml (0.6.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -390,6 +407,8 @@ GEM
     rubocop-rspec (2.7.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -468,6 +487,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin
+  adminterface
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   bundler-audit

--- a/app/webpacker/packs/active_admin.js
+++ b/app/webpacker/packs/active_admin.js
@@ -1,7 +1,13 @@
-// Load Active Admin's styles into Webpacker,
-// see `active_admin.scss` for customization.
+// Load ActiveAdmin’s styles into Webpacker.
+// See `active_admin.scss` for customisation.
 import "../styles/active_admin";
 
-import "@activeadmin/activeadmin";
+import Rails from '@rails/ujs'
+import * as ActiveStorage from '@rails/activestorage'
+import '@rails/actiontext'
+import 'trix'
+import '@cmdbrew/adminterface'
+import 'chartkick/chart.js'
 
-import "chartkick/chart.js"
+ActiveStorage.start()
+Rails.start()

--- a/app/webpacker/styles/_button.scss
+++ b/app/webpacker/styles/_button.scss
@@ -29,3 +29,7 @@ $app-button-inverse-hover-background-colour: govuk-tint($app-button-inverse-fore
   background-color: $app-button-inverse-hover-background-colour;
   box-shadow: inset 0 0 0 2px $govuk-focus-colour;
 }
+
+.app-button--small {
+  @include govuk-font($size: 16);
+}

--- a/app/webpacker/styles/_tag.scss
+++ b/app/webpacker/styles/_tag.scss
@@ -1,0 +1,8 @@
+.govuk-tag {
+  white-space: nowrap;
+}
+
+.app-tag--small {
+  @include govuk-font($size: 14, $weight: bold, $line-height: 1);
+  padding: 4px 6px;
+}

--- a/app/webpacker/styles/active_admin.scss
+++ b/app/webpacker/styles/active_admin.scss
@@ -1,17 +1,156 @@
-// Sass variable overrides must be declared before loading up Active Admin's styles.
-//
-// To view the variables that Active Admin provides, take a look at
-// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
-// Active Admin source.
-//
-// For example, to change the sidebar width:
-// $sidebar-width: 242px;
+// Import GOV.UK Frontend styles
+@function frontend-font-url($filename) {
+  @return url("~assets/fonts/" + $filename);
+}
 
-// Active Admin's got SASS!
-@import "~@activeadmin/activeadmin/src/scss/mixins";
-@import "~@activeadmin/activeadmin/src/scss/base";
+@function frontend-image-url($filename) {
+  @return url("~assets/images/" + $filename);
+}
 
-// Overriding any non-variable Sass must be done after the fact.
-// For example, to change the default status-tag color:
-//
-//   .status_tag { background: #6090DB; }
+$govuk-font-url-function: frontend-font-url;
+$govuk-image-url-function: frontend-image-url;
+
+@import "~govuk-frontend/govuk/base";
+@import "~govuk-frontend/govuk/core/typography";
+@import "~govuk-frontend/govuk/objects/all";
+
+@import "~govuk-frontend/govuk/components/button";
+@import "~govuk-frontend/govuk/components/header";
+@import "~govuk-frontend/govuk/components/table";
+@import "~govuk-frontend/govuk/components/tag";
+
+@import "~govuk-frontend/govuk/overrides/all";
+
+@import "../styles/button";
+@import "../styles/table-group";
+@import "../styles/tag";
+
+// Override default Bootstrap colour palette to match that of GOV.UK
+// https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss
+
+// Colour system
+$white: govuk-colour("white");
+$gray-100: govuk-colour("light-grey");
+$gray-200: govuk-colour("light-grey");
+$gray-300: govuk-colour("light-grey");
+$gray-400: govuk-colour("mid-grey");
+$gray-500: govuk-colour("mid-grey");
+$gray-600: govuk-colour("mid-grey");
+$gray-700: govuk-colour("dark-grey");
+$gray-800: govuk-colour("dark-grey");
+$gray-900: govuk-colour("dark-grey");
+$black: govuk-colour("black");
+
+$blue: govuk-colour("blue");
+$indigo: govuk-colour("light-purple");
+$purple: govuk-colour("purple");
+$pink: govuk-colour("pink");
+$red: govuk-colour("red");
+$orange: govuk-colour("orange");
+$yellow: govuk-colour("yellow");
+$green: govuk-colour("green");
+$teal: govuk-colour("turquoise");
+$cyan: govuk-colour("light-blue");
+
+// Colour assignments
+$primary: govuk-colour("green");
+$secondary: govuk-colour("light-grey");
+$success: $govuk-success-colour;
+$info: govuk-colour("blue");
+$warning: $govuk-error-colour;
+$danger: $govuk-error-colour;
+$light: govuk-colour("light-grey");
+$dark: govuk-colour("black");
+
+// Options
+$enable-rounded: false;
+$enable-transitions: false;
+$enable-shadows: false;
+
+// Spacing
+$spacers: (
+  0: 0,
+  1: govuk-spacing(1),
+  2: govuk-spacing(2),
+  3: govuk-spacing(3),
+  4: govuk-spacing(6),
+  5: govuk-spacing(9),
+);
+
+// Body
+$body-bg: $govuk-body-background-colour;
+$body-color: $govuk-text-colour;
+$text-muted: $govuk-secondary-text-colour;
+
+// Links
+$link-hover-color: $govuk-text-colour;
+$link-hover-decoration: underline;
+
+// Focus
+$component-active-bg: $govuk-focus-colour;
+
+// Typography
+$font-family-sans-serif: $govuk-font-family-gds-transport;
+$font-size-base: 1rem;
+$font-size-sm: $font-size-base * .875; // 14px
+$font-size-lg: $font-size-base * 1.1875; // 19px
+
+$h1-font-size: $font-size-base * 3; // 48px
+$h2-font-size: $font-size-base * 2.25; // 36px
+$h3-font-size: $font-size-base * 1.6875; // 27px
+$h4-font-size: $font-size-base * 1.5; // 24px
+$h5-font-size: $font-size-base * 1.1875; // 19px
+$h6-font-size: $font-size-base;
+
+$headings-font-weight: $govuk-font-weight-regular;
+
+// Tables
+$table-border-width: 1px;
+$table-border-color: $govuk-border-colour;
+
+// Forms
+$input-btn-padding-y: (govuk-spacing(2) - $govuk-border-width-form-element);
+$input-btn-padding-x: govuk-spacing(2);
+$input-btn-border-width: $govuk-border-width-form-element;
+$input-btn-focus-width: $govuk-focus-width;
+$input-btn-focus-color-opacity: 1.0;
+$input-btn-focus-color: $component-active-bg;
+$input-btn-focus-color: $yellow;
+$input-btn-line-height: 1;
+
+// Form - Inputs
+$input-border-color: $black;
+$input-focus-border-color: $black;
+
+// Form - Labels
+$form-label-font-size: $font-size-lg;
+$form-label-font-weight: $govuk-font-weight-bold;
+
+// Form - Check boxes
+$form-check-input-bg: $body-bg;
+$form-check-input-border: 2px solid $body-color;
+
+$form-check-input-checked-color: $body-color;
+$form-check-input-checked-bg-color: $body-bg;
+$form-check-input-checked-border-color: $body-color;
+
+$form-check-input-indeterminate-color: $body-color;
+$form-check-input-indeterminate-bg-color: $body-bg;
+$form-check-input-indeterminate-border-color: $body-color;
+
+// Breadcrumb
+$breadcrumb-active-color: $govuk-text-colour;
+$breadcrumb-divider-color: $govuk-secondary-text-colour;
+
+// Navigation bar
+$navbar-brand-font-size: $h4-font-size;
+$navbar-dark-color: $white;
+$navbar-dark-active-color: #1d8feb;
+$navbar-dark-hover-color: $white;
+$navbar-dark-brand-color: $white;
+$navbar-dark-brand-hover-color: $white;
+
+// Sass variable overrides must be declared before loading Adminterface styles.
+// See: https://adminterface.io/docs/enhancements/customizations#adminterface
+@import "~@cmdbrew/adminterface/src/scss/base";
+@import "./active_admin/overrides";

--- a/app/webpacker/styles/active_admin/_overrides.scss
+++ b/app/webpacker/styles/active_admin/_overrides.scss
@@ -1,0 +1,69 @@
+// Tactical overrides to the themed Adminterface styles
+body {
+  -webkit-font-smoothing: antialiased;
+}
+
+a:not([class]) {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+
+.btn-primary {
+  @extend .govuk-button;
+
+  .govuk-button-group & {
+    margin-bottom: 0;
+  }
+}
+
+.btn-light,
+.btn-secondary {
+  @extend .govuk-button--secondary;
+}
+
+.header {
+  margin-bottom: 0;
+  min-height: 60px;
+}
+
+.title {
+  a:not(:focus) {
+    color: $white;
+    text-decoration: none;
+  }
+}
+
+.navbar-brand,
+.navbar-nav {
+  font-weight: $govuk-font-weight-bold;
+
+  .nav-link:focus {
+    color: $govuk-focus-text-colour !important;
+    background-color: $govuk-focus-colour;
+    outline: none;
+  }
+}
+
+.breadcrumb {
+  a:not(:focus) {
+    color: $body-color;
+  }
+}
+
+.table_for:not(.attributes_table) tr.selected td {
+  background-color: govuk-tint($govuk-focus-colour, 75);
+}
+
+// Align submit/cancel buttons with left side of form
+.modal-footer {
+  flex-direction: row-reverse;
+}
+
+.formtastic fieldset.actions ol {
+  flex-direction: row;
+  gap: govuk-spacing(2);
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -20,6 +20,7 @@ $govuk-global-styles: true;
 @import "section-skip-link";
 @import "tab-navigation";
 @import "table-group";
+@import "tag";
 @import "task-list";
 @import "template";
 @import "panel";
@@ -42,8 +43,4 @@ $govuk-global-styles: true;
 // Overrides
 .govuk-button-group {
   align-items: center;
-}
-
-.govuk-tag {
-  white-space: nowrap;
 }

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -9,7 +9,7 @@ ActiveAdmin.setup do |config|
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.
   #
-  # config.site_title_link = "/"
+  config.site_title_link = "/admin"
 
   # Set an optional image to be displayed for the header
   # instead of a string (overrides :site_title)
@@ -332,6 +332,77 @@ ActiveAdmin.setup do |config|
   # You can switch to using Webpacker here.
   #
   config.use_webpacker = true
+
+  # == Adminterface
+  #
+  # https://adminterface.io/docs/enhancements/customizations
+  #
+  config.css_classes = {
+    action_items: {
+      group: "govuk-button-group govuk-!-margin-bottom-0",
+      item: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold govuk-!-margin-bottom-1",
+    },
+    attributes_table: {
+      wrapper: "app-table-group",
+    },
+    confirm_dialog: {
+      cancel: "govuk-button govuk-button--secondary govuk-!-margin-bottom-0",
+      confirm: "govuk-button govuk-!-margin-bottom-0",
+    },
+    filters: {
+      actions: {
+        cancel: "govuk-button govuk-button--secondary govuk-!-margin-bottom-0",
+        submit: "govuk-button govuk-!-margin-bottom-0",
+      },
+    },
+    footer: {
+      wrapper: "govuk-!-margin-top-9",
+      body: "govuk-body-s",
+    },
+    form: {
+      actions: {
+        cancel: "govuk-button govuk-button--secondary govuk-!-margin-bottom-0",
+        submit: "govuk-button govuk-!-margin-bottom-0",
+      },
+    },
+    header: {
+      wrapper: "govuk-header__container",
+    },
+    index_as_table: {
+      actions: {
+        dropdown: {
+          toggle: "app-button--small govuk-button govuk-button--secondary",
+        },
+      },
+      wrapper: "app-table-group",
+    },
+    panel: {
+      body: nil,
+      header: {
+        title: "govuk-heading-l govuk-!-font-size-27",
+        wrapper: nil,
+      },
+      wrapper: "govuk-!-margin-bottom-8",
+    },
+    sidebar: {
+      position: "left",
+    },
+    status_tag: {
+      'no': "app-tag--small govuk-tag govuk-tag--red",
+      unset: "app-tag--small govuk-tag govuk-tag--orange",
+      'yes': "app-tag--small govuk-tag govuk-tag--green",
+    },
+    table_tools: {
+      btn: "app-button--small govuk-button govuk-button--secondary",
+      confirm_dialog: {
+        cancel: "govuk-button govuk-button--secondary",
+        confirm: "govuk-button",
+      },
+    },
+    title_bar: {
+      wrapper: "navbar navbar-light bg-light",
+    },
+  }
 end
 
 # Print stylesheet is no longer a separate stylesheet in upstream so we can

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,7 @@
 const { environment } = require('@rails/webpacker')
-const jquery = require('./plugins/jquery')
 
-environment.plugins.prepend('jquery', jquery)
+environment.loaders.get('sass').use.splice(-1, 0, {
+  loader: 'resolve-url-loader'
+})
+
 module.exports = environment

--- a/config/webpack/plugins/jquery.js
+++ b/config/webpack/plugins/jquery.js
@@ -1,7 +1,0 @@
-const webpack = require('webpack')
-
-module.exports = new webpack.ProvidePlugin({
-  "$":"jquery",
-  "jQuery":"jquery",
-  "window.jQuery":"jquery"
-});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "^16.0.0"
   },
   "dependencies": {
-    "@activeadmin/activeadmin": "^2.9.0",
+    "@cmdbrew/adminterface": "0.3.0",
     "@hotwired/stimulus": "^3.0.0",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,6 @@
 # yarn lockfile v1
 
 
-"@activeadmin/activeadmin@^2.9.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@activeadmin/activeadmin/-/activeadmin-2.11.0.tgz#b6cd9ba3e1d6658ec91593481a636f2686fb086b"
-  integrity sha512-xuPZf5hM87nm/Z0MPZ4qKeco3oia2uJc5Zznky5tFCN8WgGQPqvaCaJ5JbgvqVIOYGUIwS4b6U7hHWlZDK0fyw==
-  dependencies:
-    jquery "^3.4.1"
-    jquery-ui "^1.12.1"
-    jquery-ujs "^1.2.2"
-
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
@@ -916,6 +907,23 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@cmdbrew/adminterface@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@cmdbrew/adminterface/-/adminterface-0.3.0.tgz#07467329388655ef7752a4436dc9c6c846bfee49"
+  integrity sha512-QxFcIW4x5ocJwW9n6DZAPDMrPexgvsOs3T3zRRUaFAKxA11Uv5V+VROL1oZgsNI/ml/NVDqQetX+iSXTzGnc1Q==
+  dependencies:
+    "@popperjs/core" "^2.10.2"
+    "@rails/actiontext" "^6.1.4"
+    "@rails/ujs" "^6.1.4"
+    bootstrap "^5.1.3"
+    bootstrap-icons "^1.5.0"
+    flatpickr "^4.6.9"
+    resolve-url-loader "^4.0.0"
+    sortablejs "^1.14.0"
+    tom-select "^1.7.5"
+    trix "^1.3.1"
+    uuid "^8.3.2"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -1009,6 +1017,16 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@orchidjs/sifter@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@orchidjs/sifter/-/sifter-0.8.2.tgz#50f0a4ba8783f2bfbde1bcec9ed97e632940555d"
+  integrity sha512-aDemVMJL2cGo82EVHXMM2y6WoWlk00V2aibvNAl2djtZG1OquirMvnOTlb2L4tjcH5cT2q1/dyHepZcxnFW5zQ==
+
+"@popperjs/core@^2.10.2":
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.4.tgz#d8c7b8db9226d2d7664553a0741ad7d0397ee503"
+  integrity sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==
+
 "@rails/actioncable@^6.0.0":
   version "6.1.5"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.5.tgz#c24ec8123a8e7e239ceabda29078df9c93752394"
@@ -1019,12 +1037,24 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
   integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
 
+"@rails/actiontext@^6.1.4":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.1.5.tgz#29006cff520b72c6845f474540a9ea142eae6380"
+  integrity sha512-V88uyueaL4VeU0u0P3GiuM0vSBYW3pluYyI7jMmZKWfGZKCspmRLDaJE+30Bx4h3ZQJcRrOCFoTU8hK0cFmCsw==
+  dependencies:
+    "@rails/activestorage" "^6.0.0"
+
 "@rails/activestorage@^6.0.0":
   version "6.1.5"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.1.5.tgz#a43929573b2ffae54857ffa3b7ac1988af42b681"
   integrity sha512-7L0eWqrguZIyvfPOpVoZRChuIgxbpBdwdVtprT6wrl5rUAbdyHr6AZczl1yS+5d6nBV0TqpVLaB1sGxi2aMbCQ==
   dependencies:
     spark-md5 "^3.0.0"
+
+"@rails/ujs@^6.1.4":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.5.tgz#bb1afddd0d771f00924f44b21634969e329532e1"
+  integrity sha512-Ir4yd2fdDldWIghavPr874copVKf6OOoecKHZiFRlPtm38tFvhyxr+ywzNieXGwolF9JQe3D5GrM8ejkzUgh5Q==
 
 "@rails/webpacker@5.4.3":
   version "5.4.3"
@@ -1392,6 +1422,14 @@ acorn@^8.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
+adjust-sourcemap-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz#fc4a0fd080f7d10471f30a7320f25560ade28c99"
+  integrity sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==
+  dependencies:
+    loader-utils "^2.0.0"
+    regex-parser "^2.2.11"
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -1734,6 +1772,16 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bootstrap-icons@^1.5.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.8.1.tgz#773c1625bcbf3e86090ea9da4386c2c6459c5582"
+  integrity sha512-IXUqislddPJfwq6H+2nTkHyr9epO9h6u1AG0OZCx616w+TgzeoCjfmI3qJMQqt1J586gN2IxzB4M99Ip4sTZ1w==
+
+bootstrap@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3223,6 +3271,11 @@ findup-sync@^3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flatpickr@^4.6.9:
+  version "4.6.11"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.11.tgz#c92f5108269c551c6b5069ecd754be610574574c"
+  integrity sha512-/rnbE/hu5I5zndLEyYfYvqE4vPDvI5At0lFcQA5eOPfjquZLcQ0HMKTL7rv5/+DvbPM3/vJcXpXjB/DjBh+1jw==
+
 flatted@^3.2.2:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
@@ -4116,23 +4169,6 @@ jest-worker@^26.5.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
-
-jquery-ui@^1.12.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.1.tgz#d0b7a42e73a04c31bb5706adf86f6f8942f64eaa"
-  integrity sha512-2VlU59N5P4HaumDK1Z3XEVjSvegFbEOQRgpHUBaB2Ak98Axl3hFhJ6RFcNQNuk9SfL6WxIbuLst8dW/U56NSiA==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
-
-jquery-ujs@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
-  integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
-
-"jquery@>=1.8.0 <4.0.0", jquery@^3.4.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -5735,7 +5771,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
   integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
@@ -5980,6 +6016,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regex-parser@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
+  integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
+
 regexp.prototype.flags@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz#b3f4c0059af9e47eca9f3f660e51d81307e72307"
@@ -6083,6 +6124,17 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-url-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz#d50d4ddc746bb10468443167acf800dcd6c3ad57"
+  integrity sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==
+  dependencies:
+    adjust-sourcemap-loader "^4.0.0"
+    convert-source-map "^1.7.0"
+    loader-utils "^2.0.0"
+    postcss "^7.0.35"
+    source-map "0.6.1"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -6474,6 +6526,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -6508,15 +6565,15 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@~0.7.2:
   version "0.7.3"
@@ -6897,6 +6954,18 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tom-select@^1.7.5:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/tom-select/-/tom-select-1.7.8.tgz#484a33b800d8574767a5803ccaad1cd6d996d17e"
+  integrity sha512-b9K+RYhbmcGiaqKssKf4N/fkn/Hle330OwOaAO786TtUNfGImR6J/IAuJP3lNOAl4rZyC4Q0uLuxE+1367rQtg==
+  dependencies:
+    "@orchidjs/sifter" "^0.8.1"
+
+trix@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.3.1.tgz#ccce8d9e72bf0fe70c8c019ff558c70266f8d857"
+  integrity sha512-BbH6mb6gk+AV4f2as38mP6Ucc1LE3OD6XxkZnAgPIduWXYtvg2mI3cZhIZSLqmMh9OITEpOBCCk88IVmyjU7bA==
 
 ts-pnp@^1.1.6:
   version "1.2.0"


### PR DESCRIPTION
Use [Adminterface](https://adminterface.io/)[^1] theme for ActiveAdmin, adjusting Bootstrap variables and overriding specific elements where required.

It’s a bit uncanny valley in places, and as more data is included other styles may need to be tweaked, but this UI:

* is responsive
* has a greater degree of colour contract 
* includes focus styles
* is more aligned with the main service.

(Bulk of this was done in about an hour, but then several hours were spent tweaking everything to get it closer to looking like GOV.UK 😅) 

[^1]: No longer being maintained, which is a bit annoying, but hopefully not too much of an issue.

| Before | After |
| - | - |
| <img width="1200" alt="Screenshot 2022-03-18 at 00 14 53" src="https://user-images.githubusercontent.com/813383/158914061-b6114a45-d82d-495d-8678-5767dffc5789.png"> | <img width="1200" alt="Screenshot 2022-03-18 at 00 01 48" src="https://user-images.githubusercontent.com/813383/158914041-71b8e588-f273-4bd3-9c29-2a8f60028cc5.png"> |
| <img width="1200" alt="Screenshot 2022-03-18 at 00 15 17" src="https://user-images.githubusercontent.com/813383/158914074-ba78d715-775f-4b17-b974-75ef461ef384.png"> | <img width="1200" alt="Screenshot 2022-03-18 at 00 02 07" src="https://user-images.githubusercontent.com/813383/158914049-28e4e873-a330-45f6-9e9a-506e64573615.png"> |
| <img width="1200" alt="Screenshot 2022-03-18 at 00 15 36" src="https://user-images.githubusercontent.com/813383/158914083-d21485ca-4692-4ec8-a042-92469f7e49aa.png"> | <img width="1200" alt="Screenshot 2022-03-18 at 00 03 53" src="https://user-images.githubusercontent.com/813383/158914055-574fe9ec-d938-45cd-b2d6-5e93ed39394e.png"> |