### PR TITLE
Cldc 1096 compare json against data dict

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -958,19 +958,19 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "2": {
                       "value": "Assured"
                     },
-                    "1": {
+                    "4": {
                       "value": "Assured Shorthold"
                     },
-                    "2": {
+                    "5": {
                       "value": "Licence agreement (almshouses only)"
                     },
-                    "3": {
+                    "1": {
                       "value": "Secure (including flexible)"
                     },
-                    "4": {
+                    "3": {
                       "value": "Other"
                     }
                   },

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -586,19 +586,19 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "2": {
                       "value": "Affordable rent basis"
                     },
-                    "2": {
+                    "3": {
                       "value": "Intermediate rent basis"
                     },
-                    "0": {
+                    "1": {
                       "value": "Social rent basis"
                     },
                     "divider": {
                       "value": true
                     },
-                    "3": {
+                    "4": {
                       "value": "Don’t know"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1002,19 +1002,19 @@
                   "hint_text": "This is also known as an ‘introductory period’.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "2": {
                       "value": "Assured"
                     },
-                    "1": {
+                    "4": {
                       "value": "Assured Shorthold"
                     },
-                    "2": {
+                    "5": {
                       "value": "Licence agreement (almshouses only)"
                     },
-                    "3": {
+                    "1": {
                       "value": "Secure (including flexible)"
                     },
-                    "4": {
+                    "3": {
                       "value": "Other"
                     }
                   },

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4607,7 +4607,7 @@
                     "3": {
                       "value": "Don’t know"
                     },
-                    "6": {
+                    "1000": {
                       "value": "Tenant prefers not to say"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1223,7 +1223,7 @@
                     "divider": {
                       "value": true
                     },
-                    "5": {
+                    "17": {
                       "value": "Tenant prefers not to say"
                     }
                   }
@@ -1240,16 +1240,16 @@
                   "hint_text": "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "19": {
                       "value": "Arab"
                     },
-                    "1": {
+                    "16": {
                       "value": "Other ethnic group"
                     }
                   },
                   "conditional_for": {
                     "ethnic_other": [
-                      1
+                      16
                     ]
                   }
                 },
@@ -1275,25 +1275,25 @@
                   "hint_text": "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "10": {
                       "value": "Bangladeshi"
                     },
-                    "1": {
+                    "15": {
                       "value": "Chinese"
                     },
-                    "2": {
+                    "8": {
                       "value": "Indian"
                     },
-                    "3": {
+                    "9": {
                       "value": "Pakistani"
                     },
-                    "4": {
+                    "11": {
                       "value": "Other ethnic group"
                     }
                   },
                   "conditional_for": {
                     "ethnic_other": [
-                      4
+                      11
                     ]
                   }
                 },
@@ -1319,13 +1319,13 @@
                   "hint_text": "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "13": {
                       "value": "African"
                     },
-                    "1": {
+                    "12": {
                       "value": "Caribbean"
                     },
-                    "2": {
+                    "14": {
                       "value": "Any other Black, African or Caribbean background"
                     }
                   },
@@ -1357,19 +1357,22 @@
                   "hint_text": "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "4": {
                       "value": "White and Black Caribbean"
                     },
-                    "1": {
+                    "5": {
                       "value": "White and Black African"
                     },
-                    "2": {
+                    "6": {
+                      "value": "White and Asian"
+                    },
+                    "7": {
                       "value": "Any other Mixed or Multiple ethnic background"
                     }
                   },
                   "conditional_for": {
                     "ethnic_other": [
-                      2
+                      7
                     ]
                   }
                 },
@@ -1395,17 +1398,14 @@
                   "hint_text": "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "English, Welsh, Northern Irish, Scottish or British"
                     },
-                    "1": {
+                    "2": {
                       "value": "Irish"
                     },
-                    "2": {
+                    "18": {
                       "value": "Gypsy or Irish Traveller"
-                    },
-                    "3": {
-                      "value": "Any other White background"
                     }
                   },
                   "conditional_for": {

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3087,16 +3087,16 @@
                   "type": "radio",
                   "check_answer_label": "Anybody in household pregnant",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes"
                     },
-                    "1": {
+                    "2": {
                       "value": "No"
                     },
                     "divider": {
                       "value": true
                     },
-                    "2": {
+                    "3": {
                       "value": "Tenant prefers not to say"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4515,12 +4515,6 @@
                     {
                       "label": "every week",
                       "depends_on": {
-                        "incfreq": 0
-                      }
-                    },
-                    {
-                      "label": "every month",
-                      "depends_on": {
                         "incfreq": 1
                       }
                     },
@@ -4528,6 +4522,12 @@
                       "label": "every month",
                       "depends_on": {
                         "incfreq": 2
+                      }
+                    },
+                    {
+                      "label": "every year",
+                      "depends_on": {
+                        "incfreq": 3
                       }
                     }
                   ]
@@ -4538,13 +4538,13 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Weekly"
                     },
-                    "1": {
+                    "2": {
                       "value": "Monthly"
                     },
-                    "2": {
+                    "3": {
                       "value": "Yearly"
                     }
                   },

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3148,16 +3148,16 @@
                   "type": "radio",
                   "check_answer_label": "Anybody in household with physical or mental health condition",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes"
                     },
-                    "1": {
+                    "2": {
                       "value": "No"
                     },
                     "divider": {
                       "value": true
                     },
-                    "2": {
+                    "3": {
                       "value": "Tenant prefers not to say"
                     }
                   }
@@ -3169,7 +3169,7 @@
               "description": "",
               "depends_on": [
                 {
-                  "illness": 0
+                  "illness": 1
                 }
               ],
               "questions": {

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -938,10 +938,10 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes"
                     },
-                    "1": {
+                    "2": {
                       "value": "No"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1064,25 +1064,25 @@
               "header": "",
               "description": "",
               "questions": {
-                "letting_in_sheltered_accommodation": {
+                "shelteredaccom": {
                   "check_answer_label": "Is this letting in sheltered accommodation?",
                   "header": "Is this letting in sheltered accommodation?",
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes – sheltered housing"
                     },
-                    "1": {
+                    "2": {
                       "value": "Yes – extra care housing"
                     },
-                    "2": {
+                    "3": {
                       "value": "No"
                     },
                     "divider": {
                       "value": true
                     },
-                    "3": {
+                    "4": {
                       "value": "Don’t know"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -2987,22 +2987,22 @@
                   "type": "radio",
                   "check_answer_label": "Household links to UK armed forces",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes – the person is a current or former regular"
                     },
-                    "1": {
+                    "4": {
                       "value": "Yes – the person is a current or former reserve"
                     },
-                    "2": {
+                    "5": {
                       "value": "Yes – the person is a spouse or civil partner of a UK armed forces member and has been bereaved or separated from them within the last 2 years"
                     },
-                    "3": {
+                    "2": {
                       "value": "No"
                     },
                     "divider": {
                       "value": true
                     },
-                    "4": {
+                    "3": {
                       "value": "Person prefers not to say"
                     }
                   }
@@ -3014,7 +3014,7 @@
               "description": "",
               "depends_on": [
                 {
-                  "armedforces": 0
+                  "armedforces": 1
                 }
               ],
               "questions": {
@@ -3048,10 +3048,10 @@
               "description": "",
               "depends_on": [
                 {
-                  "armedforces": 0
+                  "armedforces": 1
                 },
                 {
-                  "armedforces": 1
+                  "armedforces": 4
                 }
               ],
               "questions": {

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -675,14 +675,14 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "15": {
-                      "value": "First let of new-build property"
-                    },
                     "16": {
                       "value": "First let of conversion, rehabilitation or acquired property"
                     },
                     "17": {
                       "value": "First let of leased property"
+                    },
+                    "15": {
+                      "value": "First let of new-build property"
                     }
                   }
                 }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3432,9 +3432,6 @@
                     },
                     "28": {
                       "value": "Don’t know"
-                    },
-                    "10000": {
-                      "value": "Tenant prefers not to say"
                     }
                   },
                   "conditional_for": {
@@ -4606,9 +4603,6 @@
                     },
                     "3": {
                       "value": "Don’t know"
-                    },
-                    "1000": {
-                      "value": "Tenant prefers not to say"
                     }
                   }
                 }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4624,19 +4624,19 @@
                   "hint_text": "This excludes child and housing benefit, council tax support and tax credits.",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "All"
                     },
-                    "1": {
+                    "2": {
                       "value": "Some"
                     },
-                    "2": {
+                    "3": {
                       "value": "None"
                     },
                     "divider": {
                       "value": true
                     },
-                    "3": {
+                    "4": {
                       "value": "Don’t know"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3439,7 +3439,7 @@
                   },
                   "conditional_for": {
                     "other_reason_for_leaving_last_settled_home": [
-                      31
+                      20
                     ]
                   }
                 },

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3279,37 +3279,37 @@
               "header": "",
               "description": "",
               "questions": {
-                "lawaitlist": {
+                "waityear": {
                   "check_answer_label": "Length of time on local authority waiting list",
                   "header": "How long has the household been on the local authority waiting list for the new letting?",
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Just moved to local authority area"
                     },
-                    "1": {
+                    "2": {
                       "value": "Less than 1 year"
                     },
-                    "2": {
+                    "7": {
                       "value": "1 year but under 2 years"
                     },
-                    "3": {
+                    "8": {
                       "value": "2 years but under 3 years"
                     },
-                    "4": {
+                    "9": {
                       "value": "3 years but under 4 years"
                     },
-                    "5": {
+                    "10": {
                       "value": "4 years but under 5 years"
                     },
-                    "6": {
+                    "5": {
                       "value": "5 years or more"
                     },
                     "divider": {
                       "value": true
                     },
-                    "7": {
+                    "6": {
                       "value": "Don’t know"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -786,10 +786,10 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "2": {
                       "value": "Converted from previous residential or non-residential property"
                     },
-                    "0": {
+                    "1": {
                       "value": "Purpose built"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -748,28 +748,28 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "2": {
                       "value": "Bedsit"
                     },
-                    "3": {
+                    "8": {
                       "value": "Bungalow"
                     },
-                    "0": {
+                    "1": {
                       "value": "Flat or maisonette"
                     },
-                    "2": {
+                    "7": {
                       "value": "House"
                     },
-                    "6": {
+                    "10": {
                       "value": "Shared bungalow"
                     },
                     "4": {
                       "value": "Shared flat or maisonette"
                     },
-                    "5": {
+                    "9": {
                       "value": "Shared house"
                     },
-                    "7": {
+                    "6": {
                       "value": "Other"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -621,39 +621,39 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "13": {
                       "value": "Internal transfer",
                       "hint": "Excluding renewals of a fixed-term tenancy"
                     },
-                    "10": {
+                    "5": {
                       "value": "Previous tenant died with no succession"
                     },
-                    "2": {
+                    "9": {
                       "value": "Re-let to tenant who occupied same property as temporary accommodation"
                     },
-                    "0": {
+                    "14": {
                       "value": "Renewal of fixed-term tenancy"
                     },
-                    "7": {
-                      "value": "Tenant abandoned property"
-                    },
-                    "3": {
+                    "19": {
                       "value": "Tenant involved in a succession downsize"
                     },
-                    "6": {
-                      "value": "Tenant moved to care home"
-                    },
-                    "5": {
-                      "value": "Tenant moved to other social housing provider"
-                    },
-                    "4": {
+                    "8": {
                       "value": "Tenant moved to private sector or other accommodation"
                     },
-                    "9": {
-                      "value": "Tenant was evicted due to anti-social behaviour"
+                    "12": {
+                      "value": "Tenant moved to other social housing provider"
                     },
-                    "8": {
+                    "18": {
+                      "value": "Tenant moved to care home"
+                    },
+                    "6": {
+                      "value": "Tenant abandoned property"
+                    },
+                    "10": {
                       "value": "Tenant was evicted due to rent arrears"
+                    },
+                    "11": {
+                      "value": "Tenant was evicted due to anti-social behaviour"
                     }
                   }
                 }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -806,10 +806,10 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "0": {
+                    "1": {
                       "value": "Yes"
                     },
-                    "1": {
+                    "2": {
                       "value": "No"
                     }
                   }

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1020,7 +1020,7 @@
                   },
                   "conditional_for": {
                     "tenancyother": [
-                      4
+                      3
                     ]
                   }
                 },
@@ -1053,10 +1053,10 @@
               },
               "depends_on": [
                 {
-                  "tenancy": 3
+                  "tenancy": 1
                 },
                 {
-                  "tenancy": 1
+                  "tenancy": 4
                 }
               ]
             },

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -586,19 +586,19 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
+                    "1": {
+                      "value": "Social rent basis"
+                    },
                     "2": {
                       "value": "Affordable rent basis"
                     },
-                    "3": {
+                    "4": {
                       "value": "Intermediate rent basis"
-                    },
-                    "1": {
-                      "value": "Social rent basis"
                     },
                     "divider": {
                       "value": true
                     },
-                    "4": {
+                    "3": {
                       "value": "Don’t know"
                     }
                   }


### PR DESCRIPTION
Updated `config/forms/2021_2022.json` to match:

1. Option IDs from the data dictionary 
2. For some questions, ordering from the 2021/22 paper form (where it was wildly different)
3. The question key from the data dictionary 

Here's what's changed:

## Property information
* Updated options IDs on "What type was the property most recently let as?" (`unitletas`)
*  Updated options IDs AND ordering on "What is the reason for the property being vacant?" (when NOT new let) (`rsnvac`)
*  Updated ordering on "What is the reason for the property being vacant?" (when IS new let) (`rsnvac`)
*  Updated option IDs on "What type of unit is the property?" (`unittype_gn`)
*  Updated option IDs on "What type of building is the property?" (`builtype`)
*  Updated option IDs on "Is the property built or adapted to wheelchair-user standards?" (`wchair`)

## Tenancy Information 
* Updated option IDs on "Is this a starter or introductory tenancy?" (`startertenancy`)
* Updated option IDs on "What is the type of tenancy?" (`tenancy`) 
* Updated option IDs on "What is the type of tenancy after the starter period has ended?" (`tenancy`) 
  * Therefore, updated depends-on for "What is the length of the fixed-term tenancy to the nearest year?" (`tenancylength`)
* Updated **question key** (was `letting_in_sheltered_accommodation`, is now `shelteredaccom`) and option IDs on "Is this letting in sheltered accommodation?" (`shelteredaccom`)

## Household characteristics
* Updated option IDs AND added missing option for lead tenant ethnicity (multiple questions) (`ethnic`) **Currently: Tenant prefers not to say (ID 17) will NOT be captured in the output data!**

## Household needs
* Updated option IDs for "Does anybody in the household have any links to the UK armed forces?" (`armedforces`)
  * Therefore, updated depends-on options for "Is the person still serving in the UK armed forces?" (`leftreg`)
  * Therefore, updated depends-on options for "Was the person seriously injured or ill as a result of serving in the UK armed forces?" (`reservist`)
* Updated the option IDs for "Is anybody in the household pregnant?" (`preg_occ`)
* Updated the option IDs for "Does anybody in the household have a physical or mental health condition (or other illness) expected to last 12 months or more?" (`illness`)
  * Therefore, updated depends-on option for "How is the person affected by their condition or illness?" (`illness_type_x`, etc)

## Household situation
* Updated **question key** (was `lawaitlist` now `waityear`) for "How long has the household been on the local authority waiting list for the new letting?" (`waityear`)
* Updated option IDs for "How long has the household been on the local authority waiting list for the new letting?" (`waityear`)
* Updated the other dropdown for "What is the tenant’s main reason for the household leaving their last settled home?" (`reason`) so it appears when user selects "other" (option ID `20`)
* Removed "tenant prefers not to say" option from "What is the tenant’s main reason for the household leaving their last settled home?" (`reason`)

## Income, benefits and outgoings
* Updated option IDs for "How often does the household receive this amount?" (`incfreq`)
  * Therefore, updated suffix text on "How much income does the household have in total?" as this depends on `incfreq`
* Removed "tenant prefers not to say" option from "Is the household likely to be receiving any of these housing-related benefits?" (`hb`) - as this is a new option.
* Updated option IDs for "How much of the household’s income is from Universal Credit, state pensions or benefits?" (`benefits`)