### PR TITLE
CLDC-1428 Prevent creation of new 2021/22 logs

### DIFF
--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -31,7 +31,9 @@ module Validations::DateValidations
   def validate_startdate(record)
     return unless record.startdate && date_valid?("startdate", record)
 
-    if record.created_at > first_collection_end_date && record.startdate < second_collection_start_date
+    created_at = record.created_at || Time.zone.now
+
+    if created_at > first_collection_end_date && record.startdate < second_collection_start_date
       record.errors.add :startdate, I18n.t("validations.date.outside_collection_window")
     end
 

--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -31,6 +31,10 @@ module Validations::DateValidations
   def validate_startdate(record)
     return unless record.startdate && date_valid?("startdate", record)
 
+    if record.created_at > first_collection_end_date && record.startdate < second_collection_start_date
+      record.errors.add :startdate, I18n.t("validations.date.outside_collection_window")
+    end
+
     if record.startdate < first_collection_start_date || record.startdate > second_collection_end_date
       record.errors.add :startdate, I18n.t("validations.date.outside_collection_window")
     end
@@ -55,6 +59,14 @@ private
 
   def first_collection_start_date
     @first_collection_start_date ||= FormHandler.instance.forms.map { |form| form.second.start_date }.compact.min
+  end
+
+  def first_collection_end_date
+    @first_collection_end_date ||= FormHandler.instance.forms.map { |form| form.second.end_date }.compact.min
+  end
+
+  def second_collection_start_date
+    @second_collection_start_date ||= FormHandler.instance.forms.map { |form| form.second.start_date }.compact.max
   end
 
   def second_collection_end_date

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1,7 +1,7 @@
 {
   "form_type": "lettings",
   "start_date": "2021-04-01T00:00:00.000+01:00",
-  "end_date": "2022-09-01T00:00:00.000+01:00",
+  "end_date": "2022-09-05T00:00:00.000+01:00",
   "sections": {
     "tenancy_and_property": {
       "label": "Property and tenancy information",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1,7 +1,7 @@
 {
   "form_type": "lettings",
   "start_date": "2021-04-01T00:00:00.000+01:00",
-  "end_date": "2022-07-01T00:00:00.000+01:00",
+  "end_date": "2022-09-01T00:00:00.000+01:00",
   "sections": {
     "tenancy_and_property": {
       "label": "Property and tenancy information",

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe LettingsLog do
         rent_type: 4,
         hb: 1,
         hbrentshortfall: 1,
+        created_at: Time.utc(2022, 2, 8, 16, 52, 15),
       })
     end
 
@@ -1378,6 +1379,7 @@ RSpec.describe LettingsLog do
           created_by: created_by_user,
           renewal: 1,
           startdate: Time.zone.local(2021, 4, 10),
+          created_at: Time.utc(2022, 2, 8, 16, 52, 15),
         })
       end
 
@@ -1712,6 +1714,7 @@ RSpec.describe LettingsLog do
             location_id: location.id,
             renewal: 1,
             startdate: Time.zone.now,
+            created_at: Time.utc(2022, 2, 8, 16, 52, 15),
           })
         end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe LettingsLogsController, type: :request do
-
   let(:user) { FactoryBot.create(:user) }
   let(:owning_organisation) { user.organisation }
   let(:managing_organisation) { owning_organisation }

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe LettingsLogsController, type: :request do
-  include ActiveSupport::Testing::TimeHelpers
 
   let(:user) { FactoryBot.create(:user) }
   let(:owning_organisation) { user.organisation }
@@ -51,8 +50,12 @@ RSpec.describe LettingsLogsController, type: :request do
       end
 
       before do
-        travel_to Time.utc(2022, 2, 8, 16, 52, 15)
+        Timecop.freeze(Time.utc(2022, 2, 8,))
         post "/logs", headers:, params: params.to_json
+      end
+
+      after do
+        Timecop.unfreeze
       end
 
       it "returns http success" do

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe LettingsLogsController, type: :request do
       end
 
       before do
-        Timecop.freeze(Time.utc(2022, 2, 8,))
+        Timecop.freeze(Time.utc(2022, 2, 8))
         post "/logs", headers:, params: params.to_json
       end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe LettingsLogsController, type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { FactoryBot.create(:user) }
   let(:owning_organisation) { user.organisation }
   let(:managing_organisation) { owning_organisation }
@@ -49,6 +51,7 @@ RSpec.describe LettingsLogsController, type: :request do
       end
 
       before do
+        travel_to Time.utc(2022, 2, 8, 16, 52, 15)
         post "/logs", headers:, params: params.to_json
       end
 

--- a/spec/services/csv/lettings_log_csv_service_spec.rb
+++ b/spec/services/csv/lettings_log_csv_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Csv::LettingsLogCsvService do
     let(:real_2021_2022_form) { Form.new("config/forms/2021_2022.json", "2021_2022") }
 
     before do
-      LettingsLog.create!(startdate: "2021-10-10")
+      LettingsLog.create!(startdate: "2021-10-10", created_at: Time.utc(2022, 2, 8, 16, 52, 15))
       allow(FormHandler.instance).to receive(:get_form).and_return(real_2021_2022_form)
     end
 


### PR DESCRIPTION
Since we don't make any distinction between a newly created log and a log that's being edited I decided to use the `created_at` field in the database to determine whether a log should be allowed to have a tenancy start date in the 2021/22 financial year. A few points:
* This implementation means we can set the end of a collection window in the form definition and have it be closed for new submissions without needing a release
* I'm unsure if `record.startdate < second_collection_start_date` is the correct way to see if a log falls into the first collection window - I think it will always work, but there might be a more idiomatic way to check?
* We need the nullcheck on `created_at` because logs created via the API are validated before being inserted into the database, so the `created_at` field isn't populated yet
* The `lettings_log_controller` tests use a 2021 log as an example and so needs the time travel to not get an error about submitting a log after the collection window - is it worth raising a ticket to update that test to a 2022 log?