### PR TITLE
Back button on edit location page routes to check answers for locations

### DIFF
--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -3,7 +3,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: scheme_check_answers_path(@scheme.id, anchor: "locations"),
+    href: scheme_check_answers_path(@scheme, anchor: "locations"),
   ) %>
 <% end %>
 

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -3,7 +3,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: "/schemes/#{@scheme.id}/support",
+    href: scheme_check_answers_path(@scheme.id, anchor: "locations"),
   ) %>
 <% end %>
 


### PR DESCRIPTION
It was previously routing to support, was likely accidentally copied from /locations/new page