### PR TITLE
Add care home charges minimum validation

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -107,11 +107,13 @@ module Validations::FinancialValidations
       period = record.form.get_question("period", record).label_from_value(record.period).downcase
       if record.chcharge.blank?
         record.errors.add :chcharge, I18n.t("validations.financial.carehome.not_provided", period:)
-      elsif !weekly_value_in_range(record, "chcharge", 0, 1000)
+      elsif !weekly_value_in_range(record, "chcharge", 10, 1000)
         max_chcharge = record.weekly_to_value_per_period(1000)
+        min_chcharge = record.weekly_to_value_per_period(10)
         max_chcharge = [record.form.get_question("chcharge", record).prefix, max_chcharge].join("") if record.form.get_question("chcharge", record).present?
-        record.errors.add :period, I18n.t("validations.financial.carehome.over_1000", period:, min_chcharge: "£0", max_chcharge:)
-        record.errors.add :chcharge, I18n.t("validations.financial.carehome.over_1000", period:, min_chcharge: "£0", max_chcharge:)
+        min_chcharge = [record.form.get_question("chcharge", record).prefix, min_chcharge].join("") if record.form.get_question("chcharge", record).present?
+        record.errors.add :period, I18n.t("validations.financial.carehome.out_of_range", period:, min_chcharge:, max_chcharge:)
+        record.errors.add :chcharge, I18n.t("validations.financial.carehome.out_of_range", period:, min_chcharge:, max_chcharge:)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,7 @@ en:
       rent_period:
         invalid_for_org: "%{org_name} does not charge rent %{rent_period}"
       carehome:
-        over_1000: "Household rent and other charges must be between %{min_chcharge} and %{max_chcharge} if paying %{period}"
+        out_of_range: "Household rent and other charges must be between %{min_chcharge} and %{max_chcharge} if paying %{period}"
         not_provided: "Enter how much rent and other charges the household pays %{period}"
     household:
       reasonpref:

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -847,9 +847,9 @@ RSpec.describe Validations::FinancialValidations do
           record.chcharge = 1001
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "weekly for 52 weeks", max_chcharge: 1000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 10, period: "weekly for 52 weeks", max_chcharge: 1000))
           expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "weekly for 52 weeks", max_chcharge: 1000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 10, period: "weekly for 52 weeks", max_chcharge: 1000))
         end
 
         it "validates charge when period is monthly" do
@@ -857,9 +857,9 @@ RSpec.describe Validations::FinancialValidations do
           record.chcharge = 4334
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "4", max_chcharge: 4333))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 43, period: "4", max_chcharge: 4333))
           expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "4", max_chcharge: 4333))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 43, period: "4", max_chcharge: 4333))
         end
 
         it "validates charge when period is every 2 weeks" do
@@ -867,9 +867,9 @@ RSpec.describe Validations::FinancialValidations do
           record.chcharge = 2001
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "2", max_chcharge: 2000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 20, period: "2", max_chcharge: 2000))
           expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "2", max_chcharge: 2000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 20, period: "2", max_chcharge: 2000))
         end
 
         it "validates charge when period is every 4 weeks" do
@@ -877,9 +877,9 @@ RSpec.describe Validations::FinancialValidations do
           record.chcharge = 4001
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "every 4 weeks", max_chcharge: 4000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 40, period: "every 4 weeks", max_chcharge: 4000))
           expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.carehome.over_1000", min_chcharge: "£0", period: "every 4 weeks", max_chcharge: 4000))
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 40, period: "every 4 weeks", max_chcharge: 4000))
         end
       end
 
@@ -924,6 +924,48 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
             .to include(match I18n.t("validations.financial.carehome.not_provided", period: "every 4 weeks"))
+        end
+      end
+
+      context "and charges under valid limit (£10pw)" do
+        it "validates charge when period is weekly for 52 weeks" do
+          record.period = 1
+          record.chcharge = 9
+          financial_validator.validate_care_home_charges(record)
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 10, period: "weekly for 52 weeks", max_chcharge: 1000))
+          expect(record.errors["period"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 10, period: "weekly for 52 weeks", max_chcharge: 1000))
+        end
+
+        it "validates charge when period is monthly" do
+          record.period = 4
+          record.chcharge = 42
+          financial_validator.validate_care_home_charges(record)
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 43, period: "4", max_chcharge: 4333))
+          expect(record.errors["period"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 43, period: "4", max_chcharge: 4333))
+        end
+
+        it "validates charge when period is every 2 weeks" do
+          record.period = 2
+          record.chcharge = 19
+          financial_validator.validate_care_home_charges(record)
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 20, period: "2", max_chcharge: 2000))
+          expect(record.errors["period"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 20, period: "2", max_chcharge: 2000))
+        end
+
+        it "validates charge when period is every 4 weeks" do
+          record.period = 3
+          record.chcharge = 39
+          financial_validator.validate_care_home_charges(record)
+          expect(record.errors["chcharge"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 40, period: "every 4 weeks", max_chcharge: 4000))
+          expect(record.errors["period"])
+            .to include(match I18n.t("validations.financial.carehome.out_of_range", min_chcharge: 40, period: "every 4 weeks", max_chcharge: 4000))
         end
       end
     end


### PR DESCRIPTION
If the answer to Does the household pay rent or other charges for the accommodation? is Yes, then Care home charge and Total Charge in Household rent and charges should be at least £10 per week.

We already have a validation for total charge, it applies to general needs as well