### PR TITLE
Use new formbuilder config option to disable bold radio labels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
       pagy (~> 5.10.1)
       railties (>= 6.1)
       view_component (~> 2.56.2)
-    govuk_design_system_formbuilder (3.1.0)
+    govuk_design_system_formbuilder (3.1.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -225,11 +225,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.7-arm64-darwin)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.7-x86_64-darwin)
+    nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.7-x86_64-linux)
+    nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)

--- a/app/views/schemes/details.html.erb
+++ b/app/views/schemes/details.html.erb
@@ -49,8 +49,7 @@
                                            :id,
                                            :name,
                                            :description,
-                                           legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" },
-                                           bold_labels: false %>
+                                           legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
 
       <% organisations = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
 

--- a/app/views/schemes/new.html.erb
+++ b/app/views/schemes/new.html.erb
@@ -53,8 +53,7 @@
                                            :id,
                                            :name,
                                            :description,
-                                           legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" },
-                                           bold_labels: false %>
+                                           legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
 
       <% if current_user.support? %>
         <%= f.govuk_collection_select :owning_organisation_id,

--- a/app/views/schemes/support.html.erb
+++ b/app/views/schemes/support.html.erb
@@ -23,8 +23,7 @@
                                            :id,
                                            :name,
                                            :description,
-                                           legend: { text: "Level of support given", size: "m" },
-                                           bold_labels: false %>
+                                           legend: { text: "Level of support given", size: "m" } %>
 
       <% intended_length_of_stay_options_hints = { "Very short stay": "Up to one month.", "Short stay": "Up to one year.", "Medium stay": "More than one year but with an expectation to move on.", "Permanent": "Provides a home for life with no requirement for the tenant to move." } %>
 
@@ -35,8 +34,7 @@
                                            :id,
                                            :name,
                                            :description,
-                                           legend: { text: "Intended length of stay", size: "m" },
-                                           bold_labels: false %>
+                                           legend: { text: "Intended length of stay", size: "m" } %>
 
       <%= f.hidden_field :page, value: "support" %>
 

--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -1,0 +1,3 @@
+GOVUKDesignSystemFormBuilder.configure do |conf|
+  conf.default_collection_radio_buttons_auto_bold_labels = false
+end


### PR DESCRIPTION
The GOV.UK Formbuilder [now provides an option to disable the default behaviour for emboldening radio labels with hint text](https://github.com/DFE-Digital/govuk-formbuilder/releases/tag/v3.1.1). This PR uses that option to disable this behaviour, and removes the individual overrides on certain radio collections.