### PR TITLE
CLDC-1625 Added create new sales log for this organisation button on organisation view

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -7,10 +7,10 @@
 
 <div class="app-filter-layout" data-controller="filter-layout">
   <div class="govuk-button-group app-filter-toggle">
-    <% if current_page?(:controller => 'lettings_logs', :action => 'index') %>
+    <% if current_page?(controller: 'lettings_logs', action: 'index') %>
       <%= govuk_button_to "Create a new lettings log", lettings_logs_path %>
     <% end %>
-    <% if FeatureToggle.sales_log_enabled? && current_page?(:controller => 'sales_logs', :action => 'index') %>
+    <% if FeatureToggle.sales_log_enabled? && current_page?(controller: 'sales_logs', action: 'index') %>
       <%= govuk_button_to "Create a new sales log", sales_logs_path %>
     <% end %>
     <%#= govuk_link_to "Upload logs", bulk_upload_lettings_logs_path %>

--- a/app/views/organisations/logs.html.erb
+++ b/app/views/organisations/logs.html.erb
@@ -14,10 +14,10 @@
 
 <div class="app-filter-layout" data-controller="filter-layout">
   <div class="govuk-button-group app-filter-toggle">
-    <% if current_page?(:controller => 'organisations', :action => 'lettings_logs') %>
+    <% if current_page?(controller: 'organisations', action: 'lettings_logs') %>
       <%= govuk_button_to "Create a new lettings log for this organisation", lettings_logs_path(lettings_log: { owning_organisation_id: @organisation.id }, method: :post) %>
     <% end %>
-    <% if current_page?(:controller => 'organisations', :action => 'sales_logs') %>
+    <% if current_page?(controller: 'organisations', action: 'sales_logs') %>
       <%= govuk_button_to "Create a new sales log for this organisation", sales_logs_path(sales_log: { owning_organisation_id: @organisation.id }, method: :post) %>
     <% end %>
   </div>

--- a/app/views/organisations/logs.html.erb
+++ b/app/views/organisations/logs.html.erb
@@ -14,7 +14,12 @@
 
 <div class="app-filter-layout" data-controller="filter-layout">
   <div class="govuk-button-group app-filter-toggle">
-    <%= govuk_button_to "Create a new lettings log for this organisation", lettings_logs_path(lettings_log: { owning_organisation_id: @organisation.id }, method: :post) %>
+    <% if current_page?(:controller => 'organisations', :action => 'lettings_logs') %>
+      <%= govuk_button_to "Create a new lettings log for this organisation", lettings_logs_path(lettings_log: { owning_organisation_id: @organisation.id }, method: :post) %>
+    <% end %>
+    <% if current_page?(:controller => 'organisations', :action => 'sales_logs') %>
+      <%= govuk_button_to "Create a new sales log for this organisation", sales_logs_path(sales_log: { owning_organisation_id: @organisation.id }, method: :post) %>
+    <% end %>
   </div>
 
   <%= render partial: "logs/log_filters" %>

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -212,11 +212,10 @@ RSpec.describe "User Features" do
 
     context "when viewing sales logs for specific organisation" do
       let(:first_log) { organisation.sales_logs.first }
-      let!(:log_to_search) { FactoryBot.create(:sales_log, owning_organisation: user.organisation, managing_organisation_id: organisation.id) }
-      let!(:other_logs) { FactoryBot.create_list(:sales_log, 4, owning_organisation_id: organisation.id, managing_organisation_id: organisation.id) }
       let(:number_of_sales_logs) { SalesLog.count }
 
       before do
+        FactoryBot.create_list(:sales_log, 4, owning_organisation_id: organisation.id, managing_organisation_id: organisation.id)
         visit("/organisations/#{org_id}/sales-logs")
       end
 
@@ -232,7 +231,7 @@ RSpec.describe "User Features" do
         end
       end
 
-      it "can filter lettings logs" do
+      it "can filter sales logs" do
         expect(page).to have_content("#{number_of_sales_logs} total logs")
         organisation.sales_logs.map(&:id).each do |sales_log_id|
           expect(page).to have_link sales_log_id.to_s, href: "/sales-logs/#{sales_log_id}"

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "User Features" do
       click_button("Submit")
     end
 
-    context "when viewing logs for specific organisation" do
+    context "when viewing lettings logs for specific organisation" do
       let(:first_log) { organisation.lettings_logs.first }
       let!(:log_to_search) { FactoryBot.create(:lettings_log, owning_organisation: user.organisation, managing_organisation_id: organisation.id) }
       let!(:other_logs) { FactoryBot.create_list(:lettings_log, 4, owning_organisation_id: organisation.id, managing_organisation_id: organisation.id) }
@@ -189,7 +189,7 @@ RSpec.describe "User Features" do
                 expect(page).to have_link("Clear search")
               end
 
-              it "displays the logs belonging to the same organisation after I clear the search result after I clear the search resultss" do
+              it "displays the logs belonging to the same organisation after I clear the search result after I clear the search results" do
                 click_link("Clear search")
                 expect(page).to have_link(log_to_search.id.to_s)
               end
@@ -207,6 +207,40 @@ RSpec.describe "User Features" do
         click_button("Apply filters")
         expect(page).to have_current_path("/organisations/#{org_id}/lettings-logs?years[]=&years[]=2021&status[]=&user=all")
         expect(page).not_to have_link first_log.id.to_s, href: "/lettings-logs/#{first_log.id}"
+      end
+    end
+
+    context "when viewing sales logs for specific organisation" do
+      let(:first_log) { organisation.sales_logs.first }
+      let!(:log_to_search) { FactoryBot.create(:sales_log, owning_organisation: user.organisation, managing_organisation_id: organisation.id) }
+      let!(:other_logs) { FactoryBot.create_list(:sales_log, 4, owning_organisation_id: organisation.id, managing_organisation_id: organisation.id) }
+      let(:number_of_sales_logs) { SalesLog.count }
+
+      before do
+        visit("/organisations/#{org_id}/sales-logs")
+      end
+
+      it "shows a create button for that organisation" do
+        expect(page).to have_button("Create a new sales log for this organisation")
+      end
+
+      context "when creating a log for that organisation" do
+        it "pre-fills the value for owning organisation for that log" do
+          click_button("Create a new sales log for this organisation")
+          click_link("Set up this sales log")
+          expect(page).to have_content(org_name)
+        end
+      end
+
+      it "can filter lettings logs" do
+        expect(page).to have_content("#{number_of_sales_logs} total logs")
+        organisation.sales_logs.map(&:id).each do |sales_log_id|
+          expect(page).to have_link sales_log_id.to_s, href: "/sales-logs/#{sales_log_id}"
+        end
+        check("years-2021-field")
+        click_button("Apply filters")
+        expect(page).to have_current_path("/organisations/#{org_id}/sales-logs?years[]=&years[]=2021&status[]=&user=all")
+        expect(page).not_to have_link first_log.id.to_s, href: "/sales-logs/#{first_log.id}"
       end
     end
 


### PR DESCRIPTION
I just copied the existing lettings logs tests and changed them to fit sales logs. I removed the ones around searching because that isn't fully implemented yet - you can't search for e.g. purchaser code. I'm happy to add in a TODO but couldn't see a ticket to reference in the backlog.