### PR TITLE
Scheme tweaks

### DIFF
--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -2,9 +2,9 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-        text: "Back",
-        href: "/schemes/#{@scheme.id}/support",
-      ) %>
+    text: "Back",
+    href: "/schemes/#{@scheme.id}/support",
+  ) %>
 <% end %>
 
 <%= render partial: "organisations/headings", locals: { main: "Add a location to this scheme", sub: @scheme.service_name } %>

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -30,7 +30,6 @@
                                autofocus: true %>
 
       <% type_of_units_selection = Location.type_of_units.keys.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
-
       <%= f.govuk_collection_radio_buttons :type_of_unit,
                                            type_of_units_selection,
                                            :id,
@@ -38,7 +37,6 @@
                                            legend: { text: "What is this type of scheme?", size: "m" } %>
 
       <% wheelchair_user_selection = Location.wheelchair_adaptations.keys.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
-
       <%= f.govuk_collection_radio_buttons :wheelchair_adaptation,
                                            wheelchair_user_selection,
                                            :id,
@@ -49,7 +47,6 @@
       <%= govuk_section_break(visible: true, size: "m") %>
 
       <% another_location_selection = %w[Yes no].map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
-
       <%= f.govuk_collection_radio_buttons :add_another_location,
                                            another_location_selection,
                                            :id,

--- a/app/views/locations/edit_name.html.erb
+++ b/app/views/locations/edit_name.html.erb
@@ -2,9 +2,9 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-        text: "Back",
-        href: "/schemes/#{@scheme.id}/locations",
-      ) %>
+    text: "Back",
+    href: "/schemes/#{@scheme.id}/locations",
+  ) %>
 <% end %>
 
 <%= render partial: "organisations/headings", locals: { main: "Location name for #{@location.postcode}", sub: @scheme.service_name } %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,12 +1,15 @@
 <% title = @scheme.service_name %>
 <% content_for :title, title %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
     href: "/schemes/#{@scheme.id}",
   ) %>
 <% end %>
+
 <%= render partial: "organisations/headings", locals: { main: @scheme.service_name, sub: nil } %>
+
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>
 
 <%= govuk_table do |table| %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -10,40 +10,36 @@
 <% location_caption = @scheme.locations.count.eql?(1) ? "1 location" : "#{@scheme.locations.count} locations" %>
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, location_caption)) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
-    <%= govuk_table do |table| %>
-      <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-        <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>.
-      <% end %>
-      <%= table.head do |head| %>
-        <%= head.row do |row| %>
-          <% row.cell(header: true, text: "Code", html_attributes: {
-            scope: "col",
-          }) %>
-          <% row.cell(header: true, text: "Postcode", html_attributes: {
-            scope: "col",
-          }) %>
-          <% row.cell(header: true, text: "Units", html_attributes: {
-            scope: "col",
-          }) %>
-          <% row.cell(header: true, text: "Common unit type", html_attributes: {
-            scope: "col",
-          }) %>
-        <% end %>
-      <% end %>
-      <% @locations.each do |location| %>
-        <%= table.body do |body| %>
-          <%= body.row do |row| %>
-            <% row.cell(text: location.id) %>
-            <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit-name"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
-            <% row.cell(text: location.total_units) %>
-            <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>#{location.wheelchair_adaptation == 'Yes' ? "\n<span class=\"govuk-!-font-weight-regular app-!-colour-muted\">With wheelchair adaptations</span>" : ''}")) %>
-          <% end %>
-        <% end %>
+<%= govuk_table do |table| %>
+  <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
+    <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>.
+  <% end %>
+  <%= table.head do |head| %>
+    <%= head.row do |row| %>
+      <% row.cell(header: true, text: "Code", html_attributes: {
+        scope: "col",
+      }) %>
+      <% row.cell(header: true, text: "Postcode", html_attributes: {
+        scope: "col",
+      }) %>
+      <% row.cell(header: true, text: "Units", html_attributes: {
+        scope: "col",
+      }) %>
+      <% row.cell(header: true, text: "Common unit type", html_attributes: {
+        scope: "col",
+      }) %>
+    <% end %>
+  <% end %>
+  <% @locations.each do |location| %>
+    <%= table.body do |body| %>
+      <%= body.row do |row| %>
+        <% row.cell(text: location.id) %>
+        <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit-name"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
+        <% row.cell(text: location.total_units) %>
+        <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>#{location.wheelchair_adaptation == 'Yes' ? "\n<span class=\"govuk-!-font-weight-regular app-!-colour-muted\">With wheelchair adaptations</span>" : ''}")) %>
       <% end %>
     <% end %>
