### PR TITLE
Add navigation items helper

### DIFF
--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -2,13 +2,13 @@
   <div class="govuk-width-container">
     <ul class="app-primary-navigation__list">
       <% items.each do |item| %>
-        <% if highlighted_tab?(item, request.fullpath) %>
+        <% if item.current %>
           <li class="app-primary-navigation__item app-primary-navigation__item--current">
-            <%= govuk_link_to item[:name], item[:url], class: "app-primary-navigation__link", aria: { current: "page" } %>
+            <%= govuk_link_to item[:text], item[:href], class: "app-primary-navigation__link", aria: { current: "page" } %>
           </li>
         <% else %>
           <li class="app-primary-navigation__item">
-            <%= govuk_link_to item[:name], item[:url], class: "app-primary-navigation__link" %>
+            <%= govuk_link_to item[:text], item[:href], class: "app-primary-navigation__link" %>
           </li>
         <% end %>
       <% end %>

--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -5,4 +5,8 @@ class PrimaryNavigationComponent < ViewComponent::Base
     @items = items
     super
   end
+
+  def highlighted_tab?(item, _path)
+    item[:current]
+  end
 end

--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -5,8 +5,4 @@ class PrimaryNavigationComponent < ViewComponent::Base
     @items = items
     super
   end
-
-  def highlighted_tab?(item, path)
-    item.fetch(:current, false) || item.fetch(:comparable_urls).any? { |url| path.include?(url) }
-  end
 end

--- a/app/helpers/navigation_items_helper.rb
+++ b/app/helpers/navigation_items_helper.rb
@@ -1,43 +1,33 @@
 module NavigationItemsHelper
   NavigationItem = Struct.new(:text, :href, :current, :classes)
 
-  def primary_items(current_user, user)
+  def primary_items(path, current_user)
     if current_user.support?
       [
-        NavigationItem.new("Organisations", organisations_path, organisation_current?),
-        NavigationItem.new("Users", users_path, users_current?(current_user, user)),
-        NavigationItem.new("Logs", case_logs_path, logs_current?),
+        NavigationItem.new("Organisations", organisations_path, organisation_current?(path)),
+        NavigationItem.new("Users", "/users", users_current?(path)),
+        NavigationItem.new("Logs", case_logs_path, logs_current?(path)),
       ]
     else
       [
-        NavigationItem.new("Logs", case_logs_path, logs_current?),
-        NavigationItem.new("Users", users_organisation_path(current_user.organisation), users_current?(current_user, user)),
-        NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", organisation_current?),
+        NavigationItem.new("Logs", case_logs_path, logs_current?(path)),
+        NavigationItem.new("Users", users_organisation_path(current_user.organisation), users_current?(path)),
+        NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", organisation_current?(path)),
       ]
     end
   end
 
 private
 
-  def current?(current_controller, controllers)
-    current_controller.controller_name.in?(Array.wrap(controllers))
+  def logs_current?(path)
+    path.include?("/logs")
   end
 
-  def current_action?(current_controller, action)
-    current_controller.action_name == action
+  def users_current?(path)
+    path.include?("/users")
   end
 
-  def logs_current?
-    current?(controller, %w[case_logs form])
-  end
-
-  def users_current?(current_user, user)
-    return false if current_user == user
-
-    current?(controller, %w[users]) || current_action?(controller, "users")
-  end
-
-  def organisation_current?
-    current?(controller, %w[organisations]) && !current_action?(controller, "users")
+  def organisation_current?(path)
+    path.include?("/organisations") && !path.include?("/users")
   end
 end

--- a/app/helpers/navigation_items_helper.rb
+++ b/app/helpers/navigation_items_helper.rb
@@ -1,17 +1,17 @@
 module NavigationItemsHelper
   NavigationItem = Struct.new(:text, :href, :current, :classes)
 
-  def primary_items(current_user)
+  def primary_items(current_user, user)
     if current_user.support?
       [
         NavigationItem.new("Organisations", organisations_path, organisation_current?),
-        NavigationItem.new("Users", users_path, users_current?),
+        NavigationItem.new("Users", users_path, users_current?(current_user, user)),
         NavigationItem.new("Logs", case_logs_path, logs_current?),
       ]
     else
       [
         NavigationItem.new("Logs", case_logs_path, logs_current?),
-        NavigationItem.new("Users", users_organisation_path(current_user.organisation), users_current?),
+        NavigationItem.new("Users", users_organisation_path(current_user.organisation), users_current?(current_user, user)),
         NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", organisation_current?),
       ]
     end
