### PR TITLE
Cldc 1667 location details page

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -20,7 +20,7 @@ class LocationsController < ApplicationController
 
   def show; end
 
-  def deactivate; 
+  def deactivate
     render "toggle_active", locals: { action: "deactivate" }
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -18,6 +18,8 @@ class LocationsController < ApplicationController
     @location = Location.new
   end
 
+  def show; end
+
   def create
     if date_params_missing?(location_params) || valid_date_params?(location_params)
       @location = Location.new(location_params)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -20,6 +20,10 @@ class LocationsController < ApplicationController
 
   def show; end
 
+  def deactivate; 
+    render "toggle_active", locals: { action: "deactivate" }
+  end
+
   def create
     if date_params_missing?(location_params) || valid_date_params?(location_params)
       @location = Location.new(location_params)

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -22,4 +22,18 @@ module LocationsHelper
 
     resource.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) }
   end
+
+  def display_attributes(location)
+    [
+      { name: "Postcode", value: location.postcode },
+      { name: "Local authority", value: location.location_admin_district },
+      { name: "Location name", value: location.name, edit: true },
+      { name: "Total number of units at this location", value: location.units },
+      { name: "Common type of unit", value: location.type_of_unit },
+      { name: "Mobility type", value: location.mobility_type },
+      { name: "Code", value: location.location_code },
+      { name: "Availability", value: "Available from #{location.available_from.to_formatted_s(:govuk_date)}" },
+      { name: "Status", value: location.status },
+    ]
+  end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -6,6 +6,7 @@ module TagHelper
     cannot_start_yet: "Cannot start yet",
     in_progress: "In progress",
     completed: "Completed",
+    active: "Active",
   }.freeze
 
   COLOUR = {
@@ -13,6 +14,7 @@ module TagHelper
     cannot_start_yet: "grey",
     in_progress: "blue",
     completed: "green",
+    active: "green",
   }.freeze
 
   def status_tag(status, classes = [])

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -361,9 +361,13 @@ class Location < ApplicationRecord
 
   def display_attributes
     [
-      { name: "Location code ", value: location_code, suffix: false },
-      { name: "Postcode", value: postcode, suffix: county },
-      { name: "Type of unit", value: type_of_unit, suffix: false },
+      { name: "Postcode", value: postcode },
+      { name: "Local authority", value: location_admin_district },
+      { name: "Location name", value: name, edit: true  },
+      { name: "Total number of units at this location", value: units },
+      { name: "Common type of unit", value: type_of_unit },
+      { name: "Mobility type", value: mobility_type },
+      { name: "Code", value: location_code },
     ]
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -369,6 +369,7 @@ class Location < ApplicationRecord
       { name: "Mobility type", value: mobility_type },
       { name: "Code", value: location_code },
       { name: "Availability", value: "Available from #{available_from.to_formatted_s(:govuk_date)}" },
+      { name: "Status", value: status },
     ]
   end
 
@@ -401,5 +402,9 @@ private
 
   def available_from
     startdate || created_at
+  end
+
+  def status
+    "active"
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -368,6 +368,7 @@ class Location < ApplicationRecord
       { name: "Common type of unit", value: type_of_unit },
       { name: "Mobility type", value: mobility_type },
       { name: "Code", value: location_code },
+      { name: "Availability", value: "Available from #{available_from.to_formatted_s(:govuk_date)}" },
     ]
   end
 
@@ -396,5 +397,9 @@ private
       self.location_code = result[:location_code]
       self.location_admin_district = result[:location_admin_district]
     end
+  end
+
+  def available_from
+    startdate || created_at
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -359,26 +359,20 @@ class Location < ApplicationRecord
 
   enum type_of_unit: TYPE_OF_UNIT
 
-  def display_attributes
-    [
-      { name: "Postcode", value: postcode },
-      { name: "Local authority", value: location_admin_district },
-      { name: "Location name", value: name, edit: true  },
-      { name: "Total number of units at this location", value: units },
-      { name: "Common type of unit", value: type_of_unit },
-      { name: "Mobility type", value: mobility_type },
-      { name: "Code", value: location_code },
-      { name: "Availability", value: "Available from #{available_from.to_formatted_s(:govuk_date)}" },
-      { name: "Status", value: status },
-    ]
-  end
-
   def postcode=(postcode)
     if postcode
       super UKPostcode.parse(postcode).to_s
     else
       super nil
     end
