### PR TITLE
Cldc 1163 next incomplete section

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -418,7 +418,10 @@ private
   end
 
   def dynamically_not_required
-    (form.invalidated_questions(self) + form.readonly_questions).map(&:id).uniq
+    la_known_questions = []
+    la_known_questions << "la_known" if postcode_known != 0
+    la_known_questions << "previous_la_known" if previous_postcode_known != 0
+    ((form.invalidated_questions(self) + form.readonly_questions).map(&:id) + la_known_questions).uniq
   end
 
   def set_derived_fields!

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -396,7 +396,7 @@ private
   end
 
   def reset_derived_questions
-    dependent_questions = { layear: [{ key: :renewal, value: 0 }],
+    dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             homeless: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
                             underoccupation_benefitcap: [{ key: :renewal, value: 0 }] }
@@ -418,10 +418,7 @@ private
   end
 
   def dynamically_not_required
-    la_known_questions = []
-    la_known_questions << "la_known" if postcode_known != 0
-    la_known_questions << "previous_la_known" if previous_postcode_known != 0
-    ((form.invalidated_questions(self) + form.readonly_questions).map(&:id) + la_known_questions).uniq
+    (form.invalidated_questions(self) + form.readonly_questions).map(&:id).uniq
   end
 
   def set_derived_fields!
@@ -462,7 +459,7 @@ private
       self.underoccupation_benefitcap = 2 if collection_start_year == 2021
       self.homeless = 2
       self.referral = 0
-      self.layear = 1
+      self.waityear = 1
       if is_general_needs?
         # fixed term
         self.prevten = 32 if managing_organisation.provider_type == "PRP"

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -58,7 +58,7 @@ class Form
   def next_incomplete_section_redirect_path(subsection, case_log)
     subsection_ids = subsections.map(&:id)
 
-    if case_log.status == "completed" || all_subsections_except_declaration_completed?(case_log)
+    if case_log.status == "completed"
       return first_question_in_last_subsection(subsection_ids)
     end
 
@@ -119,7 +119,7 @@ class Form
 
   def invalidated_page_questions(case_log)
     # we're already treating address fields as a special case and reset their values upon saving a case_log
-    address_questions = %w[postcode_known la previous_postcode_known prevloc postcode_full ppostcode_full]
+    address_questions = %w[postcode_known la_known la previous_postcode_known previous_la_known prevloc postcode_full ppostcode_full]
     invalidated_pages(case_log).flat_map(&:questions).reject { |q| address_questions.include?(q.id) } || []
   end
 

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -27,10 +27,8 @@
 
     <%= form_with model: @case_log, method: "get" do |f| %>
       <%= f.govuk_submit "Save and return to log" do %>
-        <% if @case_log.status == "in_progress" && @case_log.status == "completed" || @case_log.form.all_subsections_except_declaration_completed?(@case_log) == false %>
+        <% if @case_log.status == "in_progress" %>
           <%= govuk_button_link_to "Save and go to next incomplete section", "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
-        <% elsif @case_log.status == "completed" || @case_log.form.all_subsections_except_declaration_completed?(@case_log) %>
-          <%= govuk_button_link_to "Save and go to submit", "/logs/#{@case_log.id}/#{@case_log.form.next_incomplete_section_redirect_path(subsection, @case_log)}", secondary: true %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -196,7 +196,12 @@
                   "header": "Do you know what local authority the property is located in?",
                   "hint_text": "",
                   "type": "radio",
-                  "hidden_in_check_answers": true,
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "la_known": 0 },
+                      { "la_known": 1 }
+                    ]
+                  },
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -1697,7 +1702,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age2_known": 0 },
+                      { "age2_known": 1 }
+                    ]
+                  }
                 },
                 "age2": {
                   "header": "Age",
@@ -1907,7 +1917,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age3_known": 0 },
+                      { "age3_known": 1 }
+                    ]
+                  }
                 },
                 "age3": {
                   "header": "Age",
@@ -2114,7 +2129,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age4_known": 0 },
+                      { "age4_known": 1 }
+                    ]
+                  }
                 },
                 "age4": {
                   "header": "Age",
@@ -2318,7 +2338,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age5_known": 0 },
+                      { "age5_known": 1 }
+                    ]
+                  }
                 },
                 "age5": {
                   "header": "Age",
@@ -2519,7 +2544,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age6_known": 0 },
+                      { "age6_known": 1 }
+                    ]
+                  }
                 },
                 "age6": {
                   "header": "Age",
@@ -2717,7 +2747,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age7_known": 0 },
+                      { "age7_known": 1 }
+                    ]
+                  }
                 },
                 "age7": {
                   "header": "Age",
@@ -2912,7 +2947,12 @@
                       0
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "age8_known": 0 },
+                      { "age8_known": 1 }
+                    ]
+                  }
                 },
                 "age8": {
                   "header": "Age",
@@ -3732,7 +3772,12 @@
                       1
                     ]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "previous_postcode_known": 0 },
