### PR TITLE
Add validation to dependent ccharge field

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -110,6 +110,7 @@ module Validations::FinancialValidations
     if record.is_carehome?
       period = record.form.get_question("period", record).label_from_value(record.period).downcase
       if record.chcharge.blank?
+        record.errors.add :is_carehome, I18n.t("validations.financial.carehome.not_provided", period:)
         record.errors.add :chcharge, I18n.t("validations.financial.carehome.not_provided", period:)
       elsif !weekly_value_in_range(record, "chcharge", 10, 1000)
         max_chcharge = record.weekly_to_value_per_period(1000)

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -1010,6 +1010,8 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_care_home_charges(record)
           expect(record.errors["chcharge"])
             .to include(match I18n.t("validations.financial.carehome.not_provided", period: "every 4 weeks"))
+          expect(record.errors["is_carehome"])
+            .to include(match I18n.t("validations.financial.carehome.not_provided", period: "every 4 weeks"))
         end
       end
 


### PR DESCRIPTION
Although both fields are on the same page, we need to add a validation here so that we can clear both values on import.

If we don't do this then the validation will continue to trigger and the importer will get stuck in an endless loop.