### PR TITLE
Fix heisenspec

### DIFF
--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Log Features" do
       end
 
       it "displays the logs belonging to the same organisation" do
-        expect(page).to have_content(log_to_search.id)
-        expect(page).to have_content(same_organisation_log.id)
-        expect(page).not_to have_content(another_organisation_log.id)
+        expect(page).to have_link(log_to_search.id.to_s)
+        expect(page).to have_link(same_organisation_log.id.to_s)
+        expect(page).not_to have_link(another_organisation_log.id.to_s)
       end
 
       context "when I search for a specific log" do
@@ -35,9 +35,9 @@ RSpec.describe "Log Features" do
           end
 
           it "displays log matching the log ID" do
-            expect(page).to have_content(log_to_search.id)
-            expect(page).not_to have_content(same_organisation_log.id)
-            expect(page).not_to have_content(another_organisation_log.id)
+            expect(page).to have_link(log_to_search.id.to_s)
+            expect(page).not_to have_link(same_organisation_log.id.to_s)
+            expect(page).not_to have_link(another_organisation_log.id.to_s)
           end
 
           context "when I want to clear results" do
@@ -45,11 +45,11 @@ RSpec.describe "Log Features" do
               expect(page).to have_link("Clear search")
             end
 
-            it "displays the logs belonging to the same organisation after I clear the search result after I clear the search resultss" do
+            it "displays the logs belonging to the same organisation after I clear the search results" do
               click_link("Clear search")
-              expect(page).to have_content(log_to_search.id)
-              expect(page).to have_content(same_organisation_log.id)
-              expect(page).not_to have_content(another_organisation_log.id)
+              expect(page).to have_link(log_to_search.id.to_s)
+              expect(page).to have_link(same_organisation_log.id.to_s)
+              expect(page).not_to have_link(another_organisation_log.id.to_s)
             end
           end
         end

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe "User Features" do
             end
 
             it "displays log matching the log ID" do
-              expect(page).to have_content(log_to_search.id)
+              expect(page).to have_link(log_to_search.id.to_s)
               other_logs.each do |log|
-                expect(page).not_to have_content(log.id)
+                expect(page).not_to have_link(log.id.to_s)
               end
             end
 
@@ -135,7 +135,7 @@ RSpec.describe "User Features" do
 
               it "displays the logs belonging to the same organisation after I clear the search result after I clear the search resultss" do
                 click_link("Clear search")
-                expect(page).to have_content(log_to_search.id)
+                expect(page).to have_link(log_to_search.id.to_s)
               end
             end
           end

--- a/spec/requests/case_logs_controller_spec.rb
+++ b/spec/requests/case_logs_controller_spec.rb
@@ -330,33 +330,33 @@ RSpec.describe CaseLogsController, type: :request do
 
           it "shows case logs matching the id" do
             get "/logs?search=#{log_to_search.id}", headers: headers, params: {}
-            expect(page).to have_content(log_to_search.id)
+            expect(page).to have_content(log_to_search.id.to_s)
             logs.each do |log|
-              expect(page).not_to have_content(log.id)
+              expect(page).not_to have_content(log.id.to_s)
             end
           end
 
           it "shows case logs matching the tenant code" do
             get "/logs?search=#{log_to_search.tenant_code}", headers: headers, params: {}
-            expect(page).to have_content(log_to_search.id)
+            expect(page).to have_link(log_to_search.id.to_s)
             logs.each do |log|
-              expect(page).not_to have_content(log.id)
+              expect(page).not_to have_link(log.id.to_s)
             end
           end
 
           it "shows case logs matching the property reference" do
             get "/logs?search=#{log_to_search.propcode}", headers: headers, params: {}
-            expect(page).to have_content(log_to_search.id)
+            expect(page).to have_content(log_to_search.id.to_s)
             logs.each do |log|
-              expect(page).not_to have_content(log.id)
+              expect(page).not_to have_link(log.id.to_s)
             end
           end
 
           it "shows case logs matching the property postcode" do
             get "/logs?search=#{log_to_search.postcode_full}", headers: headers, params: {}
