### PR TITLE
Major repairs question should be valid if void date question is

### DIFF
--- a/app/services/imports/case_logs_field_import_service.rb
+++ b/app/services/imports/case_logs_field_import_service.rb
@@ -4,6 +4,8 @@ module Imports
       case field
       when "tenant_code"
         import_from(folder, :update_tenant_code)
+      when "major_repairs"
+        import_from(folder, :update_major_repairs)
       else
         raise "Updating #{field} is not supported by the field import service"
       end
@@ -11,9 +13,29 @@ module Imports
 
   private
 
+    def update_major_repairs(xml_doc)
+      record = log(xml_doc)
+
+      if record.present?
+        previous_status = field_value(xml_doc, "meta", "status")
+        major_repairs_date = compose_date(xml_doc, "MRCDAY", "MRCMONTH", "MRCYEAR")
+        major_repairs = if major_repairs_date.present? && previous_status.include?("submitted")
+                          1
+                        elsif previous_status.include?("submitted")
+                          0
+                        end
+        if major_repairs.present? && record.majorrepairs.blank? && record.status != "completed"
+          record.update!(mrcdate: major_repairs_date, majorrepairs: major_repairs)
+        elsif record.majorrepairs.present?
+          @logger.info("Case Log #{record.id} has a value for major repairs, skipping update")
+        end
+      else
+        @logger.warn("Could not find record matching legacy ID #{old_id}")
+      end
+    end
+
     def update_tenant_code(xml_doc)
-      old_id = field_value(xml_doc, "meta", "document-id")
-      record = CaseLog.find_by(old_id:)
+      record = log(xml_doc)
 
       if record.present?
         tenant_code = string_or_nil(xml_doc, "_2bTenCode")
@@ -24,6 +46,22 @@ module Imports
         end
       else
         @logger.warn("Could not find record matching legacy ID #{old_id}")
+      end
+    end
+
+    def log(xml_doc)
+      old_id = field_value(xml_doc, "meta", "document-id")
+      CaseLog.find_by(old_id:)
+    end
+
+    def compose_date(xml_doc, day_str, month_str, year_str)
+      day = Integer(field_value(xml_doc, "xmlns", day_str), exception: false)
+      month = Integer(field_value(xml_doc, "xmlns", month_str), exception: false)
+      year = Integer(field_value(xml_doc, "xmlns", year_str), exception: false)
+      if day.nil? || month.nil? || year.nil?
+        nil
+      else
+        Time.zone.local(year, month, day)
       end
     end
 

--- a/app/services/imports/case_logs_field_import_service.rb
+++ b/app/services/imports/case_logs_field_import_service.rb
@@ -24,8 +24,9 @@ module Imports
                         elsif previous_status.include?("submitted")
                           0
                         end
-        if major_repairs.present? && record.majorrepairs.blank? && record.status != "completed"
+        if major_repairs.present? && record.majorrepairs.nil? && record.status != "completed"
           record.update!(mrcdate: major_repairs_date, majorrepairs: major_repairs)
+          @logger.info("Case Log #{record.id}'s major repair value has been updated'")
         elsif record.majorrepairs.present?
           @logger.info("Case Log #{record.id} has a value for major repairs, skipping update")
         end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -920,11 +920,51 @@
               "depends_on": [
                 {
                   "renewal": 0,
+                  "rsnvac": 5
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 6
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 8
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 9
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 10
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 11
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 12
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 13
+                },
+                {
+                  "renewal": 0,
                   "rsnvac": 16
                 },
                 {
                   "renewal": 0,
                   "rsnvac": 17
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 18
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 19
                 }
               ]
             }

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -920,11 +920,51 @@
               "depends_on": [
                 {
                   "renewal": 0,
+                  "rsnvac": 5
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 6
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 8
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 9
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 10
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 11
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 12
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 13
+                },
+                {
+                  "renewal": 0,
                   "rsnvac": 16
                 },
                 {
                   "renewal": 0,
                   "rsnvac": 17
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 18
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 19
                 }
               ]
             }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,7 @@ en:
       void_date:
         ten_years_before_tenancy_start: "The void date must be no more than 10 years before the tenancy start date"
         before_tenancy_start: "Void date must be before the tenancy start date"
-        after_mrcdate: "Void date must be after the major repairs date if provided"
+        after_mrcdate: "Void date must be before the major repairs date if provided"
       offered:
         relet_number: "Number of times the property has been re-let must be between 0 and 20"
       la:

