### PR TITLE
Cldc 1324

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -133,7 +133,7 @@ private
 
 
   def find_resource
-    @log = if is_new_log_request? || new_log_referrer?
+    @log = if new_log_request? || new_log_request_referrer?
              LettingsLog.new(owning_organisation: current_user.support? ? nil : current_user.organisation)
            else
              params.key?("sales_log") ? current_user.sales_logs.find_by(id: params[:id]) : current_user.lettings_logs.find_by(id: params[:id])

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -13,7 +13,7 @@ class FormController < ApplicationController
         session[:errors] = session[:fields] = nil
         redirect_to(successful_redirect_path)
       else
-        redirect_path = @log.not_started? ? "#{@log.model_name.param_key}s_new_#{@page.id}_path" : "#{@log.model_name.param_key}_#{@page.id}_path"
+        redirect_path = @log.not_started? ? "#{@log.model_name.param_key}_new_#{@page.id}_path" : "#{@log.model_name.param_key}_#{@page.id}_path"
         mandatory_questions_with_no_response.map do |question|
           @log.errors.add question.id.to_sym, question.unanswered_error_message
         end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -142,14 +142,14 @@ private
 
   def find_resource_by_named_id
     @log = if params[:sales_log_id].present?
-             if new_log_request?
-               SalesLog.new
-             else
                current_user.sales_logs.find_by(id: params[:sales_log_id])
-             end
            else
              if new_log_request?
-               LettingsLog.new
+               if request.path.include? ("sales-logs")
+                 SalesLog.new
+               else
+                 LettingsLog.new
+               end
              else
                current_user.lettings_logs.find_by(id: params[:lettings_log_id])
              end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -13,7 +13,7 @@ class FormController < ApplicationController
         session[:errors] = session[:fields] = nil
         redirect_to(successful_redirect_path)
       else
-        redirect_path = @log.status == "not_started" ? "#{@log.model_name.param_key}s_new_#{@page.id}_path" : "#{@log.model_name.param_key}_#{@page.id}_path"
+        redirect_path = @log.not_started? ? "#{@log.model_name.param_key}s_new_#{@page.id}_path" : "#{@log.model_name.param_key}_#{@page.id}_path"
         mandatory_questions_with_no_response.map do |question|
           @log.errors.add question.id.to_sym, question.unanswered_error_message
         end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -10,7 +10,9 @@ class FormController < ApplicationController
       responses_for_page = responses_for_page(@page)
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
-      if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page)
+      if @log.not_started? && responses_for_page.values.all?(&:blank?) && mandatory_questions_with_no_response.empty?
+        redirect_to(successful_redirect_path)
+      elsif mandatory_questions_with_no_response.empty? && @log.update(responses_for_page)
         session[:errors] = session[:fields] = nil
         redirect_to(successful_redirect_path)
       else
@@ -124,7 +126,7 @@ private
     @log = if params[:sales_log_id].present?
              current_user.sales_logs.find_by(id: params[:sales_log_id])
            elsif new_log_request?
-              create_new_resource
+             create_new_resource
            else
              current_user.lettings_logs.find_by(id: params[:lettings_log_id])
            end
@@ -143,7 +145,7 @@ private
   end
 
   def new_log_request_referrer?
-    request.referer&.split("/").include?("new")
+    request.referer&.split("/")&.include?("new")
   end
 
   def is_referrer_check_answers?

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -60,7 +60,6 @@ class FormController < ApplicationController
     end
   end
 
-
 private
 
   def restore_error_field_values
@@ -143,7 +142,7 @@ private
   end
 
   def new_log_request_referrer?
-    request.referer.split("/").include?("new")
+    request.referer&.split("/").include?("new")
   end
 
   def is_referrer_check_answers?

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -5,7 +5,8 @@ class FormController < ApplicationController
 
   def submit_form
     if @log
-      @page = @log.form.get_page(params[@log.model_name.param_key][:page])
+      log_type = @log.model_name.param_key
+      @page = @log.form.get_page(params[log_type][:page])
       responses_for_page = responses_for_page(@page)
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
@@ -13,7 +14,7 @@ class FormController < ApplicationController
         session[:errors] = session[:fields] = nil
         redirect_to(successful_redirect_path)
       else
