### PR TITLE
CLDC-1505 Buyer 1 working situation must be an adult

### DIFF
--- a/app/models/form/sales/questions/buyer1_working_situation.rb
+++ b/app/models/form/sales/questions/buyer1_working_situation.rb
@@ -21,6 +21,5 @@ class Form::Sales::Questions::Buyer1WorkingSituation < ::Form::Question
     "0" => { "value" => "Other" },
     "10" => { "value" => "Buyer prefers not to say" },
     "7" => { "value" => "Full-time student" },
-    "9" => { "value" => "Child under 16" },
   }.freeze
 end

--- a/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Form::Sales::Questions::Buyer1WorkingSituation, type: :model do
       "0" => { "value" => "Other" },
       "10" => { "value" => "Buyer prefers not to say" },
       "7" => { "value" => "Full-time student" },
-      "9" => { "value" => "Child under 16" },
     })
   end
 end


### PR DESCRIPTION
Per the comments on CLDC-1505, removed the "child under 16" option from buyer 1 working situation.