### PR TITLE
CLDC-1063: Key Contacts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   include Helpers::Email
   before_action :authenticate_user!
   before_action :find_resource, except: %i[new create]
-  before_action :authenticate_scope!, except: %i[new create]
+  before_action :authenticate_scope!, except: %i[new]
 
   def update
     if @user.update(user_params)
@@ -76,8 +76,12 @@ private
 
   def user_params
     if @user == current_user
-      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role, :is_dpo, :is_key_contact)
-    else
+      if current_user.data_coordinator?
+        params.require(:user).permit(:email, :name, :password, :password_confirmation, :role, :is_dpo, :is_key_contact)
+      else
+        params.require(:user).permit(:email, :name, :password, :password_confirmation)
+      end
+    elsif current_user.data_coordinator?
       params.require(:user).permit(:email, :name, :role, :is_dpo, :is_key_contact)
     end
   end
@@ -87,8 +91,12 @@ private
   end
 
   def authenticate_scope!
-    render_not_found and return unless current_user.organisation == @user.organisation
-    render_not_found and return if action_name == "edit_password" && current_user != @user
-    render_not_found and return unless current_user.role == "data_coordinator" || current_user == @user
+    if action_name == "create"
+      head :unauthorized and return unless current_user.data_coordinator?
+    else
+      render_not_found and return unless current_user.organisation == @user.organisation
+      render_not_found and return if action_name == "edit_password" && current_user != @user
+      render_not_found and return unless current_user.data_coordinator? || current_user == @user
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,9 +76,9 @@ private
 
   def user_params
     if @user == current_user
-      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role, :is_dpo)
+      params.require(:user).permit(:email, :name, :password, :password_confirmation, :role, :is_dpo, :is_key_contact)
     else
-      params.require(:user).permit(:email, :name, :role, :is_dpo)
+      params.require(:user).permit(:email, :name, :role, :is_dpo, :is_key_contact)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,14 @@ class User < ApplicationRecord
     last_sign_in_at ? RESET_PASSWORD_TEMPLATE_ID : SET_PASSWORD_TEMPLATE_ID
   end
 
+  def is_key_contact?
+    is_key_contact
+  end
+
+  def is_key_contact!
+    update(is_key_contact: true)
+  end
+
   def is_data_protection_officer?
     is_dpo
   end

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -24,13 +24,40 @@ module Imports
           phone: user_field_value(xml_document, "telephone-no"),
           old_user_id:,
           organisation:,
-          role: PROVIDER_TYPE[user_field_value(xml_document, "user-type")],
+          role: role(user_field_value(xml_document, "user-type")),
+          is_dpo: is_dpo?(user_field_value(xml_document, "user-type")),
+          is_key_contact: is_key_contact?(user_field_value(xml_document, "contact-priority-id")),
         )
       end
     end
 
     def user_field_value(xml_document, field)
       field_value(xml_document, "user", field)
+    end
+
+    def role(field_value)
+      return unless field_value
+
+      case field_value.downcase.strip
+      when "data provider"
+        "data_provider"
+      when "co-ordinator"
+        "data_coordinator"
+      when "private data downloader"
+        "data_accessor"
+      end
+    end
+
+    def is_dpo?(field_value)
+      return false unless field_value.present?
+
+      field_value.downcase.strip == "data protection officer"
+    end
+
+    def is_key_contact?(field_value)
+      return false unless field_value.present?
+
+      ["ecore contact", "key performance contact"].include?(field_value.downcase.strip)
     end
   end
 end

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -38,24 +38,21 @@ module Imports
     def role(field_value)
       return unless field_value
 
-      case field_value.downcase.strip
-      when "data provider"
-        "data_provider"
-      when "co-ordinator"
-        "data_coordinator"
-      when "private data downloader"
-        "data_accessor"
-      end
+      {
+        "co-ordinator" => "data_coordinator",
+        "data provider" => "data_provider",
+        "private data downloader" => "data_accessor",
+      }[field_value.downcase.strip]
     end
 
     def is_dpo?(field_value)