--- a/spec/fixtures/softwire_imports/case_logs/0ead17cb-1668-442d-898c-0d52879ff592.xml
+++ b/spec/fixtures/softwire_imports/case_logs/0ead17cb-1668-442d-898c-0d52879ff592.xml
@@ -177,8 +177,8 @@
     <Q23>1 Flat / maisonette</Q23>
     <Q24>1 Purpose built</Q24>
     <Q25>2 No</Q25>
-    <Q26/>
-    <Q27>15 First let of newbuild property</Q27>
+    <Q26>4 An Intermediate Rent basis</Q26>
+    <Q27>10 Relet - tenant evicted due to arrears</Q27>
   </Group>
   <Group>
     <Q28Auth>Leeds</Q28Auth>
@@ -516,14 +516,14 @@
     <P7NnDepDedct>0</P7NnDepDedct>
     <P8NnDepDedct>0</P8NnDepDedct>
     <DAY>30</DAY>
-    <MONTH>9</MONTH>
+    <MONTH>11</MONTH>
     <YEAR>2021</YEAR>
     <VDAY>30</VDAY>
     <VMONTH>9</VMONTH>
     <VYEAR>2021</VYEAR>
-    <MRCDAY/>
-    <MRCMONTH/>
-    <MRCYEAR/>
+    <MRCDAY>16</MRCDAY>
+    <MRCMONTH>10</MRCMONTH>
+    <MRCYEAR>2021</MRCYEAR>
     <PPOSTC1>SR7</PPOSTC1>
     <PPOSTC2>0A5</PPOSTC2>
     <POSTCODE>TS27</POSTCODE>

--- a/spec/services/imports/case_logs_field_import_service_spec.rb
+++ b/spec/services/imports/case_logs_field_import_service_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Imports::CaseLogsFieldImportService do
   let(:real_2021_2022_form) { Form.new("config/forms/2021_2022.json", "2021_2022") }
   let(:fixture_directory) { "spec/fixtures/softwire_imports/case_logs" }
 
+  let(:case_log_id) { "0ead17cb-1668-442d-898c-0d52879ff592" }
+  let(:case_log_file) { open_file(fixture_directory, case_log_id) }
+  let(:case_log_xml) { Nokogiri::XML(case_log_file) }
+  let(:remote_folder) { "case_logs" }
+  let(:old_user_id) { "c3061a2e6ea0b702e6f6210d5c52d2a92612d2aa" }
+
   def open_file(directory, filename)
     File.open("#{directory}/#{filename}.xml")
   end
@@ -18,30 +24,24 @@ RSpec.describe Imports::CaseLogsFieldImportService do
     FactoryBot.create(:organisation, old_visible_id: "1", provider_type: "PRP")
 
     # Created by users
-    FactoryBot.create(:user, old_user_id: "c3061a2e6ea0b702e6f6210d5c52d2a92612d2aa")
+    FactoryBot.create(:user, old_user_id:)
 
     # Stub the form handler to use the real form
     allow(FormHandler.instance).to receive(:get_form).with("2021_2022").and_return(real_2021_2022_form)
 
     WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/LS166FT/)
            .to_return(status: 200, body: '{"status":200,"result":{"codes":{"admin_district":"E08000035"}}}', headers: {})
+
+    # Stub the S3 file listing and download
+    allow(storage_service).to receive(:list_files)
+                                .and_return(["#{remote_folder}/#{case_log_id}.xml"])
+    allow(storage_service).to receive(:get_file_io)
+                                .with("#{remote_folder}/#{case_log_id}.xml")
+                                .and_return(case_log_file)
   end
 
-  context "when updating a specific log value" do
-    let(:case_log_id) { "0ead17cb-1668-442d-898c-0d52879ff592" }
-    let(:case_log_file) { open_file(fixture_directory, case_log_id) }
-    let(:case_log_xml) { Nokogiri::XML(case_log_file) }
-    let(:remote_folder) { "case_logs" }
+  context "when updating tenant code" do
     let(:field) { "tenant_code" }
-
-    before do
-      # Stub the S3 file listing and download
-      allow(storage_service).to receive(:list_files)
-                                  .and_return(["#{remote_folder}/#{case_log_id}.xml"])
-      allow(storage_service).to receive(:get_file_io)
-                                  .with("#{remote_folder}/#{case_log_id}.xml")
-                                  .and_return(case_log_file)
-    end
 
     context "and the case log was previously imported" do
       let(:case_log) { CaseLog.find_by(old_id: case_log_id) }
