### PR TITLE
CLDC-1384 selecting a user shows email

### DIFF
--- a/app/models/form/setup/questions/created_by_id.rb
+++ b/app/models/form/setup/questions/created_by_id.rb
@@ -13,8 +13,9 @@ class Form::Setup::Questions::CreatedById < ::Form::Question
     answer_opts = { "" => "Select an option" }
     return answer_opts unless ActiveRecord::Base.connected?
 
-    User.select(:id, :name).each_with_object(answer_opts) do |user, hsh|
-      hsh[user.id] = user.name
+    User.select(:id, :name, :email).each_with_object(answer_opts) do |user, hsh|
+      hsh[user.id] = user.name if user.name.present?
+      hsh[user.id] = user.email if user.name.blank?
       hsh
     end
   end

--- a/spec/models/form/setup/questions/created_by_id_spec.rb
+++ b/spec/models/form/setup/questions/created_by_id_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe Form::Setup::Questions::CreatedById, type: :model do
   let(:form) { instance_double(Form) }
   let!(:user_1) { FactoryBot.create(:user, name: "first user") }
   let!(:user_2) { FactoryBot.create(:user, name: "second user") }
+  let!(:user_3) { FactoryBot.create(:user, name: nil, email: "madeupmail@example.com") }
   let(:expected_answer_options) do
     {
       "" => "Select an option",
       user_1.id => user_1.name,
       user_2.id => user_2.name,
+      user_3.id => user_3.email,
     }
   end
 


### PR DESCRIPTION
If the support user is creating a log and selecting the user they are creating it for we will now display an email address for the user if their name is not provided (it's an optional field)

<img width="864" alt="Screenshot 2022-07-22 at 10 49 18" src="https://user-images.githubusercontent.com/47317567/180414330-29467728-0374-4a67-90af-10d2e5363ce1.png">
 