-      return false unless field_value.present?
+      return false if field_value.blank?
 
       field_value.downcase.strip == "data protection officer"
     end
 
     def is_key_contact?(field_value)
-      return false unless field_value.present?
+      return false if field_value.blank?
 
       ["ecore contact", "key performance contact"].include?(field_value.downcase.strip)
     end

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -14,11 +14,16 @@ module Imports
       organisation = Organisation.find_by(old_org_id: user_field_value(xml_document, "institution"))
       old_user_id = user_field_value(xml_document, "id")
       name = user_field_value(xml_document, "full-name")
+      email = user_field_value(xml_document, "email")
       if User.find_by(old_user_id:, organisation:)
         @logger.warn("User #{name} with old user id #{old_user_id} is already present, skipping.")
+      elsif (user = User.find_by(email:, organisation:))
+        is_dpo = user.is_data_protection_officer? || is_dpo?(user_field_value(xml_document, "user-type"))
+        role = highest_role(user.role, role(user_field_value(xml_document, "user-type")))
+        user.update!(role:, is_dpo:)
       else
         User.create!(
-          email: user_field_value(xml_document, "user-name"),
+          email:,
           name:,
           password: Devise.friendly_token,
           phone: user_field_value(xml_document, "telephone-no"),
@@ -43,6 +48,14 @@ module Imports
         "data provider" => "data_provider",
         "private data downloader" => "data_accessor",
       }[field_value.downcase.strip]
+    end
+
+    def highest_role(role_a, role_b)
+      return unless role_a || role_b
+      return role_a unless role_b
+      return role_b unless role_a
+
+      [role_a, role_b].map(&:to_sym).sort! { |a, b| User::ROLES[b] <=> User::ROLES[a] }.first
     end
 
     def is_dpo?(field_value)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -34,6 +34,14 @@
         legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
       %>
 
+      <%= f.govuk_collection_radio_buttons :is_key_contact,
+        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
+      %>
+
       <%= f.govuk_submit "Save changes" %>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,21 +26,23 @@
         spellcheck: "false"
       %>
 
-      <%= f.govuk_collection_radio_buttons :is_dpo,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
-        :id,
-        :name,
-        inline: true,
-        legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
-      %>
+      <% if current_user.data_coordinator? %>
+        <%= f.govuk_collection_radio_buttons :is_dpo,
+          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          :id,
+          :name,
+          inline: true,
+          legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
+        %>
 
-      <%= f.govuk_collection_radio_buttons :is_key_contact,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
-        :id,
-        :name,
-        inline: true,
-        legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
-      %>
+        <%= f.govuk_collection_radio_buttons :is_key_contact,
+          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          :id,
+          :name,
+          inline: true,
+          legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
+        %>
+      <% end %>
 
       <%= f.govuk_submit "Save changes" %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -39,6 +39,14 @@
         legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
       %>
 
+      <%= f.govuk_collection_radio_buttons :is_key_contact,
+        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
+      %>
+
       <%= f.govuk_submit "Continue" %>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -31,21 +31,23 @@
         f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" }
       %>
 
-      <%= f.govuk_collection_radio_buttons :is_dpo,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
-        :id,
-        :name,
-        inline: true,
-        legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
-      %>
+      <% if current_user.data_coordinator? %>
+        <%= f.govuk_collection_radio_buttons :is_dpo,
+          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          :id,
+          :name,
+          inline: true,
+          legend: { text: "Are #{current_user == @user ? "you" : "they"} a data protection officer?", size: "m" }
+        %>
 
-      <%= f.govuk_collection_radio_buttons :is_key_contact,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
-        :id,
-        :name,
-        inline: true,
-        legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
-      %>
+        <%= f.govuk_collection_radio_buttons :is_key_contact,
+          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          :id,
+          :name,
+          inline: true,
+          legend: { text: "Are #{current_user == @user ? "you" : "they"} a key contact?", size: "m" }
+        %>
+      <% end %>
 
       <%= f.govuk_submit "Continue" %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,13 +48,21 @@
       <%= summary_list.row do |row|
         row.key { 'Data protection officer' }
         row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
