### PR TITLE
Cldc 1394 schemes cya

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -56,7 +56,7 @@ class LocationsController < ApplicationController
       when "edit"
         location_params[:add_another_location] == "Yes" ? redirect_to(new_location_path(@location.scheme)) : redirect_to(scheme_check_answers_path(@scheme, anchor: "locations"))
       when "edit-name"
-        redirect_to(locations_path(@scheme))
+        redirect_to(scheme_check_answers_path(@scheme, anchor: "locations"))
       end
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -5,6 +5,7 @@ class SchemesController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource, except: %i[index]
   before_action :authenticate_scope!
+  before_action :redirect_if_scheme_confirmed, only: %i[primary_client_group confirm_secondary_client_group secondary_client_group support details]
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
@@ -253,5 +254,9 @@ private
     if %w[show locations primary_client_group confirm_secondary_client_group secondary_client_group support details check_answers edit_name].include?(action_name) && !((current_user.organisation == @scheme&.owning_organisation) || current_user.support?)
       render_not_found and return
     end
+  end
+
+  def redirect_if_scheme_confirmed
+    redirect_to @scheme if @scheme.confirmed?
   end
 end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -57,8 +57,8 @@ class SchemesController < ApplicationController
     if @scheme.errors.empty? && @scheme.update(scheme_params)
       if scheme_params[:confirmed] == "true"
         @scheme.locations.each {|location| location.update!(confirmed:true)}
-      end
-      if check_answers
+        redirect_to scheme_path(@scheme)
+      elsif check_answers
         if confirm_secondary_page? page
           redirect_to scheme_secondary_client_group_path(@scheme, check_answers: "true")
         else
@@ -180,7 +180,7 @@ private
         scheme_details_path(@scheme)
       end
     when "edit-name"
-      scheme_path(@scheme)
+      scheme_check_answers_path(@scheme)
     when "check-answers"
       schemes_path(scheme_id: @scheme.id)
     end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -55,6 +55,9 @@ class SchemesController < ApplicationController
 
     validation_errors scheme_params
     if @scheme.errors.empty? && @scheme.update(scheme_params)
+      if scheme_params[:confirmed] == "true"
+        @scheme.locations.each {|location| location.update!(confirmed:true)}
+      end
       if check_answers
         if confirm_secondary_page? page
           redirect_to scheme_secondary_client_group_path(@scheme, check_answers: "true")

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -56,7 +56,7 @@ class SchemesController < ApplicationController
     validation_errors scheme_params
     if @scheme.errors.empty? && @scheme.update(scheme_params)
       if scheme_params[:confirmed] == "true"
-        @scheme.locations.each { |location| location.update!(confirmed: true) }
+        @scheme.locations.update!(confirmed: true)
         flash[:notice] = if scheme_previously_confirmed
                            "#{@scheme.service_name} has been updated."
                          else

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -11,6 +11,10 @@ module CheckAnswersHelper
     end
   end
 
+  def can_change_scheme_answer?(attribute_name, scheme)
+    editable_attributes = current_user.support? ? ["Name", "Confidential information", "Housing stock owned by"] : ["Name", "Confidential information"]
+    !scheme.confirmed? || editable_attributes.include?(attribute_name) 
+  end
 private
 
   def answered_questions_count(subsection, case_log, current_user)

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -15,6 +15,14 @@ module CheckAnswersHelper
     editable_attributes = current_user.support? ? ["Name", "Confidential information", "Housing stock owned by"] : ["Name", "Confidential information"]
     !scheme.confirmed? || editable_attributes.include?(attribute_name) 
   end
+
+  def get_location_change_link_href(scheme, location)
+    if location.confirmed?
+      "/schemes/#{scheme.id}/locations/#{location.id}/edit-name"
+    else
+      "/schemes/#{scheme.id}/locations/#{location.id}/edit"
+    end
+  end
 private
 
   def answered_questions_count(subsection, case_log, current_user)

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -13,7 +13,7 @@ module CheckAnswersHelper
 
   def can_change_scheme_answer?(attribute_name, scheme)
     editable_attributes = current_user.support? ? ["Name", "Confidential information", "Housing stock owned by"] : ["Name", "Confidential information"]
-    !scheme.confirmed? || editable_attributes.include?(attribute_name) 
+    !scheme.confirmed? || editable_attributes.include?(attribute_name)
   end
 
   def get_location_change_link_href(scheme, location)
@@ -23,6 +23,7 @@ module CheckAnswersHelper
       "/schemes/#{scheme.id}/locations/#{location.id}/edit"
     end
   end
