### PR TITLE
Cldc 1392 schemes list

### DIFF
--- a/app/helpers/tab_nav_helper.rb
+++ b/app/helpers/tab_nav_helper.rb
@@ -13,7 +13,8 @@ module TabNavHelper
 
   def scheme_cell(scheme)
     link_text = scheme.service_name
-    [govuk_link_to(link_text, scheme), "<span class=\"govuk-visually-hidden\">Scheme </span><span class=\"govuk-!-font-weight-regular app-!-colour-muted\">#{scheme.primary_client_group}</span>"].join("\n")
+    link = scheme.confirmed? ? scheme : scheme_check_answers_path(scheme)
+    [govuk_link_to(link_text, link), "<span class=\"govuk-visually-hidden\">Scheme </span><span class=\"govuk-!-font-weight-regular app-!-colour-muted\">#{scheme.primary_client_group}</span>"].join("\n")
   end
 
   def org_cell(user)

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -6,7 +6,7 @@ class Scheme < ApplicationRecord
 
   scope :filter_by_id, ->(id) { where(id: (id.start_with?("S") ? id[1..] : id)) }
   scope :search_by_service_name, ->(name) { where("service_name ILIKE ?", "%#{name}%") }
-  scope :search_by_postcode, ->(postcode) { joins(:locations).where("locations.postcode ILIKE ?", "%#{postcode.delete(' ')}%") }
+  scope :search_by_postcode, ->(postcode) { joins("LEFT JOIN locations ON locations.scheme_id = schemes.id").where("locations.postcode ILIKE ?", "%#{postcode.delete(' ')}%") }
   scope :search_by, ->(param) { search_by_postcode(param).or(search_by_service_name(param)).or(filter_by_id(param)).distinct }
 
   validate :validate_confirmed

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -29,7 +29,7 @@
           <% row.cell(text: simple_format(scheme_cell(scheme), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
           <% row.cell(text: scheme.locations&.count) %>
           <% row.cell(text: scheme.managing_organisation&.name) %>
-          <% row.cell(text: scheme.created_at.to_formatted_s(:govuk_date)) %>
+          <% row.cell(text: scheme.confirmed? ? scheme.created_at.to_formatted_s(:govuk_date) : govuk_tag(colour: "grey",text: "Incomplete")) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -29,7 +29,7 @@
           <% row.cell(text: simple_format(scheme_cell(scheme), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
           <% row.cell(text: scheme.locations&.count) %>
           <% row.cell(text: scheme.managing_organisation&.name) %>
-          <% row.cell(text: scheme.confirmed? ? scheme.created_at.to_formatted_s(:govuk_date) : govuk_tag(colour: "grey",text: "Incomplete")) %>
+          <% row.cell(text: scheme.confirmed? ? scheme.created_at.to_formatted_s(:govuk_date) : govuk_tag(colour: "grey", text: "Incomplete")) %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -120,10 +120,11 @@ RSpec.describe "Schemes scheme Features" do
       end
 
       it "returns results with no location" do
-        scheme_to_search.locations.each { |location| location.destroy }
-        scheme_to_search.reload
+        scheme_without_location = FactoryBot.create(:scheme)
+        visit "/schemes"
+        fill_in("search", with: scheme_without_location.id_to_display)
         click_button("Search")
-        expect(page).to have_content(scheme_to_search.id_to_display)
+        expect(page).to have_content(scheme_without_location.id_to_display)
       end
 
       it "allows clearing the search results" do

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -119,6 +119,13 @@ RSpec.describe "Schemes scheme Features" do
         expect(page).to have_content(scheme_to_search.id_to_display)
       end
 
+      it "returns results with no location" do
+        scheme_to_search.locations.each { |location| location.destroy }
+        scheme_to_search.reload
+        click_button("Search")
+        expect(page).to have_content(scheme_to_search.id_to_display)
+      end
+
       it "allows clearing the search results" do
         fill_in("search", with: scheme_to_search.id_to_display)
         click_button("Search")

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -179,6 +179,16 @@ RSpec.describe SchemesController, type: :request do
           end
         end
 
+        it "returns results with no location" do
+          searched_scheme.locations.each { |location| location.destroy }
+          searched_scheme.reload
+          get "/schemes?search=#{search_param}"
+          expect(page).to have_content(searched_scheme.id_to_display)
+          schemes.each do |scheme|
+            expect(page).not_to have_content(scheme.id_to_display)
+          end
+        end
+
         it "updates the table caption" do
           expect(page).to have_content("1 scheme found matching ‘#{search_param}’")
         end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe SchemesController, type: :request do
         assert_select ".govuk-tag", text: /Incomplete/, count: 1
       end
 
+      it "displays a link to check answers page if the scheme is incomplete" do
+        scheme = schemes[0]
+        scheme.update!(confirmed: nil)
+        get "/schemes"
+        expect(page).to have_link(nil, href: /schemes\/#{scheme.id}\/check-answers/)
+      end
+
       it "shows a search bar" do
         expect(page).to have_field("search", type: "search")
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
+      it "shows incomplete tag if the scheme is not confirmed" do
+        schemes[0].update!(confirmed: nil)
+        get "/schemes"
+        assert_select ".govuk-tag", text: /Incomplete/, count: 1
+      end
+
       it "shows a search bar" do
         expect(page).to have_field("search", type: "search")
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -180,10 +180,9 @@ RSpec.describe SchemesController, type: :request do
         end
 
         it "returns results with no location" do
-          searched_scheme.locations.each { |location| location.destroy }
-          searched_scheme.reload
-          get "/schemes?search=#{search_param}"
-          expect(page).to have_content(searched_scheme.id_to_display)
+          scheme_without_location = FactoryBot.create(:scheme)
+          get "/schemes?search=#{scheme_without_location.id}"
+          expect(page).to have_content(scheme_without_location.id_to_display)
           schemes.each do |scheme|
             expect(page).not_to have_content(scheme.id_to_display)
           end


### PR DESCRIPTION
Display incomplete status tag instead of the created date if the scheme is not confirmed
Clicking on an incomplete scheme from the schemes list routes to the check your answers view 
Incomplete schemes can be searchable 
<img width="914" alt="image" src="https://user-images.githubusercontent.com/54268893/181032599-1b7a8100-6aba-4dd2-84d9-fc25f8e47ebb.png">
