### PR TITLE
CLDC-1140: Don't combine two separate ethnic questions

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -426,7 +426,6 @@ private
                        end
     self.nocharge = household_charge&.zero? ? 1 : 0
     self.underoccupation_benefitcap = 3 if renewal == 1 && year == 2021
-    self.ethnic = ethnic || ethnic_group
     self.housingneeds = get_housingneeds
     if is_renewal?
       self.underoccupation_benefitcap = 2 if year == 2021


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1140

In the old system we had a single ethnicity question with 19 options. In the new form this is split into two questions, where the first narrows down the options for the second.

Ultimately though, it's still the second that we want to export to CDS (i.e. the specific value equivalent to the old one).

I think the attempt to combine them came from unclear AC here: https://digital.dclg.gov.uk/jira/browse/CLDC-1050, however the "combining" is already done by the routing.