### PR TITLE
No two factor authentication for development environment

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,7 @@ class User < ApplicationRecord
   end
 
   def need_two_factor_authentication?(_request)
+    return false if Rails.env.development?
     support?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,7 @@ class User < ApplicationRecord
 
   def need_two_factor_authentication?(_request)
     return false if Rails.env.development?
+
     support?
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -142,6 +142,8 @@ RSpec.describe User, type: :model do
     end
 
     context "when the user is in development environment" do
+      let(:user) { FactoryBot.create(:user, :support) }
+
       before do
         allow(Rails.env).to receive(:development?).and_return(true)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,15 +139,15 @@ RSpec.describe User, type: :model do
       it "can filter case logs by user, year, status and organisation" do
         expect(user.case_logs_filters).to eq(%w[status years user organisation])
       end
+    end
 
-      context "when the user is in development environment" do
-        before do
-          allow(Rails.env).to receive(:development?).and_return(true)
-        end
+    context "when the user is in development environment" do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+      end
 
-        it "doesn't require 2FA" do
-          expect(user.need_two_factor_authentication?(nil)).to be false
-        end
+      it "doesn't require 2FA" do
+        expect(user.need_two_factor_authentication?(nil)).to be false
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe User, type: :model do
       it "can filter case logs by user, year, status and organisation" do
         expect(user.case_logs_filters).to eq(%w[status years user organisation])
       end
+
+      context "when the user is in development environment" do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(true)
+        end
+
+        it "doesn't require 2FA" do
+          expect(user.need_two_factor_authentication?(nil)).to be false
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe User, type: :model do
         allow(Rails.env).to receive(:development?).and_return(true)
       end
 
-      it "doesn't require 2FA" do
+      it "does not require 2FA" do
         expect(user.need_two_factor_authentication?(nil)).to be false
       end
     end


### PR DESCRIPTION
Currently the support user will need to confirm their login using 2 factor authentication. While it is a required step in production this is an unnecessary hurdle for developer. 

This small amendment will allow **any type of user** in development environment to login without 2fa.

Changes - test and code for the user model. 