### PR TITLE
Fix rent value check

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -619,9 +619,9 @@ private
   end
 
   def get_lettype
-    return unless renttype.present? && needstype.present? && owning_organisation.present? && owning_organisation[:provider_type].present?
+    return unless rent_type.present? && needstype.present? && owning_organisation.present? && owning_organisation[:provider_type].present?
 
-    case RENT_TYPE_MAPPING_LABELS[renttype]
+    case RENT_TYPE_MAPPING_LABELS[RENT_TYPE_MAPPING[rent_type]]
     when "Social Rent"
       if is_supported_housing?
         owning_organisation[:provider_type] == "PRP" ? 2 : 4

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -28,14 +28,14 @@ module Validations::SoftValidations
   def rent_in_soft_min_range?
     return unless brent && weekly_value(brent) && startdate
 
-    rent_range = LaRentRange.find_by(start_year: collection_start_year, la:, beds:, lettype:)
+    rent_range = LaRentRange.find_by(start_year: collection_start_year, la:, beds:, lettype: get_lettype)
     rent_range.present? && weekly_value(brent).between?(rent_range.hard_min, rent_range.soft_min)
   end
 
   def rent_in_soft_max_range?
     return unless brent && weekly_value(brent) && startdate
 
-    rent_range = LaRentRange.find_by(start_year: collection_start_year, la:, beds:, lettype:)
+    rent_range = LaRentRange.find_by(start_year: collection_start_year, la:, beds:, lettype: get_lettype)
     rent_range.present? && weekly_value(brent).between?(rent_range.soft_max, rent_range.hard_max)
   end
 

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Validations::SoftValidations do
-  let(:record) { FactoryBot.create(:case_log) }
+  let(:organisation) { FactoryBot.create(:organisation, provider_type: "PRP") }
+  let(:record) { FactoryBot.create(:case_log, owning_organisation: organisation) }
 
   describe "rent min max validations" do
     before do
@@ -18,7 +19,8 @@ RSpec.describe Validations::SoftValidations do
       )
 
       record.la = "E07000223"
-      record.lettype = 1
+      record.needstype = 1
+      record.rent_type = 0
       record.beds = 1
       record.period = 1
       record.startdate = Time.zone.local(2021, 10, 10)

--- a/spec/services/imports/case_logs_import_service_spec.rb
+++ b/spec/services/imports/case_logs_import_service_spec.rb
@@ -229,6 +229,31 @@ RSpec.describe Imports::CaseLogsImportService do
       end
     end
 
+    context "and the rent soft validation is triggered (rent_value_check)" do
+      before do
+        case_log_xml.at_xpath("//xmlns:Q18ai").content = 200.00
+        case_log_xml.at_xpath("//xmlns:Q18av").content = 232.02
+        case_log_xml.at_xpath("//xmlns:Q17").content = "1 Weekly for 52 weeks"
+        LaRentRange.create!(
+          start_year: 2021,
+          la: "E08000035",
+          beds: 2,
+          lettype: 1,
+          soft_max: 900,
+          hard_max: 1500,
+          soft_min: 500,
+          hard_min: 100,
+        )
+      end
+
+      it "completes the log" do
+        allow(logger).to receive(:warn)
+        case_log_service.send(:create_log, case_log_xml)
+        case_log = CaseLog.find_by(old_id: case_log_id)
+        expect(case_log.status).to eq("completed")
+      end
+    end
+
     context "and this is a supported housing log with multiple locations under a scheme" do
       let(:case_log_id) { "0b4a68df-30cc-474a-93c0-a56ce8fdad3b" }
 

--- a/spec/services/imports/case_logs_import_service_spec.rb
+++ b/spec/services/imports/case_logs_import_service_spec.rb
@@ -247,7 +247,6 @@ RSpec.describe Imports::CaseLogsImportService do
       end
 
       it "completes the log" do
-        allow(logger).to receive(:warn)
         case_log_service.send(:create_log, case_log_xml)
         case_log = CaseLog.find_by(old_id: case_log_id)
         expect(case_log.status).to eq("completed")


### PR DESCRIPTION
Rent value check field gets cleared because showing/hiding its page depends_on rent soft validation being triggered. The soft validation check depends on lettype which is only derived after we check which questions should get cleared.

This removes the `lettype` derived variable from the soft validation calculation such that both work.