### PR TITLE
CLDC-1253: Use email link in request to create a new organisation on the start page

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -22,7 +22,7 @@
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h3>
           <ul class="govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-0">
             <li>
-              <%= govuk_mail_to("submitcoredata@levellingup.gov.uk", class: "govuk-footer__link") %>
+              <%= govuk_mail_to("dluhc.digital-services@levellingup.gov.uk", subject: "CORE:", class: "govuk-footer__link") %>
             </li>
             <li class="govuk-!-margin-bottom-0">We aim to respond within 2 working&nbsp;days</li>
           </ul>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -19,7 +19,7 @@
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">Use your account details to sign in.</p>
     <p class="govuk-body">If you need to set up a new account, speak to your organisation’s CORE data coordinator. If you don’t know who that is, <%= govuk_link_to("contact the helpdesk", "https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21") %>.</p>
-    <p class="govuk-body">You can <%= govuk_link_to("request an account", "https://digital.dclg.gov.uk/jira/servicedesk/customer/portal/4/group/21") %> if your organisation doesn’t have one.</p>
+    <p class="govuk-body">You can <%= govuk_mail_to("dluhc.digital-services@levellingup.gov.uk", "request an account", subject: "CORE: Request a new account") %> if your organisation doesn’t have one.</p>
   </div>
 
   <div class="govuk-grid-column-one-third-from-desktop">


### PR DESCRIPTION
* There’s a link on the start page to contact the help desk if you need to create an account, but users would need to have a log in for Jira Service Desk (JSD), which is unlikely if they are not yet a user of CORE.

  Change this to a link to email <dluhc.digital-services@levellingup.gov.uk> with the subject line: `CORE: Request a new account`. Including ‘CORE’ in the subject line means the email will get routed through to JSD, where it can get actioned more quickly.

* Also update the email address in the footer to use the same email (this time with the subject line simply `CORE:`), as again, this means queries can be picked up and tracked within JSD.