### PR TITLE
CLDC-1188: Add visibly hidden change link text for details known questions

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1534,6 +1534,7 @@
               "description": "",
               "questions": {
                 "details_known_2": {
+                  "check_answer_label": "Details known for person 2",
                   "header": "Do you know details for person 2?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -1759,6 +1760,7 @@
               "description": "",
               "questions": {
                 "details_known_3": {
+                  "check_answer_label": "Details known for person 3",
                   "header": "Do you know details for person 3?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -1981,6 +1983,7 @@
               "description": "",
               "questions": {
                 "details_known_4": {
+                  "check_answer_label": "Details known for person 4",
                   "header": "Do you know details for person 4?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2200,6 +2203,7 @@
               "description": "",
               "questions": {
                 "details_known_5": {
+                  "check_answer_label": "Details known for person 5",
                   "header": "Do you know details for person 5?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2416,6 +2420,7 @@
               "description": "",
               "questions": {
                 "details_known_6": {
+                  "check_answer_label": "Details known for person 6",
                   "header": "Do you know details for person 6?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2629,6 +2634,7 @@
               "description": "",
               "questions": {
                 "details_known_7": {
+                  "check_answer_label": "Details known for person 7",
                   "header": "Do you know details for person 7?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2839,6 +2845,7 @@
               "description": "",
               "questions": {
                 "details_known_8": {
+                  "check_answer_label": "Details known for person 8",
                   "header": "Do you know details for person 8?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1528,6 +1528,7 @@
               "description": "",
               "questions": {
                 "details_known_2": {
+                  "check_answer_label": "Details known for person 2",
                   "header": "Do you know details for person 2?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -1760,6 +1761,7 @@
               "description": "",
               "questions": {
                 "details_known_3": {
+                  "check_answer_label": "Details known for person 3",
                   "header": "Do you know details for person 3?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -1989,6 +1991,7 @@
               "description": "",
               "questions": {
                 "details_known_4": {
+                  "check_answer_label": "Details known for person 4",
                   "header": "Do you know details for person 4?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2215,6 +2218,7 @@
               "description": "",
               "questions": {
                 "details_known_5": {
+                  "check_answer_label": "Details known for person 5",
                   "header": "Do you know details for person 5?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2438,6 +2442,7 @@
               "description": "",
               "questions": {
                 "details_known_6": {
+                  "check_answer_label": "Details known for person 6",
                   "header": "Do you know details for person 6?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2658,6 +2663,7 @@
               "description": "",
               "questions": {
                 "details_known_7": {
+                  "check_answer_label": "Details known for person 7",
                   "header": "Do you know details for person 7?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",
@@ -2875,6 +2881,7 @@
               "description": "",
               "questions": {
                 "details_known_8": {
+                  "check_answer_label": "Details known for person 8",
                   "header": "Do you know details for person 8?",
                   "hint_text": "You must provide details for everyone in the household if you know them.",
                   "type": "radio",


### PR DESCRIPTION
[CLDC-1188](https://digital.dclg.gov.uk/jira/browse/CLDC-1188)

Change link text is missing for each ‘Do you know the details for person X’ question, leading to ambiguous link text.