### PR TITLE
CLDC-1200: Use `inputmode="email"` instead of `type="email"`

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -18,9 +18,10 @@
 
       <p class="govuk-body">Enter your email address to get a new invitation link.</p>
 
-      <%= f.govuk_email_field :email,
+      <%= f.govuk_text_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
+        inputmode: "email",
         spellcheck: "false",
         value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -19,9 +19,10 @@
       <p class="govuk-body">Enter the email address you used to create your account.</p>
       <p class="govuk-body">We’ll email you a link to reset your password. This link will expire in 3 hours.</p>
 
-      <%= f.govuk_email_field :email,
+      <%= f.govuk_text_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
+        inputmode: "email",
         spellcheck: "false" %>
 
       <%= f.govuk_submit "Send email" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,9 +16,10 @@
         <%= content_for(:title) %>
       </h1>
 
-      <%= f.govuk_email_field :email,
+      <%= f.govuk_text_field :email,
         label: { text: "Email address" },
         autocomplete: "email",
+        inputmode: "email",
         spellcheck: "false" %>
 
       <%= f.govuk_password_field :password,

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -3,9 +3,10 @@
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <%= f.govuk_email_field :email,
+  <%= f.govuk_text_field :email,
     label: { text: "Email address" },
     autocomplete: "email",
+    inputmode: "email",
     spellcheck: "false" %>
 
   <%= f.govuk_submit "Resend unlock instructions" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -20,9 +20,10 @@
         label: { text: "Name", size: "m" },
         autocomplete: "name" %>
 
-      <%= f.govuk_email_field :email,
-        label: { text: "Email address", size: "m" },
+      <%= f.govuk_text_field :email,
+        label: { text: "Email address" },
         autocomplete: "email",
+        inputmode: "email",
         spellcheck: "false" %>
 
       <% if current_user.data_coordinator? || current_user.support? %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,9 +20,10 @@
         autocomplete: "name",
         label: { text: "Name (optional)", size: "m" } %>
 
-      <%= f.govuk_email_field :email,
-        label: { text: "Email address", size: "m" },
+      <%= f.govuk_text_field :email,
+        label: { text: "Email address" },
         autocomplete: "email",
+        inputmode: "email",
         spellcheck: "false",
         value: @resource.email %>
 


### PR DESCRIPTION
[CLDC-1200](https://digital.dclg.gov.uk/jira/browse/CLDC-1200)

> Voice activation users using Dragon were unable to directly dictate their email address into the email address input field. This is because the input type ‘email’ interferes with Dragon software.

Replaces all occurrences of `govuk_email_field` with `govuk_text_field` and adds the `inputmode` attribute.