### PR TITLE
Add Redis setup instructions to infrastructure documentation

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -124,10 +124,11 @@ When a pull request is opened to `main` only the Test stage runs.
     cf target -o dluhc-core -s staging
     ```
 
-3. Create required Postgres and S3 bucket backing services (this will take ~15 mins to finish creating):
+3. Create required Postgres, Redis and S3 bucket backing services (this will take ~15 mins to finish creating):
 
     ```bash
     cf create-service postgres tiny-unencrypted-13 dluhc-core-staging-postgres
+    cf create-service redis micro-6.x dluhc-core-staging-redis
     cf create-service aws-s3-bucket default dluhc-core-staging-csv-bucket
     cf create-service aws-s3-bucket default dluhc-core-staging-import-bucket
     cf create-service aws-s3-bucket default dluhc-core-staging-export-bucket
@@ -143,6 +144,7 @@ When a pull request is opened to `main` only the Test stage runs.
 
     ```bash
     cf bind-service dluhc-core-staging dluhc-core-staging-csv-bucket
+    cf bind-service dluhc-core-staging dluhc-core-staging-redis
     cf bind-service dluhc-core-staging dluhc-core-staging-import-bucket -c '{"permissions": "read-only"}'
     cf bind-service dluhc-core-staging dluhc-core-staging-export-bucket -c '{"permissions": "read-write"}'
     ```
@@ -169,10 +171,11 @@ When a pull request is opened to `main` only the Test stage runs.
     cf target -o dluhc-core -s production
     ```
 
-3. Create required Postgres and S3 bucket backing services (this will take ~15 mins to finish creating):
+3. Create required Postgres, Redis and S3 bucket backing services (this will take ~15 mins to finish creating):
 
     ```bash
     cf create-service postgres small-ha-13 dluhc-core-production-postgres
+    cf create-service redis micro-ha-6.x dluhc-core-production-redis
     cf create-service aws-s3-bucket default dluhc-core-production-csv-bucket
     cf create-service aws-s3-bucket default dluhc-core-production-import-bucket
     cf create-service aws-s3-bucket default dluhc-core-production-export-bucket
@@ -188,6 +191,7 @@ When a pull request is opened to `main` only the Test stage runs.
 
     ```bash
     cf bind-service dluhc-core-production dluhc-core-production-csv-bucket
+    cf bind-service dluhc-core-production dluhc-core-production-redis
     cf bind-service dluhc-core-production dluhc-core-production-import-bucket -c '{"permissions": "read-only"}'
     cf bind-service dluhc-core-production dluhc-core-production-export-bucket -c '{"permissions": "read-write"}'
     ```


### PR DESCRIPTION
This PR adds Redis setup instructions to the infrastructure documentation.

This was spotted by @baarkerlounger in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/868. I promised to follow up in another PR.

