### PR TITLE
Don’t use bullet list if only one value returned

### DIFF
--- a/app/helpers/details_table_helper.rb
+++ b/app/helpers/details_table_helper.rb
@@ -1,10 +1,12 @@
 module DetailsTableHelper
   def details_html(attribute)
-    if attribute[:format] == :bullet
-      list = attribute[:value].map { |la| "<li>#{la}</li>" }.join
+    if attribute[:format] == :bullet && attribute[:value].length > 1
+      list = attribute[:value].map { |value| "<li>#{value}</li>" }.join
       simple_format(list, { class: "govuk-list govuk-list--bullet" }, wrapper_tag: "ul")
     else
-      simple_format(attribute[:value].to_s, {}, wrapper_tag: "div")
+      value = attribute[:value].is_a?(Array) ? attribute[:value].first : attribute[:value]
+
+      simple_format(value.to_s, { class: "govuk-body" }, wrapper_tag: "p")
     end
   end
 end

--- a/spec/helpers/details_table_helper_spec.rb
+++ b/spec/helpers/details_table_helper_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe DetailsTableHelper do
     context "when given a simple attribute" do
       let(:attribute) { { name: "name", value: "Dummy org", editable: true } }
 
-      it "displays the string wrapped in a div" do
-        expect(details).to eq("<div>Dummy org</div>")
+      it "displays the string wrapped in a p" do
+        expect(details).to eq("<p class=\"govuk-body\">Dummy org</p>")
       end
     end
 
@@ -25,6 +25,22 @@ RSpec.describe DetailsTableHelper do
 
       it "displays the string wrapped in an unordered list with the correct classes" do
         expect(details).to eq("<ul class=\"govuk-list govuk-list--bullet\"><li>Camden</li><li>Westminster</li><li>Bristol</li></ul>")
+      end
+    end
+
+    context "when given a bullet point list with one attibute" do
+      let(:list) { %w[Camden] }
+      let(:attribute) do
+        {
+          name: "local_authorities_operated_in",
+          value: list,
+          editable: false,
+          format: :bullet,
+        }
+      end
+
+      it "displays the string wrapped in a p" do
+        expect(details).to eq("<p class=\"govuk-body\">Camden</p>")
       end
     end
   end


### PR DESCRIPTION
Don’t use a bulleted list if only one item is returned.

| Before | After |
| - | - |
| <img width="315" alt="Screenshot 2022-04-26 at 17 18 05" src="https://user-images.githubusercontent.com/813383/165346332-0c3bde6a-ddeb-4bb1-adb1-1585a5d8fc28.png"> | <img width="315" alt="Screenshot 2022-04-26 at 17 18 15" src="https://user-images.githubusercontent.com/813383/165346338-a6907d79-dcf2-4c19-8db4-30de2fd41124.png"> |
