### PR TITLE
Content tweaks for user and organisation management

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -3,8 +3,8 @@ module UserHelper
     current_user == user ? edit_account_path : edit_user_path(user)
   end
 
-  def pronoun(user, current_user)
-    current_user == user ? "you" : "they"
+  def perspective(user, current_user)
+    current_user == user ? "Are you" : "Is this person"
   end
 
   def can_edit_names?(user, current_user)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -67,7 +67,7 @@ class Organisation < ApplicationRecord
       { name: "telephone_number", value: phone, editable: true },
       { name: "type", value: display_provider_type, editable: false },
       { name: "rent_periods", value: rent_period_labels, editable: false, format: :bullet },
-      { name: "holds_own_stock", value: holds_own_stock.to_s.humanize, editable: false },
+      { name: "Owns housing stock", value: holds_own_stock ? "Yes" : "No", editable: false },
       { name: "other_stock_owners", value: other_stock_owners, editable: false },
       { name: "managing_agents", value: managing_agents, editable: false },
       { name: "data_protection_agreement", value: data_protection_agreement_string, editable: false },

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -38,13 +38,13 @@
           [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
           :id,
           :name,
-          legend: { text: "Are #{pronoun(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
+          legend: { text: "#{perspective(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
 
         <%= f.govuk_collection_radio_buttons :is_key_contact,
           [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
           :id,
           :name,
-          legend: { text: "Are #{pronoun(@user, current_user)} a key contact for this service?", size: "m" },
+          legend: { text: "#{perspective(@user, current_user)} a key contact for this service?", size: "m" },
           hint: { text: "This is a person responsible for sharing information about social housing lettings and sales data within the organisation." } %>
       <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -55,13 +55,13 @@
         [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
         :id,
         :name,
-        legend: { text: "Are #{pronoun(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
+        legend: { text: "#{perspective(@user, current_user)} the organisation’s data protection officer?", size: "m" } %>
 
       <%= f.govuk_collection_radio_buttons :is_key_contact,
         [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")],
         :id,
         :name,
-        legend: { text: "Is this user a key contact for this service?", size: "m" },
+        legend: { text: "#{perspective(@user, current_user)} a key contact for this service?", size: "m" },
         hint: { text: "This is a person responsible for sharing information about social housing lettings and sales data within the organisation." } %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Invite user to submit CORE data" %>
+<% content_for :title, "Invite somebody to submit CORE data" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link(

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,9 +80,9 @@
             row.value { @user.is_data_protection_officer? ? "Yes" : "No" }
             if can_edit_dpo?(@user, current_user)
               row.action(
-                visually_hidden_text: "are #{pronoun(@user, current_user)} a data protection officer?",
+                visually_hidden_text: "if data protection officer",
                 href: aliased_user_edit(@user, current_user),
-                html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-data-protection-officer" },
+                html_attributes: { "data-qa": "change-data-protection-officer" },
               )
             else
               row.action
@@ -94,9 +94,9 @@
             row.value { @user.is_key_contact? ? "Yes" : "No" }
             if can_edit_key_contact?(@user, current_user)
               row.action(
-                visually_hidden_text: "are #{pronoun(@user, current_user)} a key contact?",
+                visually_hidden_text: "if a key contact",
                 href: aliased_user_edit(@user, current_user),
-                html_attributes: { "data-qa": "change-are-#{pronoun(@user, current_user)}-a-key-contact" },
+                html_attributes: { "data-qa": "change-key-contact" },
               )
             else
               row.action

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "User Features" do
         click_link("Users")
         click_link("Invite user")
         expect(page).to have_current_path("/users/new")
-        expect(page).to have_content("Invite user to submit CORE data")
+        expect(page).to have_content("Invite somebody to submit CORE data")
         fill_in("user[name]", with: "New User")
         fill_in("user[email]", with: "new_user@example.com")
         choose("user-role-data-provider-field")

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe "User Features" do
 
       it "does not have change links for dpo and key contact" do
         visit("/account")
-        expect(page).not_to have_selector('[data-qa="change-are-you-a-data-protection-officer"]')
-        expect(page).not_to have_selector('[data-qa="change-are-you-a-key-contact"]')
+        expect(page).not_to have_selector('[data-qa="change-if-data-protection-officer"]')
+        expect(page).not_to have_selector('[data-qa="change-if-key-contact"]')
       end
 
       it "does not have dpo and key contact as editable fields" do
@@ -288,8 +288,8 @@ RSpec.describe "User Features" do
 
       it "has dpo and key contact as editable fields" do
         visit("/account")
-        expect(page).to have_selector('[data-qa="change-are-you-a-data-protection-officer"]')
-        expect(page).to have_selector('[data-qa="change-are-you-a-key-contact"]')
+        expect(page).to have_selector('[data-qa="change-data-protection-officer"]')
+        expect(page).to have_selector('[data-qa="change-key-contact"]')
       end
     end
 

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe UserHelper do
     end
   end
 
-  describe "pronoun" do
+  describe "perspective" do
     context "when the current logged in user is the same as the user being viewed" do
       let(:user) { current_user }
 
-      it "returns 'you'" do
-        expect(pronoun(user, current_user)).to eq("you")
+      it "returns 'Are you'" do
+        expect(perspective(user, current_user)).to eq("Are you")
       end
     end
 
     context "when the current logged in user is not the same as the user being viewed" do
-      it "returns 'they'" do
-        expect(pronoun(user, current_user)).to eq("they")
+      it "returns 'Is this person'" do
+        expect(perspective(user, current_user)).to eq("Is this person")
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "email address")
           expect(page).to have_link("Change", text: "password")
           expect(page).not_to have_link("Change", text: "role")
-          expect(page).not_to have_link("Change", text: "are you a data protection officer?")
-          expect(page).not_to have_link("Change", text: "are you a key contact?")
+          expect(page).not_to have_link("Change", text: "if data protection officer")
+          expect(page).not_to have_link("Change", text: "if a key contact")
         end
 
         it "does not allow deactivating the user" do
@@ -196,8 +196,8 @@ RSpec.describe UsersController, type: :request do
             expect(page).not_to have_link("Change", text: "email address")
             expect(page).not_to have_link("Change", text: "password")
             expect(page).not_to have_link("Change", text: "role")
-            expect(page).not_to have_link("Change", text: "are you a data protection officer?")
-            expect(page).not_to have_link("Change", text: "are you a key contact?")
+            expect(page).not_to have_link("Change", text: "if data protection officer")
+            expect(page).not_to have_link("Change", text: "if a key contact")
           end
 
           it "does not allow deactivating the user" do
@@ -511,8 +511,8 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "email address")
           expect(page).to have_link("Change", text: "password")
           expect(page).to have_link("Change", text: "role")
-          expect(page).to have_link("Change", text: "are you a data protection officer?")
-          expect(page).to have_link("Change", text: "are you a key contact?")
+          expect(page).to have_link("Change", text: "if data protection officer")
+          expect(page).to have_link("Change", text: "if a key contact")
         end
 
         it "does not allow deactivating the user" do
@@ -551,8 +551,8 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Change", text: "email address")
             expect(page).not_to have_link("Change", text: "password")
             expect(page).to have_link("Change", text: "role")
-            expect(page).to have_link("Change", text: "are they a data protection officer?")
-            expect(page).to have_link("Change", text: "are they a key contact?")
+            expect(page).to have_link("Change", text: "if data protection officer")
+            expect(page).to have_link("Change", text: "if a key contact")
           end
 
           it "allows deactivating the user" do
@@ -1168,8 +1168,8 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "email address")
           expect(page).to have_link("Change", text: "password")
           expect(page).to have_link("Change", text: "role")
-          expect(page).to have_link("Change", text: "are you a data protection officer?")
-          expect(page).to have_link("Change", text: "are you a key contact?")
+          expect(page).to have_link("Change", text: "if data protection officer")
+          expect(page).to have_link("Change", text: "if a key contact")
         end
 
         it "does not allow deactivating the user" do
@@ -1197,8 +1197,8 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Change", text: "email address")
             expect(page).not_to have_link("Change", text: "password")
             expect(page).to have_link("Change", text: "role")
-            expect(page).to have_link("Change", text: "are they a data protection officer?")
-            expect(page).to have_link("Change", text: "are they a key contact?")
+            expect(page).to have_link("Change", text: "if data protection officer")
+            expect(page).to have_link("Change", text: "if a key contact")
           end
 
           it "allows deactivating the user" do
@@ -1237,8 +1237,8 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Change", text: "email address")
             expect(page).not_to have_link("Change", text: "password")
             expect(page).to have_link("Change", text: "role")
-            expect(page).to have_link("Change", text: "are they a data protection officer?")
-            expect(page).to have_link("Change", text: "are they a key contact?")
+            expect(page).to have_link("Change", text: "if data protection officer")
+            expect(page).to have_link("Change", text: "if a key contact")
           end
         end
       end


### PR DESCRIPTION
From the mob session:

* Use **Owns housing stock** (Yes/No) instead of **Holds own stock** (True/False)
* Use **Invite somebody to submit CORE data** instead of **Invite a user to submit CORE data**
* Use **Is this person…**/**Are you…** instead of **Are they**/**Are you**. Update helper name from `pronoun` to `perspective` to reflect this change