+                      { "previous_postcode_known": 1 }
+                    ]
+                  }
                 },
                 "ppostcode_full": {
                   "check_answer_label": "Postcode of household’s last settled accommodation",
@@ -3763,7 +3808,12 @@
                   "header": "Do you know the local authority of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
-                  "hidden_in_check_answers": true,
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                      { "previous_la_known": 0 },
+                      { "previous_la_known": 1 }
+                    ]
+                  },
                   "answer_options": {
                     "1": {
                       "value": "Yes"

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -228,12 +228,6 @@ RSpec.describe "Form Check Answers Page" do
         click_link("Save and go to next incomplete section")
         expect(page).to have_current_path("/logs/#{cycle_sections_case_log.id}/tenant-code")
       end
-
-      it "they can click a button to move to the submission section when all sections have been completed", js: true do
-        visit("/logs/#{completed_case_log.id}/local-authority/check-answers")
-        click_link("Save and go to submit")
-        expect(page).to have_current_path("/logs/#{completed_case_log.id}/declaration")
-      end
     end
   end
 end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1381,10 +1381,10 @@ RSpec.describe CaseLog do
         })
       end
 
-      it "correctly derives and saves layear" do
-        record_from_db = ActiveRecord::Base.connection.execute("select layear from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["layear"]).to eq(1)
-        expect(case_log["layear"]).to eq(1)
+      it "correctly derives and saves waityear" do
+        record_from_db = ActiveRecord::Base.connection.execute("select waityear from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["waityear"]).to eq(1)
+        expect(case_log["waityear"]).to eq(1)
       end
 
       it "correctly derives and saves underoccupation_benefitcap if year is 2021" do
@@ -1703,29 +1703,29 @@ RSpec.describe CaseLog do
     context "when it changes from a renewal to not a renewal" do
       let(:case_log) { FactoryBot.create(:case_log) }
 
-      it "resets inferred layear value" do
+      it "resets inferred waityear value" do
         case_log.update!({ renewal: 1 })
 
-        record_from_db = ActiveRecord::Base.connection.execute("select layear from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["layear"]).to eq(1)
-        expect(case_log["layear"]).to eq(1)
+        record_from_db = ActiveRecord::Base.connection.execute("select waityear from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["waityear"]).to eq(1)
+        expect(case_log["waityear"]).to eq(1)
 
         case_log.update!({ renewal: 0 })
-        record_from_db = ActiveRecord::Base.connection.execute("select layear from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["layear"]).to eq(nil)
-        expect(case_log["layear"]).to eq(nil)
+        record_from_db = ActiveRecord::Base.connection.execute("select waityear from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["waityear"]).to eq(nil)
+        expect(case_log["waityear"]).to eq(nil)
       end
     end
 
     context "when it is not a renewal" do
       let(:case_log) { FactoryBot.create(:case_log) }
 
-      it "saves layear value" do
-        case_log.update!({ renewal: 0, layear: 2 })
+      it "saves waityear value" do
+        case_log.update!({ renewal: 0, waityear: 2 })
 
-        record_from_db = ActiveRecord::Base.connection.execute("select layear from case_logs where id=#{case_log.id}").to_a[0]
-        expect(record_from_db["layear"]).to eq(2)
-        expect(case_log["layear"]).to eq(2)
+        record_from_db = ActiveRecord::Base.connection.execute("select waityear from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["waityear"]).to eq(2)
+        expect(case_log["waityear"]).to eq(2)
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Form, type: :model do
 
   describe "invalidated_page_questions" do
     context "when dependencies are not met" do
-      let(:expected_invalid) { %w[la_known cbl conditional_question_no_second_question net_income_value_check dependent_question offered layear declaration] }
+      let(:expected_invalid) { %w[cbl conditional_question_no_second_question net_income_value_check dependent_question offered layear declaration] }
 
       it "returns an array of question keys whose pages conditions are not met" do
         expect(form.invalidated_page_questions(case_log).map(&:id).uniq).to eq(expected_invalid)
@@ -183,7 +183,7 @@ RSpec.describe Form, type: :model do
     end
 
     context "with two pages having the same question and only one has dependencies met" do
-      let(:expected_invalid) { %w[la_known cbl conditional_question_no_second_question net_income_value_check dependent_question offered layear declaration] }
+      let(:expected_invalid) { %w[cbl conditional_question_no_second_question net_income_value_check dependent_question offered layear declaration] }
 
       it "returns an array of question keys whose pages conditions are not met" do
         case_log["preg_occ"] = "No"


### PR DESCRIPTION
the record would not get marked as completed if postcode known was selected as `yes` because `la_known` and `previous_la_known` are not being invalidated in `invalidated_page_questions` but never answered.

Also, the age known questions were not being invalidated either but updating hidden in check answers surfaced those questions.

removed `all_subsections_except_declaration_completed` method because declaration section no longer exists

remove `Save and go to submit` button

set `waityear` instead of `layear` as per map