-        row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a data protection officer?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-data-protection-officer" })
+        if current_user.data_coordinator?
+          row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a data protection officer?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-data-protection-officer" })
+        else
+          row.action()
+        end
       end %>
 
       <%= summary_list.row do |row|
         row.key { 'Key contact' }
         row.value { @user.is_key_contact? ? "Yes" : "No" }
-        row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a key contact?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-key-contact" })
+        if current_user.data_coordinator?
+          row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a key contact?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-key-contact" })
+        else
+          row.action()
+        end
       end %>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,6 +50,12 @@
         row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
         row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a data protection officer?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-data-protection-officer" })
       end %>
+
+      <%= summary_list.row do |row|
+        row.key { 'Key contact' }
+        row.value { @user.is_key_contact? ? "Yes" : "No" }
+        row.action(visually_hidden_text: "are #{current_user == @user ? "you" : "they"} a key contact?", href: edit_user_path, html_attributes: { "data-qa": "change-are-#{current_user == @user ? "you" : "they"}-a-key-contact" })
+      end %>
     <% end %>
   </div>
 </div>

--- a/db/migrate/20220329125601_add_key_contact_field_to_user.rb
+++ b/db/migrate/20220329125601_add_key_contact_field_to_user.rb
@@ -1,0 +1,7 @@
+class AddKeyContactFieldToUser < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users, bulk: true do |t|
+      t.column :is_key_contact, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -316,6 +316,7 @@ ActiveRecord::Schema[7.0].define(version: 202202071123100) do
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
     t.boolean "is_dpo", default: false
+    t.boolean "is_key_contact", default: false
     t.string "phone"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -237,16 +237,21 @@ RSpec.describe "User Features" do
       expect(page).to have_title("Error")
     end
 
-    it "sets name, email, role and is_dpo" do
+    it "sets name, email, role, is_dpo and is_key_contact fields" do
       visit("users/new")
       fill_in("user[name]", with: "New User")
       fill_in("user[email]", with: "newuser@example.com")
       choose("user-role-data-provider-field")
       choose("user-is-dpo-true-field")
+      choose("user-is-key-contact-true-field")
       click_button("Continue")
-      expect(
-        User.find_by(name: "New User", email: "newuser@example.com", role: "data_provider", is_dpo: true),
-      ).to be_a(User)
+      expect(User.find_by(
+               name: "New User",
+               email: "newuser@example.com",
+               role: "data_provider",
+               is_dpo: true,
+               is_key_contact: true,
+             )).to be_a(User)
     end
 
     it "defaults to is_dpo false" do
@@ -274,10 +279,16 @@ RSpec.describe "User Features" do
       first(:link, "Change").click
       expect(page).to have_field("user[is_dpo]", with: true)
       choose("user-is-dpo-field")
+      choose("user-is-key-contact-true-field")
       fill_in("user[name]", with: "Updated new name")
       click_button("Save changes")
       expect(page).to have_title("Updated new name’s account")
-      expect(User.find_by(name: "Updated new name", role: "data_provider", is_dpo: false)).to be_a(User)
+      expect(User.find_by(
+               name: "Updated new name",
+               role: "data_provider",
+               is_dpo: false,
+               is_key_contact: true,
+             )).to be_a(User)
     end
   end
 end

--- a/spec/fixtures/softwire_imports/users/10c887710550844e2551b3e0fb88dc9b4a8a642b.xml
+++ b/spec/fixtures/softwire_imports/users/10c887710550844e2551b3e0fb88dc9b4a8a642b.xml
@@ -1,11 +1,11 @@
 <user:user xmlns:user="dclg:user">
-  <user:id>b7829b1a5dfb68bb1e01c08445830c0add40907c</user:id>
+  <user:id>10c887710550844e2551b3e0fb88dc9b4a8a642b</user:id>
   <user:password>xxx</user:password>
   <user:full-name>John Doe</user:full-name>
   <user:user-name>john.doe</user:user-name>
   <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
   <user:email>john.doe@gov.uk</user:email>