-        redirect_path = @log.not_started? ? "#{@log.model_name.param_key}_new_#{@page.id}_path" : "#{@log.model_name.param_key}_#{@page.id}_path"
+        redirect_path = @log.not_started? ? "#{log_type}_new_#{@page.id}_path" : "#{log_type}_#{@page.id}_path"
         mandatory_questions_with_no_response.map do |question|
           @log.errors.add question.id.to_sym, question.unanswered_error_message
         end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -131,28 +131,31 @@ private
     end
   end
 
-
   def find_resource
-    @log = if new_log_request? || new_log_request_referrer?
+    @log = if params.key?("sales_log")
+             if new_log_request? || new_log_request_referrer?
+               SalesLog.new(owning_organisation: current_user.support? ? nil : current_user.organisation)
+             else
+               current_user.sales_logs.find_by(id: params[:id])
+             end
+           elsif new_log_request? || new_log_request_referrer?
              LettingsLog.new(owning_organisation: current_user.support? ? nil : current_user.organisation)
            else
-             params.key?("sales_log") ? current_user.sales_logs.find_by(id: params[:id]) : current_user.lettings_logs.find_by(id: params[:id])
+             current_user.lettings_logs.find_by(id: params[:id])
            end
   end
 
   def find_resource_by_named_id
     @log = if params[:sales_log_id].present?
-               current_user.sales_logs.find_by(id: params[:sales_log_id])
-           else
-             if new_log_request?
-               if request.path.include? ("sales-logs")
-                 SalesLog.new
-               else
-                 LettingsLog.new
-               end
+             current_user.sales_logs.find_by(id: params[:sales_log_id])
+           elsif new_log_request?
+             if request.path.include?("sales-logs")
+               SalesLog.new
              else
-               current_user.lettings_logs.find_by(id: params[:lettings_log_id])
+               LettingsLog.new
              end
+           else
+             current_user.lettings_logs.find_by(id: params[:lettings_log_id])
            end
   end
 

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -49,7 +49,11 @@ class LettingsLogsController < LogsController
   end
 
   def edit
-    @log = current_user.lettings_logs.find_by(id: params[:id])
+    @log = if new_log_request?
+             LettingsLog.new
+           else
+             current_user.lettings_logs.find_by(id: params[:id])
+           end
     if @log
       render "logs/edit", locals: { current_user: }
     else
@@ -84,6 +88,9 @@ class LettingsLogsController < LogsController
   def csv_confirmation; end
 
 private
+  def new_log_request?
+    request.path.include?("new")
+  end
 
   def permitted_log_params
     params.require(:lettings_log).permit(LettingsLog.editable_fields)

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -97,7 +97,7 @@ private
     @log = LettingsLog.find_by(id: params[:id])
   end
 
-  def post_create_redirect_url
-    new_log_lettings_logs_path
+  def post_create_redirect_url(log)
+    log.not_started? ? new_log_lettings_logs_path : lettings_log_url(log)
   end
 end

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -88,8 +88,9 @@ class LettingsLogsController < LogsController
   def csv_confirmation; end
 
 private
+
   def new_log_request?
-    request.path.include?("new")
+    request.path.include?("new-log")
   end
 
   def permitted_log_params

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -101,7 +101,7 @@ private
     @log = LettingsLog.find_by(id: params[:id])
   end
 
-  def post_create_redirect_url(log)
-    lettings_log_url(log)
+  def post_create_redirect_url
+    new_log_lettings_logs_path
   end
 end

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -89,10 +89,6 @@ class LettingsLogsController < LogsController
 
 private
 
-  def new_log_request?
-    request.path.include?("new-log")
-  end
-
   def permitted_log_params
     params.require(:lettings_log).permit(LettingsLog.editable_fields)
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,8 +15,7 @@ private
 
     respond_to do |format|
       format.html do
-        log.save!
-        redirect_to post_create_redirect_url(log)
+        redirect_to new_log_lettings_logs_path
       end
       format.json do
         if log.save

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,7 +15,7 @@ private
 
     respond_to do |format|
       format.html do
-        redirect_to ( request.path.include?("sales") ? new_log_sales_logs_path : new_log_lettings_logs_path)
+        redirect_to(request.path.include?("sales") ? new_log_sales_logs_path : new_log_lettings_logs_path)
       end
       format.json do
         if log.save

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -11,11 +11,13 @@ private
 
   def create
     log = yield