@@ -31,7 +31,9 @@ private
     current?(controller, %w[case_logs form])
   end
 
-  def users_current?
+  def users_current?(current_user, user)
+    return false if current_user == user
+
     current?(controller, %w[users]) || current_action?(controller, "users")
   end
 

--- a/app/helpers/navigation_items_helper.rb
+++ b/app/helpers/navigation_items_helper.rb
@@ -1,0 +1,41 @@
+module NavigationItemsHelper
+  NavigationItem = Struct.new(:text, :href, :current, :classes)
+
+  def primary_items(current_user)
+    if current_user.support?
+      [
+        NavigationItem.new("Organisations", organisations_path, organisation_current?),
+        NavigationItem.new("Users", users_path, users_current?),
+        NavigationItem.new("Logs", case_logs_path, logs_current?),
+      ]
+    else
+      [
+        NavigationItem.new("Logs", case_logs_path, logs_current?),
+        NavigationItem.new("Users", users_organisation_path(current_user.organisation), users_current?),
+        NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", organisation_current?),
+      ]
+    end
+  end
+
+private
+
+  def current?(current_controller, controllers)
+    current_controller.controller_name.in?(Array.wrap(controllers))
+  end
+
+  def current_action?(current_controller, action)
+    current_controller.action_name == action
+  end
+
+  def logs_current?
+    current?(controller, %w[case_logs form])
+  end
+
+  def users_current?
+    current?(controller, %w[users]) || current_action?(controller, "users")
+  end
+
+  def organisation_current?
+    current?(controller, %w[organisations]) && !current_action?(controller, "users")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
 
     <% if !current_user.nil? %>
       <%= render PrimaryNavigationComponent.new(
-        items: primary_items(current_user)
+        items: primary_items(current_user),
       ) %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
 
     <% if !current_user.nil? %>
       <%= render PrimaryNavigationComponent.new(
-        items: primary_items(current_user),
+        items: primary_items(current_user, @user),
       ) %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,20 +65,9 @@
     ) %>
 
     <% if !current_user.nil? %>
-      <% if current_user.support? %>
-        <% items = [
-          { name: "Organisations", url: "/organisations", comparable_urls: ["/details", "/organisations"] },
-          { name: "Users", url: "/users", comparable_urls: ["/users", "/account"] },
-          { name: "Logs", url: case_logs_path, comparable_urls: ["/logs"] },
-        ] %>
-      <% else %>
-        <% items = [
-          { name: "Logs", url: case_logs_path, comparable_urls: ["/logs"] },
-          { name: "Users", url: users_organisation_path(current_user.organisation), comparable_urls: ["/users", "/account"] },
-          { name: "About your organisation", url: "/organisations/#{current_user.organisation.id}", comparable_urls: ["/organisations"] },
-        ] %>
-      <% end %>
-      <%= render PrimaryNavigationComponent.new(items:) %>
+      <%= render PrimaryNavigationComponent.new(
+        items: primary_items(current_user)
+      ) %>
     <% end %>
 
     <div class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
 
     <% if !current_user.nil? %>
       <%= render PrimaryNavigationComponent.new(
-        items: primary_items(current_user, @user),
+        items: primary_items(request.path, current_user),
       ) %>
     <% end %>
 

--- a/spec/components/primary_navigation_component_spec.rb
+++ b/spec/components/primary_navigation_component_spec.rb
@@ -2,9 +2,11 @@ require "rails_helper"
 
 RSpec.describe PrimaryNavigationComponent, type: :component do
   let(:items) do
-    [{ text: "Organisations", href: "/organisations", current: true },
-     { text: "Users", href: "/users", current: false },
-     { text: "Logs ", href: "/logs", current: false }]
+    [
+      NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
+      NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+      NavigationItemsHelper::NavigationItem.new("Logs ", "/logs", false),
+    ]
   end
 
   context "when the item is 'current' in nav tabs" do

--- a/spec/components/primary_navigation_component_spec.rb
+++ b/spec/components/primary_navigation_component_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe PrimaryNavigationComponent, type: :component do
   let(:items) do
-    [{ name: "Organisations", url: "/organisations", current: true, comparable_urls: ["/organisations", "/something-else"] },
-     { name: "Users", url: "/users", comparable_urls: ["/users"] },
-     { name: "Logs ", url: "/logs", comparable_urls: ["/logs"] }]
+    [{ text: "Organisations", href: "/organisations", current: true },
+     { text: "Users", href: "/users", current: false },
+     { text: "Logs ", href: "/logs", current: false }]
   end
 
   context "when the item is 'current' in nav tabs" do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -198,6 +198,38 @@ RSpec.describe "User Features" do
   context "when signed in as a data coordinator" do
     let!(:user) { FactoryBot.create(:user, :data_coordinator, last_sign_in_at: Time.zone.now) }
 
