### PR TITLE
Add Sidekiq Web to project

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+require "sidekiq/web"
+
 if Rails.env.staging? || Rails.env.production?
   redis_url = Configuration::PaasConfigurationService.new.redis_uris[:"dluhc-core-#{Rails.env}-redis"]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
+  mount_sidekiq = -> { mount Sidekiq::Web => "/sidekiq" }
+  authenticate(:user, :support?.to_proc, &mount_sidekiq)
+
   devise_for :users, {
     path: :account,
     controllers: {


### PR DESCRIPTION
This PR adds the Sidekiq web interface to the project. It is useful for inspecting Sidekiq failures and the queue states.

This is only accessible when you are logged in as a support user. It is accessible at /sidekiq.

