### PR TITLE
Add ERB Lint

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,24 @@
+---
+EnableDefaultLinters: true
+linters:
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Layout/ArgumentAlignment:
+        Enabled: false
+      Layout/CommentIndentation:
+        Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
+      Layout/FirstArrayElementIndentation:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development do
   gem "web-console", ">= 4.1.0"
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  gem "erb_lint", require: false
   gem "rack-mini-profiler", "~> 2.0"
   gem "rubocop-govuk", require: false
   gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,14 @@ GEM
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.17)
+    better_html (1.0.16)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -159,6 +167,14 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     encryptor (3.0.0)
+    erb_lint (0.1.1)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.10.0)
     excon (0.92.2)
     factory_bot (6.2.1)
@@ -188,6 +204,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    html_tokenizer (0.0.7)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
@@ -420,6 +437,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    smart_properties (1.17.0)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.1)
@@ -469,6 +487,7 @@ DEPENDENCIES
   chartkick
   devise!
   dotenv-rails
+  erb_lint
   factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder

--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -3,11 +3,11 @@
     <% items.each do |item| %>
       <% if item.fetch(:current, false) || current_page?(strip_query(item.fetch(:url))) %>
         <li class="app-tab-navigation__item app-tab-navigation__item--current">
-          <%= govuk_link_to item[:name], item[:url], class: 'app-tab-navigation__link', aria: { current: 'page' } %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link", aria: { current: "page" } %>
         </li>
       <% else %>
         <li class="app-tab-navigation__item">
-          <%= govuk_link_to item[:name], item[:url], class: 'app-tab-navigation__link' %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link" %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -59,4 +59,3 @@
     </table>
   </section>
 </figure>
-

--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -28,21 +28,21 @@
             <%= govuk_link_to log.id, case_log_path(log) %>
           </th>
           <td class="govuk-table__cell app-!-font-tabular">
-            <%= log.tenant_code? ? log.tenant_code : '–' %>
+            <%= log.tenant_code? ? log.tenant_code : "–" %>
           </td>
           <td class="govuk-table__cell app-!-font-tabular">
-            <%= log.propcode? ? log.propcode : '–' %>
+            <%= log.propcode? ? log.propcode : "–" %>
           </td>
           <td class="govuk-table__cell">
-            <%= log.startdate.present? ? log.startdate.to_formatted_s(:govuk_date) : '–' %>
+            <%= log.startdate.present? ? log.startdate.to_formatted_s(:govuk_date) : "–" %>
           </td>
           <td class="govuk-table__cell">
             <%= log.created_at.to_formatted_s(:govuk_date) %>
           </td>
           <td class="govuk-table__cell">
             <%= govuk_tag(
-              colour: log.status == 'completed' ? 'blue' : 'grey',
-              text: log.status.humanize
+              colour: log.status == "completed" ? "blue" : "grey",
+              text: log.status.humanize,
             ) %>
           </td>
           <% if current_user.support? %>

--- a/app/views/case_logs/bulk_upload.html.erb
+++ b/app/views/case_logs/bulk_upload.html.erb
@@ -5,8 +5,7 @@
 
   <%= f.govuk_file_field :case_log_bulk_upload,
       label: { text: content_for(:title), size: "l" },
-      hint: { text: "Upload a spreadsheet using the template" }
-  %>
+      hint: { text: "Upload a spreadsheet using the template" } %>
 
-  <%= f.govuk_submit "Upload"  %>
+  <%= f.govuk_submit "Upload" %>
 <% end %>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Log #{@case_log.id}" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
   "Logs" => "/logs",
-  content_for(:title) => ""
+  content_for(:title) => "",
 }) %>
 
 <div class="govuk-grid-row">

--- a/app/views/case_logs/index.html.erb
+++ b/app/views/case_logs/index.html.erb
@@ -13,7 +13,7 @@
   <% if @case_logs.present? %>
     <div class="app-filter-layout__content">
       <%= render partial: "log_list", locals: { case_logs: @case_logs, title: "Logs", pagy: @pagy } %>
-      <%== render partial: 'pagy/nav', locals: { pagy: @pagy, item_name: "logs" } %>
+      <%== render partial: "pagy/nav", locals: { pagy: @pagy, item_name: "logs" } %>
     </div>
   <% end %>
 </div>

--- a/app/views/case_logs/index.html.erb
+++ b/app/views/case_logs/index.html.erb
@@ -9,7 +9,7 @@
     <%#= govuk_link_to "Upload logs", bulk_upload_case_logs_path %>
   </div>
 
-  <%= render partial: "log_filters"%>
+  <%= render partial: "log_filters" %>
   <% if @case_logs.present? %>
     <div class="app-filter-layout__content">
       <%= render partial: "log_list", locals: { case_logs: @case_logs, title: "Logs", pagy: @pagy } %>
@@ -17,4 +17,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -7,8 +7,7 @@
     label: { text: "Email address" },
     autocomplete: "email",
     spellcheck: "false",
-    value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
-  %>
+    value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
 
   <%= f.govuk_submit "Resend confirmation instructions" %>
 <% end %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,12 +19,10 @@
       <%= f.govuk_password_field :password,
         label: { text: "New password" },
         hint: @minimum_password_length ? { text: "Your password must be at least #{@minimum_password_length} characters and hard to guess." } : nil,
-        autocomplete: "new-password"
-      %>
+        autocomplete: "new-password" %>
 
       <%= f.govuk_password_field :password_confirmation,
-        label: { text: "Confirm new password" }
-      %>
+        label: { text: "Confirm new password" } %>
 
       <%= f.govuk_submit "Update" %>
     </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -22,8 +22,7 @@
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
-        spellcheck: "false"
-      %>
+        spellcheck: "false" %>
 
       <%= f.govuk_submit "Send email" %>
     </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>

--- a/app/views/devise/passwords/reset_password.html.erb
+++ b/app/views/devise/passwords/reset_password.html.erb
@@ -20,12 +20,10 @@
       <%= f.govuk_password_field :password,
         label: { text: "New password" },
         hint: @minimum_password_length ? { text: "Your password must be at least #{@minimum_password_length} characters and hard to guess." } : nil,