-  <user:user-type>Private Data Downloader</user:user-type>
+  <user:user-type>Data Protection Officer</user:user-type>
   <user:active>true</user:active>
   <user:deleted>false</user:deleted>
   <user:contact-priority-id>None</user:contact-priority-id>

--- a/spec/fixtures/softwire_imports/users/b7829b1a5dfb68bb1e01c08445830c0add40907c.xml
+++ b/spec/fixtures/softwire_imports/users/b7829b1a5dfb68bb1e01c08445830c0add40907c.xml
@@ -1,0 +1,13 @@
+<user:user xmlns:user="dclg:user">
+  <user:id>b7829b1a5dfb68bb1e01c08445830c0add40907c</user:id>
+  <user:password>xxx</user:password>
+  <user:full-name>John Doe</user:full-name>
+  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
+  <user:email>john.doe@gov.uk</user:email>
+  <user:user-type>Private Data Downloader</user:user-type>
+  <user:active>true</user:active>
+  <user:deleted>false</user:deleted>
+  <user:contact-priority-id>None</user:contact-priority-id>
+  <user:telephone-no>02012345678</user:telephone-no>
+</user:user>

--- a/spec/fixtures/softwire_imports/users/d4729b1a5dfb68bb1e01c08445830c0add40907c.xml
+++ b/spec/fixtures/softwire_imports/users/d4729b1a5dfb68bb1e01c08445830c0add40907c.xml
@@ -1,0 +1,13 @@
+<user:user xmlns:user="dclg:user">
+  <user:id>d4729b1a5dfb68bb1e01c08445830c0add40907c</user:id>
+  <user:password>xxx</user:password>
+  <user:full-name>John Doe</user:full-name>
+  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
+  <user:email>john.doe@gov.uk</user:email>
+  <user:user-type>Co-ordinator</user:user-type>
+  <user:active>true</user:active>
+  <user:deleted>false</user:deleted>
+  <user:contact-priority-id>Key Performance Contact</user:contact-priority-id>
+  <user:telephone-no>02012345678</user:telephone-no>
+</user:user>

--- a/spec/fixtures/softwire_imports/users/d4729b1a5dfb68bb1e01c08445830c0add40907c.xml
+++ b/spec/fixtures/softwire_imports/users/d4729b1a5dfb68bb1e01c08445830c0add40907c.xml
@@ -2,7 +2,7 @@
   <user:id>d4729b1a5dfb68bb1e01c08445830c0add40907c</user:id>
   <user:password>xxx</user:password>
   <user:full-name>John Doe</user:full-name>
-  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:user-name>john.doe</user:user-name>
   <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
   <user:email>john.doe@gov.uk</user:email>
   <user:user-type>Co-ordinator</user:user-type>

--- a/spec/fixtures/softwire_imports/users/d6717836154cd9a58f9e2f1d3077e3ab81e07613.xml
+++ b/spec/fixtures/softwire_imports/users/d6717836154cd9a58f9e2f1d3077e3ab81e07613.xml
@@ -1,0 +1,13 @@
+<user:user xmlns:user="dclg:user">
+  <user:id>d6717836154cd9a58f9e2f1d3077e3ab81e07613</user:id>
+  <user:password>xxx</user:password>
+  <user:full-name>John Doe</user:full-name>
+  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
+  <user:email>john.doe@gov.uk</user:email>
+  <user:user-type>Co-ordinator</user:user-type>
+  <user:active>true</user:active>
+  <user:deleted>false</user:deleted>
+  <user:contact-priority-id>eCORE Contact</user:contact-priority-id>
+  <user:telephone-no>02012345678</user:telephone-no>
+</user:user>

--- a/spec/fixtures/softwire_imports/users/d6717836154cd9a58f9e2f1d3077e3ab81e07613.xml
+++ b/spec/fixtures/softwire_imports/users/d6717836154cd9a58f9e2f1d3077e3ab81e07613.xml
@@ -2,7 +2,7 @@
   <user:id>d6717836154cd9a58f9e2f1d3077e3ab81e07613</user:id>
   <user:password>xxx</user:password>
   <user:full-name>John Doe</user:full-name>
