### PR TITLE
Design review

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -13,6 +13,8 @@
 
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>
 
+<h2 class="govuk-visually-hidden">Locations</h2>
+
 <%= render SearchComponent.new(current_user:, search_label: "Search by location name or postcode", value: @searched) %>
 
 <%= govuk_section_break(visible: true, size: "m") %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -5,8 +5,6 @@
 
 <%= render partial: "organisations/headings", locals: request.path == "/organisations" ? { main: "Organisations", sub: nil } : { main: @organisation.name, sub: "Organisations" } %>
 
-<h2 class="govuk-visually-hidden">Organisations</h2>
-
 <% if current_user.support? %>
   <%= govuk_button_link_to "Create a new organisation", new_organisation_path, html: { method: :get } %>
 <% end %>

--- a/app/views/organisations/logs.html.erb
+++ b/app/views/organisations/logs.html.erb
@@ -5,11 +5,12 @@
 
 <%= render partial: "organisations/headings", locals: { main: @organisation.name, sub: nil } %>
 
-<%= render SubNavigationComponent.new(
-  items: secondary_items(request.path, @organisation.id),
-) %>
-
-<h2 class="govuk-visually-hidden">Logs</h2>
+<% if current_user.support? %>
+  <%= render SubNavigationComponent.new(
+    items: secondary_items(request.path, @organisation.id),
+  ) %>
+  <h2 class="govuk-visually-hidden">Logs</h2>
+<% end %>
 
 <div class="app-filter-layout" data-controller="filter-layout">
   <div class="govuk-button-group app-filter-toggle">

--- a/app/views/organisations/schemes.html.erb
+++ b/app/views/organisations/schemes.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :title, title %>
 
