### PR TITLE
Referral can be internal for homeless

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -111,16 +111,6 @@ module Validations::HouseholdValidations
   end
 
   def validate_referral(record)
-    if record.is_internal_transfer? && record.is_assessed_homeless?
-      record.errors.add :referral, I18n.t("validations.household.referral.assessed_homeless")
-      record.errors.add :homeless, I18n.t("validations.household.homeless.assessed.internal_transfer")
-    end
-
-    if record.is_internal_transfer? && record.is_other_homeless?
-      record.errors.add :referral, I18n.t("validations.household.referral.other_homeless")
-      record.errors.add :homeless, I18n.t("validations.household.homeless.other.internal_transfer")
-    end
-
     if record.is_internal_transfer? && record.owning_organisation.provider_type == "PRP" && record.is_prevten_la_general_needs?
       record.errors.add :referral, I18n.t("validations.household.referral.la_general_needs.internal_transfer")
       record.errors.add :prevten, I18n.t("validations.household.prevten.la_general_needs.internal_transfer")

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -643,14 +643,12 @@ RSpec.describe Validations::HouseholdValidations do
 
   describe "referral validations" do
     context "when homelessness is assessed" do
-      it "cannot be internal transfer" do
+      it "can be internal transfer" do
         record.homeless = 11
         record.referral = 1
         household_validator.validate_referral(record)
-        expect(record.errors["referral"])
-          .to include(match I18n.t("validations.household.referral.assessed_homeless"))
-        expect(record.errors["homeless"])
-          .to include(match I18n.t("validations.household.homeless.assessed.internal_transfer"))
+        expect(record.errors["referral"]).to be_empty
+        expect(record.errors["homeless"]).to be_empty
       end
 
       it "can be non internal transfer" do
@@ -668,10 +666,8 @@ RSpec.describe Validations::HouseholdValidations do
         record.referral = 1
         record.homeless = 7
         household_validator.validate_referral(record)
-        expect(record.errors["referral"])
-          .to include(match I18n.t("validations.household.referral.other_homeless"))
-        expect(record.errors["homeless"])
-          .to include(match I18n.t("validations.household.homeless.other.internal_transfer"))
+        expect(record.errors["referral"]).to be_empty
+        expect(record.errors["homeless"]).to be_empty
       end
 
       it "can be non internal transfer" do


### PR DESCRIPTION
People that are informed they will be evicted/made homeless are assessed as homeless already so the referral can still be internal.