### PR TITLE
CLDC-1550 Prevent homeless value being inferred when a letting is a renewal

### DIFF
--- a/app/models/case_log.rb
+++ b/app/models/case_log.rb
@@ -567,7 +567,6 @@ private
 
   def reset_derived_questions
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
-                            homeless: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
                             underoccupation_benefitcap: [{ key: :renewal, value: 0 }],
                             wchair: [{ key: :needstype, value: 1 }],

--- a/app/models/derived_variables/case_log_variables.rb
+++ b/app/models/derived_variables/case_log_variables.rb
@@ -46,7 +46,6 @@ module DerivedVariables::CaseLogVariables
     self.housingneeds = get_housingneeds
     if is_renewal?
       self.underoccupation_benefitcap = 2 if collection_start_year == 2021
-      self.homeless = 1
       self.referral = 0
       self.waityear = 2
       if is_general_needs?

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1242,7 +1242,7 @@
               "description": "",
               "questions": {
                 "age1_known": {
-                  "check_answers_card_number": 1, 
+                  "check_answers_card_number": 1,
                   "header": "Do you know the lead tenant’s age?",
                   "hint_text": "The ’lead’ or ’main’ tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
@@ -6209,12 +6209,7 @@
                     }
                   }
                 }
-              },
-              "depends_on": [
-                {
-                  "renewal": 0
-                }
-              ]
+              }
             },
             "previous_postcode": {
               "header": "",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1277,7 +1277,7 @@
               "description": "",
               "questions": {
                 "age1_known": {
-                  "check_answers_card_number": 1, 
+                  "check_answers_card_number": 1,
                   "header": "Do you know the lead tenant’s age?",
                   "hint_text": "The ’lead’ or ’main’ tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest.",
                   "type": "radio",
@@ -6168,12 +6168,7 @@
                     }
                   }
                 }
-              },
-              "depends_on": [
-                {
-                  "renewal": 0
-                }
-              ]
+              }
             },
             "previous_postcode": {
               "header": "",


### PR DESCRIPTION
Getting rid of the "depends on" means that the user is always asked about homelessness. No need to touch the reasonable preference question as its validation is correct, the only issue was homelessness wrongly being inferred as 1.

Double checked that renewal logs created before this change is applied now show the homelessness value in their summary, so users can go back and change it if needed.