### PR TITLE
CLDC-1224: Tenancy type and tenancy length

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -468,9 +468,19 @@ private
   end
 
   def dynamically_not_required
-    previous_la_known_field = postcode_known? ? %w[previous_la_known] : []
-    tshortfall_field = tshortfall_unknown? ? %w[tshortfall] : []
-    previous_la_known_field + tshortfall_field
+    not_required = []
+    not_required << "previous_la_known" if postcode_known?
+    not_required << "tshortfall" if tshortfall_unknown?
+    not_required << "tenancylength" if tenancylength_optional?
+
+    not_required
+  end
+
+  def tenancylength_optional?
+    return false unless collection_start_year
+    return true if collection_start_year < 2022
+
+    collection_start_year >= 2022 && ![4, 6].include?(tenancy)
   end
 
   def set_derived_fields!

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -192,10 +192,13 @@ class CaseLog < ApplicationRecord
   end
 
   def is_secure_tenancy?
+    return unless collection_start_year
+
     # 1: Secure (including flexible)
     if collection_start_year < 2022
       tenancy == 1
     else
+      # 6: Secure - fixed term, 7: Secure - lifetime
       [6, 7].include?(tenancy)
     end
   end

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -193,7 +193,11 @@ class CaseLog < ApplicationRecord
 
   def is_secure_tenancy?
     # 1: Secure (including flexible)
-    tenancy == 1
+    if collection_start_year < 2022
+      tenancy == 1
+    else
+      [6, 7].include?(tenancy)
+    end
   end
 
   def is_assured_shorthold_tenancy?

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -191,6 +191,10 @@ class CaseLog < ApplicationRecord
     tshortfall_known == 1
   end
 
+  def is_fixed_term_tenancy?
+    [4, 6].include?(tenancy)
+  end
+
   def is_secure_tenancy?
     return unless collection_start_year
 
@@ -480,7 +484,7 @@ private
     return false unless collection_start_year
     return true if collection_start_year < 2022
 
