### PR TITLE
User management tweaks

### DIFF
--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,0 +1,7 @@
+.app-tag--small {
+  @include govuk-font(14, $weight: bold);
+  padding-top: 2px;
+  padding-right: 6px;
+  padding-bottom: 2px;
+  padding-left: 6px;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -33,6 +33,7 @@ $govuk-breakpoints: (
 @import "related-navigation";
 @import "section-skip-link";
 @import "table-group";
+@import "tag";
 @import "task-list";
 @import "template";
 @import "pagination";

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, current_user == @user ? "Change your personal details" : "Change #{@user.name}’s personal details" %>
+<% content_for :title, current_user == @user ? "Change your personal details" : "Change #{@user.name.presence || 'this user'}’s personal details" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
@@ -17,10 +17,11 @@
       </h1>
 
       <%= f.govuk_text_field :name,
+        label: { text: "Name", size: "m" },
         autocomplete: "name" %>
 
       <%= f.govuk_email_field :email,
-        label: { text: "Email address" },
+        label: { text: "Email address", size: "m" },
         autocomplete: "email",
         spellcheck: "false" %>
 
@@ -34,18 +35,17 @@
           legend: { text: "Role", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_dpo,
-          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
           :id,
           :name,
-          inline: true,
-          legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" } %>
+          legend: { text: "Are #{pronoun(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_key_contact,
-          [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+          [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
           :id,
           :name,
-          inline: true,
-          legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" } %>
+          legend: { text: "Are #{pronoun(@user, current_user)} a key contact for this service?", size: "m" },
+          hint: { text: "This is a person responsible for sharing information about social housing lettings and sales data within the organisation." } %>
       <% end %>
 
       <%= f.govuk_submit "Save changes" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,22 @@
   <% @users.each do |user| %>
     <%= table.body do |body| %>
       <%= body.row do |row| %>
-        <% row.cell(text: simple_format(user_cell(user), {}, wrapper_tag: "div")) %>
+        <% row.cell do %>
+          <%= simple_format(user_cell(user), {}, wrapper_tag: "span") %>
+          <% if user.is_data_protection_officer? || user.is_key_contact? %>
+            <br>
+          <% end %>
+          <%= user.is_data_protection_officer? ? govuk_tag(
+            classes: "app-tag--small",
+            colour: "turquoise",
+            text: "Data protection officer",
+          ) : "" %>
+          <%= user.is_key_contact? ? govuk_tag(
+            classes: "app-tag--small",
+            colour: "turquoise",
+            text: "Key contact",
+          ) : "" %>
+        <% end %>
         <% row.cell(text: simple_format(org_cell(user), {}, wrapper_tag: "div")) %>
         <% row.cell(text: user.last_sign_in_at&.to_formatted_s(:govuk_date)) %>
       <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -18,10 +18,10 @@
 
       <%= f.govuk_text_field :name,
         autocomplete: "name",
-        label: { text: "Name (optional)" } %>
+        label: { text: "Name (optional)", size: "m" } %>
 
       <%= f.govuk_email_field :email,
-        label: { text: "Email address" },
+        label: { text: "Email address", size: "m" },
         autocomplete: "email",
         spellcheck: "false",
         value: @resource.email %>
@@ -48,18 +48,17 @@
         legend: { text: "Role", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_dpo,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
         :id,
         :name,
-        inline: true,
-        legend: { text: "Are #{pronoun(@user, current_user)} a data protection officer?", size: "m" } %>
+        legend: { text: "Are #{pronoun(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_key_contact,
-        [OpenStruct.new(id: false, name: "No"), OpenStruct.new(id: true, name: "Yes")],
+        [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
         :id,
         :name,
-        inline: true,
-        legend: { text: "Are #{pronoun(@user, current_user)} a key contact?", size: "m" } %>
+        legend: { text: "Is this user a key contact for this service?", size: "m" },
+        hint: { text: "This is a person responsible for sharing information about social housing lettings and sales data within the organisation." } %>
 
       <%= f.govuk_submit "Continue" %>
     </div>


### PR DESCRIPTION
Low hanging and easy to tweak improvements to user management screens:

* Show if a user is a key contact/dpo in list of users:

  <img width="1144" alt="Screenshot 2022-05-18 at 13 04 30" src="https://user-images.githubusercontent.com/813383/169035200-5900218d-bd76-4dac-8b12-0e4d39e16958.png">

* Add `.app-tag--small` modifier
* Use consistent label size for adding/editing a user
* Add missing hint describing what a key contact is
* Fix heading when editing a user who does not have name

I’d like to have added hint text describing each of the different roles in this PR, but not sure I can do that.