### PR TITLE
Cldc 1223 pregnancy soft validations

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -36,7 +36,7 @@ module Validations::HouseholdValidations
   end
 
   def validate_pregnancy(record)
-    if (record.has_pregnancy? || record.pregnancy_refused?) && !women_of_child_bearing_age_in_household(record)
+    if (record.has_pregnancy? || record.pregnancy_refused?) && women_in_household(record) && !women_of_child_bearing_age_in_household(record)
       record.errors.add :preg_occ, I18n.t("validations.household.preg_occ.no_female")
     end
   end
@@ -136,7 +136,13 @@ private
     (1..8).any? do |n|
       next if record["sex#{n}"].nil? || record["age#{n}"].nil?
 
-      (record["sex#{n}"]) == "F" && record["age#{n}"] >= 16 && record["age#{n}"] <= 50
+      (record["sex#{n}"]) == "F" && record["age#{n}"] >= 11 && record["age#{n}"] <= 65
+    end
+  end
+
+  def women_in_household(record)
+    (1..8).any? do |n|
+      record["sex#{n}"] == "F"
     end
   end
 

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -48,7 +48,23 @@ module Validations::SoftValidations
     end
   end
 
+  def no_females_in_the_household?
+    (1..8).none? do |n|
+      public_send("sex#{n}") == "F"
+    end && preg_occ == 1
+  end
+
+  def female_in_pregnant_household_in_soft_validation_range?
+    (females_in_age_range(11, 15) || females_in_age_range(51, 65)) && !females_in_age_range(16, 50)
+  end
+
 private
+
+  def females_in_age_range(min, max)
+    (1..8).any? do |n|
+      public_send("sex#{n}") == "F" && public_send("age#{n}").present? && public_send("age#{n}").between?(min, max)
+    end
+  end
 
   def tenant_is_retired?(economic_status)
     economic_status == 5

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -48,21 +48,37 @@ module Validations::SoftValidations
     end
   end
 
-  def no_females_in_the_household?
-    (1..8).none? do |n|
-      public_send("sex#{n}") == "F"
-    end && preg_occ == 1
+  def no_females_in_a_pregnant_household?
+    !females_in_the_household? && all_tenants_age_and_gender_information_completed? && preg_occ == 1
   end
 
   def female_in_pregnant_household_in_soft_validation_range?
-    (females_in_age_range(11, 15) || females_in_age_range(51, 65)) && !females_in_age_range(16, 50)
+    all_tenants_age_and_gender_information_completed? && (females_in_age_range(11, 15) || females_in_age_range(51, 65)) && !females_in_age_range(16, 50) && preg_occ == 1
+  end
+
+  def all_tenants_age_and_gender_information_completed?
+    (1..hhmemb).all? do |n|
+      public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known")
+    end
   end
 
 private
 
+  def details_known_or_lead_tenant?(tenant_number)
+    return true if tenant_number == 1
+
+    public_send("details_known_#{tenant_number}").zero?
+  end
+
   def females_in_age_range(min, max)
-    (1..8).any? do |n|
+    (1..hhmemb).any? do |n|
       public_send("sex#{n}") == "F" && public_send("age#{n}").present? && public_send("age#{n}").between?(min, max)
+    end
+  end
+
+  def females_in_the_household?
+    (1..hhmemb).any? do |n|
+      public_send("sex#{n}") == "F" || public_send("sex#{n}").nil?
     end
   end
 

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -58,7 +58,7 @@ module Validations::SoftValidations
 
   def all_tenants_age_and_gender_information_completed?
     (1..hhmemb).all? do |n|
-      public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known").zero?
+      public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known").present? && public_send("age#{n}_known").zero?
     end
   end
 

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -58,7 +58,7 @@ module Validations::SoftValidations
 
   def all_tenants_age_and_gender_information_completed?
     (1..hhmemb).all? do |n|
-      public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known")
+      public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known").zero?
     end
   end
 

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -3824,6 +3824,76 @@
                 }
               }
             },
+            "no_females_pregnant_household_value_check": {
+              "depends_on": [{ "no_females_in_the_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value":"Yes"
+                    },
+                    "1": {
+                      "value":"No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_value_check": {
+              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value":"Yes"
+                    },
+                    "1": {
+                      "value":"No"
+                    }
+                  }
+                }
+              }
+            },
             "access_needs": {
               "header": "",
               "description": "",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -92,9 +92,7 @@
                     }
                   },
                   "conditional_for": {
-                    "irproduct_other": [
-                      5
-                    ]
+                    "irproduct_other": [5]
                   }
                 },
                 "irproduct_other": {
@@ -163,9 +161,7 @@
                     }
                   },
                   "conditional_for": {
-                    "postcode_full": [
-                      1
-                    ]
+                    "postcode_full": [1]
                   },
                   "hidden_in_check_answers": true
                 },
@@ -911,9 +907,7 @@
                     }
                   },
                   "conditional_for": {
-                    "mrcdate": [
-                      1
-                    ]
+                    "mrcdate": [1]
                   }
                 },
                 "mrcdate": {
@@ -991,9 +985,7 @@
                     }
                   },
                   "conditional_for": {
-                    "tenancyother": [
-                      3
-                    ]
+                    "tenancyother": [3]
                   }
                 },
                 "tenancyother": {
@@ -1035,9 +1027,7 @@
                     }
                   },
                   "conditional_for": {
-                    "tenancyother": [
-                      3
-                    ]
+                    "tenancyother": [3]
                   }
                 },
                 "tenancyother": {
@@ -1158,6 +1148,88 @@
                 }
               }
             },
