### PR TITLE
Strip whitespaces from names before saving organisation, scheme or a user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "redis"
 gem "sentry-rails"
 gem "sentry-ruby"
 # Possessives in strings
+gem "auto_strip_attributes"
 gem "possessive"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
 
+gem "auto_strip_attributes"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem "rails", "~> 7.0.2"
 # Use postgresql as the database for Active Record
@@ -55,7 +56,6 @@ gem "redis"
 gem "sentry-rails"
 gem "sentry-ruby"
 # Possessives in strings
-gem "auto_strip_attributes"
 gem "possessive"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.609.0)
     aws-sdk-core (3.131.3)
@@ -428,6 +430,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  auto_strip_attributes
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   bundler-audit

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,7 +2,6 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def strip_whitespaces
-    self.service_name = service_name.strip unless !respond_to?("service_name") || service_name.nil?
-    self.name = name.strip unless !respond_to?("name") || name.nil?
+    fields_to_strip.each { |field| self[field] = self[field].strip if field.present? }
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-
-  def strip_whitespaces
-    fields_to_strip.each { |field| self[field] = self[field].strip if field.present? }
-  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def strip_whitespaces
+    self.service_name = service_name.strip unless !respond_to?("service_name") || service_name.nil?
+    self.name = name.strip unless !respond_to?("name") || name.nil?
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,6 +6,7 @@ class Location < ApplicationRecord
   has_paper_trail
 
   before_save :lookup_postcode!, if: :postcode_changed?
+  before_validation :strip_whitespaces
 
   attr_accessor :add_another_location
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,11 +6,8 @@ class Location < ApplicationRecord
   has_paper_trail
 
   before_save :lookup_postcode!, if: :postcode_changed?
-  before_validation :strip_whitespaces
 
-  def fields_to_strip
-    %w[name]
-  end
+  auto_strip_attributes :name
 
   attr_accessor :add_another_location
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -8,6 +8,10 @@ class Location < ApplicationRecord
   before_save :lookup_postcode!, if: :postcode_changed?
   before_validation :strip_whitespaces
 
+  def fields_to_strip
+    %w[name]
+  end
+
   attr_accessor :add_another_location
 
   scope :search_by_postcode, ->(postcode) { where("REPLACE(postcode, ' ', '') ILIKE ?", "%#{postcode.delete(' ')}%") }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,6 +12,8 @@ class Organisation < ApplicationRecord
 
   has_paper_trail
 
+  before_validation :strip_whitespace
+
   PROVIDER_TYPE = {
     LA: 1,
     PRP: 2,
@@ -73,5 +75,9 @@ class Organisation < ApplicationRecord
       { name: "managing_agents", value: managing_agents, editable: false },
       { name: "data_protection_agreement", value: data_protection_agreement_string, editable: false },
     ]
+  end
+
+  def strip_whitespace
+    self.name = name.strip unless name.nil?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -13,6 +13,11 @@ class Organisation < ApplicationRecord
   has_paper_trail
 
   before_validation :strip_whitespaces
