### PR TITLE
CLDC-771: Allow Data Coordinator to change details for users in their organisation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,7 +73,11 @@ private
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation, :role)
+    if @user == current_user
+      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role)
+    else
+      params.require(:user).permit(:email, :name, :role)
+    end
   end
 
   def find_resource
@@ -81,6 +85,8 @@ private
   end
 
   def authenticate_scope!
-    render_not_found if current_user != @user
+    render_not_found and return unless current_user.organisation == @user.organisation
+    render_not_found and return if action_name == "edit_password" && current_user != @user
+    render_not_found and return unless current_user.role == "data_coordinator" || current_user == @user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,10 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      bypass_sign_in @user
-      flash[:notice] = I18n.t("devise.passwords.updated") if user_params.key?("password")
+      if @user == current_user
+        bypass_sign_in @user
+        flash[:notice] = I18n.t("devise.passwords.updated") if user_params.key?("password")
+      end
       redirect_to user_path(@user)
     elsif user_params.key?("password")
       format_error_messages
@@ -74,9 +76,9 @@ private
 
   def user_params
     if @user == current_user
-      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role)
+      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role, :is_dpo)
     else
-      params.require(:user).permit(:email, :name, :role)
+      params.require(:user).permit(:email, :name, :role, :is_dpo)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,6 @@ class User < ApplicationRecord
     data_accessor: 0,
     data_provider: 1,
     data_coordinator: 2,
-    data_protection_officer: 3,
   }.freeze
 
   enum role: ROLES
@@ -36,5 +35,13 @@ class User < ApplicationRecord
 
   def reset_password_notify_template
     last_sign_in_at ? RESET_PASSWORD_TEMPLATE_ID : SET_PASSWORD_TEMPLATE_ID
+  end
+
+  def is_data_protection_officer?
+    is_dpo
+  end
+
+  def is_data_protection_officer!
+    update!(is_dpo: true)
   end
 end

--- a/app/services/imports/data_protection_confirmation_import_service.rb
+++ b/app/services/imports/data_protection_confirmation_import_service.rb
@@ -11,14 +11,14 @@ module Imports
       dp_officer = User.find_by(
         name: record_field_value(xml_document, "dp-user"),
         organisation: org,
-        role: "data_protection_officer",
+        is_dpo: true,
       )
 
       if dp_officer.blank?
         dp_officer = User.new(
           name: record_field_value(xml_document, "dp-user"),
           organisation: org,
-          role: "data_protection_officer",
+          is_dpo: true,
           encrypted_password: SecureRandom.hex(10),
         )
         dp_officer.save!(validate: false)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, current_user == @user ? "Change your personal details" : "Change #{@user.name}'s personal details" %>
+<% content_for :title, current_user == @user ? "Change your personal details" : "Change #{@user.name}’s personal details" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
@@ -7,7 +7,7 @@
   ) %>
 <% end %>
 
-<%= form_for(current_user, as: :user, html: { method: :patch }) do |f| %>
+<%= form_for(@user, as: :user, html: { method: :patch }) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
@@ -25,6 +25,10 @@
         autocomplete: "email",
         spellcheck: "false"
       %>
+
+      <%= f.govuk_check_boxes_fieldset :is_dpo, multiple: false, legend: { text: "Are they a data protection officer?", size: "m" } do %>
+        <%= f.govuk_check_box :is_dpo, 1, 0, multiple: false, link_errors: true, label: { text: "Yes" } %>
+      <% end %>
 
       <%= f.govuk_submit "Save changes" %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,7 +26,7 @@
         spellcheck: "false"
       %>
 
-      <%= f.govuk_check_boxes_fieldset :is_dpo, multiple: false, legend: { text: "Are they a data protection officer?", size: "m" } do %>
+      <%= f.govuk_check_boxes_fieldset :is_dpo, multiple: false, legend: { text: "Are #{@user == current_user ? "you" : "they"} a data protection officer?", size: "m" } do %>
         <%= f.govuk_check_box :is_dpo, 1, 0, multiple: false, link_errors: true, label: { text: "Yes" } %>
       <% end %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,9 +26,13 @@
         spellcheck: "false"
       %>
 
