### PR TITLE
Record PaperTrail whodunnit for console users on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -131,4 +131,20 @@ Rails.application.configure do
 
   # see https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
   config.active_record.yaml_column_permitted_classes = [Time]
+
+  # From https://github.com/paper-trail-gem/paper_trail/wiki/Setting-whodunnit-in-the-rails-console
+  console do
+    PaperTrail.request.whodunnit = lambda {
+      @paper_trail_whodunnit ||= begin
+        email = nil
+        until email.present?
+          # rubocop:disable Rails/Output
+          puts "Enter your email address for PaperTrail"
+          # rubocop:enable Rails/Output
+          email = gets.chomp
+        end
+        email
+      end
+    }
+  end
 end


### PR DESCRIPTION
This will allow us to audit who has made changes in the console to audited records.

This was taken from the PaperTrail documentation [here](https://github.com/paper-trail-gem/paper_trail/wiki/Setting-whodunnit-in-the-rails-console#ask-for-a-name-only-ifwhen-you-start-changing-records-in-the-console), but adjusted so that it is applicable only to our production environment.