+  end
+
+  def available_from
+    startdate || created_at
+  end
+
+  def status
+    "active"
   end
 
 private
@@ -398,13 +392,5 @@ private
       self.location_code = result[:location_code]
       self.location_admin_district = result[:location_admin_district]
     end
-  end
-
-  def available_from
-    startdate || created_at
-  end
-
-  def status
-    "active"
   end
 end

--- a/app/views/locations/edit_name.html.erb
+++ b/app/views/locations/edit_name.html.erb
@@ -3,7 +3,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: "/schemes/#{@scheme.id}/locations/#{@location.id}",
+    href: scheme_location_path(@scheme, @location),
   ) %>
 <% end %>
 

--- a/app/views/locations/edit_name.html.erb
+++ b/app/views/locations/edit_name.html.erb
@@ -3,7 +3,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: "/schemes/#{@scheme.id}/locations",
+    href: "/schemes/#{@scheme.id}/locations/#{@location.id}",
   ) %>
 <% end %>
 

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -52,7 +52,7 @@
     <%= table.body do |body| %>
       <%= body.row do |row| %>
         <% row.cell(text: location.id) %>
-        <% row.cell(text: simple_format(location_cell_postcode(location, "/schemes/#{@scheme.id}/locations/#{location.id}/edit-name"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
+        <% row.cell(text: simple_format(location_cell_postcode(location, "/schemes/#{@scheme.id}/locations/#{location.id}"), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
         <% row.cell(text: location.units) %>
         <% row.cell(text: simple_format("<span>#{location.type_of_unit}</span>")) %>
         <% row.cell(text: location.mobility_type) %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -22,3 +22,7 @@
     <% end %>
   <% end %>
 <% end %>
+
+<% if !Rails.env.production? %>
+    <%= govuk_button_link_to "Deactivate this location", location_deactivate_path(location_id: @location.id, id: @scheme.id), warning: true %>
+<% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -17,7 +17,7 @@
                 <%= summary_list.row do |row| %>
                 <% row.key { attr[:name] } %>
                 <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
-                <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+                <% row.action(text: "Change", href: location_edit_name_path(@scheme, location_id: @location)) if attr[:edit] %>
                 <% end %>
             <% end %>
         <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -8,20 +8,19 @@
   ) %>
 <% end %>
 
-<%= render partial: "organisations/headings", locals: { main: @location.postcode, sub: @location.name  } %>
+<%= render partial: "organisations/headings", locals: { main: @location.postcode, sub: @location.name } %>
 
 <div class="govuk-grid-row">
- <div class="govuk-grid-column-two-thirds-from-desktop" %>
-    <%= govuk_summary_list do |summary_list| %>
-    <% @location.display_attributes.each do |attr| %>
-        <%= summary_list.row do |row| %>
-        <% row.key { attr[:name] } %>
-        <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
-        <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= govuk_summary_list do |summary_list| %>
+            <% @location.display_attributes.each do |attr| %>
+                <%= summary_list.row do |row| %>
+                <% row.key { attr[:name] } %>
+                <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
+                <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+                <% end %>
+            <% end %>
         <% end %>
-    <% end %>
-    <% end %>
-
     </div>
 </div>
 <% if !Rails.env.production? %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -17,7 +17,7 @@
   <% @location.display_attributes.each do |attr| %>
     <%= summary_list.row do |row| %>
       <% row.key { attr[:name] } %>
-      <% row.value { details_html(attr) } %>
+      <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
       <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
     <% end %>
   <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -4,7 +4,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: send("locations_path", @scheme),
+    href: locations_path(@scheme),
   ) %>
 <% end %>
 

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -23,6 +23,6 @@
         <% end %>
     </div>
 </div>
-<% if !Rails.env.production? %>
+<% if FeatureToggle.location_toggle_enabled? %>
     <%= govuk_button_link_to "Deactivate this location", location_deactivate_path(location_id: @location.id, id: @scheme.id), warning: true %>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -4,7 +4,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: locations_path(@scheme),
+    href: scheme_locations_path(@scheme),
   ) %>
 <% end %>
 
@@ -17,12 +17,12 @@
                 <%= summary_list.row do |row| %>
                 <% row.key { attr[:name] } %>
                 <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
-                <% row.action(text: "Change", href: location_edit_name_path(@scheme, location_id: @location)) if attr[:edit] %>
+                <% row.action(text: "Change", href: scheme_location_edit_name_path(scheme_id: @scheme.id, location_id: @location.id)) if attr[:edit] %>
                 <% end %>
             <% end %>
         <% end %>
     </div>
 </div>
 <% if FeatureToggle.location_toggle_enabled? %>
-    <%= govuk_button_link_to "Deactivate this location", location_deactivate_path(location_id: @location.id, id: @scheme.id), warning: true %>
+    <%= govuk_button_link_to "Deactivate this location", scheme_location_deactivate_path(scheme_id: @scheme.id, location_id: @location.id), warning: true %>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= govuk_summary_list do |summary_list| %>
-            <% @location.display_attributes.each do |attr| %>
+            <% display_attributes(@location).each do |attr| %>
                 <%= summary_list.row do |row| %>
                 <% row.key { attr[:name] } %>
                 <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -10,19 +10,20 @@
 
 <%= render partial: "organisations/headings", locals: { main: @location.postcode, sub: @location.name  } %>
 
-<h2 class="govuk-visually-hidden">Location</h2>
-
-<%= govuk_summary_list do |summary_list| %>
-
-  <% @location.display_attributes.each do |attr| %>
-    <%= summary_list.row do |row| %>
-      <% row.key { attr[:name] } %>
-      <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
-      <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+<div class="govuk-grid-row">
+ <div class="govuk-grid-column-two-thirds-from-desktop" %>
+    <%= govuk_summary_list do |summary_list| %>
+    <% @location.display_attributes.each do |attr| %>
+        <%= summary_list.row do |row| %>
+        <% row.key { attr[:name] } %>
+        <% row.value { attr[:name].eql?("Status") ? status_tag(attr[:value]) : details_html(attr) } %>
+        <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+        <% end %>
     <% end %>
-  <% end %>
-<% end %>
+    <% end %>
 
+    </div>
+</div>
 <% if !Rails.env.production? %>
     <%= govuk_button_link_to "Deactivate this location", location_deactivate_path(location_id: @location.id, id: @scheme.id), warning: true %>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,0 +1,24 @@
+<% title = @location.name %>
+<% content_for :title, title %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: "Back",
+    href: send("locations_path", @scheme),
+  ) %>
+<% end %>
+
+<%= render partial: "organisations/headings", locals: { main: @location.postcode, sub: @location.name  } %>
+
+<h2 class="govuk-visually-hidden">Location</h2>
+
+<%= govuk_summary_list do |summary_list| %>
+
+  <% @location.display_attributes.each do |attr| %>
+    <%= summary_list.row do |row| %>
+      <% row.key { attr[:name] } %>
+      <% row.value { details_html(attr) } %>
+      <% row.action(text: "Change", href: location_edit_name_path(location_id: @location.id, id: @scheme.id)) if attr[:edit] %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -14,4 +14,10 @@ class FeatureToggle
 
     false
   end
+
+  def self.location_toggle_enabled?
+    return true unless Rails.env.production?
+
+    false
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     resources :locations do
       get "edit-name", to: "locations#edit_name"
       get "edit-local-authority", to: "locations#edit_local_authority"
+      get "deactivate", to: "locations#deactivate"
     end
   end
 

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -777,6 +777,11 @@ RSpec.describe "Schemes scheme Features" do
                 expect(page).to have_content "Location name for #{location.postcode}"
               end
 
+              it "allows to deactivate a location" do
+                click_link("Deactivate this location")
+                expect(page).to have_current_path("/schemes/#{scheme.id}/locations/#{location.id}/deactivate")
+              end
+
               context "when I press the back button" do
                 before do
                   click_link "Back"

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -767,6 +767,7 @@ RSpec.describe "Schemes scheme Features" do
                 expect(page).to have_content(location.mobility_type)
                 expect(page).to have_content(location.location_code)
                 expect(page).to have_content("Available from 4 April 2022")
+                expect(page).to have_content("Active")
               end
 
               it "only allows to edit the location name" do

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -757,8 +757,21 @@ RSpec.describe "Schemes scheme Features" do
                 click_link(location.postcode)
               end
 
-              it "shows available fields to edit" do
-                expect(page).to have_current_path("/schemes/#{scheme.id}/locations/#{location.id}/edit-name")
+              it "displays details about the selected location" do
+                expect(page).to have_current_path("/schemes/#{scheme.id}/locations/#{location.id}")
+                expect(page).to have_content(location.postcode)
+                expect(page).to have_content(location.location_admin_district)
+                expect(page).to have_content(location.name)
+                expect(page).to have_content(location.units)
+                expect(page).to have_content(location.type_of_unit)
+                expect(page).to have_content(location.mobility_type)
+                expect(page).to have_content(location.location_code)
+              end
+
+              it "only allows to edit the location name" do
+                assert_selector "a", text: "Change", count: 1
+
+                click_link("Change")
                 expect(page).to have_content "Location name for #{location.postcode}"
               end
 
@@ -775,14 +788,26 @@ RSpec.describe "Schemes scheme Features" do
 
               context "and I change the location name" do
                 before do
-                  fill_in "location-name-field", with: "NewName"
-                  click_button "Save and continue"
+                  click_link("Change")
                 end
 
                 it "returns to locations check your answers page and shows the new name" do
+                  fill_in "location-name-field", with: "NewName"
+                  click_button "Save and continue"
                   expect(page).to have_content location.id
                   expect(page).to have_content "NewName"
                   expect(page.current_url.split("/").last).to eq("check-answers#locations")
+                end
+
+                context "when I press the back button" do
+                  before do
+                    click_link "Back"
+                  end
+
+                  it "I see location details" do
+                    expect(page).to have_content location.name
+                    expect(page).to have_current_path("/schemes/#{scheme.id}/locations/#{location.id}")
+                  end
                 end
               end
             end

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -692,7 +692,7 @@ RSpec.describe "Schemes scheme Features" do
 
         context "when I click to see individual scheme" do
           let(:scheme) { schemes.first }
-          let!(:location) { FactoryBot.create(:location, scheme:) }
+          let!(:location) { FactoryBot.create(:location, startdate: Time.zone.local(2022, 4, 4), scheme:) }
 
           before do
             click_link(scheme.service_name)
@@ -766,6 +766,7 @@ RSpec.describe "Schemes scheme Features" do
                 expect(page).to have_content(location.type_of_unit)
                 expect(page).to have_content(location.mobility_type)
                 expect(page).to have_content(location.location_code)
+                expect(page).to have_content("Available from 4 April 2022")
               end
 
               it "only allows to edit the location name" do

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -46,4 +46,31 @@ RSpec.describe LocationsHelper do
       expect(selection_options(%w[example])).to eq([OpenStruct.new(id: "example", name: "Example")])
     end
   end
+
+  describe "display_attributes" do
+    let(:location) { FactoryBot.build(:location, startdate: Time.zone.local(2022, 8, 8)) }
+
+    it "returns correct display attributes" do
+      attributes = [
+        { name: "Postcode", value: location.postcode },
+        { name: "Local authority", value: location.location_admin_district },
+        { name: "Location name", value: location.name, edit: true },
+        { name: "Total number of units at this location", value: location.units },
+        { name: "Common type of unit", value: location.type_of_unit },
+        { name: "Mobility type", value: location.mobility_type },
+        { name: "Code", value: location.location_code },
+        { name: "Availability", value: "Available from 8 August 2022" },
+        { name: "Status", value: "active" },
+      ]
+
+      expect(display_attributes(location)).to eq(attributes)
+    end
+
+    it "displays created_at as availability date if startdate is not present" do
+      location.update!(startdate: nil)
+      availability_attribute = display_attributes(location).find { |x| x[:name] == "Availability" }[:value]
+
+      expect(availability_attribute).to eq("Available from #{location.created_at.to_formatted_s(:govuk_date)}")
+    end
+  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Location, type: :model do
   end
 
   describe "#display_attributes" do
-    let(:location) { FactoryBot.build(:location) }
+    let(:location) { FactoryBot.build(:location, startdate: Time.zone.local(2022, 8, 8)) }
 
     it "returns correct display attributes" do
       attributes = [
@@ -124,9 +124,17 @@ RSpec.describe Location, type: :model do
         { name: "Common type of unit", value: location.type_of_unit },
         { name: "Mobility type", value: location.mobility_type },
         { name: "Code", value: location.location_code },
+        { name: "Availability", value: "Available from 8 August 2022" },
       ]
 
       expect(location.display_attributes).to eq(attributes)
+    end
+
+    it "displays created_at as availability date if startdate is not present" do
+      location.update!(startdate: nil)
+      availability_attribute = location.display_attributes.find { |x| x[:name] == "Availability" }[:value]
+
+      expect(availability_attribute).to eq("Available from #{location.created_at.to_formatted_s(:govuk_date)}")
     end
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Location, type: :model do
         { name: "Mobility type", value: location.mobility_type },
         { name: "Code", value: location.location_code },
         { name: "Availability", value: "Available from 8 August 2022" },
+        { name: "Status", value: "active" },
       ]
 
       expect(location.display_attributes).to eq(attributes)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -111,4 +111,22 @@ RSpec.describe Location, type: :model do
       end
     end
   end