-  </div>
-</div>
+  <% end %>
+<% end %>
 
 <%== render partial: "pagy/nav", locals: { pagy: @pagy, item_name: "locations" } %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -2,9 +2,9 @@
 <% content_for :title, title %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-        text: "Back",
-        href: "/schemes/#{@scheme.id}",
-      ) %>
+    text: "Back",
+    href: "/schemes/#{@scheme.id}",
+  ) %>
 <% end %>
 <%= render partial: "organisations/headings", locals: { main: @scheme.service_name, sub: nil } %>
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -7,8 +7,7 @@
       ) %>
 <% end %>
 <%= render partial: "organisations/headings", locals: { main: @scheme.service_name, sub: nil } %>
-<% location_caption = @scheme.locations.count.eql?(1) ? "1 location" : "#{@scheme.locations.count} locations" %>
-<%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, location_caption)) %>
+<%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>
 
 <%= govuk_table do |table| %>
   <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -11,7 +11,7 @@
 
 <%= govuk_table do |table| %>
   <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-    <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>.
+    <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>
   <% end %>
   <%= table.head do |head| %>
     <%= head.row do |row| %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -2,9 +2,9 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link(
-        text: "Back",
-        href: "/schemes/#{@scheme.id}/support",
-      ) %>
+    text: "Back",
+    href: "/schemes/#{@scheme.id}/support",
+  ) %>
 <% end %>
 
 <%= render partial: "organisations/headings", locals: { main: "Add a location to this scheme", sub: @scheme.service_name } %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -2,8 +2,6 @@
 
 <%= render partial: "organisations/headings", locals: { main: "Check your changes before creating this scheme", sub: @scheme.service_name } %>
 
-<% location_caption = @scheme.locations.count.eql?(1) ? "1 location" : "#{@scheme.locations.count} locations" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters-from-desktop">
     <%= govuk_tabs(title: "Check your answers before creating this scheme") do |component| %>

--- a/app/views/schemes/confirm_secondary.html.erb
+++ b/app/views/schemes/confirm_secondary.html.erb
@@ -12,9 +12,7 @@
 <%= form_for(@scheme, method: :patch) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <% selection = [OpenStruct.new(id: "Yes", name: "Yes"), OpenStruct.new(id: "No", name: "No")] %>
-
       <%= f.govuk_collection_radio_buttons :has_other_client_group,
         selection,
         :id,

--- a/app/views/schemes/details.html.erb
+++ b/app/views/schemes/details.html.erb
@@ -1,79 +1,79 @@
 <% content_for :title, "Create a new supported housing scheme" %>
 
- <% content_for :before_content do %>
-   <%= govuk_back_link(
-     text: "Back",
-     href: :back,
-   ) %>
- <% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: "Back",
+    href: :back,
+  ) %>
+<% end %>
 
- <%= render partial: "organisations/headings", locals: { main: "Create a new supported housing scheme", sub: nil } %>
+<%= render partial: "organisations/headings", locals: { main: "Create a new supported housing scheme", sub: nil } %>
 
- <%= form_for(@scheme, method: :patch) do |f| %>
-   <div class="govuk-grid-row">
-     <div class="govuk-grid-column-two-thirds">
-       <%= f.govuk_error_summary %>
+<%= form_for(@scheme, method: :patch) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
 
-       <%= f.govuk_text_field :service_name,
-         label: { text: "Scheme name", size: "m" },
-         hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
+      <%= f.govuk_text_field :service_name,
+        label: { text: "Scheme name", size: "m" },
+        hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
 
-       <%= f.govuk_check_boxes_fieldset :sensitive,
-                                        legend: nil do %>
-         <%= f.govuk_check_box :sensitive,
-                               1,
-                               0,
-                               multiple: false,
-                               checked: @scheme.sensitive == "Yes",
-                               label: { text: "This scheme contains confidential information" } %>
-       <% end %>
+      <%= f.govuk_check_boxes_fieldset :sensitive,
+                                      legend: nil do %>
+        <%= f.govuk_check_box :sensitive,
+                              1,
+                              0,
+                              multiple: false,
+                              checked: @scheme.sensitive == "Yes",
+                              label: { text: "This scheme contains confidential information" } %>
+      <% end %>
 
-       <% null_option = [OpenStruct.new(id: "", name: "Select an option")] %>
-       <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
-       <% managing_org_answer_options = null_option + organisations %>
+      <% null_option = [OpenStruct.new(id: "", name: "Select an option")] %>
+      <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
+      <% managing_org_answer_options = null_option + organisations %>
 
