### PR TITLE
CLDC-1217: Retirement soft validation

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -409,9 +409,9 @@ class CaseLog < ApplicationRecord
     return unless gender
 
     if %w[M X].include?(gender)
-      "men and non-binary people"
+      "male and non-binary people"
     elsif gender == "F"
-      "women"
+      "females"
     end
   end
 

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -54,6 +54,10 @@ private
     economic_status == 5
   end
 
+  def tenant_prefers_not_to_say?(economic_status)
+    economic_status == 10
+  end
+
   def retired_under_soft_min_age?(person_num)
     age = public_send("age#{person_num}")
     economic_status = public_send("ecstat#{person_num}")
@@ -68,9 +72,10 @@ private
     age = public_send("age#{person_num}")
     economic_status = public_send("ecstat#{person_num}")
     gender = public_send("sex#{person_num}")
+    tenant_retired_or_prefers_not_say = tenant_is_retired?(economic_status) || tenant_prefers_not_to_say?(economic_status)
     return unless age && economic_status && gender
 
-    %w[M X].include?(gender) && !tenant_is_retired?(economic_status) && age > 67 ||
-      gender == "F" && !tenant_is_retired?(economic_status) && age > 60
+    %w[M X].include?(gender) && !tenant_retired_or_prefers_not_say && age > 67 ||
+      gender == "F" && !tenant_retired_or_prefers_not_say && age > 60
   end
 end

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1955,6 +1955,10 @@ RSpec.describe CaseLog do
       it "returns the expected retirement age" do
         expect(case_log.retirement_age_for_person_1).to eq(67)
       end
+
+      it "returns the expected plural" do
+        expect(case_log.plural_gender_for_person_1).to eq("male and non-binary people")
+      end
     end
 
     context "when a person gender is Female" do
@@ -1962,6 +1966,10 @@ RSpec.describe CaseLog do
 
       it "returns the expected retirement age" do
         expect(case_log.retirement_age_for_person_2).to eq(60)
+      end
+
+      it "returns the expected plural" do
+        expect(case_log.plural_gender_for_person_2).to eq("females")
       end
     end
 
@@ -1971,6 +1979,10 @@ RSpec.describe CaseLog do
       it "returns the expected retirement age" do
         expect(case_log.retirement_age_for_person_3).to eq(67)
       end
+
+      it "returns the expected plural" do
+        expect(case_log.plural_gender_for_person_3).to eq("male and non-binary people")
+      end
     end
 
     context "when the person gender is not set" do
@@ -1978,6 +1990,10 @@ RSpec.describe CaseLog do
 
       it "returns nil" do
         expect(case_log.retirement_age_for_person_3).to be_nil
+      end
+
+      it "returns the expected plural" do
+        expect(case_log.plural_gender_for_person_3).to be_nil
       end
     end
   end

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -433,7 +433,6 @@ RSpec.describe Validations::HouseholdValidations do
         record.sex2 = "M"
         record.ecstat2 = 5
         household_validator.validate_household_number_of_other_members(record)
-        household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["ecstat2"]).to be_empty
         expect(record.errors["sex2"]).to be_empty
         expect(record.errors["age2"]).to be_empty
@@ -465,7 +464,6 @@ RSpec.describe Validations::HouseholdValidations do
         record.age2 = 61
         record.sex2 = "F"
         record.ecstat2 = 5
-        household_validator.validate_household_number_of_other_members(record)
         household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["ecstat2"]).to be_empty
         expect(record.errors["sex2"]).to be_empty

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -70,4 +70,98 @@ RSpec.describe Validations::SoftValidations do
       end
     end
   end
+
+  describe "retirement soft validations" do
+    context "when the tenant is retired but under the expected retirement age" do
+      context "when the tenant is female" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "F", ecstat1: 5)
+          expect(record.person_1_retired_under_soft_min_age?).to be true
+        end
+      end
+
+      context "when the tenant is male" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "M", ecstat1: 5)
+          expect(record.person_1_retired_under_soft_min_age?).to be true
+        end
+      end
+
+      context "when the tenant is non-binary" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "X", ecstat1: 5)
+          expect(record.person_1_retired_under_soft_min_age?).to be true
+        end
+      end
+    end
+
+    context "when the tenant is not retired but over the expected retirement age" do
+      context "when the tenant is female" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "F", ecstat1: 3)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be true
+        end
+      end
+
+      context "when the tenant is male" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "M", ecstat1: 3)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be true
+        end
+      end
+
+      context "when the tenant is non-binary" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "X", ecstat1: 3)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be true
+        end
+      end
+    end
+
+    context "when the tenant prefers not to say what their economic status is but is under the expected retirement age" do
+      context "when the tenant is female" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "F", ecstat1: 10)
+          expect(record.person_1_retired_under_soft_min_age?).to be false
+        end
+      end
+
+      context "when the tenant is male" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "M", ecstat1: 10)
+          expect(record.person_1_retired_under_soft_min_age?).to be false
+        end
+      end
+
+      context "when the tenant is non-binary" do
+        it "shows the interruption screen" do
+          record.update!(age1: 43, sex1: "X", ecstat1: 10)
+          expect(record.person_1_retired_under_soft_min_age?).to be false
+        end
+      end
+    end
+
+    context "when the tenant prefers not to say what their economic status is but is over the expected retirement age" do
+      context "when the tenant is female" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "F", ecstat1: 10)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be false
+        end
+      end
+
+      context "when the tenant is male" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "M", ecstat1: 10)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be false
+        end
+      end
+
+      context "when the tenant is non-binary" do
+        it "shows the interruption screen" do
+          record.update!(age1: 85, sex1: "X", ecstat1: 10)
+          expect(record.person_1_not_retired_over_soft_max_age?).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -120,21 +120,21 @@ RSpec.describe Validations::SoftValidations do
 
     context "when the tenant prefers not to say what their economic status is but is under the expected retirement age" do
       context "when the tenant is female" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 43, sex1: "F", ecstat1: 10)
           expect(record.person_1_retired_under_soft_min_age?).to be false
         end
       end
 
       context "when the tenant is male" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 43, sex1: "M", ecstat1: 10)
           expect(record.person_1_retired_under_soft_min_age?).to be false
         end
       end
 
       context "when the tenant is non-binary" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 43, sex1: "X", ecstat1: 10)
           expect(record.person_1_retired_under_soft_min_age?).to be false
         end
@@ -143,21 +143,21 @@ RSpec.describe Validations::SoftValidations do
 
     context "when the tenant prefers not to say what their economic status is but is over the expected retirement age" do
       context "when the tenant is female" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 85, sex1: "F", ecstat1: 10)
           expect(record.person_1_not_retired_over_soft_max_age?).to be false
         end
       end
 
       context "when the tenant is male" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 85, sex1: "M", ecstat1: 10)
           expect(record.person_1_not_retired_over_soft_max_age?).to be false
         end
       end
 
       context "when the tenant is non-binary" do
-        it "shows the interruption screen" do
+        it "does not show the interruption screen" do
           record.update!(age1: 85, sex1: "X", ecstat1: 10)
           expect(record.person_1_not_retired_over_soft_max_age?).to be false
         end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1217

- [x] Don't trigger soft validation screen if tenant prefers not to say for economic status
- [x] Update content for gender

![image](https://user-images.githubusercontent.com/5101747/169070742-935a8da6-da48-4e53-b3c3-73c62274d075.png)
![image](https://user-images.githubusercontent.com/5101747/169070969-6316fa1c-1e91-4856-9f88-4bac81cc2e61.png)

