### PR TITLE
CLDC-1210: Add status tag helper

### DIFF
--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,25 @@
+module TagHelper
+  include GovukComponentsHelper
+
+  TEXT = {
+    not_started: "Not started",
+    cannot_start_yet: "Cannot start yet",
+    in_progress: "In progress",
+    completed: "Completed",
+  }.freeze
+
+  COLOUR = {
+    not_started: "grey",
+    cannot_start_yet: "grey",
+    in_progress: "blue",
+    completed: "green",
+  }.freeze
+
+  def status_tag(status, classes = [])
+    govuk_tag(
+      classes:,
+      colour: COLOUR[status.to_sym],
+      text: TEXT[status.to_sym],
+    )
+  end
+end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -1,20 +1,6 @@
 module TasklistHelper
   include GovukLinkHelper
 
-  STATUSES = {
-    not_started: "Not started",
-    cannot_start_yet: "Cannot start yet",
-    completed: "Completed",
-    in_progress: "In progress",
-  }.freeze
-
-  STYLES = {
-    not_started: "govuk-tag--grey",
-    cannot_start_yet: "govuk-tag--grey",
-    completed: "",
-    in_progress: "govuk-tag--blue",
-  }.freeze
-
   def get_next_incomplete_section(case_log)
     case_log.form.subsections.find { |subsection| subsection.is_incomplete?(case_log) }
   end

--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -41,10 +41,7 @@
           <%= log.created_at.to_formatted_s(:govuk_date) %>
         </td>
         <td class="govuk-table__cell">
-          <%= govuk_tag(
-            colour: log.status == "completed" ? "blue" : "grey",
-            text: log.status.humanize,
-          ) %>
+          <%= status_tag(log.status) %>
         </td>
         <% if current_user.support? %>
           <td class="govuk-table__cell">

--- a/app/views/case_logs/_tasklist.html.erb
+++ b/app/views/case_logs/_tasklist.html.erb
@@ -14,9 +14,7 @@
             <span class="app-task-list__task-name" id="<%= subsection.id.dasherize %>">
               <%= subsection_link(subsection, @case_log) %>
             </span>
-            <strong class="govuk-tag app-task-list__tag <%= TasklistHelper::STYLES[subsection_status] %>">
-              <%= TasklistHelper::STATUSES[subsection_status] %>
-            </strong>
+            <%= status_tag(subsection_status, "app-task-list__tag") %>
           </li>
         <% end %>
       </ul>

--- a/app/views/case_logs/edit.html.erb
+++ b/app/views/case_logs/edit.html.erb
@@ -26,7 +26,7 @@
       <p class="govuk-body">This log has not been started.</p>
     <% elsif @case_log.status == "completed" %>
       <p class="govuk-body">
-        <%= govuk_tag(text: "Completed") %>
+        <%= status_tag(@case_log.status) %>
       </p>
       <p class="govuk-body">
         You can <%= govuk_link_to "review and make changes to this log", "/logs/#{@case_log.id}/review" %> up to 3 months after the end of the current collection year, which closes on 31 March <%= @case_log.collection_start_year.present? ? @case_log.collection_start_year + 1 : "" %>.

--- a/spec/helpers/tag_helper_spec.rb
+++ b/spec/helpers/tag_helper_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe TagHelper do
+  let(:empty_case_log) { FactoryBot.create(:case_log) }
+  let(:case_log) { FactoryBot.create(:case_log, :in_progress) }
+
+  describe "get the status tag" do
+    it "returns tag with correct status text and colour" do
+      expect(status_tag(case_log.status)).to eq("<strong class=\"govuk-tag govuk-tag--blue\">In progress</strong>")
+    end
+
+    it "returns tag with correct status text and colour and custom class" do
+      expect(status_tag("not_started", "app-tag--small")).to eq("<strong class=\"govuk-tag app-tag--small govuk-tag--grey\">Not started</strong>")
+    end
+  end
+end


### PR DESCRIPTION
We use statuses in a number of places, and we should be consistent with their naming and colouring (right now we are not).

This PR consolidates status text and colours, and provides a helper for generating tags with the correct attributes. Additionally, a custom class can be supplied.