+            "no_females_pregnant_household_lead_hhmemb_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "lead_tenant_age": {
               "header": "",
               "description": "",
@@ -1175,15 +1247,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age1": [
-                      0
-                    ]
+                    "age1": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age1_known": 0 },
-                      { "age1_known": 1 }
-                    ]
+                    "depends_on": [{ "age1_known": 0 }, { "age1_known": 1 }]
                   }
                 },
                 "age1": {
@@ -1199,6 +1266,88 @@
                       "age1_known": 1
                     },
                     "value": "Not known"
+                  }
+                }
+              }
+            },
+            "no_females_pregnant_household_lead_age_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
                   }
                 }
               }
@@ -1227,6 +1376,88 @@
                     },
                     "R": {
                       "value": "Tenant prefers not to say"
+                    }
+                  }
+                }
+              }
+            },
+            "no_females_pregnant_household_lead_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
                     }
                   }
                 }
@@ -1533,24 +1764,28 @@
               "depends_on": [{ "person_1_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_1",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_1",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1560,37 +1795,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "lead_tenant_over_retirement_value_check": {
-              "depends_on": [{ "person_1_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_1_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_1",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_1",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1600,10 +1841,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -1704,15 +1945,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age2": [
-                      0
-                    ]
+                    "age2": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age2_known": 0 },
-                      { "age2_known": 1 }
-                    ]
+                    "depends_on": [{ "age2_known": 0 }, { "age2_known": 1 }]
                   }
                 },
                 "age2": {
@@ -1736,6 +1972,91 @@
                   "details_known_2": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_2_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age2_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_2_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age2_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_2_gender_identity": {
               "header": "",
@@ -1770,6 +2091,94 @@
                   "details_known_2": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_2_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_2": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_2_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_2": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_2_working_situation": {
               "header": "",
@@ -1839,24 +2248,28 @@
               "depends_on": [{ "person_2_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_2",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_2",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1866,37 +2279,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_2_over_retirement_value_check": {
-              "depends_on": [{ "person_2_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_2_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_2",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_2",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1906,10 +2325,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2007,15 +2426,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age3": [
-                      0
-                    ]
+                    "age3": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age3_known": 0 },
-                      { "age3_known": 1 }
-                    ]
+                    "depends_on": [{ "age3_known": 0 }, { "age3_known": 1 }]
                   }
                 },
                 "age3": {
@@ -2039,6 +2453,91 @@
                   "details_known_3": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_3_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age3_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_3_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age3_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_3_gender_identity": {
               "header": "",
@@ -2073,6 +2572,94 @@
                   "details_known_3": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_3_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_3": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_3_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_3": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_3_working_situation": {
               "header": "",
@@ -2142,24 +2729,28 @@
               "depends_on": [{ "person_3_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_3",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_3",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2169,37 +2760,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_3_over_retirement_value_check": {
-              "depends_on": [{ "person_3_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_3_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_3",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_3",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2209,10 +2806,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2307,15 +2904,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age4": [
-                      0
-                    ]
+                    "age4": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age4_known": 0 },
-                      { "age4_known": 1 }
-                    ]
+                    "depends_on": [{ "age4_known": 0 }, { "age4_known": 1 }]
                   }
                 },
                 "age4": {
@@ -2339,6 +2931,91 @@
                   "details_known_4": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_4_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age4_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_4_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age4_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_4_gender_identity": {
               "header": "",
@@ -2373,6 +3050,94 @@
                   "details_known_4": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_4_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_4": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_4_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_4": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_4_working_situation": {
               "header": "",
@@ -2442,24 +3207,28 @@
               "depends_on": [{ "person_4_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_4",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_4",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2469,37 +3238,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_4_over_retirement_value_check": {
-              "depends_on": [{ "person_4_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_4_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_4",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_4",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2509,10 +3284,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2604,15 +3379,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age5": [
-                      0
-                    ]
+                    "age5": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age5_known": 0 },
-                      { "age5_known": 1 }
-                    ]
+                    "depends_on": [{ "age5_known": 0 }, { "age5_known": 1 }]
                   }
                 },
                 "age5": {
@@ -2636,6 +3406,91 @@
                   "details_known_5": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_5_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age5_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_5_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age5_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_5_gender_identity": {
               "header": "",
@@ -2670,6 +3525,94 @@
                   "details_known_5": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_5_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_5": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_5_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_5": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_5_working_situation": {
               "header": "",
@@ -2739,24 +3682,28 @@
               "depends_on": [{ "person_5_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_5",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_5",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2766,37 +3713,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_5_over_retirement_value_check": {
-              "depends_on": [{ "person_5_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_5_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_5",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_5",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2806,10 +3759,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2898,15 +3851,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age6": [
-                      0
-                    ]
+                    "age6": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age6_known": 0 },
-                      { "age6_known": 1 }
-                    ]
+                    "depends_on": [{ "age6_known": 0 }, { "age6_known": 1 }]
                   }
                 },
                 "age6": {
@@ -2930,6 +3878,91 @@
                   "details_known_6": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_6_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age6_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_6_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age6_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_6_gender_identity": {
               "header": "",
@@ -2964,6 +3997,94 @@
                   "details_known_6": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_6_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_6": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_6_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_6": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_6_working_situation": {
               "header": "",
@@ -3033,24 +4154,28 @@
               "depends_on": [{ "person_6_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_6",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_6",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3060,37 +4185,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_6_over_retirement_value_check": {
-              "depends_on": [{ "person_6_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_6_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_6",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_6",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3100,10 +4231,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3189,15 +4320,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age7": [
-                      0
-                    ]
+                    "age7": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age7_known": 0 },
-                      { "age7_known": 1 }
-                    ]
+                    "depends_on": [{ "age7_known": 0 }, { "age7_known": 1 }]
                   }
                 },
                 "age7": {
@@ -3221,6 +4347,91 @@
                   "details_known_7": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_7_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age7_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_7_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age7_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_7_gender_identity": {
               "header": "",
@@ -3255,6 +4466,94 @@
                   "details_known_7": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_7_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_7": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_7_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_7": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_7_working_situation": {
               "header": "",
@@ -3324,24 +4623,28 @@
               "depends_on": [{ "person_7_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_7",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_7",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3351,37 +4654,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_7_over_retirement_value_check": {
-              "depends_on": [{ "person_7_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_7_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_7",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_7",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3391,10 +4700,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3477,15 +4786,10 @@
                     }
                   },
                   "conditional_for": {
-                    "age8": [
-                      0
-                    ]
+                    "age8": [0]
                   },
                   "hidden_in_check_answers": {
-                    "depends_on": [
-                      { "age8_known": 0 },
-                      { "age8_known": 1 }
-                    ]
+                    "depends_on": [{ "age8_known": 0 }, { "age8_known": 1 }]
                   }
                 },
                 "age8": {
@@ -3509,6 +4813,91 @@
                   "details_known_8": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_8_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age8_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_8_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age8_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_8_gender_identity": {
               "header": "",
@@ -3543,6 +4932,94 @@
                   "details_known_8": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_8_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_8": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_8_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_8": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_8_working_situation": {
               "header": "",
@@ -3612,24 +5089,28 @@
               "depends_on": [{ "person_8_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_8",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_8",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3639,37 +5120,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_8_over_retirement_value_check": {
-              "depends_on": [{ "person_8_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_8_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_8",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_8",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3679,10 +5166,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3825,22 +5312,26 @@
               }
             },
             "no_females_pregnant_household_value_check": {
-              "depends_on": [{ "no_females_in_the_household?": true }],
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.pregnancy.no_females",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "questions": {
                 "pregnancy_value_check": {
@@ -3850,32 +5341,40 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "females_in_soft_age_range_in_pregnant_household_value_check": {
-              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "questions": {
                 "pregnancy_value_check": {
@@ -3885,10 +5384,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -4224,9 +5723,7 @@
                     }
                   },
                   "conditional_for": {
-                    "reasonother": [
-                      20
-                    ]
+                    "reasonother": [20]
                   }
                 },
                 "reasonother": {
@@ -4462,9 +5959,7 @@
                     }
                   },
                   "conditional_for": {
-                    "ppostcode_full": [
-                      1
-                    ]
+                    "ppostcode_full": [1]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -4517,9 +6012,7 @@
                     }
                   },
                   "conditional_for": {
-                    "prevloc": [
-                      1
-                    ]
+                    "prevloc": [1]
                   }
                 },
                 "prevloc": {
@@ -5354,15 +6847,18 @@
               "title_text": "soft_validations.net_income.title_text",
               "informative_text": {
                 "translation": "soft_validations.net_income.hint_text",
-                "arguments": [{
-                  "key": "ecstat1",
-                  "label": true,
-                  "i18n_template": "ecstat1"
-                },
-                {"key": "earnings",
-                  "label": true,
-                  "i18n_template": "earnings"
-                }]
+                "arguments": [
+                  {
+                    "key": "ecstat1",
+                    "label": true,
+                    "i18n_template": "ecstat1"
+                  },
+                  {
+                    "key": "earnings",
+                    "label": true,
+                    "i18n_template": "earnings"
+                  }
+                ]
               },
               "questions": {
                 "net_income_value_check": {
@@ -5537,9 +7033,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5634,9 +7128,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5681,9 +7173,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5728,9 +7218,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5771,12 +7259,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5790,12 +7273,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5809,12 +7287,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5828,12 +7301,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5849,12 +7317,7 @@
                   "suffix": " every week",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -5994,12 +7457,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6013,12 +7471,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6032,12 +7485,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6051,12 +7499,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6072,12 +7515,7 @@
                   "suffix": " every 2 weeks",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6117,12 +7555,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6136,12 +7569,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6155,12 +7583,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6174,12 +7597,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6195,12 +7613,7 @@
                   "suffix": " every 4 weeks",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6240,12 +7653,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6259,12 +7667,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6278,12 +7681,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6297,12 +7695,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6318,12 +7711,7 @@
                   "suffix": " every month",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6354,22 +7742,22 @@
               "informative_text": {
                 "translation": "soft_validations.rent.min.hint_text",
                 "arguments": [
-                {
-                  "key": "la",
-                  "label": true,
-                  "i18n_template": "la"
-                },
-                { 
-                  "key": "soft_min_for_period",
-                  "label": false,
-                  "i18n_template": "soft_min_for_period"
-                },
-                {
-                  "key":"brent",
-                  "label": true,
-                  "i18n_template": "brent"
-                }
-              ]
+                  {
+                    "key": "la",
+                    "label": true,
+                    "i18n_template": "la"
+                  },
+                  {
+                    "key": "soft_min_for_period",
+                    "label": false,
+                    "i18n_template": "soft_min_for_period"
+                  },
+                  {
+                    "key": "brent",
+                    "label": true,
+                    "i18n_template": "brent"
+                  }
+                ]
               },
               "questions": {
                 "rent_value_check": {
@@ -6398,13 +7786,13 @@
                     "label": true,
                     "i18n_template": "la"
                   },
-                  { 
+                  {
                     "key": "soft_max_for_period",
                     "label": false,
                     "i18n_template": "soft_max_for_period"
                   },
                   {
-                    "key":"brent",
+                    "key": "brent",
                     "label": true,
                     "i18n_template": "brent"
                   }

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -3876,6 +3876,76 @@
                 }
               }
             },
+            "no_females_pregnant_household_value_check": {
+              "depends_on": [{ "no_females_in_the_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value":"Yes"
+                    },
+                    "1": {
+                      "value":"No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_value_check": {
+              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [{
+                  "key": "sex1",
+                  "label": true,
+                  "i18n_template": "sex1"
+                }]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value":"Yes"
+                    },
+                    "1": {
+                      "value":"No"
+                    }
+                  }
+                }
+              }
+            },
             "access_needs": {
               "header": "",
               "description": "",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -92,9 +92,7 @@
                     }
                   },
                   "conditional_for": {
-                    "irproduct_other": [
-                      5
-                    ]
+                    "irproduct_other": [5]
                   }
                 },
                 "irproduct_other": {
@@ -163,9 +161,7 @@
                     }
                   },
                   "conditional_for": {
-                    "postcode_full": [
-                      1
-                    ]
+                    "postcode_full": [1]
                   },
                   "hidden_in_check_answers": true
                 },
@@ -911,9 +907,7 @@
                     }
                   },
                   "conditional_for": {
-                    "mrcdate": [
-                      1
-                    ]
+                    "mrcdate": [1]
                   }
                 },
                 "mrcdate": {
@@ -1020,9 +1014,7 @@
                     }
                   },
                   "conditional_for": {
-                    "tenancyother": [
-                      3
-                    ]
+                    "tenancyother": [3]
                   }
                 },
                 "tenancyother": {
@@ -1067,9 +1059,7 @@
                     }
                   },
                   "conditional_for": {
-                    "tenancyother": [
-                      3
-                    ]
+                    "tenancyother": [3]
                   }
                 },
                 "tenancyother": {
@@ -1193,6 +1183,88 @@
                 }
               }
             },
+            "no_females_pregnant_household_lead_hhmemb_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "lead_tenant_age": {
               "header": "",
               "description": "",
@@ -1210,9 +1282,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age1": [
-                      0
-                    ]
+                    "age1": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -1242,6 +1312,88 @@
                 }
               }
             },
+            "no_females_pregnant_household_lead_age_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "lead_tenant_gender_identity": {
               "header": "",
               "description": "",
@@ -1266,6 +1418,88 @@
                     },
                     "R": {
                       "value": "Tenant prefers not to say"
+                    }
+                  }
+                }
+              }
+            },
+            "no_females_pregnant_household_lead_value_check": {
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_lead_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
                     }
                   }
                 }
