### PR TITLE
Sort users by organisation and role

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -10,7 +10,7 @@ class OrganisationsController < ApplicationController
   def index
     redirect_to organisation_path(current_user.organisation) unless current_user.support?
 
-    all_organisations = Organisation.all
+    all_organisations = Organisation.order(:name)
     @pagy, @organisations = pagy(filtered_collection(all_organisations, search_term))
     @searched = search_term.presence
     @total_count = all_organisations.size
@@ -21,7 +21,7 @@ class OrganisationsController < ApplicationController
   end
 
   def users
-    @pagy, @users = pagy(filtered_users(@organisation.users, search_term))
+    @pagy, @users = pagy(filtered_users(@organisation.users.sorted_by_organisation_and_role, search_term))
     @searched = search_term.presence
     @total_count = @organisation.users.size
     render "users/index"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def index
     redirect_to users_organisation_path(current_user.organisation) unless current_user.support?
 
-    all_users = User.all
+    all_users = User.sorted_by_organisation_and_role
     filtered_users = filtered_users(all_users, search_term)
     @pagy, @users = pagy(filtered_users)
     @searched = search_term.presence

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,10 +32,11 @@ class User < ApplicationRecord
 
   enum role: ROLES
 
-  scope :search_by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }
+  scope :search_by_name, ->(name) { where("users.name ILIKE ?", "%#{name}%") }
   scope :search_by_email, ->(email) { where("email ILIKE ?", "%#{email}%") }
   scope :filter_by_active, -> { where(active: true) }
   scope :search_by, ->(param) { search_by_name(param).or(search_by_email(param)) }
+  scope :sorted_by_organisation_and_role, -> { joins(:organisation).order("organisations.name", role: :desc) }
 
   def case_logs
     if support?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -199,11 +199,12 @@ RSpec.describe User, type: :model do
   end
 
   describe "scopes" do
-    before do
-      FactoryBot.create(:user, name: "Joe Bloggs", email: "joe@example.com")
-      FactoryBot.create(:user, name: "Tom Smith", email: "tom@example.com")
-      FactoryBot.create(:user, name: "Jenny Ford", email: "jenny@smith.com")
-    end
+    let(:organisation_1) { FactoryBot.create(:organisation, name: "A") }
+    let(:organisation_2) { FactoryBot.create(:organisation, name: "B") }
+    let!(:user_1) { FactoryBot.create(:user, name: "Joe Bloggs", email: "joe@example.com", organisation: organisation_1, role: "support") }
+    let!(:user_3) { FactoryBot.create(:user, name: "Tom Smith", email: "tom@example.com", organisation: organisation_1, role: "data_provider") }
+    let!(:user_2) { FactoryBot.create(:user, name: "Jenny Ford", email: "jenny@smith.com", organisation: organisation_1, role: "data_coordinator") }
+    let!(:user_4) { FactoryBot.create(:user, name: "Greg Thomas", email: "greg@org_2.com", organisation: organisation_2, role: "data_coordinator") }
 
     context "when searching by name" do
       it "returns case insensitive matching records" do
@@ -223,6 +224,12 @@ RSpec.describe User, type: :model do
       it "returns case insensitive matching records" do
         expect(described_class.search_by("Smith").count).to eq(2)
         expect(described_class.search_by("smith").count).to eq(2)
+      end
+    end
+
+    context "when using sorted by organisation and role scope" do
+      it "returns all users sorted by organisation name and then by role" do
+        expect(described_class.sorted_by_organisation_and_role.to_a).to eq([user_1, user_2, user_3, user_4])
       end
     end
   end


### PR DESCRIPTION
Currently our user and organisation views don't sort by anything so the order is somewhat random.

- [x] Sort users by organisation name and then by role (when support is viewing all users)
- [x] Sort users by role (when viewed for a single organisation)
- [x] Sort organisations by name