+
 private
 
   def answered_questions_count(subsection, case_log, current_user)

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -18,9 +18,9 @@ module CheckAnswersHelper
 
   def get_location_change_link_href(scheme, location)
     if location.confirmed?
-      "/schemes/#{scheme.id}/locations/#{location.id}/edit-name"
+      location_edit_name_path(id: scheme.id, location_id: location.id)
     else
-      "/schemes/#{scheme.id}/locations/#{location.id}/edit"
+      location_edit_path(id: scheme.id, location_id: location.id)
     end
   end
 

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -7,7 +7,9 @@
   ) %>
 <% end %>
 
-<%= form_for(@location, method: :patch, url: location_path) do |f| %>
+<%= render partial: "organisations/headings", locals: { main: "Add a location to this scheme", sub: @scheme.service_name } %>
+
+<%= form_for(@location, method: :patch, url: location_path(location_id: @location.id)) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -9,7 +9,7 @@
 
 <%= render partial: "organisations/headings", locals: { main: "Add a location to this scheme", sub: @scheme.service_name } %>
 
-<%= form_for(@location, method: :patch, url: location_path(location_id: @location.id)) do |f| %>
+<%= form_for(@location, method: :patch, url: location_path(@location)) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>

--- a/app/views/schemes/_scheme_summary_list_row.html.erb
+++ b/app/views/schemes/_scheme_summary_list_row.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= "govuk-summary-list__row #{scheme.confirmed? && attribute[:name] != 'Name' ? 'govuk-summary-list__row--no-actions' : ''}" %>">
+<div class="<%= "govuk-summary-list__row #{scheme.confirmed? && !["Name", "Confidential information", "Housing stock owned by"].include?(attribute[:name]) ? 'govuk-summary-list__row--no-actions' : ''}" %>">
     <dt class="govuk-summary-list__key">
         <%= attribute[:name].to_s %>
     </dt>
@@ -14,7 +14,7 @@
             <%= details_html(attribute) %>
         </dd>
     <% end %>
-    <% if !scheme.confirmed? || attribute[:name] == "Name" %>
+    <% if can_change_scheme_answer?(attribute[:name], scheme) %>
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="<%= change_link %>">Change</a>
         </dd>

--- a/app/views/schemes/_scheme_summary_list_row.html.erb
+++ b/app/views/schemes/_scheme_summary_list_row.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= "govuk-summary-list__row #{scheme.confirmed? && !["Name", "Confidential information", "Housing stock owned by"].include?(attribute[:name]) ? 'govuk-summary-list__row--no-actions' : ''}" %>">
+<div class="<%= "govuk-summary-list__row #{scheme.confirmed? && !can_change_scheme_answer?(attribute[:name], @scheme) ? 'govuk-summary-list__row--no-actions' : ''}" %>">
     <dt class="govuk-summary-list__key">
         <%= attribute[:name].to_s %>
     </dt>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -10,7 +10,7 @@
       <dl class="govuk-summary-list">
         <% @scheme.check_details_attributes.each do |attr| %>
           <% next if current_user.data_coordinator? && attr[:name] == ("owned by") %>
-          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_details_path(@scheme, check_answers: true) } %>
+          <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: @scheme.confirmed? ? scheme_edit_name_path(@scheme) : scheme_details_path(@scheme, check_answers: true) } %>
         <% end %>
         <% if !@scheme.arrangement_type_same? %>
         <% @scheme.check_support_services_provider_attributes.each do |attr| %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -68,7 +68,7 @@
           <%= table.body do |body| %>
             <%= body.row do |row| %>
               <% row.cell(text: location.id) %>
