### PR TITLE
Adjust referral derived value when log is a renewal

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -45,7 +45,7 @@ module DerivedVariables::LettingsLogVariables
     self.nocharge = household_charge&.zero? ? 1 : 0
     if is_renewal?
       self.underoccupation_benefitcap = 2 if collection_start_year == 2021
-      self.referral = 0
+      self.referral = 1
       self.waityear = 2
       if is_general_needs?
         # fixed term

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1431,8 +1431,8 @@ RSpec.describe LettingsLog do
 
       it "correctly derives and saves referral" do
         record_from_db = ActiveRecord::Base.connection.execute("select referral from lettings_logs where id=#{lettings_log.id}").to_a[0]
-        expect(record_from_db["referral"]).to eq(0)
-        expect(lettings_log["referral"]).to eq(0)
+        expect(record_from_db["referral"]).to eq(1)
+        expect(lettings_log["referral"]).to eq(1)
       end
 
       it "correctly derives and saves vacdays" do


### PR DESCRIPTION
Previously we inferred referral to equal `0` when renewal was `1`. This change sets `referral` to `1` when `renewal` is also `1`.

_After_ deployment, I will run the following script to migrate existing data:

```ruby
LettingsLog.where(renewal: 1, referral: 0).update_all(referral: 1)
```