@@ -1536,24 +1770,28 @@
               "depends_on": [{ "person_1_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_1",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_1",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1563,37 +1801,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "lead_tenant_over_retirement_value_check": {
-              "depends_on": [{ "person_1_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_1_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_1",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_1",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_1",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_1",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1603,10 +1847,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -1707,9 +1951,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age2": [
-                      0
-                    ]
+                    "age2": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -1744,6 +1986,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_2_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age2_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_2_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age2_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_2_gender_identity": {
               "header": "",
               "description": "",
@@ -1777,6 +2104,94 @@
                   "details_known_2": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_2_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_2": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_2_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_2": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_2_working_situation": {
               "header": "",
@@ -1849,24 +2264,28 @@
               "depends_on": [{ "person_2_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_2",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_2",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1876,37 +2295,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_2_over_retirement_value_check": {
-              "depends_on": [{ "person_2_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_2_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_2",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_2",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_2",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_2",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -1916,10 +2341,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2017,9 +2442,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age3": [
-                      0
-                    ]
+                    "age3": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -2054,6 +2477,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_3_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age3_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_3_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age3_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_3_gender_identity": {
               "header": "",
               "description": "",
@@ -2087,6 +2595,94 @@
                   "details_known_3": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_3_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_3": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_3_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_3": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_3_working_situation": {
               "header": "",
@@ -2159,24 +2755,28 @@
               "depends_on": [{ "person_3_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_3",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_3",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2186,37 +2786,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_3_over_retirement_value_check": {
-              "depends_on": [{ "person_3_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_3_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_3",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_3",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_3",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_3",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2226,10 +2832,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2324,9 +2930,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age4": [
-                      0
-                    ]
+                    "age4": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -2361,6 +2965,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_4_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age4_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_4_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age4_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_4_gender_identity": {
               "header": "",
               "description": "",
@@ -2394,6 +3083,94 @@
                   "details_known_4": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_4_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_4": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_4_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_4": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_4_working_situation": {
               "header": "",
@@ -2466,24 +3243,28 @@
               "depends_on": [{ "person_4_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_4",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_4",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2493,37 +3274,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_4_over_retirement_value_check": {
-              "depends_on": [{ "person_4_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_4_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_4",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_4",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_4",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_4",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2533,10 +3320,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2628,9 +3415,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age5": [
-                      0
-                    ]
+                    "age5": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -2665,6 +3450,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_5_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age5_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_5_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age5_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_5_gender_identity": {
               "header": "",
               "description": "",
@@ -2698,6 +3568,94 @@
                   "details_known_5": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_5_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_5": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_5_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_5": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_5_working_situation": {
               "header": "",
@@ -2770,24 +3728,28 @@
               "depends_on": [{ "person_5_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_5",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_5",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2797,37 +3759,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_5_over_retirement_value_check": {
-              "depends_on": [{ "person_5_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_5_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_5",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_5",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_5",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_5",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -2837,10 +3805,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -2929,9 +3897,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age6": [
-                      0
-                    ]
+                    "age6": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -2966,6 +3932,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_6_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age6_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_6_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age6_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_6_gender_identity": {
               "header": "",
               "description": "",
@@ -2999,6 +4050,94 @@
                   "details_known_6": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_6_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_6": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_6_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_6": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_6_working_situation": {
               "header": "",
@@ -3071,24 +4210,28 @@
               "depends_on": [{ "person_6_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_6",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_6",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3098,37 +4241,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_6_over_retirement_value_check": {
-              "depends_on": [{ "person_6_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_6_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_6",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_6",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_6",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_6",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3138,10 +4287,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3227,9 +4376,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age7": [
-                      0
-                    ]
+                    "age7": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -3264,6 +4411,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_7_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age7_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_7_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age7_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_7_gender_identity": {
               "header": "",
               "description": "",
@@ -3297,6 +4529,94 @@
                   "details_known_7": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_7_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_7": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_7_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_7": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_7_working_situation": {
               "header": "",
@@ -3369,24 +4689,28 @@
               "depends_on": [{ "person_7_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_7",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_7",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3396,37 +4720,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_7_over_retirement_value_check": {
-              "depends_on": [{ "person_7_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_7_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_7",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_7",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_7",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_7",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3436,10 +4766,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3522,9 +4852,7 @@
                     }
                   },
                   "conditional_for": {
-                    "age8": [
-                      0
-                    ]
+                    "age8": [0]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -3559,6 +4887,91 @@
                 }
               ]
             },
+            "no_females_pregnant_household_person_8_age_value_check": {
+              "depends_on": [
+                { "no_females_in_a_pregnant_household?": true, "age8_known": 0 }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_8_age_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "age8_known": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
             "person_8_gender_identity": {
               "header": "",
               "description": "",
@@ -3592,6 +5005,94 @@
                   "details_known_8": 0
                 }
               ]
+            },
+            "no_females_pregnant_household_person_8_value_check": {
+              "depends_on": [
+                {
+                  "no_females_in_a_pregnant_household?": true,
+                  "details_known_8": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.no_females",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
+            },
+            "females_in_soft_age_range_in_pregnant_household_person_8_value_check": {
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true,
+                  "details_known_8": 0
+                }
+              ],
+              "title_text": {
+                "translation": "soft_validations.pregnancy.title",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "informative_text": {
+                "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
+              },
+              "questions": {
+                "pregnancy_value_check": {
+                  "check_answer_label": "Pregnancy soft validation",
+                  "hidden_in_check_answers": true,
+                  "header": "Are you sure this is correct?",
+                  "type": "interruption_screen",
+                  "answer_options": {
+                    "0": {
+                      "value": "Yes"
+                    },
+                    "1": {
+                      "value": "No"
+                    }
+                  }
+                }
+              }
             },
             "person_8_working_situation": {
               "header": "",
@@ -3664,24 +5165,28 @@
               "depends_on": [{ "person_8_retired_under_soft_min_age?": true }],
               "title_text": {
                 "translation": "soft_validations.retirement.min.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_8",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_8",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3691,37 +5196,43 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "person_8_over_retirement_value_check": {
-              "depends_on": [{ "person_8_not_retired_over_soft_max_age?": true }],
+              "depends_on": [
+                { "person_8_not_retired_over_soft_max_age?": true }
+              ],
               "title_text": {
                 "translation": "soft_validations.retirement.max.title",
-                "arguments": [{
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.retirement.max.hint_text",
-                "arguments": [{
-                  "key": "plural_gender_for_person_8",
-                  "label": false,
-                  "i18n_template": "gender"
-                },
-                {
-                  "key": "retirement_age_for_person_8",
-                  "label": false,
-                  "i18n_template": "age"
-                }]
+                "arguments": [
+                  {
+                    "key": "plural_gender_for_person_8",
+                    "label": false,
+                    "i18n_template": "gender"
+                  },
+                  {
+                    "key": "retirement_age_for_person_8",
+                    "label": false,
+                    "i18n_template": "age"
+                  }
+                ]
               },
               "questions": {
                 "retirement_value_check": {
@@ -3731,10 +5242,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -3877,22 +5388,26 @@
               }
             },
             "no_females_pregnant_household_value_check": {
-              "depends_on": [{ "no_females_in_the_household?": true }],
+              "depends_on": [{ "no_females_in_a_pregnant_household?": true }],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.pregnancy.no_females",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "questions": {
                 "pregnancy_value_check": {
@@ -3902,32 +5417,40 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
               }
             },
             "females_in_soft_age_range_in_pregnant_household_value_check": {
-              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.pregnancy.females_not_in_soft_age_range",
-                "arguments": [{
-                  "key": "sex1",
-                  "label": true,
-                  "i18n_template": "sex1"
-                }]
+                "arguments": [
+                  {
+                    "key": "sex1",
+                    "label": true,
+                    "i18n_template": "sex1"
+                  }
+                ]
               },
               "questions": {
                 "pregnancy_value_check": {
@@ -3937,10 +5460,10 @@
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
-                      "value":"Yes"
+                      "value": "Yes"
                     },
                     "1": {
-                      "value":"No"
+                      "value": "No"
                     }
                   }
                 }
@@ -4276,9 +5799,7 @@
                     }
                   },
                   "conditional_for": {
-                    "reasonother": [
-                      20
-                    ]
+                    "reasonother": [20]
                   }
                 },
                 "reasonother": {
@@ -4474,9 +5995,7 @@
                     }
                   },
                   "conditional_for": {
-                    "ppostcode_full": [
-                      1
-                    ]
+                    "ppostcode_full": [1]
                   },
                   "hidden_in_check_answers": {
                     "depends_on": [
@@ -4537,9 +6056,7 @@
                     }
                   },
                   "conditional_for": {
-                    "prevloc": [
-                      1
-                    ]
+                    "prevloc": [1]
                   }
                 },
                 "prevloc": {
@@ -5374,15 +6891,18 @@
               "title_text": "soft_validations.net_income.title_text",
               "informative_text": {
                 "translation": "soft_validations.net_income.hint_text",
-                "arguments": [{
-                  "key": "ecstat1",
-                  "label": true,
-                  "i18n_template": "ecstat1"
-                },
-                {"key": "earnings",
-                  "label": true,
-                  "i18n_template": "earnings"
-                }]
+                "arguments": [
+                  {
+                    "key": "ecstat1",
+                    "label": true,
+                    "i18n_template": "ecstat1"
+                  },
+                  {
+                    "key": "earnings",
+                    "label": true,
+                    "i18n_template": "earnings"
+                  }
+                ]
               },
               "questions": {
                 "net_income_value_check": {
@@ -5554,9 +7074,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5651,9 +7169,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5698,9 +7214,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5745,9 +7259,7 @@
                     }
                   },
                   "conditional_for": {
-                    "chcharge": [
-                      1
-                    ]
+                    "chcharge": [1]
                   }
                 },
                 "chcharge": {
@@ -5788,12 +7300,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5807,12 +7314,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5826,12 +7328,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5845,12 +7342,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every week",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -5866,12 +7358,7 @@
                   "suffix": " every week",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6011,12 +7498,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6030,12 +7512,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6049,12 +7526,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6068,12 +7540,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 2 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6089,12 +7556,7 @@
                   "suffix": " every 2 weeks",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6134,12 +7596,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6153,12 +7610,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6172,12 +7624,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6191,12 +7638,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every 4 weeks",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6212,12 +7654,7 @@
                   "suffix": " every 4 weeks",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6257,12 +7694,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6276,12 +7708,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6295,12 +7722,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6314,12 +7736,7 @@
                   "width": 5,
                   "prefix": "£",
                   "suffix": " every month",
-                  "fields-to-add": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ],
+                  "fields-to-add": ["brent", "scharge", "pscharge", "supcharg"],
                   "result-field": "tcharge",
                   "hidden_in_check_answers": true
                 },
@@ -6335,12 +7752,7 @@
                   "suffix": " every month",
                   "readonly": true,
                   "requires_js": true,
-                  "fields_added": [
-                    "brent",
-                    "scharge",
-                    "pscharge",
-                    "supcharg"
-                  ]
+                  "fields_added": ["brent", "scharge", "pscharge", "supcharg"]
                 }
               },
               "depends_on": [
@@ -6371,22 +7783,22 @@
               "informative_text": {
                 "translation": "soft_validations.rent.min.hint_text",
                 "arguments": [
-                {
-                  "key": "la",
-                  "label": true,
-                  "i18n_template": "la"
-                },
-                {
-                  "key": "soft_min_for_period",
-                  "label": false,
-                  "i18n_template": "soft_min_for_period"
-                },
-                {
-                  "key":"brent",
-                  "label": true,
-                  "i18n_template": "brent"
-                }
-              ]
+                  {
+                    "key": "la",
+                    "label": true,
+                    "i18n_template": "la"
+                  },
+                  {
+                    "key": "soft_min_for_period",
+                    "label": false,
+                    "i18n_template": "soft_min_for_period"
+                  },
+                  {
+                    "key": "brent",
+                    "label": true,
+                    "i18n_template": "brent"
+                  }
+                ]
               },
               "questions": {
                 "rent_value_check": {
@@ -6421,11 +7833,11 @@
                     "i18n_template": "soft_max_for_period"
                   },
                   {
-                    "key":"brent",
+                    "key": "brent",
                     "label": true,
                     "i18n_template": "brent"
-                }
-              ]
+                  }
+                ]
               },
               "questions": {
                 "rent_value_check": {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
         question_required: "You must answer whether the person is still serving in the UK armed forces as you told us they’re a current or former regular"
         question_not_required: "You cannot answer whether the person is still serving in the UK armed forces as you told us they’re not a current or former regular"
       preg_occ:
-        no_female: "You must answer ‘no’ as there are no females aged 16-50 in the household"
+        no_female: "You must answer ‘no’ as there are no females aged 11-65 in the household"
       age:
         retired_male: "Male tenant who is retired must be 65 or over"
         retired_female: "Female tenant who is retired must be 60 or over"
@@ -227,7 +227,6 @@ en:
       not_joint: "This cannot be a joint tenancy as you've told us there's only one person in the household"
       joint_more_than_one_member: "There must be more than one person in the household as you've told us this is a joint tenancy"
 
-
     declaration:
       missing: "You must show the DLUHC privacy notice to the tenant before you can submit this log."
 
@@ -241,9 +240,9 @@ en:
         message: "Net income is higher than expected based on the lead tenant’s working situation. Are you sure this is correct?"
     rent:
       min:
-        hint_text: "<h1 class=\"govuk-heading-l app-panel--interruption\">You told us the rent is %{brent}</h1><p>The minimum rent for this type of property in %{la} is £%{soft_min_for_period}.</p>"
+        hint_text: '<h1 class="govuk-heading-l app-panel--interruption">You told us the rent is %{brent}</h1><p>The minimum rent for this type of property in %{la} is £%{soft_min_for_period}.</p>'
       max:
-        hint_text: "<h1 class=\"govuk-heading-l app-panel--interruption\">You told us the rent is %{brent}</h1><p>The maximum rent for this type of property in %{la} is £%{soft_max_for_period}.</p>"
+        hint_text: '<h1 class="govuk-heading-l app-panel--interruption">You told us the rent is %{brent}</h1><p>The maximum rent for this type of property in %{la} is £%{soft_max_for_period}.</p>'
     retirement:
       min:
         title: "You told us this person is under %{age} and retired"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,6 +250,10 @@ en:
       max:
         title: "You told us this person is %{age} or over and not retired"
         hint_text: "The minimum expected retirement age for %{gender} in England is %{age}."
+    pregnancy:
+      title: "You told us somebody in the household is pregnant"
+      no_females: "You also told us there are no women living at the property."
+      females_not_in_soft_age_range: "You also told us that any women living at the property are in the following age ranges:<ul><li>11 to 16</li><li>50 to 65</li></ul>"
 
   devise:
     two_factor_authentication:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
         question_required: "You must answer whether the person is still serving in the UK armed forces as you told us they’re a current or former regular"
         question_not_required: "You cannot answer whether the person is still serving in the UK armed forces as you told us they’re not a current or former regular"
       preg_occ:
-        no_female: "You must answer ‘no’ as there are no females aged 11-65 in the household"
+        no_female: "You must answer ‘no’ as there are no women aged 11-65 in the household"
       age:
         retired_male: "Male tenant who is retired must be 65 or over"
         retired_female: "Female tenant who is retired must be 60 or over"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
         question_required: "You must answer whether the person is still serving in the UK armed forces as you told us they’re a current or former regular"
         question_not_required: "You cannot answer whether the person is still serving in the UK armed forces as you told us they’re not a current or former regular"
       preg_occ:
-        no_female: "You must answer ‘no’ as there are no women aged 11-65 in the household"
+        no_female: "You must answer ‘no’ as there are no female tenants aged 11-65 in the household"
       age:
         retired_male: "Male tenant who is retired must be 65 or over"
         retired_female: "Female tenant who is retired must be 60 or over"
@@ -252,8 +252,8 @@ en:
         hint_text: "The minimum expected retirement age for %{gender} in England is %{age}."
     pregnancy:
       title: "You told us somebody in the household is pregnant"
-      no_females: "You also told us there are no women living at the property."
-      females_not_in_soft_age_range: "You also told us that any women living at the property are in the following age ranges:<ul><li>11 to 16</li><li>50 to 65</li></ul>"
+      no_females: "You also told us there are no female tenants living at the property."
+      females_not_in_soft_age_range: "You also told us that any female tenants living at the property are in the following age ranges:<ul><li>11 to 16</li><li>50 to 65</li></ul>"
 
   devise:
     two_factor_authentication:

--- a/db/migrate/20220523150557_add_pregnancy_value_check.rb
+++ b/db/migrate/20220523150557_add_pregnancy_value_check.rb
@@ -1,0 +1,5 @@
+class AddPregnancyValueCheck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :case_logs, :pregnancy_value_check, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_19_112604) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_23_150557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -224,6 +224,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_19_112604) do
     t.integer "tshortfall_known"
     t.integer "shelteredaccom"
     t.integer "retirement_value_check"
+    t.integer "pregnancy_value_check"
     t.index ["created_by_id"], name: "index_case_logs_on_created_by_id"
     t.index ["managing_organisation_id"], name: "index_case_logs_on_managing_organisation_id"
     t.index ["old_id"], name: "index_case_logs_on_old_id", unique: true

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -57,40 +57,38 @@ RSpec.describe Validations::HouseholdValidations do
 
   describe "pregnancy validations" do
     context "when there are no female tenants" do
-      it "validates that pregnancy cannot be yes" do
+      it "validates that pregnancy can be yes" do
         record.preg_occ = 1
         record.sex1 = "M"
         household_validator.validate_pregnancy(record)
-        expect(record.errors["preg_occ"])
-          .to include(match I18n.t("validations.household.preg_occ.no_female"))
+        expect(record.errors["preg_occ"]).to be_empty
       end
 
-      it "validates that pregnancy cannot be prefer not to say" do
+      it "validates that pregnancy can be prefer not to say" do
         record.preg_occ = 3
         record.sex1 = "M"
         household_validator.validate_pregnancy(record)
-        expect(record.errors["preg_occ"])
-          .to include(match I18n.t("validations.household.preg_occ.no_female"))
+        expect(record.errors["preg_occ"]).to be_empty
       end
     end
 
     context "when there are female tenants" do
-      context "but they are older than 50" do
+      context "but they are older than 65" do
         it "validates that pregnancy cannot be yes" do
           record.preg_occ = 1
           record.sex1 = "F"
-          record.age1 = 51
+          record.age1 = 66
           household_validator.validate_pregnancy(record)
           expect(record.errors["preg_occ"])
             .to include(match I18n.t("validations.household.preg_occ.no_female"))
         end
       end
 
-      context "and they are the lead tenant and under 51" do
+      context "and they are the lead tenant and under 65" do
         it "pregnancy can be yes" do
-          record.preg_occ = 0
+          record.preg_occ = 1
           record.sex1 = "F"
-          record.age1 = 32
+          record.age1 = 64
           household_validator.validate_pregnancy(record)
           expect(record.errors["preg_occ"]).to be_empty
         end
@@ -98,13 +96,26 @@ RSpec.describe Validations::HouseholdValidations do
 
       context "and they are another household member and under 51" do
         it "pregnancy can be yes" do
-          record.preg_occ = 0
+          record.preg_occ = 1
           record.sex1 = "M"
           record.age1 = 25
           record.sex3 = "F"
-          record.age3 = 32
+          record.age3 = 64
           household_validator.validate_pregnancy(record)
           expect(record.errors["preg_occ"]).to be_empty
+        end
+      end
+
+      context "and they are another household member and under 11" do
+        it "pregnancy can be yes" do
+          record.preg_occ = 1
+          record.sex1 = "M"
+          record.age1 = 25
+          record.sex3 = "F"
+          record.age3 = 10
+          household_validator.validate_pregnancy(record)
+          expect(record.errors["preg_occ"])
+          .to include(match I18n.t("validations.household.preg_occ.no_female"))
         end
       end
     end

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -168,29 +168,37 @@ RSpec.describe Validations::SoftValidations do
   describe "pregnancy soft validations" do
     context "when there are no female tenants" do
       it "shows the interruption screen" do
-        record.update!(age1: 43, sex1: "M", preg_occ: 1)
-        expect(record.no_females_in_the_household?).to be true
+        record.update!(age1: 43, sex1: "M", preg_occ: 1, hhmemb: 1, age1_known: 0)
+        expect(record.no_females_in_a_pregnant_household?).to be true
       end
     end
 
     context "when female tenants are in 11-16 age range" do
       it "shows the interruption screen" do
-        record.update!(age3: 14, sex3: "F", preg_occ: 1)
+        record.update!(age2: 14, sex2: "F", preg_occ: 1, hhmemb: 2, details_known_2: 0, age2_known: 0, age1: 18, sex1: "M", age1_known: 0)
         expect(record.female_in_pregnant_household_in_soft_validation_range?).to be true
       end
     end
 
     context "when female tenants are in 50-65 age range" do
       it "shows the interruption screen" do
-        record.update!(age1: 54, sex1: "F", preg_occ: 1)
+        record.update!(age1: 54, sex1: "F", preg_occ: 1, hhmemb: 1, age1_known: 0)
         expect(record.female_in_pregnant_household_in_soft_validation_range?).to be true
       end
     end
 
     context "when female tenants are outside or soft validation ranges" do
       it "does not show the interruption screen" do
-        record.update!(age1: 44, sex1: "F", preg_occ: 1)
+        record.update!(age1: 44, sex1: "F", preg_occ: 1, hhmemb: 1)
+        expect(record.no_females_in_a_pregnant_household?).to be false
         expect(record.female_in_pregnant_household_in_soft_validation_range?).to be false
+      end
+    end
+
+    context "when the information about the tenants is not given" do
+      it "does not show the interruption screen" do
+        record.update!(preg_occ: 1, hhmemb: 2)
+        expect(record.no_females_in_a_pregnant_household?).to be false
         expect(record.female_in_pregnant_household_in_soft_validation_range?).to be false
       end
     end

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Validations::SoftValidations do
       end
     end
 
-    context "when female tenants are outside or soft validation ranges" do
+    context "when female tenants are outside of soft validation ranges" do
       it "does not show the interruption screen" do
         record.update!(age1: 44, sex1: "F", preg_occ: 1, hhmemb: 1)
         expect(record.no_females_in_a_pregnant_household?).to be false

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -164,4 +164,35 @@ RSpec.describe Validations::SoftValidations do
       end
     end
   end
+
+  describe "pregnancy soft validations" do
+    context "when there are no female tenants" do
+      it "shows the interruption screen" do
+        record.update!(age1: 43, sex1: "M", preg_occ: 1)
+        expect(record.no_females_in_the_household?).to be true
+      end
+    end
+
+    context "when female tenants are in 11-16 age range" do
+      it "shows the interruption screen" do
+        record.update!(age3: 14, sex3: "F", preg_occ: 1)
+        expect(record.female_in_pregnant_household_in_soft_validation_range?).to be true
+      end
+    end
+
+    context "when female tenants are in 50-65 age range" do
+      it "shows the interruption screen" do
+        record.update!(age1: 54, sex1: "F", preg_occ: 1)
+        expect(record.female_in_pregnant_household_in_soft_validation_range?).to be true
+      end
+    end
+
+    context "when female tenants are outside or soft validation ranges" do
+      it "does not show the interruption screen" do
+        record.update!(age1: 44, sex1: "F", preg_occ: 1)
+        expect(record.female_in_pregnant_household_in_soft_validation_range?).to be false
+        expect(record.female_in_pregnant_household_in_soft_validation_range?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Update hard validation pregnancy age from 16-50 to 11-65
Remove hard validation if there are no women in the household
Add soft validations for when there are no women in a pregnant household or there are only women in the age ranges of 11-16/50-65

<img width="912" alt="image" src="https://user-images.githubusercontent.com/54268893/169988844-cd573aa2-90bd-4337-886c-37ab8e075fda.png">

<img width="913" alt="image" src="https://user-images.githubusercontent.com/54268893/169989007-20f183ff-dd80-429e-9e7b-5d7953a89755.png">
