### PR TITLE
CLDC-1171: User validation order

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,7 +58,7 @@ class UsersController < ApplicationController
       end
     elsif user_params.key?("password")
       format_error_messages
-      @minimum_password_length = User.password_length.min
+      @minimum_password_length = Devise.password_length.min
       render "devise/passwords/edit", locals: { resource: @user, resource_name: "user" }, status: :unprocessable_entity
     else
       format_error_messages
@@ -79,7 +79,6 @@ class UsersController < ApplicationController
       redirect_to created_user_redirect_path
     else
       unless @resource.errors[:organisation].empty?
-        @resource.errors.add(:organisation_id, message: @resource.errors[:organisation])
         @resource.errors.delete(:organisation)
       end
       render :new, status: :unprocessable_entity
@@ -87,7 +86,7 @@ class UsersController < ApplicationController
   end
 
   def edit_password
-    @minimum_password_length = User.password_length.min
+    @minimum_password_length = Devise.password_length.min
     render "devise/passwords/edit", locals: { resource: @user, resource_name: "user" }
   end
 
@@ -113,9 +112,6 @@ private
     @resource.validate
     if user_params[:role].present? && !current_user.assignable_roles.key?(user_params[:role].to_sym)
       @resource.errors.add :role, I18n.t("validations.role.invalid")
-    end
-    if user_params[:role].empty?
-      @resource.errors.add :role, I18n.t("activerecord.errors.models.user.attributes.role.blank")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,17 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :omniauthable
-  include Helpers::Email
-  devise :database_authenticatable, :recoverable, :rememberable, :validatable,
+  devise :database_authenticatable, :recoverable, :rememberable,
          :trackable, :lockable, :two_factor_authenticatable, :confirmable, :timeoutable
 
   belongs_to :organisation
   has_many :owned_case_logs, through: :organisation, dependent: :delete_all
   has_many :managed_case_logs, through: :organisation
 
-  validate :validate_email
-  validates :name, :email, presence: true
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+  validates_format_of :email, with: Devise.email_regexp
+  validates_length_of :password, within: Devise.password_length, allow_blank: true
 
   has_paper_trail ignore: %w[last_sign_in_at
                              current_sign_in_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,16 +154,4 @@ class User < ApplicationRecord
   def valid_for_authentication?
     super && active?
   end
-
-private
-
-  def validate_email
-    unless email_valid?(email)
-      if User.exists?(["email LIKE ?", "%#{email}%"])
-        errors.add :email, I18n.t("activerecord.errors.models.user.attributes.email.taken")
-      else
-        errors.add :email, I18n.t("activerecord.errors.models.user.attributes.email.invalid")
-      end
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
-  validates_format_of :email, with: Devise.email_regexp
-  validates_length_of :password, within: Devise.password_length, allow_blank: true
+  validates :email, format: { with: Devise.email_regexp }
+  validates :password, length: { within: Devise.password_length, allow_blank: true }
 
   has_paper_trail ignore: %w[last_sign_in_at
                              current_sign_in_at

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -41,7 +41,7 @@
             options: { disabled: [""], selected: @organisation_id ? answer_options.first : "" } %>
       <% end %>
 
-      <% hints_for_roles = { data_provider: ["Default role for this organisation", "Can view and submit logs for this organisation"], data_coordinator: ["Can view and submit logs for this organisation and any of its managing agents", "Can manage details for this organisation", "Can manage users for this organisation"], support: nil } %>
+      <% hints_for_roles = { data_provider: ["Can view and submit logs for this organisation"], data_coordinator: ["Can view and submit logs for this organisation and any of its managing agents", "Can manage details for this organisation", "Can manage users for this organisation"], support: nil } %>
 
       <% roles_with_hints = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints_for_roles[key.to_sym]) } %>
 
@@ -52,7 +52,8 @@
                                            lambda { |option|
                                              option.description&.map { |hint| content_tag(:li, hint) }&.reduce(:+)
                                            },
-                                           legend: { text: "Role", size: "m" } %>
+                                           legend: { text: "Role (optional)", size: "m" },
+                                           hint: { text: "This does not need to be selected if the user is a data protection officer only" } %>
 
       <%= f.govuk_submit "Continue" %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -53,7 +53,7 @@
                                              option.description&.map { |hint| content_tag(:li, hint) }&.reduce(:+)
                                            },
                                            legend: { text: "Role (optional)", size: "m" },