@@ -70,6 +70,52 @@ RSpec.describe Imports::CaseLogsFieldImportService do
       it "updates the case_log" do
         expect { import_service.send(:update_field, field, remote_folder) }
           .to(change { case_log.reload.tenant_code })
+      end
+    end
+  end
+
+  context "when updating major repairs" do
+    let(:field) { "major_repairs" }
+
+    context "and the case log already has a value" do
+      let(:case_log) { CaseLog.find_by(old_id: case_log_id) }
+
+      before do
+        Imports::CaseLogsImportService.new(storage_service, logger).create_logs(fixture_directory)
+        case_log_file.rewind
+        case_log.update!(majorrepairs: 0, mrcdate: Time.zone.local(2021, 10, 30, 10, 10, 10))
+      end
+
+      it "logs that major repairs already has a value and does not update major repairs" do
+        expect(logger).to receive(:info).with(/Case Log \d+ has a value for major repairs, skipping update/)
+        expect { import_service.send(:update_field, field, remote_folder) }
+          .not_to(change { case_log.reload.majorrepairs })
+      end
+
+      it "logs that major repairs already has a value and does not update the major repairs date" do
+        expect(logger).to receive(:info).with(/Case Log \d+ has a value for major repairs, skipping update/)
+        expect { import_service.send(:update_field, field, remote_folder) }
+          .not_to(change { case_log.reload.mrcdate })
+      end
+    end
+
+    context "and the case log was previously imported with empty fields" do
+      let(:case_log) { CaseLog.find_by(old_id: case_log_id) }
+
+      before do
+        Imports::CaseLogsImportService.new(storage_service, logger).create_logs(fixture_directory)
+        case_log_file.rewind
+        case_log.update!(mrcdate: nil, majorrepairs: nil)
+      end
+
+      it "updates the case_log major repairs date" do
+        expect { import_service.send(:update_field, field, remote_folder) }
+          .to(change { case_log.reload.mrcdate })
+      end
+
+      it "updates the case_log major repairs" do
+        expect { import_service.send(:update_field, field, remote_folder) }
+          .to(change { case_log.reload.majorrepairs })
       end
     end
   end

--- a/spec/services/imports/case_logs_field_import_service_spec.rb
+++ b/spec/services/imports/case_logs_field_import_service_spec.rb
@@ -109,11 +109,13 @@ RSpec.describe Imports::CaseLogsFieldImportService do
       end
 
       it "updates the case_log major repairs date" do
+        expect(logger).to receive(:info).with(/Case Log \d+'s major repair value has been updated/)
         expect { import_service.send(:update_field, field, remote_folder) }
           .to(change { case_log.reload.mrcdate })
       end
 
       it "updates the case_log major repairs" do
+        expect(logger).to receive(:info).with(/Case Log \d+'s major repair value has been updated/)
         expect { import_service.send(:update_field, field, remote_folder) }
           .to(change { case_log.reload.majorrepairs })
       end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1282

Major repairs should be asked if void date is asked so this PR makes the depends on the same.

Once merged we will need to:

1. Update all log statuses to account for logs that didn't previously answer Major Repairs but now need to
2. Re-import the major repairs data for all imported logs
```ruby
CaseLog.all.each { |l| l.send(:update_status!); l.save! }
```
```bash
cf run-task dluhc-core-production --command "bundle exec rake core:data_import_field['major_repairs','2022-05-10/logs/']" --name believe-major-repairs-reimport
cf run-task dluhc-core-production --command "bundle exec rake core:data_import_field['major_repairs','2022-05-27-barrow/logs/']" --name barrow-major-repairs-reimport
```



Affected imported logs missing Major Repairs: Yes, Major Repairs Date:
```bash
$ grep -rn '<MRCDAY>' | wc -l
135
```

Affected imported logs missing Major Repairs: No
```bash
$ grep -rn '<MRCDAY/>' | wc -l
1799
```

Affected total logs missing Major Repairs
```ruby
CaseLog.where(renewal: 0, rsnvac: [5, 6, 8, 9, 10, 11, 12, 13, 18, 19], majorrepairs: nil).count
=> 1922
```