-              <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
+              <% row.cell(text: simple_format(location_cell(location, get_location_change_link_href(@scheme, location)), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
               <% row.cell(text: location.units) %>
               <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
               <% row.cell(text: location.mobility_type) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     member do
       resources :locations do
         get "edit-name", to: "locations#edit_name"
+        get "edit", to: "locations#edit"
       end
     end
   end

--- a/db/migrate/20220729110846_add_confirmed_location.rb
+++ b/db/migrate/20220729110846_add_confirmed_location.rb
@@ -1,0 +1,7 @@
+class AddConfirmedLocation < ActiveRecord::Migration[7.0]
+  def change
+    change_table :locations, bulk: true do |t|
+      t.column :confirmed, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,6 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_02_125711) do
     t.string "mobility_type"
     t.datetime "startdate", precision: nil
     t.string "location_admin_district"
+    t.boolean "confirmed"
     t.index ["old_id"], name: "index_locations_on_old_id", unique: true
     t.index ["scheme_id"], name: "index_locations_on_scheme_id"
   end

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -290,11 +290,6 @@ RSpec.describe "Schemes scheme Features" do
                 end
 
                 context "when you click save" do
-                  xit "takes you to view location tab" do
-                    click_button "Save"
-                    expect(page.current_url.split("/").last).to eq("locations")
-                  end
-
                   it "displays a updated banner" do
                     click_button "Save"
                     expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -285,16 +285,20 @@ RSpec.describe "Schemes scheme Features" do
                 end
 
                 it "allows you to edit the newly added location" do
-                  click_link 'Locations'
-                  expect(page).to have_link(nil , href: /edit/)
+                  click_link "Locations"
+                  expect(page).to have_link(nil, href: /edit/)
                 end
 
                 context "when you click save" do
-                  xit "takes you to view location tab and displays a banner" do
+                  xit "takes you to view location tab" do
                     click_button "Save"
                     expect(page.current_url.split("/").last).to eq("locations")
+                  end
+
+                  it "displays a updated banner" do
+                    click_button "Save"
                     expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-                    expect(page).to have_content("updated")
+                    expect(page).to have_content("has been updated")
                   end
 
                   it "does not let you edit the saved location" do
@@ -584,11 +588,12 @@ RSpec.describe "Schemes scheme Features" do
           end
 
           it "adds scheme to the list of schemes" do
+            expect(page).to have_content "#{scheme.service_name} has been created."
+            click_link "Schemes"
             expect(page).to have_content "Supported housing schemes"
             expect(page).to have_content scheme.id_to_display
             expect(page).to have_content scheme.service_name
             expect(page).to have_content scheme.owning_organisation.name
-            expect(page).to have_content "#{scheme.service_name} has been created."
           end
         end
 
@@ -732,6 +737,13 @@ RSpec.describe "Schemes scheme Features" do
                 expect(page).to have_current_path("/schemes/#{scheme.id}/check-answers")
                 assert_selector "a", text: "Change", count: 3
               end
+
+              it "lets me save the scheme" do
+                click_button "Save"
+                expect(page).to have_current_path("/schemes/#{scheme.id}")
+                expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+                expect(page).to have_content("has been updated")
+              end
             end
           end
 
@@ -772,10 +784,10 @@ RSpec.describe "Schemes scheme Features" do
                   click_button "Save and continue"
                 end
 
-                it "returns to locations page and shows the new name" do
+                it "returns to locations check your answers page and shows the new name" do
                   expect(page).to have_content location.id
                   expect(page).to have_content "NewName"
-                  expect(page).to have_current_path("/schemes/#{scheme.id}/locations")
+                  expect(page.current_url.split("/").last).to eq("check-answers#locations")
                 end
               end
             end
@@ -858,8 +870,8 @@ RSpec.describe "Schemes scheme Features" do
                     click_link("Scheme")
                   end
 
-                  it "does not let you change details other than the name" do
-                    assert_selector "a", text: "Change", count: 1
+                  it "does not let you change details other than the name, Confidential information	and Housing stock owned by" do
+                    assert_selector "a", text: "Change", count: 3
                   end
                 end
               end
@@ -873,7 +885,6 @@ RSpec.describe "Schemes scheme Features" do
   context "when I am signed in as a data coordinator" do
     let(:user) { FactoryBot.create(:user, :data_coordinator, last_sign_in_at: Time.zone.now) }
     let!(:schemes) { FactoryBot.create_list(:scheme, 5, owning_organisation_id: user.organisation_id) }
-    let!(:scheme_to_search) { FactoryBot.create(:scheme) }
 
     before do
       visit("/logs")
@@ -890,9 +901,9 @@ RSpec.describe "Schemes scheme Features" do
 
         context "when I click to see individual scheme" do
           let(:scheme) { schemes.first }
-          let!(:location) { FactoryBot.create(:location, scheme:) }
 
           before do
+            FactoryBot.create(:location, scheme:)
             click_link(scheme.service_name)
           end
 
@@ -919,6 +930,7 @@ RSpec.describe "Schemes scheme Features" do
       end
     end
   end
+
   context "when selecting a scheme" do
     let!(:user) { FactoryBot.create(:user, :data_coordinator, last_sign_in_at: Time.zone.now) }
     let!(:schemes) { FactoryBot.create_list(:scheme, 5, owning_organisation: user.organisation, managing_organisation: user.organisation, arrangement_type: "The same organisation that owns the housing stock") }

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -290,18 +290,19 @@ RSpec.describe "Schemes scheme Features" do
                 end
 
                 context "when you click save" do
-                  it "takes you to view location tab and displays a banner" do
+                  xit "takes you to view location tab and displays a banner" do
                     click_button "Save"
                     expect(page.current_url.split("/").last).to eq("locations")
                     expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-                    expect(page).to have_content("udpated")
+                    expect(page).to have_content("updated")
                   end
 
                   it "does not let you edit the saved location" do
+                    click_link "Locations"
+                    expect(page).to have_link(nil, href: /edit(?!-name)/)
                     click_button "Save"
-                    click_link "Back"
-                    click_link 'Change'
-                    expect(page.current_url.split("/").last).to eq("edit-name")
+                    click_link "Locations"
+                    expect(page).not_to have_link(nil, href: /edit(?!-name)/)
                   end
                 end
 
@@ -310,8 +311,8 @@ RSpec.describe "Schemes scheme Features" do
                     click_link("Scheme")
                   end
 
-                  it "does not let you change details other than the name" do
-                    assert_selector "a", text: "Change", count: 1
+                  it "does not let you change details other than the name, confidential information and housing stock owner" do
+                    assert_selector "a", text: "Change", count: 3
                   end
                 end
               end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -884,7 +884,8 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a support" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let(:scheme_to_update) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let(:scheme_to_update) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
+      let!(:location) { FactoryBot.create(:location, scheme: scheme_to_update )}
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -937,6 +938,21 @@ RSpec.describe SchemesController, type: :request do
           it "updates a scheme with valid params" do
             follow_redirect!
             expect(scheme_to_update.reload.primary_client_group).to eq("Homeless families with support needs")
+          end
+        end
+
+        context "when saving a scheme" do
+          let(:params) { { scheme: { page: "check-answers", confirmed: "true" } } }
+
+          it "marks the scheme as confirmed" do
+           expect(scheme_to_update.reload.confirmed?).to eq(true)
+          end
+
+          it "marks all the scheme locations as confirmed" do
+            expect(scheme_to_update.locations.count > 0).to eq(true)
+            scheme_to_update.locations.each do |location|
+              expect(location.confirmed?).to eq(true)
+            end
           end
         end
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1177,7 +1177,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
       let!(:another_scheme) { FactoryBot.create(:scheme) }
 
       before do
@@ -1204,7 +1204,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, confirmed: nil) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1215,6 +1215,21 @@ RSpec.describe SchemesController, type: :request do
       it "returns a template for a primary-client-group" do
         expect(response).to have_http_status(:ok)
         expect(page).to have_content("What client group is this scheme intended for?")
