### PR TITLE
Allow support user to create log on behalf of other users

### DIFF
--- a/app/controllers/case_logs_controller.rb
+++ b/app/controllers/case_logs_controller.rb
@@ -105,9 +105,7 @@ private
   end
 
   def case_log_params
-    if current_user && current_user.role == "support"
-      { "created_by_id": current_user.id }.merge(api_case_log_params)
-    elsif current_user
+    if current_user && current_user.role != "support"
       org_params.merge(api_case_log_params)
     else
       api_case_log_params

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -33,7 +33,7 @@ class CaseLog < ApplicationRecord
 
   belongs_to :owning_organisation, class_name: "Organisation", optional: true
   belongs_to :managing_organisation, class_name: "Organisation", optional: true
-  belongs_to :created_by, class_name: "User"
+  belongs_to :created_by, class_name: "User", optional: true
 
   scope :filter_by_organisation, ->(org, _user = nil) { where(owning_organisation: org).or(where(managing_organisation: org)) }
   scope :filter_by_status, ->(status, _user = nil) { where status: }

--- a/app/views/case_logs/_log_list.html.erb
+++ b/app/views/case_logs/_log_list.html.erb
@@ -64,8 +64,8 @@
             <%= status_tag(log.status) %>
           <% end %>
           <% if current_user.support? %>
-            <% row.cell(text: log.owning_organisation.name) %>
-            <% row.cell(text: log.managing_organisation.name) %>
+            <% row.cell(text: log.owning_organisation&.name) %>
+            <% row.cell(text: log.managing_organisation&.name) %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -36,6 +36,38 @@
                 ]
               ]
             },
+            "user": {
+              "header": "",
+              "description": "",
+              "questions": {
+                "created_by_id": {
+                  "header": "Which user are you creating this log for?",
+                  "hint_text": "",
+                  "type": "select",
+                  "answer_options_lookup": {
+                    "class": "User",
+                    "scope": "all",
+                    "id": "id",
+                    "label": "name"
+                  }
+                }
+              },
+              "derived": true,
+              "depends_on": [
+                [
+                  {
+                    "object": "user",
+                    "method": "role",
+                    "value": "support"
+                  },
+                  {
+                    "object": "case_log",
+                    "method": "owning_organisation_id.nil?",
+                    "value": false
+                  }
+                ]
+              ]
+            },
             "needs_type": {
               "header": "",
               "description": "",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -36,6 +36,38 @@
                 ]
               ]
             },
+            "user": {
+              "header": "",
+              "description": "",
+              "questions": {
+                "created_by_id": {
+                  "header": "Which user are you creating this log for?",
+                  "hint_text": "",
+                  "type": "select",
+                  "answer_options_lookup": {
+                    "class": "User",
+                    "scope": "all",
+                    "id": "id",
+                    "label": "name"
+                  }
+                }
+              },
+              "derived": true,
+              "depends_on": [
+                [
+                  {
+                    "object": "user",
+                    "method": "role",
+                    "value": "support"
+                  },
+                  {
+                    "object": "case_log",
+                    "method": "owning_organisation_id.nil?",
+                    "value": false
+                  }
+                ]
+              ]
+            },
             "needs_type": {
               "header": "",
               "description": "",


### PR DESCRIPTION
- [x] Add question to form for support users to set the user they're creating the log on behalf of
- [ ] Limit user options to users in the organisation

Ideally we would filter the user list shown to the support user by the organisation they've selected and/or derive the organisation from the user they've selected.

This gets fiddly for a couple of reasons:

1. Currently the form attempts to gather all the answer options to a question at boot time. It can derive whether an answer option should be displayed to the user or not based on dynamic "depends_on" criteria, but there's no simple way to do that for a list of options that is itself dynamic.

2. It requires a fairly significant increase in how leaky the abstraction is. The form definition takes on significantly more knowledge of the internal working of the app (what classes exist, what methods exist etc) than it should. This is already happening to some extent but we should avoid this where possible.


The root problem here may be treating "Set up your log" as a regular part of the form, when it should perhaps be treated separately. Especially since it can't change year on year as flexibly as other parts of the form can anyway.