### PR TITLE
Check that we have an inferred check answers value

### DIFF
--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -51,7 +51,7 @@ class Form::Question
     answer = label_from_value(log[id]) if log[id].present?
     answer_label = [prefix, format_value(answer), suffix_label(log)].join("") if answer
 
-    inferred = inferred_check_answers_value["value"] if has_inferred_check_answers_value?(log)
+    inferred = inferred_check_answers_value["value"] if inferred_check_answers_value && has_inferred_check_answers_value?(log)
     return inferred if inferred.present?
 
     answer_label


### PR DESCRIPTION
Check that we have an inferred check answers value before extracting its value.

It's possible that this method returns true despite not having an `inferred_check_answers_value` set. This is an obvious smell that we will return to fix, but this is blocking production sales logs, so we need to fix it.