### PR TITLE
Update logs table column heading to say ‘Status’, not ‘Completed’

### DIFF
--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -13,7 +13,7 @@
         <th class="govuk-table__header" scope="col">Property</th>
         <th class="govuk-table__header" scope="col">Tenancy starts</th>
         <th class="govuk-table__header" scope="col">Log created</th>
-        <th class="govuk-table__header" scope="col">Completed</th>
+        <th class="govuk-table__header" scope="col">Status</th>
         <% if current_user.support? %>
           <th class="govuk-table__header" scope="col">Owning organisation</th>
           <th class="govuk-table__header" scope="col">Managing organisation</th>


### PR DESCRIPTION
Does what it says on the 🥫