+    log.save! unless api_log_params.empty?
+
     raise "Caller must pass a block that implements model creation" if log.blank?
 
     respond_to do |format|
       format.html do
-        redirect_to(post_create_redirect_url)
+        redirect_to(post_create_redirect_url(log))
       end
       format.json do
         if log.save

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -69,4 +69,8 @@ private
   def search_term
     params["search"]
   end
+
+  def new_log_request?
+    request.path.include?("new-log")
+  end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,7 +15,7 @@ private
 
     respond_to do |format|
       format.html do
-        redirect_to new_log_lettings_logs_path
+        redirect_to ( request.path.include?("sales") ? new_log_sales_logs_path : new_log_lettings_logs_path)
       end
       format.json do
         if log.save

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,7 +15,7 @@ private
 
     respond_to do |format|
       format.html do
-        redirect_to(request.path.include?("sales") ? new_log_sales_logs_path : new_log_lettings_logs_path)
+        redirect_to(post_create_redirect_url)
       end
       format.json do
         if log.save

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -47,10 +47,4 @@ class SalesLogsController < LogsController
   def permitted_log_params
     params.require(:sales_log).permit(SalesLog.editable_fields)
   end
-
-private
-
-  def new_log_request?
-    request.path.include?("new-log")
-  end
 end

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -40,8 +40,8 @@ class SalesLogsController < LogsController
     end
   end
 
-  def post_create_redirect_url(log)
-    sales_log_url(log)
+  def post_create_redirect_url
+    new_log_sales_logs_path
   end
 
   def permitted_log_params

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -40,8 +40,8 @@ class SalesLogsController < LogsController
     end
   end
 
-  def post_create_redirect_url
-    new_log_sales_logs_path
+  def post_create_redirect_url(log)
+    log.not_started? ? new_log_sales_logs_path : sales_log_url(log)
   end
 
   def permitted_log_params

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -51,6 +51,6 @@ class SalesLogsController < LogsController
 private
 
   def new_log_request?
-    request.path.include?("new")
+    request.path.include?("new-log")
   end
 end

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -28,7 +28,11 @@ class SalesLogsController < LogsController
   end
 
   def edit
-    @log = current_user.sales_logs.find_by(id: params[:id])
+    @log = if new_log_request?
+             SalesLog.new
+           else
+             current_user.sales_logs.find_by(id: params[:id])
+           end
     if @log
       render "logs/edit", locals: { current_user: }
     else
@@ -42,5 +46,11 @@ class SalesLogsController < LogsController
 
   def permitted_log_params
     params.require(:sales_log).permit(SalesLog.editable_fields)
+  end
+
+private
+
+  def new_log_request?
+    request.path.include?("new")
   end
 end

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -32,6 +32,22 @@ module CheckAnswersHelper
     "#{log.class.name.underscore}_#{redirect_path.underscore.tr('/', '_')}_path"
   end
 
+  def log_breadcrumbs(log, subsection)
+    if log.not_started?
+      {
+        "Logs" => "/logs",
+        "New log" => send("new_log_#{@log.class.name.underscore}s_path"),
+        subsection.label => "",
+      }
+    else
+      {
+        "Logs" => "/logs",
+        "Log #{@log.id}" => send("#{@log.class.name.underscore}_path", @log),
+        subsection.label => "",
+      }
+    end
+  end
+
 private
 
   def answered_questions_count(subsection, lettings_log, current_user)

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -16,8 +16,12 @@ module TasklistHelper
              "#{log.class.name.underscore}_#{subsection.id}_check_answers_path"
            else
              "#{log.class.name.underscore}_#{next_question_page(subsection, log, current_user)}_path"
-           end
-    send(path, log)
+             end
+    if log.id
+      send(path, log)
+    else
+      "/logs/new/#{next_question_page(subsection, log, current_user)}"
+    end
   end
 
   def next_question_page(subsection, log, current_user)

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -20,7 +20,7 @@ module TasklistHelper
     if log.id
       send(path, log)
     else
-      "/#{log.lettings? ? 'lettings' : 'sales'}-logs/new/#{next_question_page(subsection, log, current_user)}"
+      "/#{log.class.name.underscore.dasherize}/new/#{next_question_page(subsection, log, current_user)}"
     end
   end
 

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -20,7 +20,7 @@ module TasklistHelper
     if log.id
       send(path, log)
     else
