### PR TITLE
Extract and fix answer selected method

### DIFF
--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -228,7 +228,7 @@ class Form::Question
     resource.hint
   end
 
-  def answer_selected(case_log, answer)
+  def answer_selected?(case_log, answer)
     case_log[id].to_s == answer.id.to_s
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -230,6 +230,7 @@ class Form::Question
 
   def answer_selected?(case_log, answer)
     return false unless type == "select"
+
     case_log[id].to_s == answer.id.to_s
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -228,6 +228,10 @@ class Form::Question
     resource.hint
   end
 
+  def answer_selected(case_log, answer)
+    case_log[id].to_s == answer.id.to_s
+  end
+
 private
 
   def selected_answer_option_is_derived?(case_log)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -229,6 +229,7 @@ class Form::Question
   end
 
   def answer_selected?(case_log, answer)
+    return false unless type == "select"
     case_log[id].to_s == answer.id.to_s
   end
 

--- a/app/models/form/setup/questions/scheme_id.rb
+++ b/app/models/form/setup/questions/scheme_id.rb
@@ -10,7 +10,7 @@ class Form::Setup::Questions::SchemeId < ::Form::Question
   end
 
   def answer_options
-    answer_opts = {}
+    answer_opts = { "" => "Select an option" }
     return answer_opts unless ActiveRecord::Base.connected?
 
     Scheme.select(:id, :service_name, :primary_client_group, :secondary_client_group).each_with_object(answer_opts) do |scheme, hsh|
@@ -24,12 +24,16 @@ class Form::Setup::Questions::SchemeId < ::Form::Question
 
     user_org_scheme_ids = Scheme.select(:id).where(owning_organisation_id: case_log.created_by.organisation_id).joins(:locations).merge(Location.where("startdate <= ? or startdate IS NULL", Time.zone.today)).map(&:id)
     answer_options.select do |k, _v|
-      user_org_scheme_ids.include?(k.to_i)
+      user_org_scheme_ids.include?(k.to_i) || k.blank?
     end
   end
 
   def hidden_in_check_answers?(case_log, _current_user = nil)
     !supported_housing_selected?(case_log)
+  end
+
+  def answer_selected(case_log, answer)
+    case_log[id] == answer.name || case_log[id] == answer.resource
   end
 
 private

--- a/app/models/form/setup/questions/scheme_id.rb
+++ b/app/models/form/setup/questions/scheme_id.rb
@@ -32,7 +32,7 @@ class Form::Setup::Questions::SchemeId < ::Form::Question
     !supported_housing_selected?(case_log)
   end
 
-  def answer_selected(case_log, answer)
+  def answer_selected?(case_log, answer)
     case_log[id] == answer.name || case_log[id] == answer.resource
   end
 

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -12,7 +12,7 @@
       data-synonyms="<%= question.answer_option_synonyms(answer.resource) %>"
       data-append="<%= question.answer_option_append(answer.resource) %>"
       data-hint="<%= question.answer_option_hint(answer.resource) %>"
-      <%= @case_log[question.id] == answer.name || @case_log[question.id] == answer.resource || @case_log[question.id].to_s == answer.id ? "selected" : "" %>
+      <%= question.answer_selected(@case_log, answer) ? "selected" : "" %>
       <%= answer.id == "" ? "disabled" : "" %>><%= answer.name || answer.resource %></option>
   <% end %>
   <% end %>

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -12,7 +12,7 @@
       data-synonyms="<%= question.answer_option_synonyms(answer.resource) %>"
       data-append="<%= question.answer_option_append(answer.resource) %>"
       data-hint="<%= question.answer_option_hint(answer.resource) %>"
-      <%= question.answer_selected(@case_log, answer) ? "selected" : "" %>
+      <%= question.answer_selected?(@case_log, answer) ? "selected" : "" %>
       <%= answer.id == "" ? "disabled" : "" %>><%= answer.name || answer.resource %></option>
   <% end %>
   <% end %>

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -962,25 +962,25 @@ RSpec.describe "Schemes scheme Features" do
 
     it "does not display the schemes without a location" do
       visit("/logs/#{case_log.id}/scheme")
-      expect(find("#case-log-scheme-id-field").all("option").count).to eq(3)
+      expect(find("#case-log-scheme-id-field").all("option").count).to eq(4)
     end
 
     it "does not display the schemes with a location with a startdate in the future" do
       location.update!(startdate: Time.utc(2022, 7, 4))
       visit("/logs/#{case_log.id}/scheme")
-      expect(find("#case-log-scheme-id-field").all("option").count).to eq(2)
+      expect(find("#case-log-scheme-id-field").all("option").count).to eq(3)
     end
 
     it "does display the schemes with a location with a startdate in the past" do
       location.update!(startdate: Time.utc(2022, 5, 2))
       visit("/logs/#{case_log.id}/scheme")
-      expect(find("#case-log-scheme-id-field").all("option").count).to eq(3)
+      expect(find("#case-log-scheme-id-field").all("option").count).to eq(4)
     end
 
     it "does display the schemes with a location with a startdate being today" do
       location.update!(startdate: Time.utc(2022, 6, 3))
       visit("/logs/#{case_log.id}/scheme")
