### PR TITLE
Install geckodriver in docker_dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,8 +11,6 @@ storage
 public/assets
 .byebug_history
 
-config/master.key
-
 public/packs
 public/packs-test
 node_modules

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -23,6 +23,14 @@ RUN bundle install ${BUNDLE_FLAGS}
 COPY package.json yarn.lock /app/
 RUN yarn install --frozen-lockfile
 
+# Install gecko driver for Capybara tests
+RUN apk add firefox
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-linux64.tar.gz \
+  && tar -xvzf geckodriver-v0.31.0-linux64.tar.gz \
+  && rm geckodriver-v0.31.0-linux64.tar.gz \
+  && chmod +x geckodriver \
+  && mv geckodriver /usr/local/bin/
+
 # Copy all files to /app (except what is defined in .dockerignore)
 COPY . /app/
 


### PR DESCRIPTION
Enables you to run the test suite in docker with:

```
docker-compose build
docker-compose run --rm app /bin/bash -c 'rake db:migrate'
```
```
docker-compose run --rm app /bin/bash -c ' RAILS_ENV=test rspec'
```


Note. This PR solves the encrypted rails secrets being available in docker by just letting docker include the master key from source code in the build rather than injecting it in as a build arg. This might be slightly less secure if we were building and storing images somewhere public but we currently aren't and this simplifies everything else. 