-        autocomplete: "new-password"
-      %>
+        autocomplete: "new-password" %>
 
       <%= f.govuk_password_field :password_confirmation,
-        label: { text: "Confirm new password" }
-      %>
+        label: { text: "Confirm new password" } %>
 
       <%= f.govuk_submit "Update" %>
     </div>

--- a/app/views/devise/passwords/reset_password.html.erb
+++ b/app/views/devise/passwords/reset_password.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,12 +19,10 @@
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
-        spellcheck: "false"
-      %>
+        spellcheck: "false" %>
 
       <%= f.govuk_password_field :password,
-        autocomplete: "current-password"
-      %>
+        autocomplete: "current-password" %>
 
       <%= f.hidden_field :start, value: request["start"] %>
       <%= f.govuk_submit "Sign in" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <p class="govuk-body">Already have an account? <%= govuk_link_to "Sign in", new_session_path(resource_name) %>.</p><br />
+  <p class="govuk-body">Already have an account? <%= govuk_link_to "Sign in", new_session_path(resource_name) %>.</p>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= govuk_link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= govuk_link_to "Sign up", new_registration_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <p class="govuk-body"> You can <%= govuk_link_to "reset your password", new_password_path(resource_name) %> if you’ve forgotten it.<p><br />
+  <p class="govuk-body">You can <%= govuk_link_to "reset your password", new_password_path(resource_name) %> if you’ve forgotten it.</p>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= govuk_link_to "Didn’t receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= govuk_link_to "Didn’t receive confirmation instructions?", new_confirmation_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= govuk_link_to "Didn’t receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= govuk_link_to "Didn’t receive unlock instructions?", new_unlock_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br>
   <% end %>
 <% end %>

--- a/app/views/devise/two_factor_authentication/resend.html.erb
+++ b/app/views/devise/two_factor_authentication/resend.html.erb
@@ -2,8 +2,8 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
-    href: 'javascript:history.back()',
+    text: "Back",
+    href: "javascript:history.back()",
   ) %>
 <% end %>
 

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -15,7 +15,7 @@
       <%= f.govuk_number_field :code,
         label: { text: "Security code", size: "m" },
         width: 5,
-        autocomplete: 'one-time-code',
+        autocomplete: "one-time-code",
         autofocus: true %>
 
       <%= f.govuk_submit "Submit" %>

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -16,8 +16,7 @@
         label: { text: "Security code", size: "m" },
         width: 5,
         autocomplete: 'one-time-code',
-        autofocus: true
-      %>
+        autofocus: true %>
 
       <%= f.govuk_submit "Submit" %>
     </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -6,8 +6,7 @@
   <%= f.govuk_email_field :email,
     label: { text: "Email address" },
     autocomplete: "email",
-    spellcheck: "false"
-  %>
+    spellcheck: "false" %>
 
   <%= f.govuk_submit "Resend unlock instructions" %>
 <% end %>

--- a/app/views/filters/_checkbox_filter.html.erb
+++ b/app/views/filters/_checkbox_filter.html.erb
@@ -1,6 +1,6 @@
-<%= f.govuk_check_boxes_fieldset category.to_sym, legend: { text: label, size: "s"}, small: true, form_group: { classes: "app-filter__group" } do %>
+<%= f.govuk_check_boxes_fieldset category.to_sym, legend: { text: label, size: "s" }, small: true, form_group: { classes: "app-filter__group" } do %>
   <% options.map do |key, option| %>
-    <%= f.govuk_check_box category, "#{key}",
+    <%= f.govuk_check_box category, key.to_s,
     label: { text: option },
     checked: filter_selected?(category, key),
     size: "s" %>

--- a/app/views/form/_check_answers_table.html.erb
+++ b/app/views/form/_check_answers_table.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
-    <%= question.check_answer_label.to_s.present? ? question.check_answer_label.to_s : question.header.to_s %>
+    <%= question.check_answer_label.to_s.presence || question.header.to_s %>
   </dt>
   <dd class="govuk-summary-list__value">
     <%= get_answer_label(question, @case_log) %><br>

--- a/app/views/form/_check_answers_table.html.erb
+++ b/app/views/form/_check_answers_table.html.erb
@@ -3,9 +3,9 @@
     <%= question.check_answer_label.to_s.present? ? question.check_answer_label.to_s : question.header.to_s %>
   </dt>
   <dd class="govuk-summary-list__value">
-    <%= get_answer_label(question, @case_log) %><br/>
+    <%= get_answer_label(question, @case_log) %><br>
     <% question.get_inferred_answers(@case_log).each do |inferred_answer| %>
-     <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span><br/>
+      <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span><br>
     <% end %>
   </dd>
   <dd class="govuk-summary-list__actions">

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -12,8 +12,8 @@
       <%= f.govuk_check_box_divider %>
       <% else %>
         <%= f.govuk_check_box question.id, key,
-          label: { text: options['value'] },
-          hint: { text: options['hint'] },
+          label: { text: options["value"] },
+          hint: { text: options["hint"] },
           checked: @case_log[key] == 1,
           exclusive: after_divider,
           **stimulus_html_attributes(question) %>

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -16,8 +16,7 @@
           hint: { text: options['hint'] },
           checked: @case_log[key] == 1,
           exclusive: after_divider,
-          **stimulus_html_attributes(question)
-        %>
+          **stimulus_html_attributes(question) %>
       <% end %>
     <% end %>
 <% end %>

--- a/app/views/form/_date_question.html.erb
+++ b/app/views/form/_date_question.html.erb
@@ -1,9 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_date_field question.id.to_sym,
-    caption: caption(caption_text, page_header, conditional),
-    legend: legend(question, page_header, conditional),
-    hint: { text: question.hint_text&.html_safe },
-    width: 20,
-    **stimulus_html_attributes(question)
-%>
+  caption: caption(caption_text, page_header, conditional),
+  legend: legend(question, page_header, conditional),
+  hint: { text: question.hint_text&.html_safe },
+  width: 20,
+  **stimulus_html_attributes(question) %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -14,8 +14,7 @@
           key,
           label: { text: options['value'] },
           hint: { text: options['hint'] },
