### PR TITLE
CLDC-1388: Add mobility type and admin district back to location summary views

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -37,6 +37,12 @@
       <% row.cell(header: true, text: "Common unit type", html_attributes: {
         scope: "col",
       }) %>
+      <% row.cell(header: true, text: "Mobility type", html_attributes: {
+        scope: "col",
+      }) %>
+      <% row.cell(header: true, text: "Local authority", html_attributes: {
+        scope: "col",
+      }) %>
       <% row.cell(header: true, text: "Available from", html_attributes: {
         scope: "col",
       }) %>
@@ -49,6 +55,8 @@
         <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit-name"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
         <% row.cell(text: location.units) %>
         <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
+        <% row.cell(text: location.mobility_type) %>
+        <% row.cell(text: location.location_admin_district) %>
         <% row.cell(text: location.startdate&.to_formatted_s(:govuk_date)) %>
         <% end %>
     <% end %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -52,6 +52,12 @@
             <% row.cell(header: true, text: "Common unit type", html_attributes: {
               scope: "col",
             }) %>
+            <% row.cell(header: true, text: "Mobility type", html_attributes: {
+              scope: "col",
+            }) %>
+            <% row.cell(header: true, text: "Local authority", html_attributes: {
+              scope: "col",
+            }) %>
             <% row.cell(header: true, text: "Available from", html_attributes: {
               scope: "col",
             }) %>
@@ -64,6 +70,8 @@
               <% row.cell(text: simple_format(location_cell(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
               <% row.cell(text: location.units) %>
               <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
+              <% row.cell(text: location.mobility_type) %>
+              <% row.cell(text: location.location_admin_district) %>
               <% row.cell(text: location.startdate&.to_formatted_s(:govuk_date)) %>
               <% end %>
           <% end %>

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -804,6 +804,8 @@ RSpec.describe LocationsController, type: :request do
           expect(page).to have_content(location.id)
           expect(page).to have_content(location.postcode)
           expect(page).to have_content(location.type_of_unit)
+          expect(page).to have_content(location.mobility_type)
+          expect(page).to have_content(location.location_admin_district)
           expect(page).to have_content(location.startdate&.to_formatted_s(:govuk_date))
         end
       end


### PR DESCRIPTION
Feedback from:https://digital.dclg.gov.uk/jira/browse/CLDC-1388

This was originally done in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/769 but looks to have been lost in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/789. This PR adds the extra fields back in.