### PR TITLE
Remove organisation questions as it doesn't apply to 1.0

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -9,40 +9,6 @@
         "setup": {
           "label": "Set up this lettings log",
           "pages": {
-            "organisation_details": {
-              "header": "Organisation details",
-              "description": "",
-              "questions": {
-                "property_owner_organisation": {
-                  "check_answer_label": "Owning organisation",
-                  "header": "Which organisation owns this property?",
-                  "hint_text": "",
-                  "type": "radio",
-                  "answer_options": {
-                    "0": {
-                      "value": "A"
-                    },
-                    "1": {
-                      "value": "B"
-                    }
-                  }
-                },
-                "property_manager_organisation": {
-                  "check_answer_label": "Managing organisation",
-                  "header": "Which organisation manages this property?",
-                  "hint_text": "",
-                  "type": "radio",
-                  "answer_options": {
-                    "0": {
-                      "value": "A"
-                    },
-                    "1": {
-                      "value": "B"
-                    }
-                  }
-                }
-              }
-            },
             "needs_type": {
               "header": "",
               "description": "",


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1073

We remove the owning and managing organisation page/questions for now since it doesn't apply to 1.0 and we derive it here https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/blob/main/app/controllers/case_logs_controller.rb#L92