-          **stimulus_html_attributes(question)
-        %>
+          **stimulus_html_attributes(question) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_panel(
-  title_text: title_text,
-  classes: 'app-panel--interruption',
+  title_text:,
+  classes: "app-panel--interruption",
 ) do %>
   <%= display_informative_text(informative_text, case_log) %>
   <%= f.govuk_radio_buttons_fieldset question.id.to_sym,
@@ -12,8 +12,8 @@
       <% else %>
         <%= f.govuk_radio_button question.id,
           key,
-          label: { text: options['value'] },
-          hint: { text: options['hint'] },
+          label: { text: options["value"] },
+          hint: { text: options["hint"] },
           **stimulus_html_attributes(question) %>
       <% end %>
     <% end %>

--- a/app/views/form/_numeric_output_question.html.erb
+++ b/app/views/form/_numeric_output_question.html.erb
@@ -15,7 +15,7 @@
             step="<%= question.step %>"
             type="number"
             name="case_log[tcharge]"
-            for="<%= question.fields_added.present? ? question.fields_added.map { |x| "case-log-#{x}-field"}.join(" ") : "" %>">
+            for="<%= question.fields_added.present? ? question.fields_added.map { |x| "case-log-#{x}-field" }.join(" ") : "" %>">
       <%= case_log[question.id] %></output>
     <span class="govuk-input__suffix"><%= question.suffix %></span>
   </div>

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -5,7 +5,8 @@
   label: legend(question, page_header, conditional),
   hint: { text: question.hint_text&.html_safe },
   min: question.min, max: question.max, step: question.step,
-  width: question.width, :readonly => question.read_only?,
+  width: question.width,
+  readonly: question.read_only?,
   prefix_text: question.prefix.to_s,
   suffix_text: question.suffix.is_a?(String) ? question.suffix : nil,
   **stimulus_html_attributes(question) %>

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -1,12 +1,11 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_number_field question.id.to_sym,
-    caption: caption(caption_text, page_header, conditional),
-    label: legend(question, page_header, conditional),
-    hint: { text: question.hint_text&.html_safe },
-    min: question.min, max: question.max, step: question.step,
-    width: question.width, :readonly => question.read_only?,
-    prefix_text: question.prefix.to_s,
-    suffix_text: question.suffix.is_a?(String) ? question.suffix : nil,
-   **stimulus_html_attributes(question)
-%>
+  caption: caption(caption_text, page_header, conditional),
+  label: legend(question, page_header, conditional),
+  hint: { text: question.hint_text&.html_safe },
+  min: question.min, max: question.max, step: question.step,
+  width: question.width, :readonly => question.read_only?,
+  prefix_text: question.prefix.to_s,
+  suffix_text: question.suffix.is_a?(String) ? question.suffix : nil,
+  **stimulus_html_attributes(question) %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -1,37 +1,36 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_radio_buttons_fieldset question.id.to_sym,
-    caption: caption(caption_text, page_header, conditional),
-    legend: legend(question, page_header, conditional),
-    hint: { text: question.hint_text&.html_safe } do %>
+  caption: caption(caption_text, page_header, conditional),
+  legend: legend(question, page_header, conditional),
+  hint: { text: question.hint_text&.html_safe } do %>
 
-    <% question.displayed_answer_options.map do |key, options| %>
-      <% if key.starts_with?("divider") %>
-        <%= f.govuk_radio_divider %>
+  <% question.displayed_answer_options.map do |key, options| %>
+    <% if key.starts_with?("divider") %>
+      <%= f.govuk_radio_divider %>
+    <% else %>
+      <% conditional_question = find_conditional_question(@page, question, key) %>
+      <% if conditional_question.nil? %>
+        <%= f.govuk_radio_button question.id,
+          key,
+          label: { text: options['value'] },
+          hint: { text: options['hint'] },
+          **stimulus_html_attributes(question) %>
       <% else %>
-        <% conditional_question = find_conditional_question(@page, question, key) %>
-        <% if conditional_question.nil? %>
-          <%= f.govuk_radio_button question.id,
-            key,
-            label: { text: options['value'] },
-            hint: { text: options['hint'] },
-            **stimulus_html_attributes(question)
-          %>
-        <% else %>
-          <%= f.govuk_radio_button question.id,
-            key,
-            label: { text: options['value'] },
-            hint: { text: options['hint'] },
-            **stimulus_html_attributes(question) do %>
-              <%= render partial: "#{conditional_question.type}_question", locals: {
-                question: conditional_question,
-                caption_text: caption_text,
-                page_header: page_header,
-                f: f,
-                conditional: true
-              } %>
-          <% end %>
+        <%= f.govuk_radio_button question.id,
+          key,
+          label: { text: options['value'] },
+          hint: { text: options['hint'] },
+          **stimulus_html_attributes(question) do %>
+            <%= render partial: "#{conditional_question.type}_question", locals: {
+              question: conditional_question,
+              caption_text: caption_text,
+              page_header: page_header,
+              f: f,
+              conditional: true
+            } %>
         <% end %>
       <% end %>
     <% end %>
+  <% end %>
 <% end %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -13,21 +13,21 @@
       <% if conditional_question.nil? %>
         <%= f.govuk_radio_button question.id,
           key,
-          label: { text: options['value'] },
-          hint: { text: options['hint'] },
+          label: { text: options["value"] },
+          hint: { text: options["hint"] },
           **stimulus_html_attributes(question) %>
       <% else %>
         <%= f.govuk_radio_button question.id,
           key,
