### PR TITLE
Move link to privacy notice to declaration question

### DIFF
--- a/app/views/form/guidance/_privacy_notice.erb
+++ b/app/views/form/guidance/_privacy_notice.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body">Make sure the tenant has seen <%= govuk_link_to "the Department for Levelling Up, Housing & Communities (DLUHC) privacy notice", privacy_notice_path %> before completing this log.</p>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1114,7 +1114,6 @@
     },
     "household": {
       "label": "About the household",
-      "description": "Make sure the tenant has seen <a class=\"govuk-link\" href=\"/privacy-notice\">the Department for Levelling Up, Housing & Communities (DLUHC) privacy notice</a> before completing this section.",
       "subsections": {
         "household_characteristics": {
           "label": "Household characteristics",
@@ -1125,16 +1124,18 @@
           ],
           "pages": {
             "declaration": {
-              "header": "",
+              "header": "Department for Levelling Up, Housing & Communities privacy notice",
               "description": "",
               "questions": {
                 "declaration": {
+                  "header": "",
+                  "guidance_partial": "privacy_notice",
                   "check_answer_label": "Tenant has seen the privacy notice",
-                  "header": "Department for Levelling Up, Housing & Communities privacy notice ",
-                  "hint_text": "Make sure the tenant has seen the Department for Levelling Up, Housing & Communities (DLUHC) privacy notice before submitting this log",
                   "type": "checkbox",
                   "answer_options": {
-                    "declaration": "The tenant has seen the Department for Levelling Up, Housing & Communities (DLUHC) privacy notice"
+                    "declaration": {
+                      "value": "The tenant has seen the DLUHC privacy notice"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
I went on a circuitous route on how to get the page set up right, and realised I could have used the `description` field instead of a `guidance_partial`. But given we require HTML, and it’s better to use the `privacy_policy_path` helpers to avoid link rot, using a partial is probably the better approach anyway.

| Before | After |
| - | - |
| <img width="760" alt="Screenshot 2022-04-26 at 15 05 24" src="https://user-images.githubusercontent.com/813383/165318306-cfa1a4ae-89a3-49e8-8a9e-5450e1fbf18e.png"> | <img width="760" alt="Screenshot 2022-04-26 at 15 05 56" src="https://user-images.githubusercontent.com/813383/165318330-96256bd1-6f00-4f84-a9b0-a2266e1bbdd4.png"> |
| <img width="760" alt="Screenshot 2022-04-26 at 15 05 15" src="https://user-images.githubusercontent.com/813383/165318286-757eb5ea-9efd-4eb0-9edf-02928ee2f61a.png"> | <img width="760" alt="Screenshot 2022-04-26 at 15 05 34" src="https://user-images.githubusercontent.com/813383/165318318-6b692b2f-4070-4466-9e6c-28dcb0234cb1.png"> |
