### PR TITLE
CLDC-1619 Corrected cookie form lookup

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -6,7 +6,7 @@ class CookiesController < ApplicationController
   def show; end
 
   def update
-    analytics_consent = params[:cookies_form][:analytics_consent]
+    analytics_consent = params[:cookies_form][:accept_analytics_cookies]
     if %w[on off].include?(analytics_consent)
       cookies[:accept_analytics_cookies] = { value: analytics_consent, expires: 1.year.from_now }
     end


### PR DESCRIPTION
Form was just looking for the wrong field when updating (`analytics_consent` vs `accept_analytics_cookies`).