-  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:user-name>john.doe</user:user-name>
   <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
   <user:email>john.doe@gov.uk</user:email>
   <user:user-type>Co-ordinator</user:user-type>

--- a/spec/fixtures/softwire_imports/users/fc7625a02b24ae16162aa63ae7cb33feeec0c373.xml
+++ b/spec/fixtures/softwire_imports/users/fc7625a02b24ae16162aa63ae7cb33feeec0c373.xml
@@ -2,7 +2,7 @@
   <user:id>fc7625a02b24ae16162aa63ae7cb33feeec0c373</user:id>
   <user:password>xxx</user:password>
   <user:full-name>John Doe</user:full-name>
-  <user:user-name>john.doe@gov.uk</user:user-name>
+  <user:user-name>john.doe</user:user-name>
   <user:institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</user:institution>
   <user:email>john.doe@gov.uk</user:email>
   <user:user-type>Data Provider</user:user-type>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,13 +47,17 @@ RSpec.describe User, type: :model do
       expect(user.data_coordinator?).to be false
     end
 
+    it "is not a key contact by default" do
+      expect(user.is_key_contact?).to be false
+    end
+
     it "is not a data protection officer by default" do
       expect(user.is_data_protection_officer?).to be false
     end
 
-    it "can be set to data protection officer" do
-      expect { user.is_data_protection_officer! }
-        .to change { user.reload.is_data_protection_officer? }.from(false).to(true)
+    it "can be set to key contact" do
+      expect { user.is_key_contact! }
+        .to change { user.reload.is_key_contact? }.from(false).to(true)
     end
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -210,13 +210,14 @@ RSpec.describe UsersController, type: :request do
           expect(whodunnit_actor.id).to eq(user.id)
         end
 
-        context "when user changes email and dpo" do
-          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
+        context "when user changes email, dpo, key_contact" do
+          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true", is_key_contact: "true" } } }
 
           it "allows changing email and dpo" do
             user.reload
             expect(user.email).to eq(new_email)
             expect(user.is_data_protection_officer?).to be true
+            expect(user.is_key_contact?).to be true
           end
         end
       end
@@ -399,12 +400,13 @@ RSpec.describe UsersController, type: :request do
         end
 
         context "when user changes email and dpo" do
-          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
+          let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true", is_key_contact: "true" } } }
 
           it "allows changing email and dpo" do
             user.reload
             expect(user.email).to eq(new_email)
             expect(user.is_data_protection_officer?).to be true
+            expect(user.is_key_contact?).to be true
           end
         end
 
@@ -443,14 +445,15 @@ RSpec.describe UsersController, type: :request do
               .to change { other_user.reload.versions.last.actor&.id }.from(nil).to(user.id)
           end
 
-          context "when user changes email and dpo" do
-            let(:params) { { id: other_user.id, user: { name: new_name, email: new_email, is_dpo: "true" } } }
+          context "when user changes email, dpo, key_contact" do
+            let(:params) { { id: other_user.id, user: { name: new_name, email: new_email, is_dpo: "true", is_key_contact: "true" } } }
 
-            it "allows changing email and dpo" do
+            it "allows changing email, dpo, key_contact" do
               patch "/users/#{other_user.id}", headers: headers, params: params
               other_user.reload
               expect(other_user.email).to eq(new_email)
               expect(other_user.is_data_protection_officer?).to be true
+              expect(other_user.is_key_contact?).to be true
             end
           end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -213,11 +213,11 @@ RSpec.describe UsersController, type: :request do
         context "when user changes email, dpo, key_contact" do
           let(:params) { { id: user.id, user: { name: new_name, email: new_email, is_dpo: "true", is_key_contact: "true" } } }
 
-          it "allows changing email and dpo" do
+          it "allows changing email but not dpo or key_contact" do
             user.reload
             expect(user.email).to eq(new_email)
-            expect(user.is_data_protection_officer?).to be true
-            expect(user.is_key_contact?).to be true
+            expect(user.is_data_protection_officer?).to be false
+            expect(user.is_key_contact?).to be false
           end
         end
       end
@@ -264,6 +264,32 @@ RSpec.describe UsersController, type: :request do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_selector("#error-summary-title")
         end
