### PR TITLE
Fix saving date

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -41,7 +41,7 @@ class CaseLog < ApplicationRecord
     years.each { |year| query = query.or(filter_by_year(year)) }
     query.all
   }
-  scope :filter_by_year, ->(year) { where(startdate: Time.utc(year.to_i, 4, 1)...Time.utc(year.to_i + 1, 4, 1)) }
+  scope :filter_by_year, ->(year) { where(startdate: Time.zone.local(year.to_i, 4, 1)...Time.zone.local(year.to_i + 1, 4, 1)) }
 
   scope :filter_by_user, lambda { |selected_user, user|
                            if !selected_user.include?("all") && user.present?

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1846,6 +1846,14 @@ RSpec.describe CaseLog do
       it "can filter by year(s) AND status" do
         expect(described_class.filter_by_years(%w[2021 2022]).filter_by_status("completed").count).to eq(1)
       end
+
+      it "filters based on date boundaries correctly" do
+        case_log_1.update!(startdate: Time.zone.local(2022, 4, 1))
+        case_log_2.update!(startdate: Time.zone.local(2022, 3, 31))
+
+        expect(described_class.filter_by_years(%w[2021]).count).to eq(1)
+        expect(described_class.filter_by_years(%w[2022]).count).to eq(2)
+      end
     end
 
     context "when filtering on status" do


### PR DESCRIPTION
The startdate was being saved an hour early in the db, which meant that it was saved as 23:00 on the previous day. That became apparent when filtering by year was off by 1 day, setting timezone to utc when creating the dates fixes that