### PR TITLE
Set case log ID offset at export

### DIFF
--- a/app/services/exports/case_log_export_service.rb
+++ b/app/services/exports/case_log_export_service.rb
@@ -18,6 +18,8 @@ module Exports
       field_name.starts_with?("details_known_") || pattern_age.match(field_name) || omitted_attrs.include?(field_name) ? true : false
     end
 
+    LOG_ID_OFFSET = 300_000_000_000
+
   private
 
     def save_export_run
@@ -71,6 +73,7 @@ module Exports
             next
           else
             value = case_log.read_attribute_before_type_cast(key)
+            value += LOG_ID_OFFSET if key == "id"
             form << doc.create_element(key, value)
           end
         end

--- a/spec/services/exports/case_log_export_service_spec.rb
+++ b/spec/services/exports/case_log_export_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Exports::CaseLogExportService do
   let(:case_log) { FactoryBot.create(:case_log, :completed) }
 
   def replace_entity_ids(export_template)
-    export_template.sub!(/\{id\}/, case_log["id"].to_s)
+    export_template.sub!(/\{id\}/, (case_log["id"] + Exports::CaseLogExportService::LOG_ID_OFFSET).to_s)
     export_template.sub!(/\{owning_org_id\}/, case_log["owning_organisation_id"].to_s)
     export_template.sub!(/\{managing_org_id\}/, case_log["managing_organisation_id"].to_s)
     export_template.sub!(/\{created_by_id\}/, case_log["created_by_id"].to_s)


### PR DESCRIPTION
To ensure we don't have clashes with existing organisation data in CDS set an offset greater than their highest ID at export.

Will also need to be done for Organisations (100000000), if and when we have an export for them.