### PR TITLE
Cldc 1424 display postcode question

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -536,7 +536,8 @@ private
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             homeless: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
-                            underoccupation_benefitcap: [{ key: :renewal, value: 0 }] }
+                            underoccupation_benefitcap: [{ key: :renewal, value: 0 }],
+                            wchair: [{ key: :needstype, value: 1 }] }
 
     dependent_questions.each do |dependent, conditions|
       condition_key = conditions.first[:key]

--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -537,7 +537,8 @@ private
                             homeless: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
                             underoccupation_benefitcap: [{ key: :renewal, value: 0 }],
-                            wchair: [{ key: :needstype, value: 1 }] }
+                            wchair: [{ key: :needstype, value: 1 }],
+                            location_id: [{ key: :needstype, value: 1 }] }
 
     dependent_questions.each do |dependent, conditions|
       condition_key = conditions.first[:key]

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -34,7 +34,14 @@
                   "conditional_for": {
                     "postcode_full": [1]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [{
+                      "postcode_known": 0
+                    },
+                    {
+                      "postcode_known": 1
+                    }]
+                  }
                 },
                 "postcode_full": {
                   "check_answer_label": "Postcode",
@@ -1122,7 +1129,11 @@
               }
             },
             "females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check": {
-              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
                 "arguments": [
@@ -1248,7 +1259,11 @@
               }
             },
             "females_in_soft_age_range_in_pregnant_household_lead_age_value_check": {
-              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
                 "arguments": [
@@ -1356,7 +1371,11 @@
               }
             },
             "females_in_soft_age_range_in_pregnant_household_lead_value_check": {
-              "depends_on": [{ "female_in_pregnant_household_in_soft_validation_range?": true }],
+              "depends_on": [
+                {
+                  "female_in_pregnant_household_in_soft_validation_range?": true
+                }
+              ],
               "title_text": {
                 "translation": "soft_validations.pregnancy.title",
                 "arguments": [

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -34,7 +34,14 @@
                   "conditional_for": {
                     "postcode_full": [1]
                   },
-                  "hidden_in_check_answers": true
+                  "hidden_in_check_answers": {
+                    "depends_on": [{
+                      "postcode_known": 0
+                    },
+                    {
+                      "postcode_known": 1
+                    }]
+                  }
                 },
                 "postcode_full": {
                   "check_answer_label": "Postcode",

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1843,7 +1843,7 @@ RSpec.describe CaseLog do
     end
 
     context "when it changes from a supported housing to not a supported housing" do
-      let(:location) { FactoryBot.create(:location, mobility_type: "A") }
+      let(:location) { FactoryBot.create(:location, mobility_type: "A", postcode: "SW1P 4DG") }
       let(:case_log) { FactoryBot.create(:case_log, location:) }
 
       it "resets inferred wchair value" do
@@ -1857,6 +1857,18 @@ RSpec.describe CaseLog do
         record_from_db = ActiveRecord::Base.connection.execute("select needstype from case_logs where id=#{case_log.id}").to_a[0]
         expect(record_from_db["wchair"]).to eq(nil)
         expect(case_log["wchair"]).to eq(nil)
+      end
+
+      it "resets location" do
+        case_log.update!({ needstype: 2 })
+
+        record_from_db = ActiveRecord::Base.connection.execute("select location_id from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["location_id"]).to eq(location.id)
+        expect(case_log["location_id"]).to eq(location.id)
+        case_log.update!({ needstype: 1 })
+        record_from_db = ActiveRecord::Base.connection.execute("select location_id from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["location_id"]).to eq(nil)
+        expect(case_log["location_id"]).to eq(nil)
       end
     end
 

--- a/spec/models/case_log_spec.rb
+++ b/spec/models/case_log_spec.rb
@@ -1842,6 +1842,24 @@ RSpec.describe CaseLog do
       end
     end
 
+    context "when it changes from a supported housing to not a supported housing" do
+      let(:location) { FactoryBot.create(:location, mobility_type: "A") }
+      let(:case_log) { FactoryBot.create(:case_log, location:) }
+
+      it "resets inferred wchair value" do
+        case_log.update!({ needstype: 2 })
+
+        record_from_db = ActiveRecord::Base.connection.execute("select wchair from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["wchair"]).to eq(2)
+        expect(case_log["wchair"]).to eq(2)
+
+        case_log.update!({ needstype: 1 })
+        record_from_db = ActiveRecord::Base.connection.execute("select needstype from case_logs where id=#{case_log.id}").to_a[0]
+        expect(record_from_db["wchair"]).to eq(nil)
+        expect(case_log["wchair"]).to eq(nil)
+      end
+    end
+
     context "when it is not a renewal" do
       let(:case_log) { FactoryBot.create(:case_log) }
 


### PR DESCRIPTION
Reset wchair when needstype changes from supported housing to not supported housing - this was causing the property information into `in progress` state, which meant that it went straight to check your answers page.
Check your answers page for general needs now displays the `postcode_known` question in case it was not answered
<img width="672" alt="image" src="https://user-images.githubusercontent.com/54268893/182874577-98ce20c1-4294-42a5-94cf-749c38240750.png">

We also reset location for the case log to nil if case log needstype changes to general needs. It was not being reset as part of the `reset_not_routed_questions` because it is marked as a special case - if there is only 1 location available we don't route to the locations question, instead we infer that location as the answer and we don't want it to be cleared