### PR TITLE
CLDC-1620 Add Google Tag Manager scripts to layout

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AnalyticsHelper
+  def get_gtm_container
+    # Additional environments tbc
+    "GTM-M6GS7FF"
+  end
+
+  def get_gtm_id
+    # Additional environments tbc
+    "G-1RH26G5KVP"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
     <% else %>
       <script>
         // For adding the script once the user has given permission
-        window.ecfAnalyticsScript = "https://www.googletagmanager.com/gtag/js?id=<%= gtm_id %>";
+        window.analyticsScript = "https://www.googletagmanager.com/gtag/js?id=<%= gtm_id %>";
       </script>
     <% end %>
     <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
     <%= javascript_include_tag "vendor/polyfill-output-value.js" %>
     <%= javascript_include_tag "vendor/outerHTML.js" %>
 
-    <% gtm_container = "GTM-M6GS7FF" %>
-    <% gtm_id = "G-1RH26G5KVP" %>
+    <% gtm_container = get_gtm_container %>
+    <% gtm_id = get_gtm_id %>
 
     <!-- Google Tag Manager (doesn't store personal info until permission given) -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,34 @@
     </script>
     <%= javascript_include_tag "vendor/polyfill-output-value.js" %>
     <%= javascript_include_tag "vendor/outerHTML.js" %>
+
+    <% gtm_container = "GTM-M6GS7FF" %>
+    <% gtm_id = "G-1RH26G5KVP" %>
+
+    <!-- Google Tag Manager (doesn't store personal info until permission given) -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= gtm_container %>');</script>
+    <!-- End Google Tag Manager -->
+
+    <% if cookies[:accept_analytics_cookies] == "on" %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= gtm_id %>"></script>
+    <% else %>
+      <script>
+        // For adding the script once the user has given permission
+        window.ecfAnalyticsScript = "https://www.googletagmanager.com/gtag/js?id=<%= gtm_id %>";
+      </script>
+    <% end %>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '<%= gtm_id %>');
+    </script>
+
     <%= javascript_include_tag "application", defer: true %>
 
     <% if content_for?(:head) %>
@@ -43,6 +71,13 @@
     <script>
       document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     </script>
+
+    <!-- Google Tag Manager (noscript) -->
+    <% if cookies[:accept_analytics_cookies] %>
+      <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=<% gtm_container %>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+    <% end %>
 
     <%= govuk_skip_link %>
 


### PR DESCRIPTION
Currently won't do much, since we don't have the cookie consent banner or page. Once CLDC-1618 or CLDC-1619 is in, then it should Just Work.

Have verified in local dev that IDs etc are behaving (by commenting out the cookie check and confirming that pageviews appear in GA).