+      end
+    end
+
+    describe "#create" do
+      let(:params) do
+        {
+          "user": {
+            name: "new user",
+            email: "new_user@example.com",
+            role: "data_coordinator",
+          },
+        }
+      end
+      let(:request) { post "/users/", headers: headers, params: params }
+
+      before do
+        sign_in user
+      end
+
+      it "does not invite a new user" do
+        expect { request }.not_to change(User, :count)
+      end
+
+      it "returns 401 unauthorized" do
+        request
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -513,42 +539,43 @@ RSpec.describe UsersController, type: :request do
         end
       end
     end
-  end
 
-  describe "#create" do
-    let(:params) do
-      {
-        "user": {
-          name: "new user",
-          email: "new_user@example.com",
-          role: "data_coordinator",
-        },
-      }
-    end
-    let(:request) { post "/users/", headers: headers, params: params }
+    describe "#create" do
+      let(:user) { FactoryBot.create(:user, :data_coordinator) }
+      let(:params) do
+        {
+          "user": {
+            name: "new user",
+            email: "new_user@example.com",
+            role: "data_coordinator",
+          },
+        }
+      end
+      let(:request) { post "/users/", headers: headers, params: params }
 
-    before do
-      sign_in user
-    end
-
-    it "invites a new user" do
-      expect { request }.to change(User, :count).by(1)
-    end
-
-    it "redirects back to organisation users page" do
-      request
-      expect(response).to redirect_to("/organisations/#{user.organisation.id}/users")
-    end
-
-    context "when the email is already taken" do
       before do
-        FactoryBot.create(:user, email: "new_user@example.com")
+        sign_in user
       end
 
-      it "shows an error" do
+      it "invites a new user" do
+        expect { request }.to change(User, :count).by(1)
+      end
+
+      it "redirects back to organisation users page" do
         request
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(page).to have_content(I18n.t("validations.email.taken"))
+        expect(response).to redirect_to("/organisations/#{user.organisation.id}/users")
+      end
+
+      context "when the email is already taken" do
+        before do
+          FactoryBot.create(:user, email: "new_user@example.com")
+        end
+
+        it "shows an error" do
+          request
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.email.taken"))
+        end
       end
     end
   end

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Imports::UserImportService do
       end
     end
 
+    context "when the user is a data accessor" do
+      let(:old_user_id) { "b7829b1a5dfb68bb1e01c08445830c0add40907c" }
+
+      it "sets their role correctly" do
+        FactoryBot.create(:organisation, old_org_id:)
+        import_service.create_users("user_directory")
+        expect(User.find_by(old_user_id:)).to be_data_accessor
+      end
+    end
+
     context "when the user was a 'Key Performance Contact' in the old system" do
       let(:old_user_id) { "d4729b1a5dfb68bb1e01c08445830c0add40907c" }
 


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1063

- [x] Add field to data model
- [x] Add field to edit, new and show user views and permit updates in controller
- [x] Import key contact status from softwire data
- [x] Data providers can't edit DPO or Key Contact fields
- [x] Email addresses aren't unique in the softwire system (same person can have multiple accounts for different roles). Handle importing them correctly with the highest role.
- [x] Handle importing data protection officer status correctly

Data Coordinator viewing another user:
![image](https://user-images.githubusercontent.com/5101747/160620463-e2a2a73b-b94e-42b0-9ac8-fd41a0b1be75.png)

Data Coordinator editing another user:
![image](https://user-images.githubusercontent.com/5101747/160620559-090e174f-af67-4559-8ea1-ce1fed240622.png)

Data coordinator inviting a new user:
![image](https://user-images.githubusercontent.com/5101747/160620637-50849f54-5fd4-4693-a0ca-a4043031f484.png)

Data Provider viewing their details:
![image](https://user-images.githubusercontent.com/5101747/160647946-af25eaf0-a56a-4990-b8d3-711a0ce4f234.png)

Data Provider editing their details:
![image](https://user-images.githubusercontent.com/5101747/160648223-7d483900-297e-46f7-ab55-a96e5fa054a2.png)
