### PR TITLE
Fix user view for no role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,6 @@ class User < ApplicationRecord
   has_one_time_password(encrypted: true)
 
   ROLES = {
-    data_accessor: 0,
     data_provider: 1,
     data_coordinator: 2,
     support: 99,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,7 +63,7 @@
 
       <%= summary_list.row do |row|
             row.key { "Role" }
-            row.value { @user.role.humanize }
+            row.value { @user.role&.humanize }
             if can_edit_roles?(@user, current_user)
               row.action(
                 visually_hidden_text: "role",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe User, type: :model do
     end
 
     it "has case logs through their organisation" do
-      expect(user.case_logs.to_a).to eq([owned_case_log, managed_case_log])
+      expect(user.case_logs.to_a).to match_array([owned_case_log, managed_case_log])
     end
 
     it "has case log status helper methods" do
-      expect(user.completed_case_logs.to_a).to eq([owned_case_log])
-      expect(user.not_completed_case_logs.to_a).to eq([managed_case_log])
+      expect(user.completed_case_logs.to_a).to match_array([owned_case_log])
+      expect(user.not_completed_case_logs.to_a).to match_array([managed_case_log])
     end
 
     it "has a role" do
@@ -103,20 +103,11 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "when the user is a data accessor" do
-      let(:user) { FactoryBot.create(:user, :data_accessor) }
-
-      it "cannot assign roles" do
-        expect(user.assignable_roles).to eq({})
-      end
-    end
-
     context "when the user is a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
 
       it "can assign all roles except support" do
         expect(user.assignable_roles).to eq({
-          data_accessor: 0,
           data_provider: 1,
           data_coordinator: 2,
         })
@@ -141,7 +132,6 @@ RSpec.describe User, type: :model do
 
       it "can assign all roles" do
         expect(user.assignable_roles).to eq({
-          data_accessor: 0,
           data_provider: 1,
           data_coordinator: 2,
           support: 99,

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -164,6 +164,19 @@ RSpec.describe UsersController, type: :request do
         end
       end
 
+      context "when the user does not have a role because they are a data protection officer only" do
+        let(:user) { FactoryBot.create(:user, role: nil) }
+
+        before do
+          sign_in user
+          get "/users/#{user.id}", headers:, params: {}
+        end
+
+        it "shows their details" do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
       context "when the current user does not match the user ID" do
         before do
           sign_in user

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -58,16 +58,6 @@ RSpec.describe Imports::UserImportService do
       end
     end
 
-    context "when the user is a data accessor" do
-      let(:old_user_id) { "b7829b1a5dfb68bb1e01c08445830c0add40907c" }
-
-      it "sets their role correctly" do
-        FactoryBot.create(:organisation, old_org_id:)
-        import_service.create_users("user_directory")
-        expect(User.find_by(old_user_id:)).to be_data_accessor
-      end
-    end
-
     context "when the user is a data protection officer" do
       let(:old_user_id) { "10c887710550844e2551b3e0fb88dc9b4a8a642b" }
 


### PR DESCRIPTION
https://sentry.io/organizations/dluhc-core/issues/3314962691/?project=6196323

-  Data protection officers may have no other role - fix error with user details view for that case
-  Remove data accessor as a role as organisations don't use it in that way
-  Order independent array comparison for user log specs