### PR TITLE
CLDC-1104-orgs-list-default-view-support-user

### DIFF
--- a/app/controllers/auth/two_factor_authentication_controller.rb
+++ b/app/controllers/auth/two_factor_authentication_controller.rb
@@ -22,4 +22,12 @@ private
       render :show, status: :unprocessable_entity
     end
   end
+
+  def after_two_factor_success_path_for(resource)
+    if resource.is_a?(User) && resource.support?
+      "/organisations"
+    else
+      super
+    end
+  end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -399,6 +399,16 @@ RSpec.describe "User Features" do
         )
         click_button("Sign in")
       end
+
+      it "the admin user is redirected to the organisations list page on successful sign in" do
+        visit("/account/sign-in")
+        fill_in("user[email]", with: support_user.email)
+        fill_in("user[password]", with: support_user.password)
+        click_button("Sign in")
+        fill_in("code", with: otp)
+        click_button("Submit")
+        expect(page).to have_current_path("/organisations")
+      end
     end
 
     context "with a valid 2FA code" do


### PR DESCRIPTION
makes the organisations list page the default view for when a support user logs in to the system i.e. Support users are redirected to the orgs list page on successful login