### PR TITLE
Add fail fast flag to pipelines

### DIFF
--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec --exclude-pattern "features/*"
+          bundle exec rspec --exclude-pattern "features/*" --fail-fast
 
   feature_test:
     name: Feature Tests
@@ -138,7 +138,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec spec/features
+          bundle exec rspec spec/features --fail-fast
 
   lint:
     name: Lint

--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec --exclude-pattern "features/*"
+          bundle exec rspec --exclude-pattern "features/*" --fail-fast
 
   feature_test:
     name: Feature Tests
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec spec/features
+          bundle exec rspec spec/features --fail-fast
 
   lint:
     name: Lint


### PR DESCRIPTION
Adds the `--fail-fast` flag to the pipelines to free up the runners if a test fails. This will be particularly useful if the commit is already known to have failing tests or for stopping right away on any flaky tests