-       <%= f.govuk_collection_select :managing_organisation_id,
-                                     managing_org_answer_options,
-                                     :id,
-                                     :name,
-                                     label: { text: "Which organisation manages this scheme?", size: "m" },
-                                     options: { required: true },
-                                     "data-controller": %w[accessible-autocomplete conditional-filter] %>
+      <%= f.govuk_collection_select :managing_organisation_id,
+                                    managing_org_answer_options,
+                                    :id,
+                                    :name,
+                                    label: { text: "Which organisation manages this scheme?", size: "m" },
+                                    options: { required: true },
+                                    "data-controller": %w[accessible-autocomplete conditional-filter] %>
 
-       <% if current_user.support? %>
-         <%= f.govuk_collection_select :owning_organisation_id,
-                                       organisations,
-                                       :id,
-                                       :name,
-                                       label: { text: "Which organisation owns the housing stock for this scheme?", size: "m" },
-                                       "data-controller": %w[accessible-autocomplete conditional-filter] %>
-       <% end %>
+      <% if current_user.support? %>
+        <%= f.govuk_collection_select :owning_organisation_id,
+                                      organisations,
+                                      :id,
+                                      :name,
+                                      label: { text: "Which organisation owns the housing stock for this scheme?", size: "m" },
+                                      "data-controller": %w[accessible-autocomplete conditional-filter] %>
+      <% end %>
 
-       <% if current_user.data_coordinator? %>
-         <%= f.hidden_field :owning_organisation_id, value: current_user.organisation.id %>
-       <% end %>
+      <% if current_user.data_coordinator? %>
+        <%= f.hidden_field :owning_organisation_id, value: current_user.organisation.id %>
+      <% end %>
 
-       <% scheme_types_selection = Scheme.scheme_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
+      <% scheme_types_selection = Scheme.scheme_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
 
-       <%= f.govuk_collection_radio_buttons :scheme_type,
-         scheme_types_selection,
-         :id,
-         :name,
-         legend: { text: "What is this type of scheme?", size: "m" } %>
+      <%= f.govuk_collection_radio_buttons :scheme_type,
+        scheme_types_selection,
+        :id,
+        :name,
+        legend: { text: "What is this type of scheme?", size: "m" } %>
 
-       <% care_acts_selection = Scheme.registered_under_care_acts.keys.reverse.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
+      <% care_acts_selection = Scheme.registered_under_care_acts.keys.reverse.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
 
-       <%= f.govuk_collection_radio_buttons :registered_under_care_act,
-         care_acts_selection,
-         :id,
-         :name,
-         legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
+      <%= f.govuk_collection_radio_buttons :registered_under_care_act,
+        care_acts_selection,
+        :id,
+        :name,
+        legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
 
-        <%= f.hidden_field :page, value: "details" %>
-        <% if request.query_parameters["check_answers"] %>
-            <%= f.hidden_field :check_answers, value: "true" %>
-        <% end %>
-       <%= f.govuk_submit "Save and continue" %>
-     </div>
-   </div>
- <% end %>
+      <%= f.hidden_field :page, value: "details" %>
+      <% if request.query_parameters["check_answers"] %>
+          <%= f.hidden_field :check_answers, value: "true" %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/schemes/details.html.erb
+++ b/app/views/schemes/details.html.erb
@@ -16,7 +16,7 @@
 
        <%= f.govuk_text_field :service_name,
          label: { text: "Scheme name", size: "m" },
-         hint: { text: "This is how you’ll refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
+         hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
 
        <%= f.govuk_check_boxes_fieldset :sensitive,
                                         legend: nil do %>

--- a/app/views/schemes/edit_name.html.erb
+++ b/app/views/schemes/edit_name.html.erb
@@ -1,46 +1,46 @@
 <% content_for :title, "Scheme details" %>
 
- <% content_for :before_content do %>
-   <%= govuk_back_link(
-     text: "Back",
-     href: :back,
-   ) %>
- <% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: "Back",
+    href: :back,
+  ) %>
+<% end %>
 
- <%= render partial: "organisations/headings", locals: { main: "Scheme details", sub: @scheme.service_name } %>
+<%= render partial: "organisations/headings", locals: { main: "Scheme details", sub: @scheme.service_name } %>
 
- <%= form_for(@scheme, method: :patch) do |f| %>
-   <div class="govuk-grid-row">
-     <div class="govuk-grid-column-two-thirds">
-       <%= f.govuk_error_summary %>
+<%= form_for(@scheme, method: :patch) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
 
