### PR TITLE
Extract voiddate out of the if statement

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -59,14 +59,10 @@ module DerivedVariables::LettingsLogVariables
     self.hhtype = household_type
     self.new_old = new_or_existing_tenant
 
-    if is_supported_housing?
-      if location
-        self.wchair = location.mobility_type_before_type_cast == "W" ? 1 : 2
-      end
-      if is_renewal?
-        self.voiddate = startdate
-      end
+    if is_supported_housing? && location
+      self.wchair = location.mobility_type_before_type_cast == "W" ? 1 : 2
     end
+    self.voiddate = startdate if is_renewal?
     self.vacdays = property_vacant_days
 
     set_housingneeds_fields if housingneeds?

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -245,6 +245,7 @@ RSpec.describe "Form Check Answers Page" do
           reason: 4,
           ppostcode_full: "SE2 6RT",
           mrcdate: Time.zone.parse("03/11/2019"),
+          renewal: 0,
         )
       end
 

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "validations" do
       :in_progress,
       owning_organisation: user.organisation,
       managing_organisation: user.organisation,
+      renewal: 0,
     )
   end
   let(:empty_lettings_log) do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1395,7 +1395,6 @@ RSpec.describe LettingsLog do
           renewal: 1,
           startdate: Time.zone.local(2021, 4, 10),
           created_at: Time.utc(2022, 2, 8, 16, 52, 15),
-          needstype: 2,
         })
       end
 


### PR DESCRIPTION
Voiddate should be set to start date for general needs logs as well if the log is a renewal.

Updated some tests to contain renewal: no, because otherwise this validation gets triggered `Voiddate Void date must be before the major repairs date if provided`

All of the renewal logs on prod do not have a major repairs date, so this validation should not be an issue.

Will need to update all the renewal logs to have the same voiddate as startdate, and will need to run an updated command mentioned in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/900

```
LettingsLog.where(renewal: 1, voiddate: nil).update_all("voiddate=startdate")
LettingsLog.where(renewal: 1, vacdays: nil).update_all(vacdays: 0)
```