-      "/logs/new/#{next_question_page(subsection, log, current_user)}"
+      "/#{log.lettings? ? "lettings" : "sales"}-logs/new/#{next_question_page(subsection, log, current_user)}"
     end
   end
 

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -16,11 +16,11 @@ module TasklistHelper
              "#{log.class.name.underscore}_#{subsection.id}_check_answers_path"
            else
              "#{log.class.name.underscore}_#{next_question_page(subsection, log, current_user)}_path"
-             end
+           end
     if log.id
       send(path, log)
     else
-      "/#{log.lettings? ? "lettings" : "sales"}-logs/new/#{next_question_page(subsection, log, current_user)}"
+      "/#{log.lettings? ? 'lettings' : 'sales'}-logs/new/#{next_question_page(subsection, log, current_user)}"
     end
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -76,7 +76,7 @@ class Form
     if nxt_page == :check_answers
       "#{type}_log_#{subsection_for_page(page).id}_check_answers_path"
     else
-      log.id ? "#{type}_log_#{nxt_page}_path" : "new_#{nxt_page}_#{type}_logs_path"
+      log.id ? "#{type}_log_#{nxt_page}_path" : "#{type}_logs_new_#{nxt_page}_path"
     end
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -74,14 +74,18 @@ class Form
   def next_page_redirect_path(page, log, current_user)
     nxt_page = next_page(page, log, current_user)
     if nxt_page == :check_answers
-      "#{type}_log_#{subsection_for_page(page).id}_check_answers_path"
+      log.not_started? ? "#{type}_log_new_#{subsection_for_page(page).id}_check_answers_path" : "#{type}_log_#{subsection_for_page(page).id}_check_answers_path"
     else
-      log.id ? "#{type}_log_#{nxt_page}_path" : "#{type}_log_new_#{nxt_page}_path"
+      log.not_started? ? "#{type}_log_new_#{nxt_page}_path" : "#{type}_log_#{nxt_page}_path"
     end
   end
 
   def cancel_path(page, log)
-    "#{log.class.name.underscore}_#{page.subsection.id}_check_answers_path"
+    if log.not_started?
+      "#{log.class.name.underscore}_new_#{page.subsection.id}_check_answers_path"
+    else
+      "#{log.class.name.underscore}_#{page.subsection.id}_check_answers_path"
+    end
   end
 
   def next_incomplete_section_redirect_path(subsection, log)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -76,7 +76,7 @@ class Form
     if nxt_page == :check_answers
       "#{type}_log_#{subsection_for_page(page).id}_check_answers_path"
     else
-      "#{type}_log_#{nxt_page}_path"
+      log.id ? "#{type}_log_#{nxt_page}_path" : "new_#{nxt_page}_#{type}_logs_path"
     end
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -76,7 +76,7 @@ class Form
     if nxt_page == :check_answers
       "#{type}_log_#{subsection_for_page(page).id}_check_answers_path"
     else
-      log.id ? "#{type}_log_#{nxt_page}_path" : "#{type}_logs_new_#{nxt_page}_path"
+      log.id ? "#{type}_log_#{nxt_page}_path" : "#{type}_log_new_#{nxt_page}_path"
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -122,7 +122,11 @@ class Form::Question
   end
 
   def action_href(log, page_id)
-    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=check_answers"
+    if log.not_started?
+      "/#{log.model_name.param_key.dasherize}/new/#{page_id.to_s.dasherize}?referrer=check_answers"
+    else
+      "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=check_answers"
+    end
   end
 
   def completed?(log)

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, "#{subsection.id.humanize} - Check your answers" %>
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-  "Logs" => "/logs",
-  "Log #{@log.id}" => send("#{@log.class.name.underscore}_path", @log),
-  subsection.label => "",
-  }) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: log_breadcrumbs(@log, subsection)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -4,8 +4,10 @@
   <%= govuk_back_link(href: "javascript:history.back()") %>
 <% end %>
 
+<% path_url = @log.id ? form_lettings_log_path(@log) : new_form_lettings_logs_path %>
+
 <div data-controller="govukfrontend"></div>
-<%= form_with model: @log, url: form_lettings_log_path(@log), method: "post", local: true do |f| %>
+<%= form_with model: @log, url: path_url, method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-<%= @page.questions[0].type == "interruption_screen" ? "full-from-desktop" : "two-thirds-from-desktop" %>">
       <% remove_other_page_errors(@log, @page) %>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Log #{@log.id}" %>