+      end
+
+      context "and the scheme is confirmed" do
+        before do
+          scheme.update!(confirmed: true)
+          get "/schemes/#{scheme.id}/primary-client-group"
+        end
+
+        it "redirects to a view scheme page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(path).to match("/schemes/#{scheme.id}")
+          expect(page).to have_content(scheme.service_name)
+          assert_select "a", text: /Change/, count: 3
+        end
       end
     end
   end
@@ -1243,7 +1258,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
       let!(:another_scheme) { FactoryBot.create(:scheme) }
 
       before do
@@ -1270,7 +1285,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, confirmed: nil) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1281,6 +1296,21 @@ RSpec.describe SchemesController, type: :request do
       it "returns a template for a confirm-secondary-client-group" do
         expect(response).to have_http_status(:ok)
         expect(page).to have_content("Does this scheme provide for another client group?")
+      end
+
+      context "and the scheme is confirmed" do
+        before do
+          scheme.update!(confirmed: true)
+          get "/schemes/#{scheme.id}/confirm-secondary-client-group"
+        end
+
+        it "redirects to a view scheme page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(path).to match("/schemes/#{scheme.id}")
+          expect(page).to have_content(scheme.service_name)
+          assert_select "a", text: /Change/, count: 3
+        end
       end
     end
   end
@@ -1309,7 +1339,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
       let!(:another_scheme) { FactoryBot.create(:scheme) }
 
       before do
@@ -1336,7 +1366,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, confirmed: nil) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1347,6 +1377,21 @@ RSpec.describe SchemesController, type: :request do
       it "returns a template for a secondary-client-group" do
         expect(response).to have_http_status(:ok)
         expect(page).to have_content("What is the other client group?")
+      end
+
+      context "and the scheme is confirmed" do
+        before do
+          scheme.update!(confirmed: true)
+          get "/schemes/#{scheme.id}/secondary-client-group"
+        end
+
+        it "redirects to a view scheme page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(path).to match("/schemes/#{scheme.id}")
+          expect(page).to have_content(scheme.service_name)
+          assert_select "a", text: /Change/, count: 3
+        end
       end
     end
   end
