### PR TITLE
Corrected typo in page title + heading

### DIFF
--- a/app/views/logs/csv_confirmation.html.erb
+++ b/app/views/logs/csv_confirmation.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "We've sending you an email" %>
+<% content_for :title, "We’re sending you an email" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel(title_text: "We're sending you an email") %>
+    <%= govuk_panel(title_text: "We’re sending you an email") %>
 
     <p class="govuk-body">It should arrive in a few minutes, but it could take longer.</p>
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -783,7 +783,7 @@ RSpec.describe LettingsLogsController, type: :request do
 
         it "confirms that the user will receive an email with the requested CSV" do
           get "/lettings-logs/csv-confirmation"
-          expect(CGI.unescape_html(response.body)).to include("We're sending you an email")
+          expect(CGI.unescape_html(response.body)).to include("We’re sending you an email")
         end
       end
     end


### PR DESCRIPTION
Fixes a typo and uses the correct apostrophe (have also confirmed locally that the apostrophe is not HTML escaped in the page title).

<img width="107" alt="image" src="https://user-images.githubusercontent.com/4071936/190173091-7681bc76-0fe0-43ee-8fe9-3dab19a3bc5f.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/4071936/190173128-38892d7b-6f1f-4469-874c-98c48dd8df55.png">