-          label: { text: options['value'] },
-          hint: { text: options['hint'] },
+          label: { text: options["value"] },
+          hint: { text: options["hint"] },
           **stimulus_html_attributes(question) do %>
             <%= render partial: "#{conditional_question.type}_question", locals: {
               question: conditional_question,
-              caption_text: caption_text,
-              page_header: page_header,
-              f: f,
-              conditional: true
+              caption_text:,
+              page_header:,
+              f:,
+              conditional: true,
             } %>
         <% end %>
       <% end %>

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -2,7 +2,7 @@
 
 <% selected = @case_log.public_send(question.id) || "" %>
 <%= answers = question.displayed_answer_options.map { |key, value| OpenStruct.new(id: key, name: value) }
- f.govuk_collection_select question.id.to_sym,
+  f.govuk_collection_select question.id.to_sym,
     answers,
     :id,
     :name,
@@ -10,5 +10,4 @@
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
     options: { disabled: [""], selected: selected },
-    "data-controller": "accessible-autocomplete"
- %>
+    "data-controller": "accessible-autocomplete" %>

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -1,13 +1,13 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <% selected = @case_log.public_send(question.id) || "" %>
-<%= answers = question.displayed_answer_options.map { |key, value| OpenStruct.new(id: key, name: value) }
-  f.govuk_collection_select question.id.to_sym,
+<%= answers = question.displayed_answer_options.map { |key, value| OpenStruct.new(id: key, name: value) } %>
+  <%= f.govuk_collection_select question.id.to_sym,
     answers,
     :id,
     :name,
     caption: caption(caption_text, page_header, conditional),
     label: legend(question, page_header, conditional),
     hint: { text: question.hint_text&.html_safe },
-    options: { disabled: [""], selected: selected },
+    options: { disabled: [""], selected: },
     "data-controller": "accessible-autocomplete" %>

--- a/app/views/form/_text_question.html.erb
+++ b/app/views/form/_text_question.html.erb
@@ -1,9 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_field question.id.to_sym,
-    caption: caption(caption_text, page_header, conditional),
-    label: legend(question, page_header, conditional),
-    hint: { text: question.hint_text&.html_safe },
-    width: question.width ? question.width : nil,
-    **stimulus_html_attributes(question)
-%>
+  caption: caption(caption_text, page_header, conditional),
+  label: legend(question, page_header, conditional),
+  hint: { text: question.hint_text&.html_safe },
+  width: question.width ? question.width : nil,
+  **stimulus_html_attributes(question) %>

--- a/app/views/form/_text_question.html.erb
+++ b/app/views/form/_text_question.html.erb
@@ -4,5 +4,5 @@
   caption: caption(caption_text, page_header, conditional),
   label: legend(question, page_header, conditional),
   hint: { text: question.hint_text&.html_safe },
-  width: question.width ? question.width : nil,
+  width: question.width || nil,
   **stimulus_html_attributes(question) %>

--- a/app/views/form/_textarea_question.html.erb
+++ b/app/views/form/_textarea_question.html.erb
@@ -4,5 +4,5 @@
   caption: caption(caption_text, page_header, conditional),
   label: legend(question, page_header, conditional),
   hint: { text: question.hint_text&.html_safe },
-  width: question.width ? question.width : nil,
+  width: question.width || nil,
   **stimulus_html_attributes(question) %>

--- a/app/views/form/_textarea_question.html.erb
+++ b/app/views/form/_textarea_question.html.erb
@@ -1,9 +1,8 @@
 <%= render partial: "form/guidance/#{question.guidance_partial}" if question.guidance_partial %>
 
 <%= f.govuk_text_area question.id.to_sym,
-    caption: caption(caption_text, page_header, conditional),
-    label: legend(question, page_header, conditional),
-    hint: { text: question.hint_text&.html_safe },
-    width: question.width ? question.width : nil,
-    **stimulus_html_attributes(question)
-%>
+  caption: caption(caption_text, page_header, conditional),
+  label: legend(question, page_header, conditional),
+  hint: { text: question.hint_text&.html_safe },
+  width: question.width ? question.width : nil,
+  **stimulus_html_attributes(question) %>

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -26,7 +26,7 @@
           <%= govuk_button_link_to 'Save and go to next incomplete section', "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
         <% elsif @case_log.status == "completed" || @case_log.form.all_subsections_except_declaration_completed?(@case_log) %>
           <%= govuk_button_link_to 'Save and go to submit', "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
-        <% end%>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "#{subsection.id.humanize} - Check your answers" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
   "Logs" => "/logs",
-  "Log #{@case_log.id.to_s}" => "/logs/" + @case_log.id.to_s,
-  subsection.label => ""
+  "Log #{@case_log.id}" => "/logs/#{@case_log.id}",
+  subsection.label => "",
 }) %>
 
 <div class="govuk-grid-row">
@@ -16,16 +16,16 @@
 
     <dl class="govuk-summary-list">
       <% subsection.applicable_questions(@case_log).each do |question| %>
-        <%= render partial: 'form/check_answers_table', locals: { question: question, case_log: @case_log } %>
+        <%= render partial: "form/check_answers_table", locals: { question:, case_log: @case_log } %>
       <% end %>
     </dl>
 
     <%= form_with model: @case_log, method: "get" do |f| %>
-      <%= f.govuk_submit 'Save and return to log' do %>
+      <%= f.govuk_submit "Save and return to log" do %>
         <% if @case_log.status == "in_progress" && @case_log.status == "completed" || @case_log.form.all_subsections_except_declaration_completed?(@case_log) == false %>
-          <%= govuk_button_link_to 'Save and go to next incomplete section', "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
+          <%= govuk_button_link_to "Save and go to next incomplete section", "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
         <% elsif @case_log.status == "completed" || @case_log.form.all_subsections_except_declaration_completed?(@case_log) %>
-          <%= govuk_button_link_to 'Save and go to submit', "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
+          <%= govuk_button_link_to "Save and go to submit", "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/form/guidance/_what_counts_as_income.html.erb
+++ b/app/views/form/guidance/_what_counts_as_income.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary_text: 'What counts as income?') do %>
+<%= govuk_details(summary_text: "What counts as income?") do %>
   <p class="govuk-body">You should include any income after tax from:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>employment</li>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -11,7 +11,7 @@
 
 <%= form_with model: @case_log, url: form_case_log_path(@case_log), method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
