### PR TITLE
Ensure breakpoint in filter layout JS matches that used in CSS

### DIFF
--- a/app/frontend/controllers/filter_layout_controller.js
+++ b/app/frontend/controllers/filter_layout_controller.js
@@ -4,7 +4,7 @@ import { FilterToggle } from '../modules/filter_toggle.js'
 export default class extends Controller {
   connect () {
     const filterToggle = new FilterToggle({
-      bigModeMediaQuery: '(min-width: 48.0625em)',
+      bigModeMediaQuery: '(min-width: 57.5625em)', // 921px (wide breakpoint)
       closeButton: {
         container: this.element.querySelector('.app-filter__header'),
         text: 'Close'


### PR DESCRIPTION
There is currently a no-mans land between 769px and 920px where the filter layout shows the filter bar above the page automatically, with no means of closing or toggling it.

This is because the breakpoint used for `bigModeMediaQuery` option in the JavaScript module doesn’t match that used in the CSS.

This PR matches the 2 back up, preventing this no-mans land from existing.