### PR TITLE
Fix financial validation

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -69,7 +69,7 @@ module Validations::FinancialValidations
       record.errors.add :tcharge, I18n.t("validations.financial.tcharge.under_10")
     end
 
-    answered_questions = [record.tcharge, record.chcharge].concat(record.household_charge && record.household_charge.zero? ? [record.household_charge] : [])
+    answered_questions = [record.tcharge, record.chcharge].concat(record.household_charge && record.household_charge == 1 ? [record.household_charge] : [])
     if answered_questions.count(&:present?) > 1
       record.errors.add :tcharge, I18n.t("validations.financial.charges.complete_1_of_3") if record.tcharge.present?
       record.errors.add :chcharge, I18n.t("validations.financial.charges.complete_1_of_3") if record.chcharge.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
         period:
           not_in_range: "Basic rent is outside of the expected range based on this period"
       charges:
-        complete_1_of_3: "Answer only one of the following questions: 'total charges', 'care home charges' or 'does the household pay rent or charges?'"
+        complete_1_of_3: "Answer only one of the following questions: 'total charges', 'care home charges' or answer 'no' to the 'does the household pay rent or charges?' question"
       tcharge:
         under_10: "Total charge must be at least £10 per week"
 

--- a/spec/fixtures/complete_case_log.json
+++ b/spec/fixtures/complete_case_log.json
@@ -141,7 +141,7 @@
     "renewal": 0,
     "new_build_handover_date": "01/01/2019",
     "has_benefits": 1,
-    "household_charge": 1,
+    "household_charge": 0,
     "is_carehome": 1,
     "letting_in_sheltered_accommodation": 0,
     "declaration": 1,

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe Validations::FinancialValidations do
         it "returns an error for 3 charge types selected" do
           record.tcharge = 19.99
           record.chcharge = 20
-          record.household_charge = 0
+          record.household_charge = 1
           financial_validator.validate_rent_amount(record)
           expect(record.errors["tcharge"])
             .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
@@ -677,9 +677,9 @@ RSpec.describe Validations::FinancialValidations do
             .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
 
-        it "returns an error for tcharge and household_charge types selected" do
+        it "returns an error for tcharge type and household_charge not paid selected" do
           record.tcharge = 19.99
-          record.household_charge = 0
+          record.household_charge = 1
           financial_validator.validate_rent_amount(record)
           expect(record.errors["chcharge"])
             .to be_empty
@@ -689,9 +689,9 @@ RSpec.describe Validations::FinancialValidations do
             .to include(match I18n.t("validations.financial.charges.complete_1_of_3"))
         end
 
-        it "returns an error for chcharge and household_charge types selected" do
+        it "returns an error for chcharge type and household_charge not paid selected" do
           record.chcharge = 20
-          record.household_charge = 0
+          record.household_charge = 1
           financial_validator.validate_rent_amount(record)
           expect(record.errors["tcharge"])
             .to be_empty
@@ -702,8 +702,8 @@ RSpec.describe Validations::FinancialValidations do
         end
       end
 
-      it "does not return an error for household_charge being yes" do
-        record.household_charge = 0
+      it "does not return an error for household_charge being no" do
+        record.household_charge = 1
         financial_validator.validate_rent_amount(record)
         expect(record.errors["tcharge"])
           .to be_empty
@@ -714,7 +714,7 @@ RSpec.describe Validations::FinancialValidations do
       end
 
       it "does not return an error for chcharge being selected" do
-        record.household_charge = 1
+        record.household_charge = 0
         record.chcharge = 20
         financial_validator.validate_rent_amount(record)
         expect(record.errors["tcharge"])
@@ -726,7 +726,7 @@ RSpec.describe Validations::FinancialValidations do
       end
 
       it "does not return an error for tcharge being selected" do
-        record.household_charge = 1
+        record.household_charge = 0
         record.tcharge = 19.99
         financial_validator.validate_rent_amount(record)
         expect(record.errors["tcharge"])


### PR DESCRIPTION
Fix the value in financial validation, instead of allowing only one out of 3 to be answered for:
- `total charge`
- `care home charge`
- `yes` to `does the household pay rent or charges?`

allow only 1 out of 3 of the following:
- `total charge`
- `care home charge`
- `no` to `does the household pay rent or charges?`