### PR TITLE
Fix scheme question when case log doesn't have an organisation yet

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -539,10 +539,17 @@ private
     self.created_by = nil if created_by.organisation != owning_organisation
   end
 
+  def reset_scheme
+    return unless scheme && owning_organisation
+
+    self.scheme = nil if scheme.owning_organisation != owning_organisation
+  end
+
   def reset_invalidated_dependent_fields!
     return unless form
 
     reset_created_by
+    reset_scheme
     reset_not_routed_questions
     reset_derived_questions
   end

--- a/app/models/form/setup/questions/scheme_id.rb
+++ b/app/models/form/setup/questions/scheme_id.rb
@@ -20,11 +20,11 @@ class Form::Setup::Questions::SchemeId < ::Form::Question
   end
 
   def displayed_answer_options(case_log)
-    return {} unless case_log.created_by
-
-    user_org_scheme_ids = Scheme.select(:id).where(owning_organisation_id: case_log.created_by.organisation_id).joins(:locations).merge(Location.where("startdate <= ? or startdate IS NULL", Time.zone.today)).map(&:id)
+    organisation = case_log.owning_organisation || case_log.created_by&.organisation
+    schemes = organisation ? Scheme.select(:id).where(owning_organisation_id: organisation.id) : Scheme.select(:id)
+    filtered_scheme_ids = schemes.joins(:locations).merge(Location.where("startdate <= ? or startdate IS NULL", Time.zone.today)).map(&:id)
     answer_options.select do |k, _v|
-      user_org_scheme_ids.include?(k.to_i) || k.blank?
+      filtered_scheme_ids.include?(k.to_i) || k.blank?
     end
   end
 

--- a/spec/models/form/setup/questions/location_id_spec.rb
+++ b/spec/models/form/setup/questions/location_id_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Form::Setup::Questions::LocationId, type: :model do
 
   context "when getting available locations" do
     let(:scheme) { FactoryBot.create(:scheme) }
-    let(:case_log) { FactoryBot.create(:case_log, scheme:, needstype: 2) }
+    let(:case_log) { FactoryBot.create(:case_log, owning_organisation: scheme.owning_organisation, scheme:, needstype: 2) }
 
     context "when there are no locations" do
       it "the displayed_answer_options is an empty hash" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -93,6 +93,33 @@ RSpec.describe FormController, type: :request do
             expect(response.body).to match("What counts as income?")
           end
         end
+
+        context "when viewing the setup section schemes page" do
+          context "when the user is support" do
+            let(:user) { FactoryBot.create(:user, :support) }
+
+            context "when organisation and user have not been selected yet" do
+              let(:case_log) do
+                FactoryBot.create(
+                  :case_log,
+                  owning_organisation: nil,
+                  managing_organisation: nil,
+                  created_by: nil,
+                  needstype: 2,
+                )
+              end
+
+              before do
+                FactoryBot.create_list(:location, 5)
+              end
+
+              it "returns an unfiltered list of schemes" do
+                get "/logs/#{case_log.id}/scheme", headers: headers, params: {}
+                expect(response.body.scan("<option value=").count).to eq(6)
+              end
+            end
+          end
+        end
       end
 
       context "when displaying check answers pages" do

--- a/spec/services/exports/case_log_export_service_spec.rb
+++ b/spec/services/exports/case_log_export_service_spec.rb
@@ -247,9 +247,12 @@ RSpec.describe Exports::CaseLogExportService do
 
   context "when exporting a supporting housing case logs in XML" do
     let(:export_file) { File.open("spec/fixtures/exports/supported_housing_logs.xml", "r:UTF-8") }
-    let(:location) { FactoryBot.create(:location, :export) }
+    let(:organisation) { FactoryBot.create(:organisation, provider_type: "LA") }
+    let(:user) { FactoryBot.create(:user, organisation:) }
+    let(:scheme) { FactoryBot.create(:scheme, :export, owning_organisation: organisation) }
+    let(:location) { FactoryBot.create(:location, :export, scheme:) }
 
-    let(:case_log) { FactoryBot.create(:case_log, :completed, :export, :sh, scheme: location.scheme, location:) }
+    let(:case_log) { FactoryBot.create(:case_log, :completed, :export, :sh, scheme:, location:, created_by: user, owning_organisation: organisation) }
 
     it "generates an XML export file with the expected content" do
       expected_content = replace_entity_ids(case_log, export_file.read)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/dluhc-core/issues/3438180511

Triggered when you try to view the schemes question as a support user without having answered the organisation question or the created by question yet.