-    <div class=<%= @page.questions[0].type == "interruption_screen" ? "govuk-grid-column-full-from-desktop" : "govuk-grid-column-two-thirds-from-desktop"%>>
+    <div class="govuk-grid-column-<%= @page.questions[0].type == "interruption_screen" ? "full-from-desktop" : "two-thirds-from-desktop" %>">
       <% remove_other_page_errors(@case_log, @page) %>
       <%= f.govuk_error_summary %>
 
@@ -29,7 +29,7 @@
       <% end %>
 
       <% @page.non_conditional_questions.map do |question| %>
-        <div id=<%= question.id + "_div " %><%= display_question_key_div(@page, question) %> >
+        <div id="<%= question.id %>_div" <%= display_question_key_div(@page, question) %>>
           <% if question.read_only? %>
             <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
           <% end %>
@@ -44,11 +44,11 @@
       <%= f.hidden_field :page, value: @page.id %>
       <% if @case_log.form.is_last_question?(@page, @subsection, @case_log) %>
         <%= f.govuk_submit "Submit lettings log", accesskey: "s" %>
-      <%else %>
+      <% else %>
         <% if !@page.id.include?("value_check") %>
-          <%= f.govuk_submit "Save and continue", accesskey: "s"  %>
+          <%= f.govuk_submit "Save and continue", accesskey: "s" %>
         <% end %>
-      <%end %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, @page.header.present? ? @page.header : @page.questions.first().header.html_safe %>
+<% content_for :title, @page.header.presence || @page.questions.first.header.html_safe %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
-    href: 'javascript:history.back()',
+    text: "Back",
+    href: "javascript:history.back()",
   ) %>
 <% end %>
 
@@ -34,9 +34,9 @@
             <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
           <% end %>
           <% if question.type == "interruption_screen" %>
-            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption_text: @subsection.label, page_header: @page.header, case_log: @case_log, title_text: @page.title_text, informative_text:  @page.informative_text, form: @form, f: f, conditional: false } %>
+            <%= render partial: "form/#{question.type}_question", locals: { question:, caption_text: @subsection.label, page_header: @page.header, case_log: @case_log, title_text: @page.title_text, informative_text: @page.informative_text, form: @form, f:, conditional: false } %>
           <% else %>
-            <%= render partial: "form/#{question.type}_question", locals: { question: question, caption_text: @subsection.label, page_header: @page.header, case_log: @case_log, f: f, conditional: false } %>
+            <%= render partial: "form/#{question.type}_question", locals: { question:, caption_text: @subsection.label, page_header: @page.header, case_log: @case_log, f:, conditional: false } %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -1,13 +1,16 @@
 <div class="app-card">
   <h2 class="govuk-heading-s">Collection resources</h2>
 
-  <%= render DocumentListComponent.new(items: [{
-    name: "Lettings log for tenants (2022/23)",
-    href: "https://core.communities.gov.uk/public/download/guides-and-manuals/2022-23%20Lettings%20paper%20form.pdf?download-format=pdf",
-    metadata: "PDF, 654 KB, 4 pages"
-  }, {
-    name: "Lettings log for tenants (2021/22)",
-    href: "https://core.communities.gov.uk/public/download/guides-and-manuals/2021_22%20Lettings%20Log.pdf?download-format=pdf",
-    metadata: "PDF, 302 KB, 3 pages"
-  }]) %>
+  <%= render DocumentListComponent.new(items: [
+    {
+      name: "Lettings log for tenants (2022/23)",
+      href: "https://core.communities.gov.uk/public/download/guides-and-manuals/2022-23%20Lettings%20paper%20form.pdf?download-format=pdf",
+      metadata: "PDF, 654 KB, 4 pages",
+    },
+    {
+      name: "Lettings log for tenants (2021/22)",
+      href: "https://core.communities.gov.uk/public/download/guides-and-manuals/2021_22%20Lettings%20Log.pdf?download-format=pdf",
+      metadata: "PDF, 302 KB, 3 pages",
+    },
+  ]) %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,19 +4,19 @@
     <title><%= browser_title(yield(:title), @pagy, @admin_user, @user, @organisation, @case_log, @resource) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
-    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag asset_path('images/favicon.ico') %>
-    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= tag.meta name: "viewport", content: "width=device-width, initial-scale=1" %>
+    <%= tag.meta property: "og:image", content: asset_path("images/govuk-opengraph-image.png") %>
+    <%= tag.meta name: "theme-color", content: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path("images/favicon.ico") %>
+    <%= favicon_link_tag asset_path("images/govuk-mask-icon.svg"), rel: "mask-icon", type: "image/svg", color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon.png"), rel: "apple-touch-icon", type: "image/png" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-152x152.png"), rel: "apple-touch-icon", type: "image/png", size: "152x152" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-167x167.png"), rel: "apple-touch-icon", type: "image/png", size: "167x167" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "vendor/html5shiv.min.js" %>
     <script>
-      window.html5.elements = 'output';
+      window.html5.elements = "output";
       html5.shivDocument(document);
     </script>
     <%= javascript_include_tag "vendor/polyfill-output-value.js" %>
@@ -37,43 +37,44 @@
 
   <body class="govuk-template__body app-template--wide">
     <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     </script>
 
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-      logotype: 'GOV.UK',
-      service_name: t('service_name'),
-      service_url: current_user.nil? ? "/" : '/logs'
+      logotype: "GOV.UK",
+      service_name: t("service_name"),
+      service_url: current_user.nil? ? "/" : "/logs",
     ) do |component|
       if current_user.nil?
