### PR TITLE
Fix sign in validation error copy

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -9,10 +9,10 @@ en:
     failure:
       already_authenticated: "You are already signed in"
       inactive: "Your account has not been activated yet"
-      invalid: "Incorrect %{authentication_keys} email or password"
+      invalid: "Incorrect %{authentication_keys} or password"
       locked: "Your account has been locked."
       last_attempt: "You have one more attempt before your account is locked"
-      not_found_in_database: "Incorrect %{authentication_keys} email or password"
+      not_found_in_database: "Incorrect %{authentication_keys} or password"
       timeout: "Your session expired. Sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing"
       unconfirmed: "You must confirm your email address before continuing"


### PR DESCRIPTION
These errors were injecting devise's `authentication_keys` which includes email and was duplicating that copy (e.g., "Incorrect email email or password")

This PR removes the second 'email' string.

Previously:
![screencapture-dluhc-core-production-london-cloudapps-digital-account-sign-in-2022-08-11-16_37_17](https://user-images.githubusercontent.com/31316/184334468-c5d7601e-cec9-429c-aabb-5236422fea33.png)
.