+    context "when viewing users" do
+      before do
+        visit("/logs")
+        fill_in("user[email]", with: user.email)
+        fill_in("user[password]", with: "pAssword1")
+        click_button("Sign in")
+        click_link("Users")
+      end
+
+      it "highlights the users navigation tab" do
+        expect(page).to have_css('[aria-current="page"]', text: "Users")
+        expect(page).not_to have_css('[aria-current="page"]', text: "About your organisation")
+        expect(page).not_to have_css('[aria-current="page"]', text: "Logs")
+      end
+    end
+
+    context "when viewing your organisation details" do
+      before do
+        visit("/logs")
+        fill_in("user[email]", with: user.email)
+        fill_in("user[password]", with: "pAssword1")
+        click_button("Sign in")
+        click_link("About your organisation")
+      end
+
+      it "highlights the users navigation tab" do
+        expect(page).to have_css('[aria-current="page"]', text: "About your organisation")
+        expect(page).not_to have_css('[aria-current="page"]', text: "Users")
+        expect(page).not_to have_css('[aria-current="page"]', text: "Logs")
+      end
+    end
+
     context "when viewing your account" do
       before do
         visit("/logs")
@@ -211,6 +243,11 @@ RSpec.describe "User Features" do
         expect(page).to have_link("Your account")
         click_link("Your account")
         expect(page).to have_current_path("/account")
+      end
+
+      it "does not highlight the users navigation tab" do
+        visit("/account")
+        expect(page).not_to have_css('[aria-current="page"]', text: "Users")
       end
 
       it "can navigate to change your password page from main account page" do

--- a/spec/helpers/navigation_items_helper_spec.rb
+++ b/spec/helpers/navigation_items_helper_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe NavigationItemsHelper do
+  let(:current_user) { FactoryBot.create(:user, :data_coordinator) }
+
+  let(:users_path) { "/organisations/#{current_user.organisation.id}/users" }
+  let(:organisation_path) { "/organisations/#{current_user.organisation.id}" }
+
+  describe "#primary items" do
+    context "when the user is a data coordinator" do
+      context "when the user is on the users page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Logs", "/logs", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, true),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items(users_path, current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on their organisation details page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Logs", "/logs", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, true),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("#{organisation_path}/details", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the account page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Logs", "/logs", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
+        end
+      end
+    end
+
+    context "when the user is a support user" do
+      let(:current_user) { FactoryBot.create(:user, :support) }
+
+      context "when the user is on the users page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", true),
+            NavigationItemsHelper::NavigationItem.new("Logs", "/logs", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/users", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the account page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Logs", "/logs", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -357,6 +357,10 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "are you a data protection officer?")
           expect(page).to have_link("Change", text: "are you a key contact?")
         end
+
+        it "does not highlight the users navigation tab" do
+          expect(page).not_to have_css('[aria-current="page"]', text: "Users")
+        end
       end
 
       context "when the current user does not match the user ID" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -357,10 +357,6 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "are you a data protection officer?")
           expect(page).to have_link("Change", text: "are you a key contact?")
         end
-
-        it "does not highlight the users navigation tab" do
-          expect(page).not_to have_css('[aria-current="page"]', text: "Users")
-        end
       end
 
       context "when the current user does not match the user ID" do


### PR DESCRIPTION
(Follows on from #520, where I thought I’d fixed this… 😓)

With the users being a concern of an organisation, it’s hard to correctly highlight the current item in the primary navigation. Options with the current approach is that either ‘Users’ is not highlighted when visiting `/users`, or both ‘Users’ and ‘Your organisation’ are highlighted if we go by the URL (or current controller).

<img width="430" alt="Screenshot 2022-04-27 at 11 06 27" src="https://user-images.githubusercontent.com/813383/165522624-3c5b109e-e988-4e27-a8bd-fb57cb40ab73.png">

This is an attempt to abstract out the logic required to ensure the correct item in the (primary) navigation is highlighted, based both on the current controller AND the current action.

Over engineered? My suspicion is that managing this stuff will get more complicated once we start to add support views which have a second row of navigation, so this might be the start of a way of handling that complexity and moving it out of the views.

### To do

- [ ] Don’t highlight ‘Users’ when viewing pages in ‘Your account’ 