-      <%= f.govuk_check_boxes_fieldset :is_dpo, multiple: false, legend: { text: "Are #{@user == current_user ? "you" : "they"} a data protection officer?", size: "m" } do %>
-        <%= f.govuk_check_box :is_dpo, 1, 0, multiple: false, link_errors: true, label: { text: "Yes" } %>
-      <% end %>
+      <%= f.govuk_collection_radio_buttons :is_dpo,
+        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Are they a data protection officer?", size: "m" }
+      %>
 
       <%= f.govuk_submit "Save changes" %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -31,7 +31,7 @@
         :id,
         :name,
         inline: true,
-        legend: { text: "Are they a data protection officer?", size: "m" }
+        legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
       %>
 
       <%= f.govuk_submit "Save changes" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Change your personal details" %>
+<% content_for :title, current_user == @user ? "Change your personal details" : "Change #{@user.name}'s personal details" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -31,9 +31,13 @@
         f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" }
       %>
 
-      <%= f.govuk_check_boxes_fieldset :is_dpo, legend: { text: "Are they a data protection officer?", size: "m" } do %>
-        <%= f.govuk_check_box :is_dpo, :is_dpo, label: { text: "Yes" } %>
-      <% end %>
+      <%= f.govuk_collection_radio_buttons :is_dpo,
+        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Are they a data protection officer?", size: "m" }
+      %>
 
       <%= f.govuk_submit "Continue" %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -36,7 +36,7 @@
         :id,
         :name,
         inline: true,
-        legend: { text: "Are they a data protection officer?", size: "m" }
+        legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
       %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -31,6 +31,10 @@
         f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" }
       %>
 
+      <%= f.govuk_check_boxes_fieldset :is_dpo, legend: { text: "Are they a data protection officer?", size: "m" } do %>
+        <%= f.govuk_check_box :is_dpo, :is_dpo, label: { text: "Yes" } %>
+      <% end %>
+
       <%= f.govuk_submit "Continue" %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, current_user == @user ? "Your account" : "#{@user.name}'s account" %>
+<% content_for :title, current_user == @user ? "Your account" : "#{@user.name}’s account" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -13,32 +13,42 @@
     <%= govuk_summary_list do |summary_list| %>
       <%= summary_list.row do |row|
         row.key { 'Name' }
-        row.value { current_user.name }
+        row.value { @user.name }
         row.action(visually_hidden_text: 'name', href: edit_user_path, html_attributes: { 'data-qa': 'change-name' })
       end %>
 
       <%= summary_list.row() do |row|
         row.key { 'Email address' }
-        row.value { current_user.email }
+        row.value { @user.email }
         row.action(visually_hidden_text: 'email address', href: edit_user_path, html_attributes: { 'data-qa': 'change-email' })
       end %>
 
       <%= summary_list.row do |row|
         row.key { 'Password' }
         row.value { '••••••••' }
-        row.action(visually_hidden_text: 'password', href: password_edit_user_path, html_attributes: { 'data-qa': 'change-password' })
+        if current_user == @user
+          row.action(visually_hidden_text: 'password', href: password_edit_user_path, html_attributes: { 'data-qa': 'change-password' })
+        else
+          row.action()
+        end
       end %>
 
       <%= summary_list.row do |row|
         row.key { 'Organisation' }
-        row.value { current_user.organisation.name }
+        row.value { @user.organisation.name }
         row.action()
       end %>
 
       <%= summary_list.row do |row|
         row.key { 'Role' }
-        row.value { current_user.role.humanize }
+        row.value { @user.role.humanize }
         row.action()
+      end %>
+
+      <%= summary_list.row do |row|
+        row.key { 'Data protection officer' }
+        row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
+        row.action(visually_hidden_text: 'are they a data protection officer?', href: edit_user_path, html_attributes: { 'data-qa': 'change-are-they-a-data-protection-officer' })
       end %>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Your account" %>
+<% content_for :title, current_user == @user ? "Your account" : "#{@user.name}'s account" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,7 +48,7 @@
       <%= summary_list.row do |row|
         row.key { 'Data protection officer' }
         row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