-        component.navigation_item(text: 'Sign in', href: user_session_path)
-      elsif
-        component.navigation_item(text: 'Logs', href: case_logs_path)
-        component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
-        component.navigation_item(text: 'Your account', href: account_path)
-        component.navigation_item(text: 'Sign out', href: destroy_user_session_path)
+        component.navigation_item(text: "Sign in", href: user_session_path)
+      else
+        component.navigation_item(text: "Logs", href: case_logs_path)
+        component.navigation_item(text: "Your organisation", href: "/organisations/#{current_user.organisation.id}")
+        component.navigation_item(text: "Your account", href: account_path)
+        component.navigation_item(text: "Sign out", href: destroy_user_session_path)
       end
     end %>
 
     <div class="govuk-width-container">
       <aside>
         <%= govuk_phase_banner(
-          tag: { text: 'Beta' },
-          text: "This is a new service – help us improve it by <a class=\"govuk-link\" href=\"#{t('feedback_form')}\" rel=\"noreferrer noopener\" target=\"_blank\">giving us your feedback (opens in a new tab)</a>".html_safe
+          tag: { text: "Beta" },
+          text: "This is a new service – help us improve it by <a class=\"govuk-link\" href=\"#{t('feedback_form')}\" rel=\"noreferrer noopener\" target=\"_blank\">giving us your feedback (opens in a new tab)</a>".html_safe,
         ) %>
         <%= content_for(:breadcrumbs) %>
         <%= content_for(:before_content) %>
       </aside>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <% if flash.notice && !flash.notice.include?('translation missing') %>
+        <% if flash.notice && !flash.notice.include?("translation missing") %>
           <%= govuk_notification_banner(
-            title_text: 'Success',
+            title_text: "Success",
             success: true, title_heading_level: 3,
-            title_id: "swanky-notifications") do |notification_banner|
-              notification_banner.heading(text: flash.notice)
+            title_id: "swanky-notifications"
+          ) do |notification_banner|
+            notification_banner.heading(text: flash.notice)
           end %>
         <% end %>
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,10 +15,10 @@
     <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "vendor/html5shiv.min.js" %>
-    <%= javascript_tag do -%>
+    <script>
       window.html5.elements = 'output';
       html5.shivDocument(document);
-    <% end -%>
+    </script>
     <%= javascript_include_tag "vendor/polyfill-output-value.js" %>
     <%= javascript_include_tag "vendor/outerHTML.js" %>
     <%= javascript_include_tag "application", defer: true %>
@@ -43,20 +43,19 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-        logotype: 'GOV.UK',
-        service_name: t('service_name'),
-        service_url: current_user.nil? ? "/" : '/logs'
-      ) do |component|
-        if current_user.nil?
-          component.navigation_item(text: 'Sign in', href: user_session_path)
-        elsif
-          component.navigation_item(text: 'Logs', href: case_logs_path)
-          component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
-          component.navigation_item(text: 'Your account', href: account_path)
-          component.navigation_item(text: 'Sign out', href: destroy_user_session_path)
-        end
+      logotype: 'GOV.UK',
+      service_name: t('service_name'),
+      service_url: current_user.nil? ? "/" : '/logs'
+    ) do |component|
+      if current_user.nil?
+        component.navigation_item(text: 'Sign in', href: user_session_path)
+      elsif
+        component.navigation_item(text: 'Logs', href: case_logs_path)
+        component.navigation_item(text: 'Your organisation', href: "/organisations/#{current_user.organisation.id}")
+        component.navigation_item(text: 'Your account', href: account_path)
+        component.navigation_item(text: 'Sign out', href: destroy_user_session_path)
       end
-    %>
+    end %>
 
     <div class="govuk-width-container">
       <aside>
@@ -69,14 +68,13 @@
       </aside>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <% if flash.notice && !flash.notice.include?('translation missing')  %>
+        <% if flash.notice && !flash.notice.include?('translation missing') %>
           <%= govuk_notification_banner(
             title_text: 'Success',
             success: true, title_heading_level: 3,
             title_id: "swanky-notifications") do |notification_banner|
               notification_banner.heading(text: flash.notice)
-            end
-          %>
+          end %>
         <% end %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/views/layouts/organisations.html.erb
+++ b/app/views/layouts/organisations.html.erb
@@ -5,7 +5,7 @@
 
   <% items = tab_items(current_user) %>
 
-  <%= render TabNavigationComponent.new(items: items) %>
+  <%= render TabNavigationComponent.new(items:) %>
 
   <h2 class="govuk-visually-hidden"><%= content_for(:tab_title) %></h2>
 

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -15,29 +15,24 @@
       </h1>
 
       <%= f.govuk_text_field :name,
-        autocomplete: "name"
-      %>
+        autocomplete: "name" %>
 
       <%= f.govuk_text_field :address_line1,
         label: { text: "Address line 1" },
-        autocomplete: "address-line1"
-      %>
+        autocomplete: "address-line1" %>
 
       <%= f.govuk_text_field :address_line2,
         label: { text: "Address line 2" },
-        autocomplete: "address-line2"
-      %>
+        autocomplete: "address-line2" %>
 
       <%= f.govuk_text_field :postcode,
         autocomplete: "postal-code",
-        width: 10
-      %>
+        width: 10 %>
 
       <%= f.govuk_phone_field :phone,
         label: { text: "Telephone number" },
         autocomplete: "tel",
-        width: 20
-      %>
+        width: 20 %>
 
       <%= f.govuk_submit "Save changes" %>
     </div>

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -10,17 +10,21 @@
       <% @organisation.display_attributes.each do |attr| %>
 
         <% if current_user.data_coordinator? && attr[:editable] %>
-          <%= summary_list.row do |row|
-            row.key { attr[:name].to_s.humanize }
-            row.value { simple_format(attr[:value].to_s, {}, wrapper_tag: "div") }
-            row.action(visually_hidden_text: 'name', href: edit_organisation_path, html_attributes: { 'data-qa': "change-#{attr[:name]}" })
-          end %>
+          <%= summary_list.row do |row| %>
+            <% row.key { attr[:name].to_s.humanize } %>
+            <% row.value { simple_format(attr[:value].to_s, {}, wrapper_tag: "div") } %>
+            <% row.action(
+              visually_hidden_text: "name",
+              href: edit_organisation_path,
+              html_attributes: { "data-qa": "change-#{attr[:name]}" },
+            ) %>
+          <% end %>
         <% else %>