+<% content_for :title, "Log #{@log.id ? @log.id : "new"}" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
   "Logs" => @log.lettings? ? lettings_logs_path : sales_logs_path,
   content_for(:title) => "",

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Log #{@log.id ? @log.id : "new"}" %>
+<% content_for :title, @log.id ? "Log #{@log.id}" : "New log" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
   "Logs" => @log.lettings? ? lettings_logs_path : sales_logs_path,
   content_for(:title) => "",

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -11,7 +11,7 @@
       <%= govuk_button_to "Create a new lettings log", create_new_log_lettings_logs_path, method: :get %>
     <% end %>
     <% if FeatureToggle.sales_log_enabled? && current_page?(:controller => 'sales_logs', :action => 'index') %>
-      <%= govuk_button_to "Create a new sales log", sales_logs_path %>
+      <%= govuk_button_to "Create a new sales log", create_new_log_sales_logs_path, method: :get %>
     <% end %>
     <%#= govuk_link_to "Upload logs", bulk_upload_lettings_logs_path %>
   </div>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -8,7 +8,7 @@
 <div class="app-filter-layout" data-controller="filter-layout">
   <div class="govuk-button-group app-filter-toggle">
     <% if current_page?(:controller => 'lettings_logs', :action => 'index') %>
-      <%= govuk_button_to "Create a new lettings log", lettings_logs_path %>
+      <%= govuk_button_to "Create a new lettings log", create_new_log_lettings_logs_path, method: :get %>
     <% end %>
     <% if FeatureToggle.sales_log_enabled? && current_page?(:controller => 'sales_logs', :action => 'index') %>
       <%= govuk_button_to "Create a new sales log", sales_logs_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,18 @@ Rails.application.routes.draw do
     end
   end
 
+  FormHandler.instance.forms.each do |_key, form|
+    form.pages.map do |page|
+      get "/lettings-log/new/#{page.id.to_s.dasherize}", to: "form#show_page"
+      get "/sales-log/new/#{page.id.to_s.dasherize}", to: "form#show_page"
+    end
+
+    form.subsections.map do |subsection|
+      get "/lettings-log/new/#{subsection.id.to_s.dasherize}/check-answers", to: "form#check_answers"
+      get "/sales-log/new/#{subsection.id.to_s.dasherize}/check-answers", to: "form#check_answers"
+    end
+  end
+
   get "/accessibility-statement", to: "content#accessibility_statement"
   get "/privacy-notice", to: "content#privacy_notice"
   get "/data-sharing-agreement", to: "content#data_sharing_agreement"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,11 @@ Rails.application.routes.draw do
   end
 
   resources :sales_logs, path: "/sales-logs" do
+    collection do
+      get "create-new-log", to: "sales_logs#create"
+      get "new-log", to: "sales_logs#show"
+    end
+
     FormHandler.instance.sales_forms.each do |_key, form|
       form.pages.map do |page|
         get page.id.to_s.dasherize, to: "form#show_page"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   root to: "start#index"
 
   get "/logs", to: redirect("/lettings-logs")
+  get "/logs/new/organisation", to: "form#show_new_page"
   get "/accessibility-statement", to: "content#accessibility_statement"
   get "/privacy-notice", to: "content#privacy_notice"
   get "/data-sharing-agreement", to: "content#data_sharing_agreement"
@@ -82,11 +83,17 @@ Rails.application.routes.draw do
     collection do
       get "create-new-log", to: "lettings_logs#create"
       get "new-log", to: "lettings_logs#show"
+      post "new-form", to: "form#submit_form"
       post "bulk-upload", to: "bulk_upload#bulk_upload"
       get "bulk-upload", to: "bulk_upload#show"
       get "csv-download", to: "lettings_logs#download_csv"
       post "email-csv", to: "lettings_logs#email_csv"
       get "csv-confirmation", to: "lettings_logs#csv_confirmation"
+      FormHandler.instance.forms.each do |_key, form|
+        form.pages.map do |page|
+          get "new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
+        end
+      end
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,8 @@ Rails.application.routes.draw do
 
   FormHandler.instance.forms.each do |_key, form|
     form.pages.map do |page|