-        row.action(visually_hidden_text: 'are they a data protection officer?', href: edit_user_path, html_attributes: { 'data-qa': 'change-are-they-a-data-protection-officer' })
+        row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a data protection officer?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-data-protection-officer" })
       end %>
     <% end %>
   </div>

--- a/db/migrate/20220328105332_change_dpo_to_attribute.rb
+++ b/db/migrate/20220328105332_change_dpo_to_attribute.rb
@@ -1,0 +1,7 @@
+class ChangeDpoToAttribute < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users, bulk: true do |t|
+      t.column :is_dpo, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,6 +315,7 @@ ActiveRecord::Schema[7.0].define(version: 202202071123100) do
     t.integer "failed_attempts", default: 0
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
+    t.boolean "is_dpo", default: false
     t.string "phone"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       role { "data_coordinator" }
     end
     trait :data_protection_officer do
-      role { "data_protection_officer" }
+      is_dpo { true }
     end
     created_at { Time.zone.now }
     updated_at { Time.zone.now }

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe "User Features" do
       choose("user-is-dpo-true-field")
       click_button("Continue")
       expect(
-        User.find_by(name: "New User", email: "newuser@example.com", role: "data_provider", is_dpo: true)
+        User.find_by(name: "New User", email: "newuser@example.com", role: "data_provider", is_dpo: true),
       ).to be_a(User)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe User, type: :model do
       expect(user.data_provider?).to be true
       expect(user.data_coordinator?).to be false
     end
+
+    it "is not a data protection officer by default" do
+      expect(user.is_data_protection_officer?).to be false
+    end
+
+    it "can be set to data protection officer" do
+      expect { user.is_data_protection_officer! }
+        .to change { user.reload.is_data_protection_officer? }.from(false).to(true)
+    end
   end
 
   describe "paper trail" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe UsersController, type: :request do
         end
 
         context "when user changes email and dpo" do
-          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "1" } } }
+          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
 
           it "allows changing email and dpo" do
             user.reload
@@ -399,7 +399,7 @@ RSpec.describe UsersController, type: :request do
         end
 
         context "when user changes email and dpo" do
-          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "1" } } }
+          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
 
           it "allows changing email and dpo" do
             user.reload
@@ -444,7 +444,7 @@ RSpec.describe UsersController, type: :request do
           end
 
           context "when user changes email and dpo" do
-            let(:params) { { id: other_user.id, user: { name: new_name, email: new_email, is_dpo: "1" } } }
+            let(:params) { { id: other_user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
 
             it "allows changing email and dpo" do
               patch "/users/#{other_user.id}", headers: headers, params: params

--- a/spec/services/imports/data_protection_confirmation_import_service_spec.rb
+++ b/spec/services/imports/data_protection_confirmation_import_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Imports::DataProtectionConfirmationImportService do
         it "creates a data protection officer without sign in credentials" do
           expect { import_service.create_data_protection_confirmations("data_protection_directory") }
             .to change(User, :count).by(1)
-          data_protection_officer = User.find_by(organisation:, role: "data_protection_officer")
+          data_protection_officer = User.find_by(organisation:, is_dpo: true)
           expect(data_protection_officer.email).to eq("")
         end
 


### PR DESCRIPTION
For users in their organisation Data Coordinators can:

- Update name
- Update email
- Update role

They cannot update password (only the user themselves can do that). (Though they technically could update email and use that to reset password).

Data coordinator viewing users account:
![image](https://user-images.githubusercontent.com/5101747/160400638-24d10c53-5e1c-4d3f-9bb4-2131f5ca2a9f.png)

Data coordinator editing users account:
![image](https://user-images.githubusercontent.com/5101747/160568495-aacbef4e-e216-45f4-b757-69ecd4b142ec.png)

Data coordinator viewing their own account:
![image](https://user-images.githubusercontent.com/5101747/160400819-4c905e26-8eb4-486f-8de4-c4761d390f84.png)

Data coordinator editing their own account:
![image](https://user-images.githubusercontent.com/5101747/160568537-6edea67a-30ba-4501-9d56-a00f89226eaf.png)