-    collection_start_year >= 2022 && ![4, 6].include?(tenancy)
+    collection_start_year >= 2022 && !is_fixed_term_tenancy?
   end
 
   def set_derived_fields!

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -994,7 +994,7 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "4": {
                       "value": "Assured Shorthold Tenancy (AST) - Fixed term"
                     },
                     "6": {
@@ -1041,7 +1041,7 @@
                   "hint_text": "This is also known as an ‘introductory period’.",
                   "type": "radio",
                   "answer_options": {
-                    "1": {
+                    "4": {
                       "value": "Assured Shorthold Tenancy (AST) - Fixed term"
                     },
                     "6": {
@@ -6297,7 +6297,7 @@
                   "label": true,
                   "i18n_template": "la"
                 },
-                { 
+                {
                   "key": "soft_min_for_period",
                   "label": false,
                   "i18n_template": "soft_min_for_period"
@@ -6336,7 +6336,7 @@
                     "label": true,
                     "i18n_template": "la"
                   },
-                  { 
+                  {
                     "key": "soft_max_for_period",
                     "label": false,
                     "i18n_template": "soft_max_for_period"

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1095,10 +1095,13 @@
               },
               "depends_on": [
                 {
-                  "tenancy": 1
+                  "tenancy": 4
                 },
                 {
                   "tenancy": 6
+                },
+                {
+                  "tenancy": 3
                 }
               ]
             },

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Validations::TenancyValidations do
   subject(:tenancy_validator) { validator_class.new }
 
   let(:validator_class) { Class.new { include Validations::TenancyValidations } }
-  let(:record) { FactoryBot.create(:case_log) }
+  let(:record) { FactoryBot.create(:case_log, startdate: Time.zone.local(2021, 5, 1)) }
 
   describe "fixed term tenancy validations" do
     context "when fixed term tenancy" do
@@ -62,44 +62,134 @@ RSpec.describe Validations::TenancyValidations do
         end
       end
 
-      context "when type of tenancy is secure" do
-        let(:expected_error) { I18n.t("validations.tenancy.length.secure") }
+      context "when the collection start year is before 2022" do
+        context "when type of tenancy is secure" do
+          let(:expected_error) { I18n.t("validations.tenancy.length.secure") }
 
-        before { record.tenancy = 1 }
+          before { record.tenancy = 1 }
 
-        context "when tenancy length is greater than 1" do
-          it "adds an error" do
-            record.tenancylength = 1
-            tenancy_validator.validate_fixed_term_tenancy(record)
-            expect(record.errors["tenancylength"]).to include(match(expected_error))
-            expect(record.errors["tenancy"]).to include(match(expected_error))
+          context "when tenancy length is greater than 1" do
+            it "adds an error" do
+              record.tenancylength = 1
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is less than 100" do
+            it "adds an error" do
+              record.tenancylength = 100
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is between 2-99" do
+            it "does not add an error" do
+              record.tenancylength = 3
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
+          end
+
+          context "when tenancy length has not been answered" do
+            it "does not add an error" do
+              record.tenancylength = nil
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
+          end
+        end
+      end
+
+      context "when the collection start year is 2022 or later" do
+        let(:record) { FactoryBot.create(:case_log, startdate: Time.zone.local(2022, 5, 1)) }
+
+        context "when type of tenancy is Secure - fixed term" do
+          let(:expected_error) { I18n.t("validations.tenancy.length.secure") }
+
+          before { record.tenancy = 6 }
+
+          context "when tenancy length is greater than 1" do
+            it "adds an error" do
+              record.tenancylength = 1
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is less than 100" do
+            it "adds an error" do
+              record.tenancylength = 100
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is between 2-99" do
+            it "does not add an error" do
+              record.tenancylength = 3
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
+          end
+
+          context "when tenancy length has not been answered" do
+            it "does not add an error" do
+              record.tenancylength = nil
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
           end
         end
 
-        context "when tenancy length is less than 100" do
-          it "adds an error" do
-            record.tenancylength = 100
-            tenancy_validator.validate_fixed_term_tenancy(record)
-            expect(record.errors["tenancylength"]).to include(match(expected_error))
-            expect(record.errors["tenancy"]).to include(match(expected_error))
-          end
-        end
+        context "when type of tenancy is Secure - lifetime" do
+          let(:expected_error) { I18n.t("validations.tenancy.length.secure") }
 
-        context "when tenancy length is between 2-99" do
-          it "does not add an error" do
-            record.tenancylength = 3
-            tenancy_validator.validate_fixed_term_tenancy(record)
-            expect(record.errors["tenancylength"]).to be_empty
-            expect(record.errors["tenancy"]).to be_empty
-          end
-        end
+          before { record.tenancy = 7 }
 
-        context "when tenancy length has not been answered" do
-          it "does not add an error" do
-            record.tenancylength = nil
-            tenancy_validator.validate_fixed_term_tenancy(record)
-            expect(record.errors["tenancylength"]).to be_empty
-            expect(record.errors["tenancy"]).to be_empty
+          context "when tenancy length is greater than 1" do
+            it "adds an error" do
+              record.tenancylength = 1
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is less than 100" do
+            it "adds an error" do
+              record.tenancylength = 100
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to include(match(expected_error))
+              expect(record.errors["tenancy"]).to include(match(expected_error))
+            end
+          end
+
+          context "when tenancy length is between 2-99" do
+            it "does not add an error" do
+              record.tenancylength = 3
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
+          end
+
+          context "when tenancy length has not been answered" do
+            it "does not add an error" do
+              record.tenancylength = nil
+              tenancy_validator.validate_fixed_term_tenancy(record)
+              expect(record.errors["tenancylength"]).to be_empty
+              expect(record.errors["tenancy"]).to be_empty
+            end
           end
         end
       end

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe CaseLogsController, type: :request do
                                 owning_organisation: organisation,
                                 mrcdate: Time.zone.local(2022, 2, 1),
                                 startdate: Time.zone.local(2022, 12, 1),
+                                tenancy: 6,
                                 managing_organisation: organisation)
             end
 
@@ -260,6 +261,7 @@ RSpec.describe CaseLogsController, type: :request do
                                 owning_organisation: organisation,
                                 mrcdate: Time.zone.local(2022, 2, 1),
                                 startdate: Time.zone.local(2022, 12, 1),
+                                tenancy: 6,
                                 managing_organisation: organisation)
             end
             let!(:case_log_2022_in_progress) do
@@ -267,6 +269,7 @@ RSpec.describe CaseLogsController, type: :request do
                                 owning_organisation: organisation,
                                 mrcdate: Time.zone.local(2022, 2, 1),
                                 startdate: Time.zone.local(2022, 12, 1),
+                                tenancy: 6,
                                 managing_organisation: organisation)
             end
 


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1224

- [x] From Rachel (1 Secure no longer exists. It has been split into 6 & 7). Incorrectly using 1 rather than 4 for AST.
- [x] Tenancy length is not mandatory for 21/22
- [x] Tenancy length is mandatory for 22/23 (Assured Shorthold and Secure Fixed Term)
- [x] Tenancy length is optional for "Other"
- [x] Tenancy length is hidden for other 22/23 options