### PR TITLE
Organisation Page Consistency

### DIFF
--- a/app/views/layouts/organisations.html.erb
+++ b/app/views/layouts/organisations.html.erb
@@ -1,6 +1,11 @@
 <% content_for :content do %>
   <h1 class="govuk-heading-l">
-    <%= organisation_header(request.path, current_user, @organisation) %>
+    <% if current_user.support? %>
+        <span class="govuk-caption-l"><%= @organisation.name %></span>
+        <%= content_for(:title) %>
+    <% else %>
+        Your organisation <%= content_for(:title) %>
+    <% end %>
   </h1>
 
   <% items = tab_items(current_user) %>

--- a/app/views/layouts/organisations.html.erb
+++ b/app/views/layouts/organisations.html.erb
@@ -1,11 +1,9 @@
 <% content_for :content do %>
   <h1 class="govuk-heading-l">
-    <% if current_user.support? %>
-        <span class="govuk-caption-l"><%= @organisation.name %></span>
-        <%= content_for(:title) %>
-    <% else %>
-        Your organisation <%= content_for(:title) %>
+    <% if current_user.support? && request.path != "/organisations" %>
+      <span class="govuk-caption-l"><%= @organisation.name %></span>
     <% end %>
+    <%= content_for(:title) %>
   </h1>
 
   <% items = tab_items(current_user) %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, current_user.support? ? "Details" : "Your organisation (Details)" %>
+<% content_for :title, current_user.support? ? "Details" : "Your organisation" %>
 
 <% content_for :tab_title do %>
   <%= "Details" %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Your organisation (Details)" %>
+<% content_for :title, current_user.support? ? "Details" : "Your organisation (Details)" %>
 
 <% content_for :tab_title do %>
   <%= "Details" %>


### PR DESCRIPTION
Design before (in built product) is inconsistent. This PR attempts to make it consistent. It's possible that page title and page header actually need to be two separate things in the case of being on a nested resource page?

**Customer Support View:**

Before:
![image](https://user-images.githubusercontent.com/5101747/170509678-b1732791-0b29-4de6-b96b-eae09346f27f.png)
![image](https://user-images.githubusercontent.com/5101747/170509655-8f2aa8d9-04df-4c32-b8cc-1f3106075af4.png)


After:
![image](https://user-images.githubusercontent.com/5101747/170509488-cab059ce-e63c-4998-9d89-b20fd9caee78.png) 
![image](https://user-images.githubusercontent.com/5101747/170509540-4a05d092-a299-4ffc-865f-39a2b64b749d.png)



Coordinator view is unchanged
