### PR TITLE
Cldc 489 referral validation

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -277,6 +277,10 @@ class CaseLog < ApplicationRecord
     landlord == 2
   end
 
+  def is_prevten_la_general_needs?
+    [30, 31].any?(prevten)
+  end
+
 private
 
   PIO = Postcodes::IO.new

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -122,7 +122,7 @@ private
     %i[scharge pscharge supcharg].each do |charge|
       maximum = CHARGE_MAXIMUMS.dig(charge, LANDLORD_VALUES[record.landlord], NEEDSTYPE_VALUES[record.needstype])
 
-      if maximum.present? && record[charge].present? && !weekly_value_in_range(record, charge, 0, maximum) 
+      if maximum.present? && record[charge].present? && !weekly_value_in_range(record, charge, 0, maximum)
         record.errors.add charge, I18n.t("validations.financial.rent.#{charge}.#{LANDLORD_VALUES[record.landlord]}.#{NEEDSTYPE_VALUES[record.needstype]}")
       end
     end

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -122,7 +122,7 @@ private
     %i[scharge pscharge supcharg].each do |charge|
       maximum = CHARGE_MAXIMUMS.dig(charge, LANDLORD_VALUES[record.landlord], NEEDSTYPE_VALUES[record.needstype])
 
-      if maximum.present? && !weekly_value_in_range(record, charge, 0, maximum)
+      if maximum.present? && !weekly_value_in_range(record, charge, 0, maximum) && record[charge].present?
         record.errors.add charge, I18n.t("validations.financial.rent.#{charge}.#{LANDLORD_VALUES[record.landlord]}.#{NEEDSTYPE_VALUES[record.needstype]}")
       end
     end

--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -122,7 +122,7 @@ private
     %i[scharge pscharge supcharg].each do |charge|
       maximum = CHARGE_MAXIMUMS.dig(charge, LANDLORD_VALUES[record.landlord], NEEDSTYPE_VALUES[record.needstype])
 
-      if maximum.present? && !weekly_value_in_range(record, charge, 0, maximum) && record[charge].present?
+      if maximum.present? && record[charge].present? && !weekly_value_in_range(record, charge, 0, maximum) 
         record.errors.add charge, I18n.t("validations.financial.rent.#{charge}.#{LANDLORD_VALUES[record.landlord]}.#{NEEDSTYPE_VALUES[record.needstype]}")
       end
     end

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -104,6 +104,11 @@ module Validations::HouseholdValidations
       record.errors.add :referral, I18n.t("validations.household.referral.other_homeless")
       record.errors.add :homeless, I18n.t("validations.household.homeless.other.internal_transfer")
     end
+
+    if record.is_internal_transfer? && record.this_landlord? && record.is_prevten_la_general_needs?
+      record.errors.add :referral, I18n.t("validations.household.referral.la_general_needs.internal_transfer")
+      record.errors.add :prevten, I18n.t("validations.household.prevten.la_general_needs.internal_transfer")
+    end
   end
 
   def validate_prevloc(record)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,8 @@ en:
         over_20_foster_care: "Answer cannot be children's home or foster care as the lead tenant is 20 or older"
         male_refuge: "Answer cannot be refuge as the lead tenant identifies as male"
         internal_transfer: "Answer cannot be %{prevten} as you already told us this tenancy is an internal transfer"
+        la_general_needs:
+          internal_transfer: "Answer cannot be a fixed-term or lifetime local authority general needs tenancy as you already told us it's the same landlord on the tenancy agreement and it is an internal transfer"
       referral:
         secure_tenancy: "Answer must be internal transfer as you already told us this is a secure tenancy"
         rsnvac_non_temp: "Answer cannot be this source of referral as you already told us this is a re-let to tenant who occupied the same property as temporary accommodation"
@@ -185,6 +187,8 @@ en:
         other_homeless: "Answer cannot be internal transfer as you already told us the tenant was considered homeless by their landlord"
         prevten_invalid: "Answer cannot be internal transfer as you already told us the household situation immediately before this letting was %{prevten}"
         reason_permanently_decanted: "Answer must be internal transfer as you already told us the tenant was permanently decanted from another property owned by this landlord"