-          <%= summary_list.row do |row|
-            row.key { attr[:name].to_s.humanize }
-            row.value { simple_format(attr[:value].to_s, {}, wrapper_tag: "div") }
-            row.action()
-          end %>
+          <%= summary_list.row do |row| %>
+            <% row.key { attr[:name].to_s.humanize } %>
+            <% row.value { simple_format(attr[:value].to_s, {}, wrapper_tag: "div") } %>
+            <% row.action %>
+          <% end %>
         <% end %>
 
       <% end %>

--- a/app/views/organisations/users.html.erb
+++ b/app/views/organisations/users.html.erb
@@ -9,19 +9,19 @@
 <% end %>
 <%= govuk_table do |table| %>
   <%= table.head do |head| %>
-    <%= head.row do |row|
-      row.cell(header: true, text: "Name and email adress")
-      row.cell(header: true, text: "Organisation and role")
-      row.cell(header: true, text: "Last logged in")
-    end %>
+    <%= head.row do |row| %>
+      <% row.cell(header: true, text: "Name and email adress") %>
+      <% row.cell(header: true, text: "Organisation and role") %>
+      <% row.cell(header: true, text: "Last logged in") %>
+    <% end %>
   <% end %>
   <% @organisation.users.each do |user| %>
     <%= table.body do |body| %>
-      <%= body.row do |row|
-        row.cell(text: simple_format(user_cell(user), {}, wrapper_tag: "div"))
-        row.cell(text: simple_format(org_cell(user), {}, wrapper_tag: "div"))
-        row.cell(text: user.last_sign_in_at&.to_formatted_s(:govuk_date) )
-      end %>
+      <%= body.row do |row| %>
+        <% row.cell(text: simple_format(user_cell(user), {}, wrapper_tag: "div")) %>
+        <% row.cell(text: simple_format(org_cell(user), {}, wrapper_tag: "div")) %>
+        <% row.cell(text: user.last_sign_in_at&.to_formatted_s(:govuk_date)) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/pagy/_nav.html.erb
+++ b/app/views/pagy/_nav.html.erb
@@ -5,7 +5,7 @@
     <ul class="app-pagination__list">
       <li class="app-pagination__item app-pagination__item--prev">
         <% if pagy.prev %>
-          <a class="app-pagination__link" href=<%= "/logs?page=#{pagy.prev}" %>>
+          <a class="app-pagination__link" href="<%= "/logs?page=#{pagy.prev}" %>">
         <% end %>
           <span class="app-pagination__link-title">
             <svg class="app-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
@@ -20,12 +20,12 @@
         <% elsif item.is_a?(String) %>
           <li class="app-pagination__item app-pagination__item--current"><span class="govuk-visually-hidden">Page </span><%= item %><span class="govuk-visually-hidden"> (current page) </span></li>
         <% else %>
-          <li class="app-pagination__item"><a class="app-pagination__link" href=<%= "/logs?page=#{item}" %>><span class="govuk-visually-hidden">Page </span><%= item %></a></li>
+          <li class="app-pagination__item"><a class="app-pagination__link" href="<%= "/logs?page=#{item}" %>"><span class="govuk-visually-hidden">Page </span><%= item %></a></li>
         <% end %>
       <% end %>
       <li class="app-pagination__item app-pagination__item--next">
         <% if pagy.next %>
-          <a class="app-pagination__link" href=<%= "/logs?page=#{pagy.next}" %>>
+          <a class="app-pagination__link" href="<%= "/logs?page=#{pagy.next}" %>">
         <% end %>
           Next <span class="govuk-visually-hidden">page</span>
           <span class="app-pagination__link-title">

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -10,10 +10,10 @@
     <p class="govuk-body">The data will be used to update the national record for social housing. It will also help to inform policy about the cost of social housing and what type of housing needs to be built.</p>
     <p class="govuk-body">This service is only for social housing in England.</p>
 
-    <% start_path = current_user ? case_logs_path : (user_session_path + "?start=true") %>
+    <% start_path = current_user ? case_logs_path : "#{user_session_path}?start=true" %>
     <%= govuk_start_button(
-      text: 'Start now',
-      href: start_path
+      text: "Start now",
+      href: start_path,
     ) %>
 
     <h2 class="govuk-heading-m">Before you start</h2>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,36 +17,31 @@
       </h1>
 
       <%= f.govuk_text_field :name,
-        autocomplete: "name"
-      %>
+        autocomplete: "name" %>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
-        spellcheck: "false"
-      %>
+        spellcheck: "false" %>
 
       <% if current_user.data_coordinator? || current_user.support? %>
         <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) }
 
-          f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" }
-        %>
+          f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_dpo,
           [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
           :id,
           :name,
           inline: true,
-          legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" }
-        %>
+          legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_key_contact,
           [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
           :id,
           :name,
           inline: true,
-          legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" }
-        %>
+          legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" } %>
       <% end %>
 
       <%= f.govuk_submit "Save changes" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>
@@ -25,9 +25,13 @@
         spellcheck: "false" %>
 
       <% if current_user.data_coordinator? || current_user.support? %>
-        <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) }
+        <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
 
-          f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" } %>
+        <%= f.govuk_collection_radio_buttons :role,
+          roles,
+          :id,
+          :name,
+          legend: { text: "Role", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_dpo,
           [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>
@@ -25,8 +25,13 @@
         spellcheck: "false",
         value: @resource.email %>
 
-      <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) }
-        f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" } %>
+      <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
+
+      <%= f.govuk_collection_radio_buttons :role,
+        roles,
+        :id,
+        :name,
+        legend: { text: "Role", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_dpo,
         [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -17,35 +17,30 @@
       </h1>
 
       <%= f.govuk_text_field :name,
-        autocomplete: "name"
-      %>
+        autocomplete: "name" %>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
         spellcheck: "false",
-        value: @resource.email
-      %>
+        value: @resource.email %>
 
       <%= roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) }
