### PR TITLE
Enable new link styles

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -9,6 +9,7 @@
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 $govuk-global-styles: true;
+$govuk-new-link-styles: true;
 
 @import "~govuk-frontend/govuk/all";
 


### PR DESCRIPTION
Enable new link styles, which is currently an opt-in setting in `govuk-frontend`. Shows a thicker underline when hovering over a link, making it clear when a link is active. Already being used on GOV.UK, so opting in means our service matches the behaviour on the main website.