-<%= render partial: "organisations/headings", locals: current_user.support? ? { main: @organisation.name, sub: nil } : { main: "Schemes", sub: current_user.organisation.name } %>
+<%= render partial: "organisations/headings", locals: current_user.support? ? { main: @organisation.name, sub: nil } : { main: "Supported housing schemes", sub: current_user.organisation.name } %>
 
 <% if current_user.support? %>
   <%= render SubNavigationComponent.new(

--- a/app/views/organisations/schemes.html.erb
+++ b/app/views/organisations/schemes.html.erb
@@ -15,6 +15,12 @@
 
 <h2 class="govuk-visually-hidden">Supported housing schemes</h2>
 
+<%= govuk_details(
+  classes: "govuk-!-width-two-thirds",
+  summary_text: "What is a supported housing scheme?",
+  text: "A supported housing scheme (also known as a ‘supported housing service’) provides shared or self-contained housing for a particular client group, for example younger or vulnerable people. A single scheme can contain multiple units, for example bedrooms in shared houses or a bungalow with 3 bedrooms.",
+) %>
+
 <%= render SearchComponent.new(current_user:, search_label: "Search by scheme name, code or postcode", value: @searched) %>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/organisations/schemes.html.erb
+++ b/app/views/organisations/schemes.html.erb
@@ -9,11 +9,10 @@
   <%= render SubNavigationComponent.new(
     items: secondary_items(request.path, @organisation.id),
   ) %>
+  <h2 class="govuk-visually-hidden">Supported housing schemes</h2>
 <% end %>
 
 <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
-
-<h2 class="govuk-visually-hidden">Supported housing schemes</h2>
 
 <%= govuk_details(
   classes: "govuk-!-width-two-thirds",

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -8,9 +8,8 @@
   <%= render SubNavigationComponent.new(
     items: secondary_items(request.path, @organisation.id),
   ) %>
+  <h2 class="govuk-visually-hidden">About this organisation</h2>
 <% end %>
-
-<h2 class="govuk-visually-hidden">About this organisation</h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/organisations/users.html.erb
+++ b/app/views/organisations/users.html.erb
@@ -5,11 +5,12 @@
 
 <%= render partial: "organisations/headings", locals: { main: @organisation.name, sub: nil } %>
 
-<%= render SubNavigationComponent.new(
-  items: secondary_items(request.path, @organisation.id),
-) %>
-
-<h2 class="govuk-visually-hidden">Users</h2>
+<% if current_user.support? %>
+  <%= render SubNavigationComponent.new(
+    items: secondary_items(request.path, @organisation.id),
+  ) %>
+  <h2 class="govuk-visually-hidden">Users</h2>
+<% end %>
 
 <% if current_user.data_coordinator? || current_user.support? %>
   <%= govuk_button_link_to "Invite user", new_user_path(organisation_id: @organisation.id), html: { method: :get } %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -2,78 +2,76 @@
 <%= render partial: "organisations/headings", locals: { main: "Check your changes before creating this scheme", sub: @scheme.service_name } %>
 
 <%= form_for(@scheme, as: :scheme, method: :patch) do |f| %>
-  <div class="govuk-grid-row">
-    <%= f.govuk_error_summary %>
-      <%= govuk_tabs(title: "Check your answers before creating this scheme") do |component| %>
-        <% component.tab(label: "Scheme") do %>
-          <h2 class="govuk-visually-hidden">Scheme</h2>
-          <dl class="govuk-summary-list">
-            <% @scheme.check_details_attributes.each do |attr| %>
-              <% next if current_user.data_coordinator? && attr[:name] == ("owned by") %>
-              <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_details_path(@scheme, check_answers: true) } %>
-            <% end %>
-            <% if !@scheme.arrangement_type_same? %>
-            <% @scheme.check_support_services_provider_attributes.each do |attr| %>
-              <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_support_services_provider_path(@scheme, check_answers: true) } %>
-              <% end %>
-            <% end %>
-            <% @scheme.check_primary_client_attributes.each do |attr| %>
-              <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_primary_client_group_path(@scheme, check_answers: true) } %>
-            <% end %>
-            <% @scheme.check_secondary_client_confirmation_attributes.each do |attr| %>
-              <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_confirm_secondary_client_group_path(@scheme, check_answers: true) } %>
-            <% end %>
-            <% if @scheme.has_other_client_group == "Yes" %>
-              <% @scheme.check_secondary_client_attributes.each do |attr| %>
-                <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_secondary_client_group_path(@scheme, check_answers: true) } %>
-              <% end %>
-            <% end %>
-            <% @scheme.check_support_attributes.each do |attr| %>
-              <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_support_path(@scheme, check_answers: true) } %>
-            <% end %>
-          </dl>
+  <%= f.govuk_error_summary %>
+  <%= govuk_tabs(title: "Check your answers before creating this scheme") do |component| %>
+    <% component.tab(label: "Scheme") do %>
+      <h2 class="govuk-visually-hidden">Scheme</h2>
+      <dl class="govuk-summary-list">
+        <% @scheme.check_details_attributes.each do |attr| %>
+          <% next if current_user.data_coordinator? && attr[:name] == ("owned by") %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_details_path(@scheme, check_answers: true) } %>
         <% end %>
-        <% component.tab(label: "Locations") do %>
-          <h2 class="govuk-visually-hidden">Locations</h2>
-          <%= govuk_table do |table| %>
-            <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-              <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>
-            <% end %>
-            <%= table.head do |head| %>
-              <%= head.row do |row| %>
-                <% row.cell(header: true, text: "Code", html_attributes: {
-                  scope: "col",
-                }) %>
-                <% row.cell(header: true, text: "Postcode", html_attributes: {
-                  scope: "col",
-                }) %>
-                <% row.cell(header: true, text: "Units", html_attributes: {
-                  scope: "col",
-                }) %>
-                <% row.cell(header: true, text: "Common unit type", html_attributes: {
-                  scope: "col",
-                }) %>
-                <% row.cell(header: true, text: "Available from", html_attributes: {
-                  scope: "col",
-                }) %>
-              <% end %>
-            <% end %>
-            <% @scheme.locations.each do |location| %>
-              <%= table.body do |body| %>
-                <%= body.row do |row| %>
-                  <% row.cell(text: location.id) %>
-                  <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
-                  <% row.cell(text: location.units) %>
-                  <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
-                  <% row.cell(text: location.startdate&.to_formatted_s(:govuk_date)) %>
-                  <% end %>
-              <% end %>
-            <% end %>
+        <% if !@scheme.arrangement_type_same? %>
+        <% @scheme.check_support_services_provider_attributes.each do |attr| %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_support_services_provider_path(@scheme, check_answers: true) } %>
           <% end %>
