### PR TITLE
CLDC-779 Add missing copy to accessibility statement

### DIFF
--- a/app/views/content/accessibility_statement.md
+++ b/app/views/content/accessibility_statement.md
@@ -60,12 +60,16 @@ An empty link on the ‘Users’ page within ‘Your Organisation’ will cause 
 
 We plan to fix this by December 2022.
 
+An optional field is not clearly labelled on the ‘Invite user to submit CORE data’ page. This fails WCAG 2.1 success criteria 3.3.2 Labels or Instructions (Level A).
+
+We plan to fix this by December 2022.
+
 A skip link for an error message on the ‘Household’s combined income after tax’ page doesn’t work. This fails WCAG 2.1 success criteria 4.1.2 Name, Role, Value (Level A).
 
 We plan to fix this by December 2022.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 27 July 2022. It was last reviewed on 29 July 2022.
+This statement was prepared on 27 July 2022. It was last reviewed on 1 August 2022.
 
 This website was last tested on 14 March 2022. The test was carried out by the Digital Accessibility Centre (DAC).


### PR DESCRIPTION
Ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-779

We updated the copy of the accessibility statement in 91b797c but there was some copy missed from the original document provided to us. This change adds the missing copy, and bumps the last reviewed date on the statement.

The copy doc is [here](https://mhclg.sharepoint.com.mcas.ms/:w:/r/sites/DataCollectionTeam/_layouts/15/doc2.aspx?sourcedoc=%7B0F3E9B17-C9E5-49D2-9178-8F8FB13E6D09%7D&file=Accessibility%20statement.docx&action=default&mobileredirect=true&cid=56fc8029-28e7-421c-aeaa-ed7b5c61e63d).