### PR TITLE
Search schemes by postcode

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -5,7 +5,7 @@ class Scheme < ApplicationRecord
 
   scope :search_by_code, ->(code) { where("code ILIKE ?", "%#{code}%") }
   scope :search_by_service_name, ->(name) { where("service_name ILIKE ?", "%#{name}%") }
-  scope :search_by_postcode, ->(postcode) { joins(:locations).where("REPLACE(locations.postcode, ' ', '') ILIKE ?", "%#{postcode.delete(' ')}%") }
+  scope :search_by_postcode, ->(postcode) { joins(:locations).where("locations.postcode ILIKE ?", "%#{postcode.delete(' ')}%") }
   scope :search_by, ->(param) { search_by_postcode(param).or(search_by_service_name(param)).or(search_by_code(param)).distinct }
 
   SCHEME_TYPE = {

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -5,7 +5,8 @@ class Scheme < ApplicationRecord
 
   scope :search_by_code, ->(code) { where("code ILIKE ?", "%#{code}%") }
   scope :search_by_service_name, ->(name) { where("service_name ILIKE ?", "%#{name}%") }
-  scope :search_by, ->(param) { search_by_code(param).or(search_by_service_name(param)) }
+  scope :search_by_postcode, ->(postcode) { joins(:locations).where("REPLACE(locations.postcode, ' ', '') ILIKE ?", "%#{postcode.delete(' ')}%") }
+  scope :search_by, ->(param) { search_by_postcode(param).or(search_by_service_name(param)).or(search_by_code(param)).distinct }
 
   SCHEME_TYPE = {
     0 => "Missings",

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :location do
     location_code { Faker::Name.initials(number: 10) }
-    postcode { Faker::Address.postcode.delete(' ') }
+    postcode { Faker::Address.postcode.delete(" ") }
     address_line1 { Faker::Address.street_name }
     address_line2 { Faker::Address.city }
     type_of_unit { Faker::Lorem.word }

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :location do
     location_code { Faker::Name.initials(number: 10) }
-    postcode { Faker::Address.postcode }
+    postcode { Faker::Address.postcode.delete(' ') }
     address_line1 { Faker::Address.street_name }
     address_line2 { Faker::Address.city }
     type_of_unit { Faker::Lorem.word }

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Scheme, type: :model do
     describe "scopes" do
       let!(:scheme_1) { FactoryBot.create(:scheme) }
       let!(:scheme_2) { FactoryBot.create(:scheme) }
+      let!(:location) { FactoryBot.create(:location, scheme: scheme_1) }
+      let!(:location_2) { FactoryBot.create(:location, scheme: scheme_2) }
 
       context "when searching by code" do
         it "returns case insensitive matching records" do
@@ -34,7 +36,25 @@ RSpec.describe Scheme, type: :model do
         end
       end
 
-      context "when searching by all searchable field" do
+      context "when searching by postcode" do
+        it "returns case insensitive matching records" do
+          expect(described_class.search_by_postcode(location.postcode.upcase).count).to eq(1)
+          expect(described_class.search_by_postcode(location.postcode.downcase).count).to eq(1)
+          expect(described_class.search_by_postcode(location.postcode.downcase).first.locations.first.postcode).to eq(location.postcode)
+          expect(described_class.search_by_postcode(location_2.postcode.upcase).count).to eq(1)
+          expect(described_class.search_by_postcode(location_2.postcode.downcase).count).to eq(1)
+          expect(described_class.search_by_postcode(location_2.postcode.downcase).first.locations.first.postcode).to eq(location_2.postcode)
+        end
+
+        it "returns case search results for postcodes without space" do
+          expect(described_class.search_by_postcode(location.postcode.delete(" ")).count).to eq(1)
+          expect(described_class.search_by_postcode(location.postcode.delete(" ")).first.locations.first.postcode).to eq(location.postcode)
+          expect(described_class.search_by_postcode(location_2.postcode.delete(" ")).count).to eq(1)
+          expect(described_class.search_by_postcode(location_2.postcode.delete(" ")).first.locations.first.postcode).to eq(location_2.postcode)
+        end
+      end
+
+      context "when searching by all searchable fields" do
         it "returns case insensitive matching records" do
           expect(described_class.search_by(scheme_1.code.upcase).count).to eq(1)
           expect(described_class.search_by(scheme_1.code.downcase).count).to eq(1)

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe Scheme, type: :model do
           expect(described_class.search_by_postcode(location_2.postcode.downcase).count).to eq(1)
           expect(described_class.search_by_postcode(location_2.postcode.downcase).first.locations.first.postcode).to eq(location_2.postcode)
         end
-
-        it "returns case search results for postcodes without space" do
-          expect(described_class.search_by_postcode(location.postcode.delete(" ")).count).to eq(1)
-          expect(described_class.search_by_postcode(location.postcode.delete(" ")).first.locations.first.postcode).to eq(location.postcode)
-          expect(described_class.search_by_postcode(location_2.postcode.delete(" ")).count).to eq(1)
-          expect(described_class.search_by_postcode(location_2.postcode.delete(" ")).first.locations.first.postcode).to eq(location_2.postcode)
-        end
       end
 
       context "when searching by all searchable fields" do

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe OrganisationsController, type: :request do
           let(:search_param) { "CODE321" }
 
           before do
+            FactoryBot.create(:location, scheme: searched_scheme)
             allow(user).to receive(:need_two_factor_authentication?).and_return(false)
             get "/organisations/#{organisation.id}/schemes?search=#{search_param}"
           end
@@ -144,6 +145,7 @@ RSpec.describe OrganisationsController, type: :request do
           let(:search_param) { "CODE321" }
 
           before do
+            FactoryBot.create(:location, scheme: searched_scheme)
             get "/organisations/#{organisation.id}/schemes?search=#{search_param}"
           end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe SchemesController, type: :request do
         let(:search_param) { "CODE321" }
 
         before do
+          FactoryBot.create(:location, scheme: searched_scheme)
           get "/schemes?search=#{search_param}"
         end
 


### PR DESCRIPTION
Add a search by postcode scope. The join with locations table means that search_by will only return the results that have associated location with it whenever searching, _but we are not displaying the schemes without location anyway_ - yes we are, but perhaps we shouldn't !