-          <%= govuk_button_link_to "Add a location", new_location_path(id: @scheme.id), secondary: true %>
+        <% end %>
+        <% @scheme.check_primary_client_attributes.each do |attr| %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_primary_client_group_path(@scheme, check_answers: true) } %>
+        <% end %>
+        <% @scheme.check_secondary_client_confirmation_attributes.each do |attr| %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_confirm_secondary_client_group_path(@scheme, check_answers: true) } %>
+        <% end %>
+        <% if @scheme.has_other_client_group == "Yes" %>
+          <% @scheme.check_secondary_client_attributes.each do |attr| %>
+            <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_secondary_client_group_path(@scheme, check_answers: true) } %>
+          <% end %>
+        <% end %>
+        <% @scheme.check_support_attributes.each do |attr| %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_support_path(@scheme, check_answers: true) } %>
+        <% end %>
+      </dl>
+    <% end %>
+    <% component.tab(label: "Locations") do %>
+      <h2 class="govuk-visually-hidden">Locations</h2>
+      <%= govuk_table do |table| %>
+        <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
+          <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>
+        <% end %>
+        <%= table.head do |head| %>
+          <%= head.row do |row| %>
+            <% row.cell(header: true, text: "Code", html_attributes: {
+              scope: "col",
+            }) %>
+            <% row.cell(header: true, text: "Postcode", html_attributes: {
+              scope: "col",
+            }) %>
+            <% row.cell(header: true, text: "Units", html_attributes: {
+              scope: "col",
+            }) %>
+            <% row.cell(header: true, text: "Common unit type", html_attributes: {
+              scope: "col",
+            }) %>
+            <% row.cell(header: true, text: "Available from", html_attributes: {
+              scope: "col",
+            }) %>
+          <% end %>
+        <% end %>
+        <% @scheme.locations.each do |location| %>
+          <%= table.body do |body| %>
+            <%= body.row do |row| %>
+              <% row.cell(text: location.id) %>
+              <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
+              <% row.cell(text: location.units) %>
+              <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
+              <% row.cell(text: location.startdate&.to_formatted_s(:govuk_date)) %>
+              <% end %>
+          <% end %>
         <% end %>
       <% end %>
-  </div>
+      <%= govuk_button_link_to "Add a location", new_location_path(id: @scheme.id), secondary: true %>
+    <% end %>
+  <% end %>
   <%= f.hidden_field :page, value: "check-answers" %>
   <%= f.hidden_field :confirmed, value: "true" %>
   <% button_label = @scheme.confirmed? ? "Save" : "Create scheme" %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -6,6 +6,7 @@
     <%= f.govuk_error_summary %>
       <%= govuk_tabs(title: "Check your answers before creating this scheme") do |component| %>
         <% component.tab(label: "Scheme") do %>
+          <h2 class="govuk-visually-hidden">Scheme</h2>
           <dl class="govuk-summary-list">
             <% @scheme.check_details_attributes.each do |attr| %>
               <% next if current_user.data_coordinator? && attr[:name] == ("owned by") %>
@@ -33,6 +34,7 @@
           </dl>
         <% end %>
         <% component.tab(label: "Locations") do %>
+          <h2 class="govuk-visually-hidden">Locations</h2>
           <%= govuk_table do |table| %>
             <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
               <strong><%= @scheme.locations.count %></strong> <%= @scheme.locations.count.eql?(1) ? "location" : "locations" %>

--- a/app/views/schemes/index.html.erb
+++ b/app/views/schemes/index.html.erb
@@ -5,8 +5,6 @@
 
 <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Supported housing schemes", sub: nil } : { main: "Supported housing schemes", sub: current_user.organisation.name } %>
 
-<h2 class="govuk-visually-hidden">Supported housing schemes</h2>
-
 <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
 
 <%= render SearchComponent.new(current_user:, search_label: "Search by scheme name, code or postcode", value: @searched) %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -12,6 +12,8 @@
 
 <%= render SubNavigationComponent.new(items: scheme_items(request.path, @scheme.id, "Locations")) %>
 
