### PR TITLE
CLDC-1166: Include guidance partial on both income questions

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -4539,12 +4539,13 @@
           ],
           "pages": {
             "income_known": {
-              "header": "",
+              "header": "Household’s combined income after tax",
               "description": "",
               "questions": {
                 "net_income_known": {
                   "check_answer_label": "Do you know the household’s combined income?",
-                  "header": "Do you know the household’s combined income?",
+                  "header": "Do you know the household’s combined income after tax?",
+                  "guidance_partial": "what_counts_as_income",
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
@@ -4570,7 +4571,7 @@
                   "net_income_known": 0
                 }
               ],
-              "header": "Household’s combined income after tax",
+              "header": "Total household income",
               "description": "",
               "questions": {
                 "earnings": {


### PR DESCRIPTION
We want to show the guidance about what counts as income on both questions that ask for the household’s total combined income.

* Adding the partial to the first questions means we need to add a page title separate from the fieldset’s legend to keep the complexity low when form is announced by screen readers.
* Page titles should be unique

This is the result:

***

1. ### Household’s combined income after tax
    [▶︎ What count’s as income?](#)
  
   #### Do you know the household’s combined income after tax?

2. ### Total household income
   [▶︎ What count’s as income?](#)
  
   #### How much income does the household have in total?
   #### How often does the household receive this amount?

***

| Before | After |
| - | - |
| <img width="720" alt="Screenshot 2022-04-26 at 17 57 17" src="https://user-images.githubusercontent.com/813383/165353541-0594dfb4-1154-4bd4-83b5-e7ccee78d104.png"> | <img width="720" alt="Screenshot 2022-04-26 at 17 56 47" src="https://user-images.githubusercontent.com/813383/165353669-06e10859-208c-419f-a062-2727d182652d.png"> | 
<img width="720" alt="Screenshot 2022-04-26 at 17 57 42" src="https://user-images.githubusercontent.com/813383/165353554-1da2416c-2e81-454c-b715-51e9fdb1d139.png"> | <img width="720" alt="Screenshot 2022-04-26 at 17 56 59" src="https://user-images.githubusercontent.com/813383/165353692-6c57a7d5-e7e3-4c8b-a2ce-71e8ce5ac62f.png"> |
