### PR TITLE
Set vacdays after setting the voiddate

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -58,7 +58,6 @@ module DerivedVariables::LettingsLogVariables
 
     self.hhtype = household_type
     self.new_old = new_or_existing_tenant
-    self.vacdays = property_vacant_days
 
     if is_supported_housing?
       if location
@@ -68,6 +67,7 @@ module DerivedVariables::LettingsLogVariables
         self.voiddate = startdate
       end
     end
+    self.vacdays = property_vacant_days
 
     set_housingneeds_fields if housingneeds?
   end

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1395,6 +1395,7 @@ RSpec.describe LettingsLog do
           renewal: 1,
           startdate: Time.zone.local(2021, 4, 10),
           created_at: Time.utc(2022, 2, 8, 16, 52, 15),
+          needstype: 2,
         })
       end
 
@@ -1430,6 +1431,12 @@ RSpec.describe LettingsLog do
         record_from_db = ActiveRecord::Base.connection.execute("select referral from lettings_logs where id=#{lettings_log.id}").to_a[0]
         expect(record_from_db["referral"]).to eq(0)
         expect(lettings_log["referral"]).to eq(0)
+      end
+
+      it "correctly derives and saves vacdays" do
+        record_from_db = ActiveRecord::Base.connection.execute("select vacdays from lettings_logs where id=#{lettings_log.id}").to_a[0]
+        expect(record_from_db["vacdays"]).to eq(0)
+        expect(lettings_log["vacdays"]).to eq(0)
       end
     end
 


### PR DESCRIPTION
Set vacdays correctly for supported housing, renewal letting logs.
We use voiddate to calculate vacdays, so we should set voiddate before setting vacdays.

Would need to run this on prod to update the existing logs:
LettingsLog.where(needstype: 2, renewal: 1).update_all(vacdays: 0)