-            expect(page).to have_content(log_to_search.id)
+            expect(page).to have_link(log_to_search.id.to_s)
             logs.each do |log|
-              expect(page).not_to have_content(log.id)
+              expect(page).not_to have_link(log.id.to_s)
             end
           end
 
@@ -365,10 +365,10 @@ RSpec.describe CaseLogsController, type: :request do
 
             it "displays all matching logs" do
               get "/logs?search=#{log_to_search.postcode_full}", headers: headers, params: {}
-              expect(page).to have_content(log_to_search.id)
+              expect(page).to have_link(log_to_search.id.to_s)
               expect(page).to have_content(matching_postcode_log.id)
               logs.each do |log|
-                expect(page).not_to have_content(log.id)
+                expect(page).not_to have_link(log.id.to_s)
               end
             end
           end
@@ -391,9 +391,9 @@ RSpec.describe CaseLogsController, type: :request do
             it "doesn't display any logs" do
               get "/logs?search=foobar", headers:, params: {}
               logs.each do |log|
-                expect(page).not_to have_content(log.id)
+                expect(page).not_to have_link(log.id.to_s)
               end
-              expect(page).not_to have_content(log_to_search.id)
+              expect(page).not_to have_link(log_to_search.id.to_s)
             end
           end
 
@@ -401,9 +401,9 @@ RSpec.describe CaseLogsController, type: :request do
             it "doesn't display any logs" do
               get "/logs?search=", headers:, params: {}
               logs.each do |log|
-                expect(page).not_to have_content(log.id)
+                expect(page).not_to have_link(log.id.to_s)
               end
-              expect(page).not_to have_content(log_to_search.id)
+              expect(page).not_to have_link(log_to_search.id.to_s)
             end
           end
 
@@ -414,10 +414,10 @@ RSpec.describe CaseLogsController, type: :request do
 
             it "shows only logs matching both search and filters" do
               get "/logs?search=#{matching_postcode}&status[]=#{matching_status}", headers: headers, params: {}
-              expect(page).to have_content(log_matching_filter_and_search.id)
-              expect(page).not_to have_content(log_to_search.id)
+              expect(page).to have_link(log_matching_filter_and_search.id.to_s)
+              expect(page).not_to have_link(log_to_search.id.to_s)
               logs.each do |log|
-                expect(page).not_to have_content(log.id)
+                expect(page).not_to have_link(log.id.to_s)
               end
             end
           end


### PR DESCRIPTION
```ruby
User Features when user is support user when viewing logs for specific organisation when searching for specific logs when I search for a specific log when I fill in search information and press the search button displays log matching the log ID
     Failure/Error: expect(page).not_to have_content(log.id)
       expected not to find text "20" in "Skip to main content\nGOV.UK Submit social housing lettings and sales data (CORE)\nMenu\nYour account Sign out\nBeta This is a new service – help us improve it by giving us your feedback (opens in a new tab)\nOrganisations Users Logs\nLogs About this organisation\nFilters\nCollection year\n2021/22\n2022/23\nStatus\nNot started\nIn progress\nCompleted\nLogs\nAll\nYours\nApply filters\nSearch by log ID, tenant code, property reference or postcode\nSearch\n1 log found matching ‘16’ of 5 total logs. Clear search Download (CSV) Log Tenant Property Tenancy starts Log created Log Status Owning organisation Managing organisation Log 16 – – 2 June 2022 8 February 2022 In progress DLUHC DLUHC\nGet help with this service\nOnline helpdesk\nCORE helpdesk (opens in a new tab)\nTelephone\n0333 202 5084 Monday to Friday, 9am to 5:30pm(except public holidays)\nEmail\nsubmitcoredata@levellingup.gov.uk We aim to respond within 2 working days\nHelpful links\nPrivacy notice\n© Crown copyright"
     # ./spec/features/organisation_spec.rb:127:in `block (8 levels) in <top (required)>'
     # ./spec/features/organisation_spec.rb:126:in `each'
     # ./spec/features/organisation_spec.rb:126:in `block (7 levels) in <top (required)>'
```

Rather than look for the log id anywhere in the html content we should look specifically for a link instead.