### PR TITLE
Allow illness type to be refused

### DIFF
--- a/app/services/imports/case_logs_import_service.rb
+++ b/app/services/imports/case_logs_import_service.rb
@@ -95,6 +95,7 @@ module Imports
       (1..10).each do |index|
         attributes["illness_type_#{index}"] = illness_type(xml_doc, index, attributes["illness"])
       end
+      attributes["illness_type_0"] = 1 if (1..10).all? { |idx| attributes["illness_type_#{idx}"].nil? || attributes["illness_type_#{idx}"].zero? }
 
       attributes["prevten"] = unsafe_string_as_integer(xml_doc, "Q11")
       attributes["prevloc"] = string_or_nil(xml_doc, "Q12aONS")
@@ -203,13 +204,17 @@ module Imports
       differences = []
       attributes.each do |key, value|
         case_log_value = case_log.send(key.to_sym)
-        next if key == "majorrepairs"
+        next if fields_not_present_in_softwire_data.include?(key)
 
         if value != case_log_value
           differences.push("#{key} #{value.inspect} #{case_log_value.inspect}")
         end
       end
       @logger.warn "Differences found when saving log #{case_log.old_id}: #{differences}" unless differences.empty?
+    end
+
+    def fields_not_present_in_softwire_data
+      %w[majorrepairs illness_type_0]
     end
 
     def check_status_completed(case_log, previous_status)

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3286,6 +3286,9 @@
                     },
                     "illness_type_10": {
                       "value": "Other"
+                    },
+                    "illness_type_0": {
+                      "value": "Tenant prefers not to say"
                     }
                   }
                 }

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -3329,6 +3329,9 @@
                     },
                     "illness_type_10": {
                       "value": "Other"
+                    },
+                    "illness_type_0": {
+                      "value": "Tenant prefers not to say"
                     }
                   }
                 }

--- a/db/migrate/20220506092350_add_prefers_not_to_say_illness_type_to_case_logs.rb
+++ b/db/migrate/20220506092350_add_prefers_not_to_say_illness_type_to_case_logs.rb
@@ -1,0 +1,5 @@
+class AddPrefersNotToSayIllnessTypeToCaseLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :case_logs, :illness_type_0, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_27_160536) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_06_092350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -221,6 +221,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_27_160536) do
     t.string "old_id"
     t.integer "joint"
     t.bigint "created_by_id"
+    t.integer "illness_type_0"
     t.index ["created_by_id"], name: "index_case_logs_on_created_by_id"
     t.index ["managing_organisation_id"], name: "index_case_logs_on_managing_organisation_id"
     t.index ["old_id"], name: "index_case_logs_on_old_id", unique: true

--- a/spec/fixtures/exports/case_logs.xml
+++ b/spec/fixtures/exports/case_logs.xml
@@ -163,6 +163,7 @@
     <old_id/>
     <joint/>
     <created_by_id>{created_by_id}</created_by_id>
+    <illness_type_0/>
     <providertype>1</providertype>
   </form>
 </forms>


### PR DESCRIPTION
Illness type (condition affects) question wasn't mandatory in the old system so we should allow it to be refused here too:

- [x] Add an option for tenant refuses to say to 21/22 and 22/23 forms
- [x] For imported logs set illness type to `Tenant prefers not to say` when illness is true and no illness type is set

For export to CDS we can just omit this field if wanted and all other illness type fields will still be 0 as before.