### PR TITLE
Logs type refactoring

### DIFF
--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -18,10 +18,10 @@ class Form::Page
 
   delegate :form, to: :subsection
 
-  def routed_to?(lettings_log, _current_user)
+  def routed_to?(log, _current_user)
     return true unless depends_on || subsection.depends_on
 
-    subsection.enabled?(lettings_log) && form.depends_on_met(depends_on, lettings_log)
+    subsection.enabled?(log) && form.depends_on_met(depends_on, log)
   end
 
   def non_conditional_questions

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -63,7 +63,7 @@ class Form::Question
       if question.present?
         question.label_from_value(log[question_id])
       else
-        Array(question_id.to_s.split(".")).inject(log) { |log, method| log.present? ? log.public_send(*method) : "" }
+        Array(question_id.to_s.split(".")).inject(log) { |l, method| l.present? ? l.public_send(*method) : "" }
       end
     end
   end

--- a/app/models/form/setup/pages/created_by.rb
+++ b/app/models/form/setup/pages/created_by.rb
@@ -13,7 +13,7 @@ class Form::Setup::Pages::CreatedBy < ::Form::Page
     ]
   end
 
-  def routed_to?(_lettings_log, current_user)
+  def routed_to?(_log, current_user)
     !!current_user&.support?
   end
 end

--- a/app/models/form/setup/pages/organisation.rb
+++ b/app/models/form/setup/pages/organisation.rb
@@ -13,7 +13,7 @@ class Form::Setup::Pages::Organisation < ::Form::Page
     ]
   end
 
-  def routed_to?(_lettings_log, current_user)
+  def routed_to?(_log, current_user)
     !!current_user&.support?
   end
 end

--- a/app/models/form/setup/questions/created_by_id.rb
+++ b/app/models/form/setup/questions/created_by_id.rb
@@ -19,10 +19,10 @@ class Form::Setup::Questions::CreatedById < ::Form::Question
     end
   end
 
-  def displayed_answer_options(lettings_log)
-    return answer_options unless lettings_log.owning_organisation
+  def displayed_answer_options(log)
+    return answer_options unless log.owning_organisation
 
-    user_ids = lettings_log.owning_organisation.users.pluck(:id) + [""]
+    user_ids = log.owning_organisation.users.pluck(:id) + [""]
     answer_options.select { |k, _v| user_ids.include?(k) }
   end
 
@@ -32,7 +32,7 @@ class Form::Setup::Questions::CreatedById < ::Form::Question
     answer_options[value]
   end
 
-  def hidden_in_check_answers?(_lettings_log, current_user)
+  def hidden_in_check_answers?(_log, current_user)
     !current_user.support?
   end
 
@@ -42,7 +42,7 @@ class Form::Setup::Questions::CreatedById < ::Form::Question
 
 private
 
-  def selected_answer_option_is_derived?(_lettings_log)
+  def selected_answer_option_is_derived?(_log)
     false
   end
 end

--- a/app/models/form/setup/questions/owning_organisation_id.rb
+++ b/app/models/form/setup/questions/owning_organisation_id.rb
@@ -19,7 +19,7 @@ class Form::Setup::Questions::OwningOrganisationId < ::Form::Question
     end
   end
 
-  def displayed_answer_options(_lettings_log)
+  def displayed_answer_options(_log)
     answer_options
   end
 
@@ -29,7 +29,7 @@ class Form::Setup::Questions::OwningOrganisationId < ::Form::Question
     answer_options[value]
   end
 
-  def hidden_in_check_answers?(_lettings_log, current_user)
+  def hidden_in_check_answers?(_log, current_user)
     !current_user.support?
   end
 
@@ -39,7 +39,7 @@ class Form::Setup::Questions::OwningOrganisationId < ::Form::Question
 
 private
 
-  def selected_answer_option_is_derived?(_lettings_log)
+  def selected_answer_option_is_derived?(_log)
     false
   end
 end

--- a/app/models/form/subsection.rb
+++ b/app/models/form/subsection.rb
@@ -17,40 +17,40 @@ class Form::Subsection
     @questions ||= pages.flat_map(&:questions)
   end
 
-  def enabled?(lettings_log)
+  def enabled?(log)
     return true unless depends_on
 
     depends_on.any? do |conditions_set|
       conditions_set.all? do |subsection_id, dependent_status|
-        form.get_subsection(subsection_id).status(lettings_log) == dependent_status.to_sym
+        form.get_subsection(subsection_id).status(log) == dependent_status.to_sym
       end
     end
   end
 
-  def status(lettings_log)
-    unless enabled?(lettings_log)
+  def status(log)
+    unless enabled?(log)
       return :cannot_start_yet
     end
 
-    qs = applicable_questions(lettings_log)
-    qs_optional_removed = qs.reject { |q| lettings_log.optional_fields.include?(q.id) }
-    return :not_started if qs.count.positive? && qs.all? { |question| lettings_log[question.id].blank? || question.read_only? || question.derived? }
-    return :completed if qs_optional_removed.all? { |question| question.completed?(lettings_log) }
+    qs = applicable_questions(log)
+    qs_optional_removed = qs.reject { |q| log.optional_fields.include?(q.id) }
+    return :not_started if qs.count.positive? && qs.all? { |question| log[question.id].blank? || question.read_only? || question.derived? }
+    return :completed if qs_optional_removed.all? { |question| question.completed?(log) }
 
     :in_progress
   end
 
-  def is_incomplete?(lettings_log)
-    %i[not_started in_progress].include?(status(lettings_log))
+  def is_incomplete?(log)
+    %i[not_started in_progress].include?(status(log))
   end
 
-  def is_started?(lettings_log)
-    %i[in_progress completed].include?(status(lettings_log))
+  def is_started?(log)
+    %i[in_progress completed].include?(status(log))
   end
 
-  def applicable_questions(lettings_log)
+  def applicable_questions(log)
     questions.select do |q|
-      (q.displayed_to_user?(lettings_log) && !q.derived?) || q.has_inferred_check_answers_value?(lettings_log)
+      (q.displayed_to_user?(log) && !q.derived?) || q.has_inferred_check_answers_value?(log)
     end
   end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -58,4 +58,16 @@ private
     subsection_statuses = form.subsections.map { |subsection| subsection.status(self) }.uniq
     subsection_statuses.all? { |status| not_started_statuses.include?(status) }
   end
+
+  def reset_created_by
+    return unless created_by && owning_organisation
+
+    self.created_by = nil if created_by.organisation != owning_organisation
+  end
+
+  def reset_invalidated_dependent_fields!
+    return unless form
+
+    form.reset_not_routed_questions(self)
+  end
 end


### PR DESCRIPTION
- [x] Refer to `log` rather than `lettings-log` in places that are common to sales/logs, i.e. where we're really in the context of a form and either type of log could be passed in
- [x] Resetting log data for questions that have been invalidated by changes to other questions (i.e. because of the change another question we no longer route to this question) is more to do with the form navigation/behaviour than it is to do with log data so we move that method to the form class.