### PR TITLE
Don’t let Webpack mangle static resources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,8 +31,8 @@ module.exports = {
         use: ['babel-loader'],
       },
       {
-        test: /\.(png|jpe?g|gif|eot|woff2|woff|ttf|svg|ico)$/i,
-        use: 'file-loader',
+        test: /\.(png|jpe?g|gif|eot|woff|woff2|ttf|svg|ico)$/i,
+        type: 'asset/resource'
       },
       {
         test: /\.(scss|css)/i,


### PR DESCRIPTION
Don’t use `file-loader` for static resources, else if it’s not a binary file, Webpack _does things_ 😱