-                                           hint: { text: "This does not need to be selected if the user is a data protection officer only" } %>
+                                           hint: { text: "You do not need to select a role if the user is a data protection officer only. You can tell us that this user is a data protection officer after you have invited them." } %>
 
       <%= f.govuk_submit "Continue" %>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,7 +184,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = URI::MailTo::EMAIL_REGEXP
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,8 +78,8 @@ en:
         user:
           attributes:
             organisation_id:
-              blank: "Enter the existing organisation’s name"
-              invalid: "Enter the existing organisation’s name"
+              blank: "Select the user’s organisation"
+              invalid: "Select the user’s organisation"
             name:
               blank: "Enter a name"
             email:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -227,17 +227,15 @@ RSpec.describe User, type: :model do
   end
 
   describe "validate" do
-    let(:organisation) { FactoryBot.create(:organisation) }
-
     context "when a user does not have values for required fields" do
-      let(:user) { described_class.new(organisation:) }
+      let(:user) { described_class.new }
 
       before do
         user.validate
       end
 
-      it "validates name presence before email presence" do
-        expect(user.errors.map(&:attribute).uniq).to eq(%i[name email])
+      it "validates name, email and organisation presence in the correct order" do
+        expect(user.errors.map(&:attribute).uniq).to eq(%i[name email password organisation_id])
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -225,4 +225,50 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "validate" do
+    let(:organisation) { FactoryBot.create(:organisation) }
+
+    context "when a user does not have values for required fields" do
+      let(:user) { described_class.new(organisation:) }
+
+      before do
+        user.validate
+      end
+
+      it "validates name presence before email presence" do
+        expect(user.errors.map(&:attribute).uniq).to eq(%i[name email])
+      end
+    end
+
+    context "when a too short password is entered" do
+      let(:password) { "123" }
+      let(:error_message) { "Validation failed: Password #{I18n.t('errors.messages.too_short', count: 8)}" }
+
+      it "validates password length" do
+        expect { FactoryBot.create(:user, password:) }
+          .to raise_error(ActiveRecord::RecordInvalid, error_message)
+      end
+    end
+
+    context "when an invalid email is entered" do
+      let(:invalid_email) { "not_an_email" }
+      let(:error_message) { "Validation failed: Email #{I18n.t('activerecord.errors.models.user.attributes.email.invalid')}" }
+
+      it "validates email format" do
+        expect { FactoryBot.create(:user, email: invalid_email) }
+          .to raise_error(ActiveRecord::RecordInvalid, error_message)
+      end
+    end
+
+    context "when the email entered has already been used" do
+      let(:user) { FactoryBot.create(:user) }
+      let(:error_message) { "Validation failed: Email #{I18n.t('activerecord.errors.models.user.attributes.email.taken')}" }
+
+      it "validates email uniqueness" do
+        expect { FactoryBot.create(:user, email: user.email) }
+          .to raise_error(ActiveRecord::RecordInvalid, error_message)
+      end
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -922,7 +922,6 @@ RSpec.describe UsersController, type: :request do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.name.blank"))
           expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
-          expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.role.blank"))
         end
       end
     end

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Imports::UserImportService do
     end
 
     it "refuses to create a user belonging to a non existing organisation" do
-      expect(logger).to receive(:error).with(/Organisation must exist/)
+      expect(logger).to receive(:error).with(/ActiveRecord::RecordInvalid/)
       import_service.create_users("user_directory")
     end
 


### PR DESCRIPTION
Fixes the last two comments on: https://digital.dclg.gov.uk/jira/browse/CLDC-1171

This ordering comes from including `Devise::Validatable` which includes a few default validations (email and password) which run before our name validations. It's an optional module that's expected to be removed if you need to customise it (https://github.com/heartcombo/devise/blob/main/lib/devise/models/validatable.rb).

So we remove it here and add our own instead in the correct order.

We also make role optional as we have some real world users in production already who do not currently have a role, as they are data protection officers only (which can be combined with another role for some users), and do not interact with the system in any other way.

Long term it might make sense to refactor roles into their own model rather than making them an attribute of users, such that a user can have multiple roles but that seems beyond the scope here.

Support user view:
![image](https://user-images.githubusercontent.com/5101747/183104762-1a554524-b9ee-431d-a1af-539c84a0430a.png)

Coordinator view:
![image](https://user-images.githubusercontent.com/5101747/183106199-b325264c-4ed3-4b4e-b0bb-d75b46bbef85.png)

