### PR TITLE
IE 11 Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "webpack-remove-empty-scripts": "^0.7.3"
   },
   "version": "0.1.0",
-  "devDependencies": {},
+  "devDependencies": {
+    "are-you-es5": "^2.1.2"
+  },
   "browserslist": {
     "production": [
       "last 1 version",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,9 @@ module.exports = {
         test: /\.(js|ts)$/,
         include: [
           path.resolve(__dirname, 'node_modules/@hotwired/stimulus'),
+          path.resolve(__dirname, 'node_modules/@stimulus/polyfills'),
           path.resolve(__dirname, 'node_modules/@rails/actioncable'),
+          path.resolve(__dirname, 'node_modules/chartjs'),
           path.resolve(__dirname, 'app/frontend/controllers'),
         ],
         use: ['babel-loader'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,6 +1194,11 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
+acorn@^6.0.6:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
 acorn@^8.4.1, acorn@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
@@ -1257,6 +1262,21 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+are-you-es5@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/are-you-es5/-/are-you-es5-2.1.2.tgz#d75511a174a3f842d70cc784aec0bcaff5a57547"
+  integrity sha512-gkT2bLCfzyJJr3lYoxZKScdD/Yp5zzghi+3KawONTvH/7rrgU3RMXYvGQnOTlqEFVgZFpEGj/6bZ6sF/9YtddA==
+  dependencies:
+    acorn "^6.0.6"
+    array-flatten "^2.1.0"
+    commander "^2.19.0"
+    find-up "^4.1.0"
+
+array-flatten@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
+  integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
 array-union@^3.0.1:
   version "3.0.1"
@@ -1438,7 +1458,7 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1717,7 +1737,7 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==


### PR DESCRIPTION
This PR adds `are-you-es5` as a dev dependency which can be used like:

```
$ yarn are-you-es5 check -r .
yarn run v1.22.18
$ /home/dan/Documents/submit-social-housing-lettings-and-sales-data/node_modules/.bin/are-you-es5 check -r .
❌ @hotwired/stimulus is not ES5
❌ @hotwired/turbo is not ES5
❌ @hotwired/turbo-rails is not ES5
❌ @stimulus/polyfills is not ES5
❌ chart.js is not ES5
❌ mini-css-extract-plugin is not ES5


Babel-loader exclude regex:
/[\\/]node_modules[\\/](?!(@hotwired\/stimulus|@hotwired\/turbo|@hotwired\/turbo-rails|@stimulus\/polyfills|chart.js|mini-css-extract-plugin)[\\/])/
Non-ES5 dependencies detected.
```

It adds all non-ES5 modules to our webpack config include to be transpiled.

- [ ] Transpile Turbo