-        f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" }
-      %>
+        f.govuk_collection_radio_buttons :role, roles, :id, :name, legend: { text: "Role", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_dpo,
         [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
         :id,
         :name,
         inline: true,
-        legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" }
-      %>
+        legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_key_contact,
         [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
         :id,
         :name,
         inline: true,
-        legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" }
-      %>
+        legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" } %>
 
       <%= f.govuk_submit "Continue" %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,70 +12,86 @@
 
     <%= govuk_summary_list do |summary_list| %>
       <%= summary_list.row do |row|
-        row.key { "Name" }
-        row.value { @user.name }
-        if can_edit_names?(@user, current_user)
-          row.action(visually_hidden_text: "name", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-name" })
-        else
-          row.action()
-        end
-      end %>
-
-      <%= summary_list.row() do |row|
-        row.key { "Email address" }
-        row.value { @user.email }
-        if can_edit_emails?(@user, current_user)
-          row.action(visually_hidden_text: "email address", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-email-address" })
-        else
-          row.action()
-        end
-      end %>
+            row.key { "Name" }
+            row.value { @user.name }
+            if can_edit_names?(@user, current_user)
+              row.action(visually_hidden_text: "name", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-name" })
+            else
+              row.action
+            end
+          end %>
 
       <%= summary_list.row do |row|
-        row.key { "Password" }
-        row.value { "••••••••" }
-        if can_edit_password?(@user, current_user)
-          row.action(visually_hidden_text: "password", href: edit_password_account_path, html_attributes: { "data-qa": "change-password" })
-        else
-          row.action()
-        end
-      end %>
+            row.key { "Email address" }
+            row.value { @user.email }
+            if can_edit_emails?(@user, current_user)
+              row.action(visually_hidden_text: "email address", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-email-address" })
+            else
+              row.action
+            end
+          end %>
 
       <%= summary_list.row do |row|
-        row.key { "Organisation" }
-        row.value { @user.organisation.name }
-        row.action()
-      end %>
+            row.key { "Password" }
+            row.value { "••••••••" }
+            if can_edit_password?(@user, current_user)
+              row.action(
+                visually_hidden_text: "password",
+                href: edit_password_account_path,
+                html_attributes: { "data-qa": "change-password" },
+              )
+            else
+              row.action
+            end
+          end %>
 
       <%= summary_list.row do |row|
-        row.key { "Role" }
-        row.value { @user.role.humanize }
-        if can_edit_roles?(@user, current_user)
-          row.action(visually_hidden_text: "role", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-role" })
-        else
-          row.action()
-        end
-      end %>
+            row.key { "Organisation" }
+            row.value { @user.organisation.name }
+            row.action
+          end %>
 
       <%= summary_list.row do |row|
-        row.key { "Data protection officer" }
-        row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
-        if can_edit_dpo?(@user, current_user)
-          row.action(visually_hidden_text: "are #{pronoun(@user, current_user)} a data protection officer?", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-data-protection-officer" })
-        else
-          row.action()
-        end
-      end %>
+            row.key { "Role" }
+            row.value { @user.role.humanize }
+            if can_edit_roles?(@user, current_user)
+              row.action(
+                visually_hidden_text: "role",
+                href: aliased_user_edit(@user, current_user),
+                html_attributes: { "data-qa": "change-role" },
+              )
+            else
+              row.action
+            end
+          end %>
 
       <%= summary_list.row do |row|
-        row.key { "Key contact" }
-        row.value { @user.is_key_contact? ? "Yes" : "No" }
-        if can_edit_key_contact?(@user, current_user)
-          row.action(visually_hidden_text: "are #{pronoun(@user, current_user)} a key contact?", href: aliased_user_edit(@user, current_user), html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-key-contact" })
-        else
-          row.action()
-        end
-      end %>
+            row.key { "Data protection officer" }
+            row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
+            if can_edit_dpo?(@user, current_user)
+              row.action(
+                visually_hidden_text: "are #{pronoun(@user, current_user)} a data protection officer?",
+                href: aliased_user_edit(@user, current_user),
+                html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-data-protection-officer" },
+              )
+            else
+              row.action
+            end
+          end %>
+
+      <%= summary_list.row do |row|
+            row.key { "Key contact" }
+            row.value { @user.is_key_contact? ? "Yes" : "No" }
+            if can_edit_key_contact?(@user, current_user)
+              row.action(
+                visually_hidden_text: "are #{pronoun(@user, current_user)} a key contact?",
+                href: aliased_user_edit(@user, current_user),
+                html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-key-contact" },
+              )
+            else
+              row.action
+            end
+          end %>
     <% end %>
   </div>
 </div>

--- a/spec/features/reset_password.html.erb
+++ b/spec/features/reset_password.html.erb
@@ -20,12 +20,10 @@
       <%= f.govuk_password_field :password,
         label: { text: "New password" },
         hint: @minimum_password_length ? { text: "Your password must be at least #{@minimum_password_length} characters and hard to guess." } : nil,
-        autocomplete: "new-password"
-      %>
+        autocomplete: "new-password" %>
 
       <%= f.govuk_password_field :password_confirmation,
-        label: { text: "Confirm new password" }
-      %>
+        label: { text: "Confirm new password" } %>
 
       <%= f.govuk_submit "Update" %>
     </div>

--- a/spec/features/reset_password.html.erb
+++ b/spec/features/reset_password.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    text: 'Back',
+    text: "Back",
     href: :back,
   ) %>
 <% end %>


### PR DESCRIPTION
Right now, we lint Ruby code for syntax errors, but don’t do the same for Ruby code used in ERB templates. This has lead to inconsistent code style, both across the application, but often within the same ERB templates.

This PR:
* Adds [ERB Lint](https://github.com/Shopify/erb-lint) as a development dependency
* Enables the [default ERB linters](https://github.com/Shopify/erb-lint#Linters) as well as [RuboCop](https://github.com/Shopify/erb-lint#Rubocop) using our config (disabling rules where relevant)
* Lints code against this config

Hopefully none of the changes are controversial, given they follow the rules we are using elsewhere.

It might be worth creating a lint task that runs Rubocop, ERB Lint and SCSS Lint together, but that can come in a later PR.