### PR TITLE
Fix support services provider page display

### DIFF
--- a/app/views/schemes/support_services_provider.html.erb
+++ b/app/views/schemes/support_services_provider.html.erb
@@ -7,8 +7,6 @@
   ) %>
 <% end %>
 
-<%= render partial: "organisations/headings", locals: { main: "Which organisation provides the support services used by this scheme?", sub: nil } %>
-
 <%= form_for(@scheme, method: :patch) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -22,7 +20,7 @@
                                     managing_org_answer_options,
                                     :id,
                                     :name,
-                                    label: { text: "Which organisation manages this scheme?", size: "m" },
+                                    label: { text: "Which organisation provides the support services used by this scheme?", size: "m" },
                                     options: { required: true },
                                     "data-controller": %w[accessible-autocomplete conditional-filter] %>
 


### PR DESCRIPTION
Updated the support provider page to match the design

<img width="771" alt="Screenshot 2022-07-22 at 09 27 43" src="https://user-images.githubusercontent.com/47317567/180398284-05a5f879-4f17-4dd6-a675-fd7c1a00d243.png">
