### PR TITLE
Fix routing for tshortfall

### DIFF
--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -5784,19 +5784,19 @@
               "depends_on": [
                 {
                   "hb": 1,
-                  "hbrentshortfall": 0
+                  "hbrentshortfall": 1
                 },
                 {
                   "hb": 6,
-                  "hbrentshortfall": 0
+                  "hbrentshortfall": 1
                 },
                 {
                   "hb": 7,
-                  "hbrentshortfall": 0
+                  "hbrentshortfall": 1
                 },
                 {
                   "hb": 8,
-                  "hbrentshortfall": 0
+                  "hbrentshortfall": 1
                 }
               ]
             }

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -5789,14 +5789,6 @@
                 {
                   "hb": 6,
                   "hbrentshortfall": 1
-                },
-                {
-                  "hb": 7,
-                  "hbrentshortfall": 1
-                },
-                {
-                  "hb": 8,
-                  "hbrentshortfall": 1
                 }
               ]
             }


### PR DESCRIPTION
This was fixed here https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/514 for 21/22 but missed for 22/23.

Once merged there are 3 logs whose statuses will need updating and which will need additional data inputting:

```ruby
CaseLog.where(owning_organisation: Organisation.find(2)).where("created_at > ?", Date.yesterday.beginning_of_day).where(hb: [1, 6, 7, 8], hbrentshortfall: 1).map(&:id)
=> [3292, 3300, 3304]
```