### PR TITLE
Differentiate between internal and external interfaces

### DIFF
--- a/app/frontend/styles/_header.scss
+++ b/app/frontend/styles/_header.scss
@@ -21,3 +21,8 @@
     }
   }
 }
+
+.app-header--orange,
+.app-header--orange .govuk-header__container {
+  border-bottom-color: govuk-colour("orange");
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
     end
   end
 
-  def govuk_header_classes
+  def govuk_header_classes(current_user)
     if current_user && current_user.support?
       "app-header app-header--orange"
     else
@@ -17,7 +17,7 @@ module ApplicationHelper
     end
   end
 
-  def govuk_phase_banner_tag
+  def govuk_phase_banner_tag(current_user)
     if current_user && current_user.support?
       { colour: "orange", text: "Support beta" }
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,22 @@ module ApplicationHelper
     end
   end
 
+  def govuk_header_classes
+    if current_user && current_user.support?
+      "app-header app-header--orange"
+    else
+      "app-header"
+    end
+  end
+
+  def govuk_phase_banner_tag
+    if current_user && current_user.support?
+      { colour: "orange", text: "Support beta" }
+    else
+      { text: "Beta" }
+    end
+  end
+
 private
 
   def paginated_title(title, pagy)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-      classes: govuk_header_classes,
+      classes: govuk_header_classes(current_user),
       service_url: current_user.nil? ? "/" : "/logs",
       navigation_classes: "govuk-header__navigation--end",
     ) do |component|
@@ -60,7 +60,7 @@
 
     <%= govuk_phase_banner(
       classes: "govuk-width-container",
-      tag: govuk_phase_banner_tag,
+      tag: govuk_phase_banner_tag(current_user),
       text: "This is a new service – help us improve it by #{feedback_link}".html_safe,
     ) %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-      classes: "app-header",
+      classes: govuk_header_classes,
       service_url: current_user.nil? ? "/" : "/logs",
       navigation_classes: "govuk-header__navigation--end",
     ) do |component|
@@ -60,7 +60,7 @@
 
     <%= govuk_phase_banner(
       classes: "govuk-width-container",
-      tag: { text: "Beta" },
+      tag: govuk_phase_banner_tag,
       text: "This is a new service – help us improve it by #{feedback_link}".html_safe,
     ) %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,6 +7,33 @@ RSpec.describe ApplicationHelper do
   let(:case_log) { FactoryBot.build(:case_log, :in_progress) }
   let(:pagy) { nil }
 
+  describe "govuk_header_classes" do
+    context "with external user" do
+      expect(govuk_header_classes) .to eq("app-header")
+    end
+
+    context "with internal support user" do
+      let(:current_user) { FactoryBot.create(:user, :support) }
+      expect(govuk_header_classes) .to eq("app-header app-header--orange")
+    end
+  end
+
+  describe "govuk_phase_banner_tag" do
+    context "with external user" do
+      expect(govuk_phase_banner_tag) .to eq({
+        text: "Beta",
+      })
+    end
+
+    context "with support user" do
+      let(:current_user) { FactoryBot.create(:user, :support) }
+      expect(govuk_phase_banner_tag) .to eq({
+        colour: "orange",
+        text: "Support beta",
+      })
+    end
+  end
+
   describe "browser_title" do
     context "with no pagination" do
       it "returns correct browser title when title is given" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,31 +6,40 @@ RSpec.describe ApplicationHelper do
   let(:subsection) { form.get_subsection("household_characteristics") }
   let(:case_log) { FactoryBot.build(:case_log, :in_progress) }
   let(:pagy) { nil }
+  let(:current_user) { FactoryBot.create(:user) }
 
   describe "govuk_header_classes" do
     context "with external user" do
-      expect(govuk_header_classes) .to eq("app-header")
+      it "shows the standard app header" do
+        expect(govuk_header_classes(current_user)).to eq("app-header")
+      end
     end
 
     context "with internal support user" do
       let(:current_user) { FactoryBot.create(:user, :support) }
-      expect(govuk_header_classes) .to eq("app-header app-header--orange")
+
+      it "shows an orange header" do
+        expect(govuk_header_classes(current_user)).to eq("app-header app-header--orange")
+      end
     end
   end
 
   describe "govuk_phase_banner_tag" do
     context "with external user" do
-      expect(govuk_phase_banner_tag) .to eq({
-        text: "Beta",
-      })
+      it "shows the standard phase tag" do
+        expect(govuk_phase_banner_tag(current_user)).to eq({ text: "Beta" })
+      end
     end
 
     context "with support user" do
       let(:current_user) { FactoryBot.create(:user, :support) }
-      expect(govuk_phase_banner_tag) .to eq({
-        colour: "orange",
-        text: "Support beta",
-      })
+
+      it "shows an orange phase tag" do
+        expect(govuk_phase_banner_tag(current_user)).to eq({
+          colour: "orange",
+          text: "Support beta",
+        })
+      end
     end
   end
 


### PR DESCRIPTION
As an extra safeguard, using a different border and tag colour in the header can help distinguish the internal support interface (which has more destructive functions) and external customer facing interface, especially if a user may have access to both. 

It also helps us identify the different views/permissions when reviewing the design.

## External customer

<img width="1140" alt="Screenshot 2022-06-14 at 13 19 29" src="https://user-images.githubusercontent.com/813383/173576034-b24e9912-5ce6-4778-9ad6-8385b6dad669.png">

## Internal support user

<img width="1140" alt="Screenshot 2022-06-14 at 13 19 56" src="https://user-images.githubusercontent.com/813383/173576053-d13af0cc-ab8b-4265-b8ca-6f8d4087a947.png">
