### PR TITLE
Store object changes in PaperTrail versions

### DIFF
--- a/db/migrate/20220902082245_add_object_changes_to_versions.rb
+++ b/db/migrate/20220902082245_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[7.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_23_083657) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_02_082245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -240,34 +240,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_23_083657) do
     t.index ["scheme_id"], name: "index_case_logs_on_scheme_id"
   end
 
-  create_table "data_protection_confirmations", force: :cascade do |t|
-    t.bigint "organisation_id"
-    t.bigint "data_protection_officer_id"
-    t.boolean "confirmed"
-    t.string "old_id"
-    t.string "old_org_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["data_protection_officer_id"], name: "dpo_user_id"
-    t.index ["organisation_id", "data_protection_officer_id", "confirmed"], name: "data_protection_confirmations_unique", unique: true
-    t.index ["organisation_id"], name: "index_data_protection_confirmations_on_organisation_id"
-  end
-
-  create_table "la_rent_ranges", force: :cascade do |t|
-    t.integer "ranges_rent_id"
-    t.integer "lettype"
-    t.string "la"
-    t.integer "beds"
-    t.decimal "soft_min", precision: 10, scale: 2
-    t.decimal "soft_max", precision: 10, scale: 2
-    t.decimal "hard_min", precision: 10, scale: 2
-    t.decimal "hard_max", precision: 10, scale: 2
-    t.integer "start_year"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["start_year", "lettype", "beds", "la"], name: "index_la_rent_ranges_on_start_year_and_lettype_and_beds_and_la", unique: true
-  end
-
   create_table "locations", force: :cascade do |t|
     t.string "location_code"
     t.string "postcode"
@@ -415,6 +387,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_23_083657) do
     t.string "whodunnit"
     t.text "object"
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
If you add an object_changes column to your versions table, PaperTrail will store the changes diff in each version.

You can test this by making a change on an audited model and inspecting the `changeset`:

```ruby
irb(main):008:0> Organisation.last.versions.last.changeset
  PaperTrail::Version Load (0.4ms)  SELECT "versions".* FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2 ORDER BY "versions"."created_at" DESC, "versions"."id" DESC LIMIT $3  [["item_id", 2], ["item_type", "Organisation"], ["LIMIT", 1]]
  Organisation Load (0.2ms)  SELECT "organisations".* FROM "organisations" WHERE "organisations"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
=> {"name"=>["FooBar LTD", "BarFoo"], "updated_at"=>[Thu, 18 Aug 2022 10:59:18.067767000 BST +01:00, Fri, 02 Sep 2022 09:28:15.401814000 BST +01:00]}
```