@@ -1375,7 +1420,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
       let!(:another_scheme) { FactoryBot.create(:scheme) }
 
       before do
@@ -1398,11 +1443,26 @@ RSpec.describe SchemesController, type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "and the scheme is confirmed" do
+        before do
+          scheme.update!(confirmed: true)
+          get "/schemes/#{scheme.id}/support"
+        end
+
+        it "redirects to a view scheme page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(path).to match("/schemes/#{scheme.id}")
+          expect(page).to have_content(scheme.service_name)
+          assert_select "a", text: /Change/, count: 2
+        end
+      end
     end
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, confirmed: nil) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1507,7 +1567,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
       let!(:another_scheme) { FactoryBot.create(:scheme) }
 
       before do
@@ -1530,11 +1590,26 @@ RSpec.describe SchemesController, type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "and the scheme is confirmed" do
+        before do
+          scheme.update!(confirmed: true)
+          get "/schemes/#{scheme.id}/details"
+        end
+
+        it "redirects to a view scheme page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(path).to match("/schemes/#{scheme.id}")
+          expect(page).to have_content(scheme.service_name)
+          assert_select "a", text: /Change/, count: 2
+        end
+      end
     end
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, confirmed: nil) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -37,14 +37,6 @@ RSpec.describe SchemesController, type: :request do
         get "/schemes"
       end
 
-      context "when params scheme_id is present" do
-        it "shows a success banner" do
-          get "/schemes", params: { scheme_id: schemes.first.id }
-          follow_redirect!
-          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-        end
-      end
-
       it "redirects to the organisation schemes path" do
         follow_redirect!
         expect(path).to match("/organisations/#{user.organisation.id}/schemes")
@@ -91,13 +83,6 @@ RSpec.describe SchemesController, type: :request do
 
       it "shows the total organisations count" do
         expect(CGI.unescape_html(response.body)).to match("<strong>#{schemes.count}</strong> total schemes")
-      end
-
-      context "when params scheme_id is present" do
-        it "shows a success banner" do
-          get "/schemes", params: { scheme_id: schemes.first.id }
-          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-        end
       end
 
       context "when paginating over 20 results" do
@@ -885,9 +870,10 @@ RSpec.describe SchemesController, type: :request do
     context "when signed in as a support" do
       let(:user) { FactoryBot.create(:user, :support) }
       let(:scheme_to_update) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
-      let!(:location) { FactoryBot.create(:location, scheme: scheme_to_update )}
+      # let!(:location) { FactoryBot.create(:location, scheme: scheme_to_update) }
 
       before do
+        FactoryBot.create(:location, scheme: scheme_to_update)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
         patch "/schemes/#{scheme_to_update.id}", params:
@@ -945,7 +931,7 @@ RSpec.describe SchemesController, type: :request do
           let(:params) { { scheme: { page: "check-answers", confirmed: "true" } } }
 
           it "marks the scheme as confirmed" do
-           expect(scheme_to_update.reload.confirmed?).to eq(true)
+            expect(scheme_to_update.reload.confirmed?).to eq(true)
           end
 
           it "marks all the scheme locations as confirmed" do

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1393,7 +1393,7 @@ RSpec.describe SchemesController, type: :request do
           assert_select "a", text: /Change/, count: 3
         end
       end
-      
+
       it "does not show the primary client group as an option" do
         expect(scheme.primary_client_group).not_to be_nil
         expect(page).not_to have_content("Homeless families with support needs")


### PR DESCRIPTION
This is a part of CLDC 1394 ticket that addresses some of the navigation around scheme check answers:

- [x] When you create a scheme and add locations it should route to Check your answers page (Scheme details tab)
- [x] When you edit a confirmed scheme name it should route to Check your answers page (Scheme details tab) This would only show change links for the editable fields
- [x] When you add a location to an already confirmed scheme it should route to Check your answers page (location tab). Only the newly added location can be editable, can only edit location names for the others.
- [x] "Create scheme" button is replaced with "Save” button on a confirmed scheme, saving the locations marks them as confirmed, the confirmation banner should say ‘updated’ not ‘created’
- [x] Clicking Save takes you back to the locations list for the scheme - this is not implemented, it takes the user back to the view scheme with only the editable fields having a "change" link
- [x] Clicking that link takes you to the change name form, and clicking save takes you back to CYA (Scheme details tab)
- [x] Navigating to form pages for confirmed scheme directly redirects you to view scheme page