-       <%= f.govuk_text_field :service_name,
-         label: { text: "Scheme name", size: "m" },
-         hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
+      <%= f.govuk_text_field :service_name,
+        label: { text: "Scheme name", size: "m" },
+        hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
 
-       <%= f.govuk_check_boxes_fieldset :sensitive,
-                                           legend: nil do %>
-         <%= f.govuk_check_box :sensitive,
-                               1,
-                               0,
-                               multiple: false,
-                               checked: @scheme.sensitive == "Yes",
-                               label: { text: "This scheme contains confidential information" } %>
-       <% end %>
+      <%= f.govuk_check_boxes_fieldset :sensitive,
+                                          legend: nil do %>
+        <%= f.govuk_check_box :sensitive,
+                              1,
+                              0,
+                              multiple: false,
+                              checked: @scheme.sensitive == "Yes",
+                              label: { text: "This scheme contains confidential information" } %>
+      <% end %>
 
-       <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
-       <% if current_user.support? %>
-         <%= f.govuk_collection_select :owning_organisation_id,
-                                       organisations,
-                                       :id,
-                                       :name,
-                                       label: { text: "Which organisation owns the housing stock for this scheme?", size: "m" },
-                                       "data-controller": %w[accessible-autocomplete conditional-filter] %>
-       <% end %>
+      <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
+      <% if current_user.support? %>
+        <%= f.govuk_collection_select :owning_organisation_id,
+                                      organisations,
+                                      :id,
+                                      :name,
+                                      label: { text: "Which organisation owns the housing stock for this scheme?", size: "m" },
+                                      "data-controller": %w[accessible-autocomplete conditional-filter] %>
+      <% end %>
 
-       <%= f.hidden_field :page, value: "edit-name" %>
+      <%= f.hidden_field :page, value: "edit-name" %>
 
-       <%= f.govuk_submit "Save changes" %>
-     </div>
-   </div>
- <% end %>
+      <%= f.govuk_submit "Save changes" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/schemes/edit_name.html.erb
+++ b/app/views/schemes/edit_name.html.erb
@@ -16,7 +16,7 @@
 
        <%= f.govuk_text_field :service_name,
          label: { text: "Scheme name", size: "m" },
-         hint: { text: "This is how you’ll refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
+         hint: { text: "This is how you refer to this supported housing scheme within your organisation. For example, the name could relate to the address or location. You’ll be able to see the client group when selecting it." } %>
 
        <%= f.govuk_check_boxes_fieldset :sensitive,
                                            legend: nil do %>
@@ -29,7 +29,6 @@
        <% end %>
 
        <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
-
        <% if current_user.support? %>
          <%= f.govuk_collection_select :owning_organisation_id,
                                        organisations,

--- a/app/views/schemes/new.html.erb
+++ b/app/views/schemes/new.html.erb
@@ -53,7 +53,6 @@
       <% end %>
 
       <% scheme_types_selection = Scheme.scheme_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
-
       <%= f.govuk_collection_radio_buttons :scheme_type,
         scheme_types_selection,
         :id,
@@ -61,7 +60,6 @@
         legend: { text: "What is this type of scheme?", size: "m" } %>
 
       <% care_acts_selection = Scheme.registered_under_care_acts.keys.reverse.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
-
       <%= f.govuk_collection_radio_buttons :registered_under_care_act,
         care_acts_selection,
         :id,

--- a/app/views/schemes/primary_client_group.html.erb
+++ b/app/views/schemes/primary_client_group.html.erb
@@ -14,9 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend">
-      </legend>
-
       <% primary_client_group_selection = Scheme.primary_client_groups.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
       <%= f.govuk_collection_radio_buttons :primary_client_group,
         primary_client_group_selection,

--- a/app/views/schemes/secondary_client_group.html.erb
+++ b/app/views/schemes/secondary_client_group.html.erb
@@ -21,10 +21,10 @@
         :name,
         legend: nil %>
 
-        <%= f.hidden_field :page, value: "secondary-client-group" %>
-        <% if request.query_parameters["check_answers"] == "true" %>
-          <%= f.hidden_field :check_answers, value: "true" %>
-        <% end %>
+      <%= f.hidden_field :page, value: "secondary-client-group" %>
+      <% if request.query_parameters["check_answers"] == "true" %>
+        <%= f.hidden_field :check_answers, value: "true" %>
+      <% end %>
 
       <%= f.govuk_submit "Save and continue" %>
     </div>

--- a/app/views/schemes/secondary_client_group.html.erb
+++ b/app/views/schemes/secondary_client_group.html.erb
@@ -14,9 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend">
-      </legend>
-
       <% secondary_client_group_selection = Scheme.secondary_client_groups.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
       <%= f.govuk_collection_radio_buttons :secondary_client_group,
         secondary_client_group_selection,

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -10,7 +10,7 @@
 
 <%= render partial: "organisations/headings", locals: { main: @scheme.service_name, sub: nil } %>
 
-<%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, @scheme.locations.count.eql?(1) ? "1 location" : "#{@scheme.locations.count} locations")) %>
+<%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -13,7 +13,7 @@
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, @scheme.locations.count.eql?(1) ? "1 location" : "#{@scheme.locations.count} locations")) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters-from-desktop">
     <%= govuk_summary_list do |summary_list| %>
       <% @scheme.display_attributes.each do |attr| %>
         <% next if current_user.data_coordinator? && attr[:name] == ("Housing stock owned by") %>