+        la_general_needs:
+          internal_transfer: "Answer cannot be internal transfer as you already told us it's the same landlord on the tenancy agreement and the household had either a fixed-term or lifetime local authority general needs tenancy immediately before this letting"
       homeless:
         assessed:
           internal_transfer: "Answer cannot be assessed as homeless as you already told us this tenancy is an internal transfer"

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Form::Question, type: :model do
       let(:subsection_id) { "property_information" }
       let(:page_id) { "property_postcode" }
       let(:case_log) { FactoryBot.build(:case_log, :in_progress, postcode_known: 0, postcode_full: nil) }
-      let(:question_id) { "property_postcode" }
+      let(:question_id) { "postcode_full" }
 
       it "displays 'change' in the check answers link text" do
         expect(question.update_answer_link_name(case_log)).to match(/Change/)

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Validations::FinancialValidations do
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "supcharg", value: 81 },
          }].each do |test_case|
-          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+          it "does not allow charges outside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
             record[test_case[:charge][:field]] = test_case[:charge][:value]
             financial_validator.validate_rent_amount(record)
@@ -341,7 +341,7 @@ RSpec.describe Validations::FinancialValidations do
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "supcharg", value: 990 },
          }].each do |test_case|
-          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+          it "does not allow charges outside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
             record[test_case[:charge][:field]] = test_case[:charge][:value]
             financial_validator.validate_rent_amount(record)
@@ -440,7 +440,7 @@ RSpec.describe Validations::FinancialValidations do
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "supcharg", value: 122 },
          }].each do |test_case|
-          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+          it "does not allow charges outside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
             record[test_case[:charge][:field]] = test_case[:charge][:value]
             financial_validator.validate_rent_amount(record)
@@ -537,12 +537,35 @@ RSpec.describe Validations::FinancialValidations do
            period: { label: "every 2 weeks", value: 2 },
            charge: { field: "supcharg", value: 241 },
          }].each do |test_case|
-          it "does not allow charges outide the range when period is #{test_case[:period][:label]}" do
+          it "does not allow charges outside the range when period is #{test_case[:period][:label]}" do
             record.period = test_case[:period][:value]
             record[test_case[:charge][:field]] = test_case[:charge][:value]
             financial_validator.validate_rent_amount(record)
             expect(record.errors[test_case[:charge][:field]])
               .to include(match I18n.t("validations.financial.rent.#{test_case[:charge][:field]}.other_landlord.supported_housing"))
+          end
+        end
+
+        context "when charges are not given" do
+          [{
+            period: { label: "weekly", value: 1 },
+            charge: { field: "scharge", value: nil },
+          },
+           {
+             period: { label: "weekly", value: 1 },
+             charge: { field: "pscharge", value: nil },
+           },
+           {
+             period: { label: "weekly", value: 1 },
+             charge: { field: "supcharg", value: nil },
+           }].each do |test_case|
+            it "does not error" do
+              record.period = test_case[:period][:value]
+              record[test_case[:charge][:field]] = test_case[:charge][:value]
+              financial_validator.validate_rent_amount(record)
+              expect(record.errors[test_case[:charge][:field]])
+                .to be_empty
+            end
           end
         end
 

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -196,6 +196,24 @@ RSpec.describe Validations::HouseholdValidations do
         expect(record.errors["referral"])
           .to be_empty
       end
+
+      it "cannot have `this landlord` as landlord and Housing situation before this letting cannot be LA general needs" do
+        record.landlord = 1
+        record.prevten = 30
+        record.referral = 1
+        household_validator.validate_referral(record)
+        expect(record.errors["referral"])
+          .to include(match(I18n.t("validations.household.referral.la_general_needs.internal_transfer")))
+        expect(record.errors["prevten"])
+          .to include(match(I18n.t("validations.household.prevten.la_general_needs.internal_transfer")))
+
+        record.prevten = 31
+        household_validator.validate_referral(record)
+        expect(record.errors["referral"])
+          .to include(match(I18n.t("validations.household.referral.la_general_needs.internal_transfer")))
+        expect(record.errors["prevten"])
+          .to include(match(I18n.t("validations.household.prevten.la_general_needs.internal_transfer")))
+      end
     end
   end
 


### PR DESCRIPTION
Add referral validation:
Referral cannot be 1 (internal transfer) if response to `Who is the landlord on the tenancy agreement?` is 1 (this landlord) and `Housing situation before this letting` is either 30 (Fixed term Local Authority General Needs tenancy) or 31 (Lifetime Local Authority General Needs tenancy)

Also only validate the charges if they're present