-      get "/lettings-logs/new/#{page.id.to_s.dasherize}", to: "form#show_page"
-      get "/sales-logs/new/#{page.id.to_s.dasherize}", to: "form#show_page"
+      get "/lettings-log/new/#{page.id.to_s.dasherize}", to: "form#show_page"
+      get "/sales-log/new/#{page.id.to_s.dasherize}", to: "form#show_page"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,8 @@ Rails.application.routes.draw do
 
   FormHandler.instance.forms.each do |_key, form|
     form.pages.map do |page|
-      get "/lettings-logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
-      get "/sales-logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
+      get "/lettings-logs/new/#{page.id.to_s.dasherize}", to: "form#show_page"
+      get "/sales-logs/new/#{page.id.to_s.dasherize}", to: "form#show_page"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,8 @@ Rails.application.routes.draw do
 
   FormHandler.instance.forms.each do |_key, form|
     form.pages.map do |page|
-      get "/logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
+      get "/lettings-logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
+      get "/sales-logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,8 @@ Rails.application.routes.draw do
 
   resources :lettings_logs, path: "/lettings-logs" do
     collection do
+      get "create-new-log", to: "lettings_logs#create"
+      get "new-log", to: "lettings_logs#show"
       post "bulk-upload", to: "bulk_upload#bulk_upload"
       get "bulk-upload", to: "bulk_upload#show"
       get "csv-download", to: "lettings_logs#download_csv"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,13 @@ Rails.application.routes.draw do
   root to: "start#index"
 
   get "/logs", to: redirect("/lettings-logs")
-  get "/logs/new/organisation", to: "form#show_new_page"
+
+  FormHandler.instance.forms.each do |_key, form|
+    form.pages.map do |page|
+      get "/logs/new/#{page.id.to_s.dasherize}", to: "form#show_new_page"
+    end
+  end
+
   get "/accessibility-statement", to: "content#accessibility_statement"
   get "/privacy-notice", to: "content#privacy_notice"
   get "/data-sharing-agreement", to: "content#data_sharing_agreement"

--- a/spec/factories/lettings_log.rb
+++ b/spec/factories/lettings_log.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
       rent_type { 1 }
       startdate { Time.zone.local(2022, 5, 1) }
     end
+    trait :just_started do
+      rent_type { 1 }
+    end
     trait :in_progress do
       status { 1 }
       tenancycode { Faker::Name.initials(number: 10) }

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Form Navigation" do
   let(:empty_lettings_log) do
     FactoryBot.create(
       :lettings_log,
+      :just_started,
       owning_organisation: user.organisation,
       managing_organisation: user.organisation,
       created_by: user,

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "validations" do
   let(:empty_lettings_log) do
     FactoryBot.create(
       :lettings_log,
+      :just_started,
       owning_organisation: user.organisation,
       managing_organisation: user.organisation,
     )

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe "Lettings Log Features" do
       end
     end
 
+    context "when creating a new log" do
+      it "creates a log after answering at least 1 question" do
+        visit("/lettings-logs")
+        expect { click_button("Create a new lettings log") }.to change(LettingsLog, :count).by(0)
+       end
+    end
+
     context "when returning to the list of logs via breadcrumbs link" do
       before do
         visit("/lettings-logs")

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Lettings Log Features" do
       it "creates a log after answering at least 1 question" do
         visit("/lettings-logs")
         expect { click_button("Create a new lettings log") }.to change(LettingsLog, :count).by(0)
-       end
+      end
     end
 
     context "when returning to the list of logs via breadcrumbs link" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe FormController, type: :request do
         let(:lettings_log) do
           FactoryBot.create(
             :lettings_log,
+            :just_started,
             owning_organisation: organisation,
             managing_organisation: organisation,
           )

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe LettingsLogsController, type: :request do
       before do
         RequestHelper.stub_http_requests
         sign_in user
-        post "/lettings-logs", headers:
+        post "/lettings-logs", headers:, params: { lettings_log: { tenancycode: "1234" } }
       end
 
       it "tracks who created the record" do


### PR DESCRIPTION
When submitting the form we don't save the log if it's not started and doesn't have any responses in the request.
Add routes for new (unsaved) log and route to them unless at least 1 question is answered.
Doesn't currently work for the support user logs, because they have 2 extra questions that need to be answered (owning organisation and created by). 
Few options to accommodate it are: 
 - keep the values for those 2 answers in memory before another question gets answered and we can persist the log
 - Mark the records that were created by support user as `in progress` and persist the log, when one of those questions is answered