+<h2 class="govuk-visually-hidden">Scheme</h2>
+
 <div class="govuk-grid-row">
   <%= govuk_summary_list do |summary_list| %>
     <% @scheme.display_attributes.each do |attr| %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -14,15 +14,13 @@
 
 <h2 class="govuk-visually-hidden">Scheme</h2>
 
-<div class="govuk-grid-row">
-  <%= govuk_summary_list do |summary_list| %>
-    <% @scheme.display_attributes.each do |attr| %>
-      <% next if current_user.data_coordinator? && attr[:name] == ("Housing stock owned by") %>
-      <%= summary_list.row do |row| %>
-        <% row.key { attr[:name].eql?("Registered under Care Standards Act 2000") ? "Registered under Care Standards Act 2000" : attr[:name].to_s.humanize } %>
-        <% row.value { details_html(attr) } %>
-        <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] %>
-      <% end %>
+<%= govuk_summary_list do |summary_list| %>
+  <% @scheme.display_attributes.each do |attr| %>
+    <% next if current_user.data_coordinator? && attr[:name] == ("Housing stock owned by") %>
+    <%= summary_list.row do |row| %>
+      <% row.key { attr[:name].eql?("Registered under Care Standards Act 2000") ? "Registered under Care Standards Act 2000" : attr[:name].to_s.humanize } %>
+      <% row.value { details_html(attr) } %>
+      <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] %>
     <% end %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :title, title %>
 
-<%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Users", sub: nil } : { main: "User", sub: current_user.organisation.name } %>
+<%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Users", sub: nil } : { main: "Users", sub: current_user.organisation.name } %>
 
 <% if current_user.data_coordinator? || current_user.support? %>
   <%= govuk_button_link_to "Invite user", new_user_path, html: { method: :get } %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,8 +5,6 @@
 
 <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Users", sub: nil } : { main: "User", sub: current_user.organisation.name } %>
 
-<h2 class="govuk-visually-hidden">Users</h2>
-
 <% if current_user.data_coordinator? || current_user.support? %>
   <%= govuk_button_link_to "Invite user", new_user_path, html: { method: :get } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,7 +325,7 @@ en:
       name: "Location name (optional)"
       units: "Total number of units at this location"
       type_of_unit: "What is the most common type of unit at this location?"
-      startdate: "When did the first property in this location become available under this scheme?"
+      startdate: "When did the first property in this location become available under this scheme? (optional)"
       add_another_location: "Do you want to add another location?"
       mobility_type: "What are the mobility standards for the majority of units in this location?"
     descriptions:

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -116,11 +116,6 @@ RSpec.describe OrganisationsController, type: :request do
           expect(page).to have_field("search", type: "search")
         end
 
-        it "has hidden accessibility field with description" do
-          expected_field = "<h2 class=\"govuk-visually-hidden\">Supported housing schemes</h2>"
-          expect(CGI.unescape_html(response.body)).to include(expected_field)
-        end
-
         it "shows only schemes belonging to the same organisation" do
           expect(page).to have_content(same_org_scheme.id_to_display)
           schemes.each do |scheme|

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -93,11 +93,6 @@ RSpec.describe SchemesController, type: :request do
         expect(CGI.unescape_html(response.body)).to match("<strong>#{schemes.count}</strong> total schemes.")
       end
 
-      it "has hidden accebility field with description" do
-        expected_field = "<h2 class=\"govuk-visually-hidden\">Supported housing schemes</h2>"
-        expect(CGI.unescape_html(response.body)).to include(expected_field)
-      end
-
       context "when params scheme_id is present" do
         it "shows a success banner" do
           get "/schemes", params: { scheme_id: schemes.first.id }


### PR DESCRIPTION
* Add missing guidance dropdown to explain to data coordinators what schemes are:

  <img width="750" alt="Screenshot 2022-07-27 at 16 14 17" src="https://user-images.githubusercontent.com/813383/181284104-efd16427-64ba-4bb1-afa7-2581d251052a.png">

* Correct use of visually hidden page headings (should only be used where sub navigation appears)

* Add visually hidden titles for tab content sections

* Fix ‘User’ typo (should be ‘Users’)

* Say ‘Supported housing schemes’ in page heading

* State that location start date is optional 

* Remove needless (and layout bug inducing) grid row markup within scheme pages