--- a/app/views/schemes/support.html.erb
+++ b/app/views/schemes/support.html.erb
@@ -28,7 +28,7 @@
         :name,
         legend: { text: "Intended length of stay", size: "m" } %>
 
-        <%= f.hidden_field :page, value: "support" %>
+      <%= f.hidden_field :page, value: "support" %>
 
       <%= f.govuk_submit "Save and continue" %>
     </div>

--- a/app/views/schemes/support.html.erb
+++ b/app/views/schemes/support.html.erb
@@ -14,9 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend">
-      </legend>
-
       <% support_type_selection = Scheme.support_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
       <%= f.govuk_collection_radio_buttons :support_type,
         support_type_selection,

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -198,12 +198,12 @@ RSpec.describe "Schemes scheme Features" do
 
             it "shows service and locations tab" do
               expect(page).to have_link("Scheme")
-              expect(page).to have_link("#{scheme.locations.count} locations")
+              expect(page).to have_link("Locations")
             end
 
             context "when I click locations link" do
               before do
-                click_link("#{scheme.locations.count} locations")
+                click_link("Locations")
               end
 
               it "shows details of those locations" do
@@ -725,7 +725,7 @@ RSpec.describe "Schemes scheme Features" do
 
           context "when I click to see locations" do
             before do
-              click_link "1 location"
+              click_link "Locations"
             end
 
             it "I see location details" do

--- a/spec/helpers/navigation_items_helper_spec.rb
+++ b/spec/helpers/navigation_items_helper_spec.rb
@@ -190,13 +190,13 @@ RSpec.describe NavigationItemsHelper do
         let(:expected_scheme_items) do
           [
             NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", true),
-            NavigationItemsHelper::NavigationItem.new("1 location", "/schemes/1/locations", false),
+            NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", false),
           ]
         end
 
         it "returns navigation items with Schemes item set as current" do
           expect(primary_items("/schemes/1", current_user)).to eq(expected_navigation_items)
-          expect(scheme_items("/schemes/1", 1, "1 location")).to eq(expected_scheme_items)
+          expect(scheme_items("/schemes/1", 1, "Locations")).to eq(expected_scheme_items)
         end
       end
 
@@ -213,13 +213,13 @@ RSpec.describe NavigationItemsHelper do
         let(:expected_scheme_items) do
           [
             NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", false),
-            NavigationItemsHelper::NavigationItem.new("1 location", "/schemes/1/locations", true),
+            NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", true),
           ]
         end
 
         it "returns navigation items with Schemes item set as current" do
           expect(primary_items("/schemes/1/locations", current_user)).to eq(expected_navigation_items)
-          expect(scheme_items("/schemes/1/locations", 1, "1 location")).to eq(expected_scheme_items)
+          expect(scheme_items("/schemes/1/locations", 1, "Locations")).to eq(expected_scheme_items)
         end
       end
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -418,7 +418,7 @@ RSpec.describe LocationsController, type: :request do
         it "updates existing location for scheme with valid params and redirects to correct page" do
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("1 location")
+          expect(page).to have_content("Locations")
         end
 
         it "updates existing location for scheme with valid params" do
@@ -541,7 +541,7 @@ RSpec.describe LocationsController, type: :request do
         it "updates existing location for scheme with valid params and redirects to correct page" do
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("1 location")
+          expect(page).to have_content("Locations")
         end
 
         it "updates existing location for scheme with valid params" do


### PR DESCRIPTION
* Don’t show number of locations in secondary navigation (shown in caption now)
* Correct width for details and locations pages
* Remove empty `legend` elements
* Whitespace/syntax tidy up