### PR TITLE
Fix Swagger docs not loading external resources

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" type="text/css" href="//pagecdn.io/lib/swagger-ui/v4.12.0/swagger-ui.css">
+<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui.css">
 <title>OpenAPI DLUHC CORE Data Collection</title>
-<body><div id="openapi"><script src="//pagecdn.io/lib/swagger-ui/v4.12.0/swagger-ui-bundle.js"></script>
+<body><div id="openapi"><script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui-bundle.min.js"></script>
 <script>
 window.onload = function () {
   const ui = SwaggerUIBundle({


### PR DESCRIPTION
Think pointing to cdnjs.com using a fully resolved URL should fix the external assets 404ing.