### PR TITLE
Perf

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -22,7 +22,7 @@ class CaseLog < ApplicationRecord
   has_paper_trail
 
   validates_with CaseLogValidator
-  before_validation :reset_start_year!, if: :startdate_changed?
+  before_validation :recalculate_start_year!, if: :startdate_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
   before_validation :reset_invalidated_dependent_fields!
@@ -74,8 +74,9 @@ class CaseLog < ApplicationRecord
     @start_year = startdate < window_end_date ? startdate.year - 1 : startdate.year
   end
 
-  def reset_start_year!
+  def recalculate_start_year!
     @start_year = nil
+    collection_start_year
   end
 
   def form_name

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -74,6 +74,10 @@ class CaseLog < ApplicationRecord
     @start_year = startdate < window_end_date ? startdate.year - 1 : startdate.year
   end
 
+  def reset_start_year!
+    @start_year = nil
+  end
+
   def form_name
     return unless startdate
 

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -22,6 +22,7 @@ class CaseLog < ApplicationRecord
   has_paper_trail
 
   validates_with CaseLogValidator
+  before_validation :reset_start_year!, if: :startdate_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
   before_validation :reset_invalidated_dependent_fields!
@@ -66,10 +67,11 @@ class CaseLog < ApplicationRecord
   end
 
   def collection_start_year
+    return @start_year if @start_year
     return unless startdate
 
     window_end_date = Time.zone.local(startdate.year, 4, 1)
-    startdate < window_end_date ? startdate.year - 1 : startdate.year
+    @start_year = startdate < window_end_date ? startdate.year - 1 : startdate.year
   end
 
   def form_name


### PR DESCRIPTION
Before:
```ruby
==================================
  Mode: cpu(1000)
  Samples: 779 (0.00% miss rate)
  GC: 75 (9.63%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        96  (12.3%)          55   (7.1%)     TZInfo::DataSources::TransitionsDataTimezoneInfo#periods_for_local
        38   (4.9%)          38   (4.9%)     (marking)
        37   (4.7%)          37   (4.7%)     (sweeping)
       503  (64.6%)          30   (3.9%)     CaseLog#collection_start_year
        46   (5.9%)          29   (3.7%)     ActiveModel::LazyAttributeSet#fetch_value
        84  (10.8%)          26   (3.3%)     TZInfo::Timestamp.for
        22   (2.8%)          22   (2.8%)     Time.utc
        20   (2.6%)          20   (2.6%)     Time#getlocal
        60   (7.7%)          19   (2.4%)     ActiveRecord::AttributeMethods::Read#_read_attribute
        17   (2.2%)          17   (2.2%)     Time#+
        57   (7.3%)          16   (2.1%)     CaseLog::GeneratedAttributeMethods#startdate
       234  (30.0%)          15   (1.9%)     Class#new
        21   (2.7%)          15   (1.9%)     Hash#fetch
       199  (25.5%)          14   (1.8%)     TZInfo::Timezone#period_for_local
        25   (3.2%)          14   (1.8%)     Array#bsearch_index
        91  (11.7%)          13   (1.7%)     ActiveSupport::TimeWithZone#to_time
        36   (4.6%)          13   (1.7%)     TZInfo::Timestamp.for_time
       261  (33.5%)          12   (1.5%)     ActiveSupport::TimeZone#local
       119  (15.3%)          11   (1.4%)     Comparable#<

Completed 302 Found in 3177ms (ActiveRecord: 33.9ms | Allocations: 2348411)
```


After (once memoized):
```ruby
==================================
  Mode: cpu(1000)
  Samples: 190 (0.00% miss rate)
  GC: 21 (11.05%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        25  (13.2%)          15   (7.9%)     ActiveRecord::AttributeMethods::Read#read_attribute
        12   (6.3%)          12   (6.3%)     (sweeping)
        17   (8.9%)          12   (6.3%)     ActiveModel::LazyAttributeSet#fetch_value
        28  (14.7%)          10   (5.3%)     CaseLog#dynamically_not_required
         8   (4.2%)           8   (4.2%)     (marking)
        44  (23.2%)           8   (4.2%)     Form#depends_on_met
        16   (8.4%)           8   (4.2%)     Kernel#public_send
       116  (61.1%)           7   (3.7%)     Form::Subsection#status
       155  (81.6%)           6   (3.2%)     Hash#each
       161  (84.7%)           6   (3.2%)     Array#any?
       163  (85.8%)           6   (3.2%)     Array#select
        19  (10.0%)           6   (3.2%)     Form::Question#enabled?
         6   (3.2%)           6   (3.2%)     Kernel#is_a?
       163  (85.8%)           5   (2.6%)     Form::Page#routed_to?
        59  (31.1%)           5   (2.6%)     Form::Subsection#applicable_questions
        14   (7.4%)           5   (2.6%)     ActiveRecord::AttributeMethods::Read#_read_attribute
         7   (3.7%)           5   (2.6%)     Object#present?
Completed 302 Found in 833ms (ActiveRecord: 14.6ms | Allocations: 922361)
```