-      expect(find("#case-log-scheme-id-field").all("option").count).to eq(3)
+      expect(find("#case-log-scheme-id-field").all("option").count).to eq(4)
     end
   end
 end

--- a/spec/models/form/setup/questions/owning_organisation_id_spec.rb
+++ b/spec/models/form/setup/questions/owning_organisation_id_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe Form::Setup::Questions::OwningOrganisationId, type: :model do
       answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: nil, resource: value) }
       answers.each do |answer|
         if answer.resource == "Select an option"
-          expect(question.answer_selected(case_log, answer)).to eq(true)
+          expect(question.answer_selected?(case_log, answer)).to eq(true)
         else
-          expect(question.answer_selected(case_log, answer)).to eq(false)
+          expect(question.answer_selected?(case_log, answer)).to eq(false)
         end
       end
     end
@@ -87,9 +87,9 @@ RSpec.describe Form::Setup::Questions::OwningOrganisationId, type: :model do
       answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) }
       answers.each do |answer|
         if answer.id == organisation_1.id
-          expect(question.answer_selected(case_log, answer)).to eq(true)
+          expect(question.answer_selected?(case_log, answer)).to eq(true)
         else
-          expect(question.answer_selected(case_log, answer)).to eq(false)
+          expect(question.answer_selected?(case_log, answer)).to eq(false)
         end
       end
     end

--- a/spec/models/form/setup/questions/property_reference_spec.rb
+++ b/spec/models/form/setup/questions/property_reference_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Form::Setup::Questions::PropertyReference, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
+  let(:case_log) { FactoryBot.create(:case_log) }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -37,5 +38,9 @@ RSpec.describe Form::Setup::Questions::PropertyReference, type: :model do
 
   it "is not marked as derived" do
     expect(question.derived?).to be false
+  end
+
+  it "returns false for answer_selected" do
+    expect(question.answer_selected?(case_log, {})).to be false
   end
 end

--- a/spec/models/form/setup/questions/scheme_id_spec.rb
+++ b/spec/models/form/setup/questions/scheme_id_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe Form::Setup::Questions::SchemeId, type: :model do
         answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) }
         answers.each do |answer|
           if answer.resource == "Select an option"
-            expect(question.answer_selected(case_log, answer)).to eq(true)
+            expect(question.answer_selected?(case_log, answer)).to eq(true)
           else
-            expect(question.answer_selected(case_log, answer)).to eq(false)
+            expect(question.answer_selected?(case_log, answer)).to eq(false)
           end
         end
       end
@@ -87,9 +87,9 @@ RSpec.describe Form::Setup::Questions::SchemeId, type: :model do
         answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) }
         answers.each do |answer|
           if answer.id == scheme.id
-            expect(question.answer_selected(case_log, answer)).to eq(true)
+            expect(question.answer_selected?(case_log, answer)).to eq(true)
           else
-            expect(question.answer_selected(case_log, answer)).to eq(false)
+            expect(question.answer_selected?(case_log, answer)).to eq(false)
           end
         end
       end

--- a/spec/models/form/setup/questions/scheme_id_spec.rb
+++ b/spec/models/form/setup/questions/scheme_id_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Form::Setup::Questions::SchemeId, type: :model do
     let(:organisation_2) { FactoryBot.create(:organisation) }
     let(:user) { FactoryBot.create(:user, organisation:) }
     let(:scheme) { FactoryBot.create(:scheme, owning_organisation: organisation) }
-    let(:case_log) { FactoryBot.create(:case_log, created_by: user) }
+    let(:case_log) { FactoryBot.create(:case_log, created_by: user, needstype: 2) }
 
     before do
       FactoryBot.create(:scheme, owning_organisation: organisation_2)
@@ -56,14 +56,42 @@ RSpec.describe Form::Setup::Questions::SchemeId, type: :model do
       end
 
       it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
-        expected_answer = { scheme.id.to_s => scheme }
+        expected_answer = { "" => "Select an option", scheme.id.to_s => scheme }
         expect(question.displayed_answer_options(case_log)).to eq(expected_answer)
       end
     end
 
     context "when there are no schemes with locations" do
-      it "returns an empty hash" do
-        expect(question.displayed_answer_options(case_log)).to eq({})
+      it "returns a hash with one empty option" do
+        expect(question.displayed_answer_options(case_log)).to eq({ "" => "Select an option" })
+      end
+    end
+
+    context "when the question is not answered" do
+      it "returns 'select an option' as selected answer" do
+        case_log.update!(scheme: nil)
+        answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) }
+        answers.each do |answer|
+          if answer.resource == "Select an option"
+            expect(question.answer_selected(case_log, answer)).to eq(true)
+          else
+            expect(question.answer_selected(case_log, answer)).to eq(false)
+          end
+        end
+      end
+    end
+
+    context "when the question is answered" do
+      it "returns 'select an option' as selected answer" do
+        case_log.update!(scheme:)
+        answers = question.displayed_answer_options(case_log).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) }
+        answers.each do |answer|
+          if answer.id == scheme.id
+            expect(question.answer_selected(case_log, answer)).to eq(true)
+          else
+            expect(question.answer_selected(case_log, answer)).to eq(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Extract answer_selected method that determines if the given answer for the question is selected. 
Handle schema_id question differently than other select questions because of it's structure.
Add an empty ("Select an option") option to the schema_id question.