### PR TITLE
Add auto spacing to main wrapper

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,7 +74,7 @@
       <%= content_for(:breadcrumbs) %>
       <%= content_for(:before_content) %>
 
-      <main class="govuk-main-wrapper" id="main-content" role="main">
+      <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <% if flash.notice && !flash.notice.include?("translation missing") %>
           <%= govuk_notification_banner(
             title_text: "Success",


### PR DESCRIPTION
Obscure `govuk-frontend` detail:

> Using the `.govuk-main-wrapper--auto-spacing` modifier should apply the correct spacing depending on whether there are any elements (such the back link, breadcrumbs or phase banner components) before the `.govuk-main-wrapper` in the `govuk-width-container`.

– https://github.com/alphagov/govuk-frontend/blob/2695c08c60d18ee808a73018ab5153260a9c30cb/package/govuk/objects/_main-wrapper.scss#L42