### PR TITLE
CLDC-1218: Fix hbrentshortfall import

### DIFF
--- a/app/services/imports/case_logs_import_service.rb
+++ b/app/services/imports/case_logs_import_service.rb
@@ -125,8 +125,8 @@ module Imports
       attributes["supcharg"] = safe_string_as_decimal(xml_doc, "Q18aiv")
       attributes["tcharge"] = safe_string_as_decimal(xml_doc, "Q18av")
 
-      attributes["hbrentshortfall"] = hbshortfall(xml_doc)
       attributes["tshortfall"] = safe_string_as_decimal(xml_doc, "Q18dyes")
+      attributes["hbrentshortfall"] = hbshortfall(xml_doc, attributes)
 
       attributes["voiddate"] = compose_date(xml_doc, "VDAY", "VMONTH", "VYEAR")
       attributes["mrcdate"] = compose_date(xml_doc, "MRCDAY", "MRCMONTH", "MRCYEAR")
@@ -520,10 +520,9 @@ module Imports
       ((2..8).map { |x| string_or_nil(xml_doc, "P#{x}Rel") } + [string_or_nil(xml_doc, "P1Sex")]).compact
     end
 
-    def hbshortfall(xml_doc)
+    def hbshortfall(xml_doc, attributes)
       shortfall = unsafe_string_as_integer(xml_doc, "Q18d")
-      tshortfall = safe_string_as_decimal(xml_doc, "Q18dyes")
-      if tshortfall.blank? && shortfall == 1 && overridden?(xml_doc, "xmlns", "Q18dyes")
+      if attributes["tshortfall"].blank? && shortfall == 1 && overridden?(xml_doc, "xmlns", "Q18dyes")
         # If they have said there is a shortfall but then not entered one, and that has been
         # manually overridden we instead infer that they actually didn't know whether there is a shortfall.
         3

--- a/app/services/imports/case_logs_import_service.rb
+++ b/app/services/imports/case_logs_import_service.rb
@@ -125,8 +125,8 @@ module Imports
       attributes["supcharg"] = safe_string_as_decimal(xml_doc, "Q18aiv")
       attributes["tcharge"] = safe_string_as_decimal(xml_doc, "Q18av")
 
-      attributes["hbrentshortfall"] = unsafe_string_as_integer(xml_doc, "Q18d")
-      attributes["tshortfall"] = tshortfall(xml_doc, attributes)
+      attributes["hbrentshortfall"] = hbshortfall(xml_doc)
+      attributes["tshortfall"] = safe_string_as_decimal(xml_doc, "Q18dyes")
 
       attributes["voiddate"] = compose_date(xml_doc, "VDAY", "VMONTH", "VYEAR")
       attributes["mrcdate"] = compose_date(xml_doc, "MRCDAY", "MRCMONTH", "MRCYEAR")
@@ -520,11 +520,16 @@ module Imports
       ((2..8).map { |x| string_or_nil(xml_doc, "P#{x}Rel") } + [string_or_nil(xml_doc, "P1Sex")]).compact
     end
 
-    def tshortfall(xml_doc, attributes)
-      shortfall = safe_string_as_decimal(xml_doc, "Q18dyes")
-      return 0 if shortfall.blank? && attributes["hbrentshortfall"] == 1 && overridden?(xml_doc, "xmlns", "Q18dyes")
-
-      shortfall
+    def hbshortfall(xml_doc)
+      shortfall = unsafe_string_as_integer(xml_doc, "Q18d")
+      tshortfall = safe_string_as_decimal(xml_doc, "Q18dyes")
+      if tshortfall.blank? && shortfall == 1 && overridden?(xml_doc, "xmlns", "Q18dyes")
+        # If they have said there is a shortfall but then not entered one, and that has been
+        # manually overridden we instead infer that they actually didn't know whether there is a shortfall.
+        3
+      else
+        shortfall
+      end
     end
   end
 end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1218

We have hbrentshortfall which asks:
After the household has received any housing-related benefits, will they still need to pay for rent and charges?

1: Yes
2: No
3: Don't know
If they say 3: Don't know, we don't route them to the tshortfall question and it's not expected to be answered. Counter to what we expected currently they are saying they do know there is one, then haven't entered one which our validation catches, but has been manually overridden. 
Instead if they have said there is a shortfall but not entered an amount and this has been manually overridden then we infer "Don't know" for hbrentshortfall.
