### PR TITLE
Add docs dir to dockerignore and cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,0 @@
-.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,5 +19,6 @@ node_modules
 vendor/cache
 yarn-debug.log*
 .yarn-integrity
+app/docs/*
 
 .env


### PR DESCRIPTION
Don't symlink cfignore to gitignore so we can exclude files from builds that we don't exclude from git and vice versa.

Add docs to cfignore and docker ignore so we don't add doc files to our builds.