### PR TITLE
Log status on log

### DIFF
--- a/app/frontend/controllers/index.js
+++ b/app/frontend/controllers/index.js
@@ -14,6 +14,3 @@ application.register("govukfrontend", GovukfrontendController)
 
 import NumericQuestionController from "./numeric_question_controller.js"
 application.register("numeric-question", NumericQuestionController)
-
-import TasklistController from "./tasklist_controller.js"
-application.register("tasklist", TasklistController)

--- a/app/frontend/controllers/tasklist_controller.js
+++ b/app/frontend/controllers/tasklist_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  addHighlight() {
-    let section_to_highlight = this.element.dataset.info;
-    document.getElementById(section_to_highlight).classList.add('tasklist_item_highlight');
-  }
-}

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -15,7 +15,7 @@
               <%= subsection_link(subsection, @case_log) %>
             </span>
             <strong class="govuk-tag app-task-list__tag <%= TasklistHelper::STYLES[subsection_status] %>"
-                    id=<%= subsection.id.dasherize %>>
+                    id="<%= subsection.id.dasherize %>">
               <%= TasklistHelper::STATUSES[subsection_status] %>
             </strong>
           </li>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -18,10 +18,7 @@
         </p>
         <p>
           <% if next_incomplete_section.present? %>
-            <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>"
-              data-controller="tasklist"
-              data-action="tasklist#addHighlight"
-              data-info=<%= next_incomplete_section.id %>>
+            <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>">
               Skip to next incomplete section: <%= next_incomplete_section.label %>
             </a>
           <% end %>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -22,7 +22,7 @@
       </p>
       <p>
         <% if next_incomplete_section.present? %>
-          <a class="app-section-skip-link" href="#<%= next_incomplete_section.id %>"
+          <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>"
             data-controller="tasklist"
             data-action="tasklist#addHighlight"
             data-info=<%= next_incomplete_section.id %>>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -11,25 +11,25 @@
         <%= content_for(:title) %>
       </h1>
 
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-        This log is
-        <%= @case_log.status.to_s.humanize.downcase %>
-      </h2>
+      <% if @case_log.status == "in_progress" %>
+        <p class="govuk-body govuk-!-margin-bottom-7"><%= get_subsections_count(@case_log, :completed) %> of <%= get_subsections_count(@case_log, :all) %> sections completed.</p>
+        <p class="govuk-body govuk-!-margin-bottom-2">
+          <% next_incomplete_section = get_next_incomplete_section(@case_log) %>
+        </p>
+        <p>
+          <% if next_incomplete_section.present? %>
+            <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>"
+              data-controller="tasklist"
+              data-action="tasklist#addHighlight"
+              data-info=<%= next_incomplete_section.id %>>
+              Skip to next incomplete section: <%= next_incomplete_section.label %>
+            </a>
+          <% end %>
+        </p>
+      <% elsif @case_log.status == "not_started" %>
+        <p class="govuk-body">This log has not been started.</p>
+      <% end %>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">You have completed <%= get_subsections_count(@case_log, :completed) %> of <%= get_subsections_count(@case_log, :all) %> sections.</p>
-      <p class="govuk-body govuk-!-margin-bottom-2">
-        <% next_incomplete_section = get_next_incomplete_section(@case_log) %>
-      </p>
-      <p>
-        <% if next_incomplete_section.present? %>
-          <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>"
-            data-controller="tasklist"
-            data-action="tasklist#addHighlight"
-            data-info=<%= next_incomplete_section.id %>>
-            Skip to next incomplete section: <%= next_incomplete_section.label %>
-          </a>
-        <% end %>
-      </p>
       <%= render "tasklist" %>
     </div>
   </div>

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -42,4 +42,13 @@ RSpec.describe "Task List" do
     visit("/logs/#{empty_case_log.id}")
     expect(page).to have_link("Skip to next incomplete section", href: /#household-characteristics/)
   end
+
+  context "when the 'Skip to next incomplete section is clicked'" do
+    it "jumps to the next incomplete section" do
+      answer_all_questions_in_income_subsection(empty_case_log)
+      visit("/logs/#{empty_case_log.id}")
+      click_link("Skip to next incomplete section")
+      expect(page).to have_current_path("/logs/#{empty_case_log.id}#household-characteristics")
+    end
+  end
 end

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -26,19 +26,20 @@ RSpec.describe "Task List" do
     sign_in user
   end
 
-  it "skips to the first section if no answers are completed" do
+  it "shows if the section has not been started" do
     visit("/logs/#{empty_case_log.id}")
-    expect(page).to have_link("Skip to next incomplete section", href: /#household_characteristics/)
+    expect(page).to have_content("This log has not been started.")
   end
 
-  it "shows the number of completed sections if no sections are completed" do
-    visit("/logs/#{empty_case_log.id}")
-    expect(page).to have_content("You have completed 0 of 9 sections.")
-  end
-
-  it "shows the number of completed sections if one section is completed" do
+  it "shows number of completed sections if one section is completed" do
     answer_all_questions_in_income_subsection(empty_case_log)
     visit("/logs/#{empty_case_log.id}")
-    expect(page).to have_content("You have completed 1 of 9 sections.")
+    expect(page).to have_content("1 of 9 sections completed.")
+  end
+
+  it "show skip link for next incomplete section" do
+    answer_all_questions_in_income_subsection(empty_case_log)
+    visit("/logs/#{empty_case_log.id}")
+    expect(page).to have_link("Skip to next incomplete section", href: /#household-characteristics/)
   end
 end

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -42,13 +42,4 @@ RSpec.describe "Task List" do
     visit("/logs/#{empty_case_log.id}")
     expect(page).to have_link("Skip to next incomplete section", href: /#household-characteristics/)
   end
-
-  context "when the 'Skip to next incomplete section is clicked'" do
-    it "jumps to the next incomplete section" do
-      answer_all_questions_in_income_subsection(empty_case_log)
-      visit("/logs/#{empty_case_log.id}")
-      click_link("Skip to next incomplete section")
-      expect(page).to have_current_path("/logs/#{empty_case_log.id}#household-characteristics")
-    end
-  end
 end


### PR DESCRIPTION
- Fix link to next incomplete section ([CLDC-1085](https://digital.dclg.gov.uk/jira/browse/CLDC-1085))
- Update text for a log that has not been started: This log has not been started.
- Update text for in progress log: X of X sections completed. (removal of another ‘you’ – multiple users can collaborate on a log)

Supersedes https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/404 as Github is being weird about updating that one.