### PR TITLE
Configure new Redis instances for Sidekiq and Rack::Attack

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,10 @@ AllCops:
 
 Style/Documentation:
   Enabled: false
+
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - staging
+    - development
+    - test

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,7 +5,7 @@ if Rails.env.development? || Rails.env.test?
   Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
   Rack::Attack.enabled = false
 else
-  redis_url = Configuration::PaasConfigurationService.new.redis_uris[:"dluhc-core-#{Rails.env}-redis-rate-limit"]
+  redis_url = Configuration::PaasConfigurationService.new.redis_uris[:"dluhc-core-#{Rails.env}-redis"]
   Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(url: redis_url)
 end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+if Rails.env.staging? || Rails.env.production?
+  redis_url = Configuration::PaasConfigurationService.new.redis_uris[:"dluhc-core-#{Rails.env}-redis"]
+
+  Sidekiq.configure_server do |config|
+    config.redis = { url: redis_url }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: redis_url }
+  end
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,7 +21,7 @@ applications:
       RAILS_ENV: staging
     services:
       - dluhc-core-staging-postgres
-      - dluhc-core-staging-redis-rate-limit
+      - dluhc-core-staging-redis
 
   - name: dluhc-core-production
     <<: *defaults
@@ -35,4 +35,4 @@ applications:
     host: submit-social-housing-lettings-sales-data
     services:
       - dluhc-core-production-postgres
-      - dluhc-core-production-redis-rate-limit
+      - dluhc-core-production-redis


### PR DESCRIPTION
Previously we had one instance called `dluhc-core-{environment}-redis-rate-limit` that was used exclusively for `Rack::Attack`.

This PR configures Sidekiq and Rack::Attack to use a new generically named instance called `dluhc-core-{environment}-redis` on `staging` and `production`. 

These new Redis instances have already been provisioned on each environment. Staging is a `micro-6.x` and production is `micro-ha-6.x`.

Later, once this PR has been deployed, I will remove `dluhc-core-{environment}-redis-rate-limit` instances.