### PR TITLE
Devise fields don't need versioning

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -6,7 +6,18 @@ class AdminUser < ApplicationRecord
 
   has_one_time_password(encrypted: true)
 
-  has_paper_trail
+  has_paper_trail ignore: %w[last_sign_in_at
+                             current_sign_in_at
+                             current_sign_in_ip
+                             last_sign_in_ip
+                             failed_attempts
+                             unlock_token
+                             locked_at
+                             reset_password_token
+                             reset_password_sent_at
+                             remember_created_at
+                             sign_in_count
+                             updated_at]
 
   validates :phone, presence: true, numericality: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,18 @@ class User < ApplicationRecord
   has_many :owned_case_logs, through: :organisation
   has_many :managed_case_logs, through: :organisation
 
-  has_paper_trail
+  has_paper_trail ignore: %w[last_sign_in_at
+                             current_sign_in_at
+                             current_sign_in_ip
+                             last_sign_in_ip
+                             failed_attempts
+                             unlock_token
+                             locked_at
+                             reset_password_token
+                             reset_password_sent_at
+                             remember_created_at
+                             sign_in_count
+                             updated_at]
 
   ROLES = {
     data_accessor: 0,

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -61,5 +61,24 @@ RSpec.describe AdminUser, type: :model do
       admin_user.update!(phone: "09673867853")
       expect(admin_user.paper_trail.previous_version.phone).to eq("07563867654")
     end
+
+    it "signing in does not create a new version" do
+      expect {
+        admin_user.update!(
+          last_sign_in_at: Time.zone.now,
+          current_sign_in_at: Time.zone.now,
+          current_sign_in_ip: "127.0.0.1",
+          last_sign_in_ip: "127.0.0.1",
+          failed_attempts: 3,
+          unlock_token: "dummy",
+          locked_at: Time.zone.now,
+          reset_password_token: "dummy",
+          reset_password_sent_at: Time.zone.now,
+          remember_created_at: Time.zone.now,
+          sign_in_count: 5,
+          updated_at: Time.zone.now,
+        )
+      }.not_to change(admin_user.versions, :count)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -77,5 +77,24 @@ RSpec.describe User, type: :model do
       user.update!(name: "new test name")
       expect(user.paper_trail.previous_version.name).to eq("Danny Rojas")
     end
+
+    it "signing in does not create a new version" do
+      expect {
+        user.update!(
+          last_sign_in_at: Time.zone.now,
+          current_sign_in_at: Time.zone.now,
+          current_sign_in_ip: "127.0.0.1",
+          last_sign_in_ip: "127.0.0.1",
+          failed_attempts: 3,
+          unlock_token: "dummy",
+          locked_at: Time.zone.now,
+          reset_password_token: "dummy",
+          reset_password_sent_at: Time.zone.now,
+          remember_created_at: Time.zone.now,
+          sign_in_count: 5,
+          updated_at: Time.zone.now,
+        )
+      }.not_to change(user.versions, :count)
+    end
   end
 end


### PR DESCRIPTION
Let's not totally explode our database storage requirements by creating a new paper trail version every time someone logs in or mistypes a password.