### PR TITLE
Reset all invalidated page questions

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -296,7 +296,7 @@ private
       enabled = form.enabled_page_questions(self)
       answer_options = enabled.map(&:id).include?(question.id) ? enabled.find { |q| q.id == question.id }.answer_options : []
       contains_selected_answer_option = answer_options.present? ? answer_options.key?(public_send(question.id).to_s) : false
-      if !contains_selected_answer_option && respond_to?(question.id.to_s) && (question.type == "radio" || question.type == "checkbox")
+      if !contains_selected_answer_option && respond_to?(question.id.to_s)
         public_send("#{question.id}=", nil)
       end
     end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -5592,11 +5592,35 @@
               },
               "depends_on": [
                 {
-                  "has_benefits": 1,
+                  "hb": 1,
                   "household_charge": 0
                 },
                 {
-                  "has_benefits": 1,
+                  "hb": 1,
+                  "household_charge": null
+                },
+                {
+                  "hb": 6,
+                  "household_charge": 0
+                },
+                {
+                  "hb": 6,
+                  "household_charge": null
+                },
+                {
+                  "hb": 7,
+                  "household_charge": 0
+                },
+                {
+                  "hb": 7,
+                  "household_charge": null
+                },
+                {
+                  "hb": 8,
+                  "household_charge": 0
+                },
+                {
+                  "hb": 8,
                   "household_charge": null
                 }
               ]
@@ -5619,7 +5643,19 @@
               },
               "depends_on": [
                 {
-                  "has_benefits": 1,
+                  "hb": 1,
+                  "hbrentshortfall": 0
+                },
+                {
+                  "hb": 6,
+                  "hbrentshortfall": 0
+                },
+                {
+                  "hb": 7,
+                  "hbrentshortfall": 0
+                },
+                {
+                  "hb": 8,
                   "hbrentshortfall": 0
                 }
               ]

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1413,6 +1413,14 @@ RSpec.describe CaseLog do
       it "clears the answer" do
         expect { case_log.update!(preg_occ: nil) }.to change(case_log, :cbl).from(1).to(nil)
       end
+
+      context "when the question type does not have answer options" do
+        let(:case_log) { FactoryBot.create(:case_log, :in_progress, housingneeds_a: 1, tenant_code: "test") }
+
+        it "clears the answer" do
+          expect { case_log.update!(housingneeds_a: 0) }.to change(case_log, :tenant_code).from("test").to(nil)
+        end
+      end
     end
 
     context "with two pages having the same question key, only one's dependency is met" do


### PR DESCRIPTION
1. We should reset all invalidated page answers (i.e. question where the question, page or subsection depends_on conditions aren't met as a result of the new data). Previously we were only doing it for Radio and Checkbox questions.

2. We should not use derived variables in `depends_on` conditions since those are calculated *after* the invalidated questions are reset, so we should use their constituent questions or - if that is not possible, the derivation needs to be treated as a special case and done before invalidation.