+
+  def fields_to_strip
+    %w[name]
+  end
+  
   PROVIDER_TYPE = {
     LA: 1,
     PRP: 2,

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,8 +12,7 @@ class Organisation < ApplicationRecord
 
   has_paper_trail
 
-  before_validation :strip_whitespace
-
+  before_validation :strip_whitespaces
   PROVIDER_TYPE = {
     LA: 1,
     PRP: 2,
@@ -75,9 +74,5 @@ class Organisation < ApplicationRecord
       { name: "managing_agents", value: managing_agents, editable: false },
       { name: "data_protection_agreement", value: data_protection_agreement_string, editable: false },
     ]
-  end
-
-  def strip_whitespace
-    self.name = name.strip unless name.nil?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -17,7 +17,7 @@ class Organisation < ApplicationRecord
   def fields_to_strip
     %w[name]
   end
-  
+
   PROVIDER_TYPE = {
     LA: 1,
     PRP: 2,

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,11 +12,7 @@ class Organisation < ApplicationRecord
 
   has_paper_trail
 
-  before_validation :strip_whitespaces
-
-  def fields_to_strip
-    %w[name]
-  end
+  auto_strip_attributes :name
 
   PROVIDER_TYPE = {
     LA: 1,

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -19,7 +19,7 @@ class Scheme < ApplicationRecord
 
   validate :validate_confirmed
 
-  before_validation :strip_whitespace
+  before_validation :strip_whitespaces
 
   SENSITIVE = {
     No: 0,
@@ -229,9 +229,5 @@ class Scheme < ApplicationRecord
         end
       end
     end
-  end
-
-  def strip_whitespace
-    self.service_name = service_name.strip unless service_name.nil?
   end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -19,11 +19,7 @@ class Scheme < ApplicationRecord
 
   validate :validate_confirmed
 
-  before_validation :strip_whitespaces
-
-  def fields_to_strip
-    %w[service_name]
-  end
+  auto_strip_attributes :service_name
 
   SENSITIVE = {
     No: 0,

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -21,6 +21,10 @@ class Scheme < ApplicationRecord
 
   before_validation :strip_whitespaces
 
+  def fields_to_strip
+    %w[service_name]
+  end
+
   SENSITIVE = {
     No: 0,
     Yes: 1,

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -19,6 +19,8 @@ class Scheme < ApplicationRecord
 
   validate :validate_confirmed
 
+  before_validation :strip_whitespace
+
   SENSITIVE = {
     No: 0,
     Yes: 1,
@@ -227,5 +229,9 @@ class Scheme < ApplicationRecord
         end
       end
     end
+  end
+
+  def strip_whitespace
+    self.service_name = service_name.strip unless service_name.nil?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ApplicationRecord
 
   has_one_time_password(encrypted: true)
 
+  before_validation :strip_whitespace
+
   ROLES = {
     data_provider: 1,
     data_coordinator: 2,
@@ -164,5 +166,9 @@ private
         errors.add :email, I18n.t("activerecord.errors.models.user.attributes.email.invalid")
       end
     end
+  end
+
+  def strip_whitespace
+    self.name = name.strip unless name.nil?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
 
   has_one_time_password(encrypted: true)
 
-  before_validation :strip_whitespace
+  before_validation :strip_whitespaces
 
   ROLES = {
     data_provider: 1,
@@ -166,9 +166,5 @@ private
         errors.add :email, I18n.t("activerecord.errors.models.user.attributes.email.invalid")
       end
     end
-  end
-
-  def strip_whitespace
-    self.name = name.strip unless name.nil?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,11 +27,7 @@ class User < ApplicationRecord
 
   has_one_time_password(encrypted: true)
 
-  before_validation :strip_whitespaces
-
-  def fields_to_strip
-    %w[name]
-  end
+  auto_strip_attributes :name
 
   ROLES = {
     data_provider: 1,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ApplicationRecord
 
   before_validation :strip_whitespaces
 
+  def fields_to_strip
+    %w[name]
+  end
+
   ROLES = {
     data_provider: 1,
     data_coordinator: 2,

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe LocationsController, type: :request do
     context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
       let!(:scheme) { FactoryBot.create(:scheme) }
-      let(:params) { { location: { name: "Test", units: "5", type_of_unit: "Bungalow", add_another_location: "No", postcode: "ZZ1 1ZZ", mobility_type: "N" } } }
+      let(:params) { { location: { name: " Test", units: "5", type_of_unit: "Bungalow", add_another_location: "No", postcode: "ZZ1 1ZZ", mobility_type: "N" } } }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -962,7 +962,7 @@ RSpec.describe OrganisationsController, type: :request do
       end
 
       describe "#create" do
-        let(:name) { "Unique new org name" }
+        let(:name) { " Unique new org name" }
         let(:address_line1) { "12 Random Street" }
         let(:address_line2) { "Manchester" }
         let(:postcode) { "MD1 5TR" }
@@ -993,7 +993,7 @@ RSpec.describe OrganisationsController, type: :request do
         it "sets the organisation attributes correctly" do
           request
           organisation = Organisation.find_by(housing_registration_no:)
-          expect(organisation.name).to eq(name)
+          expect(organisation.name).to eq("Unique new org name")
           expect(organisation.address_line1).to eq(address_line1)
           expect(organisation.address_line2).to eq(address_line2)
           expect(organisation.postcode).to eq(postcode)

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe SchemesController, type: :request do
     context "when signed in as a data coordinator" do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
       let(:params) do
-        { scheme: { service_name: "testy",
+        { scheme: { service_name: "  testy ",
                     sensitive: "1",
                     scheme_type: "Foyer",
                     registered_under_care_act: "No",

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -841,7 +841,7 @@ RSpec.describe UsersController, type: :request do
       let(:params) do
         {
           "user": {
-            name: "new user",
+            name: "new user ",
             email: "new_user@example.com",
             role: "data_coordinator",
           },
@@ -850,7 +850,7 @@ RSpec.describe UsersController, type: :request do
 
       let(:personalisation) do
         {
-          name: params[:user][:name],
+          name: "new user",
           email: params[:user][:email],
           organisation: user.organisation.name,
           link: include("/account/confirmation?confirmation_token="),
@@ -869,6 +869,14 @@ RSpec.describe UsersController, type: :request do
       it "sends an invitation email" do
         expect(notify_client).to receive(:send_email).with(email_address: params[:user][:email], template_id: User::CONFIRMABLE_TEMPLATE_ID, personalisation:).once
         request
+      end
+
+      it "creates a new scheme for user organisation with valid params" do
+        request
+
+        expect(User.last.name).to eq("new user")
+        expect(User.last.email).to eq("new_user@example.com")
+        expect(User.last.role).to eq("data_coordinator")
       end
 
       it "redirects back to organisation users page" do


### PR DESCRIPTION
Saving it with a space was erroring out when trying to select them from an accessible select. 
It also makes sense not to store the leading/trailing spaces in the names