### PR TITLE
Update secondary client group options

### DIFF
--- a/app/views/schemes/secondary_client_group.html.erb
+++ b/app/views/schemes/secondary_client_group.html.erb
@@ -14,7 +14,7 @@
 
       <%= render partial: "organisations/headings", locals: { main: "What is the other client group?", sub: @scheme.service_name } %>
 
-      <% secondary_client_group_selection = Scheme.secondary_client_groups.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key) } %>
+      <% secondary_client_group_selection = Scheme.secondary_client_groups.keys.excluding("Missing", @scheme.primary_client_group).map { |key, _| OpenStruct.new(id: key, name: key) } %>
       <%= f.govuk_collection_radio_buttons :secondary_client_group,
         secondary_client_group_selection,
         :id,

--- a/spec/features/schemes_helpers.rb
+++ b/spec/features/schemes_helpers.rb
@@ -44,7 +44,7 @@ module SchemesHelpers
   end
 
   def fill_in_and_save_secondary_client_group
-    choose "Homeless families with support needs"
+    choose "Offenders and people at risk of offending"
     click_button "Save and continue"
   end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1334,7 +1334,7 @@ RSpec.describe SchemesController, type: :request do
 
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
+      let!(:scheme) { FactoryBot.create(:scheme, primary_client_group: Scheme::PRIMARY_CLIENT_GROUP[:"Homeless families with support needs"]) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1345,6 +1345,11 @@ RSpec.describe SchemesController, type: :request do
       it "returns a template for a secondary-client-group" do
         expect(response).to have_http_status(:ok)
         expect(page).to have_content("What is the other client group?")
+      end
+
+      it "does not show the primary client group as an option" do
+        expect(scheme.primary_client_group).not_to be_nil
+        expect(page).not_to have_content("Homeless families with support needs")
       end
     end
   end


### PR DESCRIPTION
Filter out the primary client group option from secondary client group question when creating a scheme

Co-authored-by: Sam Collard <Sam.Collard@softwire.com>