+
+  describe "#display_attributes" do
+    let(:location) { FactoryBot.build(:location) }
+
+    it "returns correct display attributes" do
+      attributes = [
+        { name: "Postcode", value: location.postcode },
+        { name: "Local authority", value: location.location_admin_district },
+        { name: "Location name", value: location.name, edit: true },
+        { name: "Total number of units at this location", value: location.units },
+        { name: "Common type of unit", value: location.type_of_unit },
+        { name: "Mobility type", value: location.mobility_type },
+        { name: "Code", value: location.location_code },
+      ]
+
+      expect(location.display_attributes).to eq(attributes)
+    end
+  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -111,31 +111,4 @@ RSpec.describe Location, type: :model do
       end
     end
   end
-
-  describe "#display_attributes" do
-    let(:location) { FactoryBot.build(:location, startdate: Time.zone.local(2022, 8, 8)) }
-
-    it "returns correct display attributes" do
-      attributes = [
-        { name: "Postcode", value: location.postcode },
-        { name: "Local authority", value: location.location_admin_district },
-        { name: "Location name", value: location.name, edit: true },
-        { name: "Total number of units at this location", value: location.units },
-        { name: "Common type of unit", value: location.type_of_unit },
-        { name: "Mobility type", value: location.mobility_type },
-        { name: "Code", value: location.location_code },
-        { name: "Availability", value: "Available from 8 August 2022" },
-        { name: "Status", value: "active" },
-      ]
-
-      expect(location.display_attributes).to eq(attributes)
-    end
-
-    it "displays created_at as availability date if startdate is not present" do
-      location.update!(startdate: nil)
-      availability_attribute = location.display_attributes.find { |x| x[:name] == "Availability" }[:value]
-
-      expect(availability_attribute).to eq("Available from #{location.created_at.to_formatted_s(:govuk_date)}")
-    end
-  end
 end


### PR DESCRIPTION
- Add show location page with location details and allow to change the location name
- Display default `active` status as a tag in the details. (Status is always `active`, changing/determining the status would need to be done as a separate task, maybe as part of deactivation task)
- Add feature flagged `Deactivate this location` button that currently renders a new empty deactivate location page

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/54268893/200615796-f4583779-27c6-479c-a712-cb3224cff10c.png">
