### PR TITLE
CLDC-1189: Make logs link less ambiguous

### DIFF
--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -24,7 +24,9 @@
       <% case_logs.map do |log| %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">
-          <%= govuk_link_to log.id, case_log_path(log) %>
+          <%= govuk_link_to case_log_path(log) do %>
+            <span class="govuk-visually-hidden">Log </span><%= log.id %>
+          <% end %>
         </th>
         <td class="govuk-table__cell app-!-font-tabular">
           <%= log.tenant_code? ? log.tenant_code : "–" %>

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -309,8 +309,8 @@ RSpec.describe CaseLogsController, type: :request do
           end
 
           it "only shows case logs for your organisation" do
-            expected_case_row_log = "<a class=\"govuk-link\" href=\"/logs/#{case_log.id}\">#{case_log.id}</a>"
-            unauthorized_case_row_log = "<a class=\"govuk-link\" href=\"/logs/#{unauthorized_case_log.id}\">#{unauthorized_case_log.id}</a>"
+            expected_case_row_log = "<span class=\"govuk-visually-hidden\">Log </span>#{case_log.id}"
+            unauthorized_case_row_log = "<span class=\"govuk-visually-hidden\">Log </span>#{unauthorized_case_log.id}"
             expect(CGI.unescape_html(response.body)).to include(expected_case_row_log)
             expect(CGI.unescape_html(response.body)).not_to include(unauthorized_case_row_log)
           end


### PR DESCRIPTION
Prefix log links in table with ‘Log ’, which is visually hidden but can be announced when browsing links on the page. 