### PR TITLE
Cldc 1668 deactivate location

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -164,11 +164,10 @@ private
 
   def deactivation_date
     return if params[:location].blank?
+    collection_start_date = FormHandler.instance.current_collection_start_date
+    return collection_start_date if params[:location][:deactivation_date_type] == "default"
 
     return @location.errors.add(:deactivation_date_type, message: I18n.t("validations.location.deactivation_date.not_selected")) if params[:location][:deactivation_date].blank? && params[:location][:deactivation_date_type].blank?
-    collection_start_date = FormHandler.instance.current_collection_start_date
-
-    return collection_start_date if params[:location][:deactivation_date_type].to_i == 1
     return params[:location][:deactivation_date] if params[:location][:deactivation_date_type].blank?
 
     day = params[:location]["deactivation_date(3i)"]

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -39,6 +39,10 @@ class LocationsController < ApplicationController
     end
   end
 
+  def reactivate
+    render "toggle_active", locals: { action: "reactivate" }
+  end
+
   def create
     if date_params_missing?(location_params) || valid_date_params?(location_params)
       @location = Location.new(location_params)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -31,7 +31,7 @@ class LocationsController < ApplicationController
         @location.deactivation_date_type = params[:location][:deactivation_date_type]
         render "toggle_active", locals: { action: "deactivate" }, status: :unprocessable_entity
       else
-        render "toggle_active_confirm", locals: { action: "deactivate", deactivation_date: deactivation_date }
+        render "toggle_active_confirm", locals: { action: "deactivate", deactivation_date: }
       end
     end
   end
@@ -168,12 +168,11 @@ private
       flash[:notice] = "#{@location.name || @location.postcode} has been deactivated"
     end
     redirect_to scheme_location_path(@scheme, @location)
-    return
   end
 
   def deactivation_date_errors
     if params[:location][:deactivation_date].blank? && params[:location][:deactivation_date_type].blank?
-      @location.errors.add(:deactivation_date_type, message: I18n.t("validations.location.deactivation_date.not_selected")) 
+      @location.errors.add(:deactivation_date_type, message: I18n.t("validations.location.deactivation_date.not_selected"))
     end
 
     if params[:location][:deactivation_date_type] == "other"
@@ -183,7 +182,7 @@ private
 
       collection_start_date = FormHandler.instance.current_collection_start_date
 
-      if [day, month, year].any?(&:blank?) 
+      if [day, month, year].any?(&:blank?)
         { day:, month:, year: }.each do |period, value|
           @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.not_entered", period: period.to_s)) if value.blank?
         end
@@ -197,6 +196,7 @@ private
 
   def deactivation_date
     return if params[:location].blank?
+
     collection_start_date = FormHandler.instance.current_collection_start_date
     return collection_start_date if params[:location][:deactivation_date_type] == "default"
     return params[:location][:deactivation_date] if params[:location][:deactivation_date_type].blank?

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -172,10 +172,23 @@ private
     month = params[:location]["deactivation_date(2i)"]
     year = params[:location]["deactivation_date(1i)"]
 
-    if [day, month, year].all?(&:present?) && Date.valid_date?(year.to_i, month.to_i, day.to_i) && year.to_i.between?(2000, 2200)
-      Date.new(year.to_i, month.to_i, day.to_i)
+
+    if [day, month, year].any?(&:blank?) || !Date.valid_date?(year.to_i, month.to_i, day.to_i) || !year.to_i.between?(2000, 2200)
+      set_deactivation_date_errors(day, month, year)
     else
-      @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.not_entered"))
+      Date.new(year.to_i, month.to_i, day.to_i)
+    end
+  end
+
+  def set_deactivation_date_errors(day, month, year)
+    if [day, month, year].any?(&:blank?)
+      {day:, month:, year:}.each do |period, value| 
+        @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.not_entered", period: period.to_s )) if value.blank?
+      end
+    elsif !Date.valid_date?(year.to_i, month.to_i, day.to_i)
+      @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.invalid"))
+    elsif !year.to_i.between?(2000, 2200)
+      @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.invalid"))
     end
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -24,6 +24,7 @@ class LocationsController < ApplicationController
     deactivation_date_value = deactivation_date
 
     if @location.errors.present?
+      @location.deactivation_date_type = params[:location][:deactivation_date_type].to_i
       render "toggle_active", locals: { action: "deactivate" }, status: :unprocessable_entity
     elsif deactivation_date_value.blank?
       render "toggle_active", locals: { action: "deactivate" }
@@ -163,8 +164,12 @@ private
 
   def deactivation_date
     return if params[:location].blank?
-    return @location.errors.add(:deactivation_date, message: I18n.t("validations.location.deactivation_date.not_selected")) if params[:location][:deactivation_date].blank?
-    return params[:location][:deactivation_date] unless params[:location][:deactivation_date] == "other"
+
+    return @location.errors.add(:deactivation_date_type, message: I18n.t("validations.location.deactivation_date.not_selected")) if params[:location][:deactivation_date].blank? && params[:location][:deactivation_date_type].blank?
+    collection_start_date = FormHandler.instance.current_collection_start_date
+
+    return collection_start_date if params[:location][:deactivation_date_type].to_i == 1
+    return params[:location][:deactivation_date] if params[:location][:deactivation_date_type].blank?
 
     day = params[:location]["deactivation_date(3i)"]
     month = params[:location]["deactivation_date(2i)"]

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -164,7 +164,7 @@ private
 
   def confirm_deactivation
     if @location.update(deactivation_date: params[:location][:deactivation_date])
-      # update the logs
+      @location.lettings_logs.filter_by_before_startdate( params[:location][:deactivation_date]).update(location: nil)
       flash[:notice] = "#{@location.name} has been deactivated"
     end
     redirect_to scheme_locations_path(@scheme)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -21,7 +21,15 @@ class LocationsController < ApplicationController
   def show; end
 
   def deactivate
-    render "toggle_active", locals: { action: "deactivate" }
+    if params[:deactivation_date].blank?
+      render "toggle_active", locals: { action: "deactivate" }
+    elsif (params[:confirm])
+      # update the deactivation_date
+      # update the logs
+      # redirect to location page
+    else
+      render "toggle_active_confirm", locals: {action: "deactivate", deactivation_date: params[:deactivation_date]}
+    end
   end
 
   def create
@@ -128,7 +136,7 @@ private
   end
 
   def authenticate_action!
-    if %w[new edit update create index edit_name edit_local_authority].include?(action_name) && !((current_user.organisation == @scheme&.owning_organisation) || current_user.support?)
+    if %w[new edit update create index edit_name edit_local_authority deactivate].include?(action_name) && !((current_user.organisation == @scheme&.owning_organisation) || current_user.support?)
       render_not_found and return
     end
   end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -165,7 +165,6 @@ private
 
   def confirm_deactivation
     if @location.update(deactivation_date: params[:location][:deactivation_date])
-      @location.lettings_logs.filter_by_before_startdate( params[:location][:deactivation_date]).update(location: nil)
       flash[:notice] = "#{@location.name || @location.postcode} has been deactivated"
     end
     redirect_to scheme_location_path(@scheme, @location)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -22,15 +22,9 @@ class LocationsController < ApplicationController
 
   def deactivate
     if params[:location][:confirm].present? && params[:location][:deactivation_date].present?
-      if @location.update(deactivation_date: params[:location][:deactivation_date])
-        # update the logs
-        flash[:notice] = "#{@location.name} has been deactivated"
-      end
-      redirect_to scheme_locations_path(@scheme)
+      confirm_deactivation
     else
-
       deactivation_date_errors
-
       if @location.errors.present?
         @location.deactivation_date_type = params[:location][:deactivation_date_type]
         render "toggle_active", locals: { action: "deactivate" }, status: :unprocessable_entity
@@ -168,7 +162,14 @@ private
     location_params["location_admin_district"] != "Select an option"
   end
 
-
+  def confirm_deactivation
+    if @location.update(deactivation_date: params[:location][:deactivation_date])
+      # update the logs
+      flash[:notice] = "#{@location.name} has been deactivated"
+    end
+    redirect_to scheme_locations_path(@scheme)
+    return
+  end
 
   def deactivation_date_errors
     if params[:location][:deactivation_date].blank? && params[:location][:deactivation_date_type].blank?
@@ -193,7 +194,6 @@ private
       end
     end
   end
-
 
   def deactivation_date
     return if params[:location].blank?

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -21,7 +21,9 @@ class LocationsController < ApplicationController
   def show; end
 
   def deactivate
-    if params[:location][:confirm].present? && params[:location][:deactivation_date].present?
+    if params[:location].blank?
+      render "toggle_active", locals: { action: "deactivate" }
+    elsif params[:location][:confirm].present? && params[:location][:deactivation_date].present?
       confirm_deactivation
     else
       deactivation_date_errors
@@ -29,12 +31,7 @@ class LocationsController < ApplicationController
         @location.deactivation_date_type = params[:location][:deactivation_date_type]
         render "toggle_active", locals: { action: "deactivate" }, status: :unprocessable_entity
       else
-        deactivation_date_value = deactivation_date
-        if deactivation_date_value.blank?
-          render "toggle_active", locals: { action: "deactivate" }
-        else
-          render "toggle_active_confirm", locals: { action: "deactivate", deactivation_date: deactivation_date_value }
-        end
+        render "toggle_active_confirm", locals: { action: "deactivate", deactivation_date: deactivation_date }
       end
     end
   end
@@ -169,9 +166,9 @@ private
   def confirm_deactivation
     if @location.update(deactivation_date: params[:location][:deactivation_date])
       @location.lettings_logs.filter_by_before_startdate( params[:location][:deactivation_date]).update(location: nil)
-      flash[:notice] = "#{@location.name} has been deactivated"
+      flash[:notice] = "#{@location.name || @location.postcode} has been deactivated"
     end
-    redirect_to scheme_locations_path(@scheme)
+    redirect_to scheme_location_path(@scheme, @location)
     return
   end
 

--- a/app/frontend/controllers/conditional_question_controller.js
+++ b/app/frontend/controllers/conditional_question_controller.js
@@ -10,14 +10,14 @@ export default class extends Controller {
       const selectedValue = this.element.value
       const dataInfo = JSON.parse(this.element.dataset.info)
       const conditionalFor = dataInfo.conditional_questions
-      const logType = dataInfo.log_type
+      const type = dataInfo.type
 
       Object.entries(conditionalFor).forEach(([targetQuestion, conditions]) => {
         if (!conditions.map(String).includes(String(selectedValue))) {
-          const textNumericInput = document.getElementById(`${logType}-log-${targetQuestion.replaceAll('_', '-')}-field`)
+          const textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field`)
           if (textNumericInput == null) {
             const dateInputs = [1, 2, 3].map((idx) => {
-              return document.getElementById(`${logType}_log_${targetQuestion}_${idx}i`)
+              return document.getElementById(`${type.replaceAll('-', '_')}_${targetQuestion}_${idx}i`)
             })
             this.clearDateInputs(dateInputs)
           } else {

--- a/app/helpers/question_attribute_helper.rb
+++ b/app/helpers/question_attribute_helper.rb
@@ -7,6 +7,14 @@ module QuestionAttributeHelper
     merge_controller_attributes(*attribs)
   end
 
+  def basic_conditional_html_attributes(conditional_for, type)
+    {
+      "data-controller": "conditional-question",
+      "data-action": "click->conditional-question#displayConditional",
+      "data-info": { conditional_questions: conditional_for, type: type }.to_json,
+    }
+  end
+
 private
 
   def numeric_question_html_attributes(question)
@@ -27,7 +35,7 @@ private
     {
       "data-controller": "conditional-question",
       "data-action": "click->conditional-question#displayConditional",
-      "data-info": { conditional_questions: question.conditional_for, log_type: question.form.type }.to_json,
+      "data-info": { conditional_questions: question.conditional_for, type: "#{question.form.type}-log" }.to_json,
     }
   end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -8,7 +8,7 @@ module TagHelper
     completed: "Completed",
     active: "Active",
     deactivating_soon: "Deactivating soon",
-    deactivated: "Deactivated"
+    deactivated: "Deactivated",
   }.freeze
 
   COLOUR = {
@@ -18,7 +18,7 @@ module TagHelper
     completed: "green",
     active: "green",
     deactivating_soon: "yellow",
-    deactivated: "grey"
+    deactivated: "grey",
   }.freeze
 
   def status_tag(status, classes = [])

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -7,6 +7,8 @@ module TagHelper
     in_progress: "In progress",
     completed: "Completed",
     active: "Active",
+    deactivating_soon: "Deactivating soon",
+    deactivated: "Deactivated"
   }.freeze
 
   COLOUR = {
@@ -15,6 +17,8 @@ module TagHelper
     in_progress: "blue",
     completed: "green",
     active: "green",
+    deactivating_soon: "yellow",
+    deactivated: "grey"
   }.freeze
 
   def status_tag(status, classes = [])

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -50,7 +50,7 @@ class FormHandler
   end
 
   def current_collection_start_date
-    Time.utc(current_collection_start_year, 4, 5)
+    Time.utc(current_collection_start_year, 4, 1)
   end
 
   def form_name_from_start_year(year, type)

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -49,6 +49,10 @@ class FormHandler
     today < window_end_date ? today.year - 1 : today.year
   end
 
+  def current_collection_start_date
+    Time.utc(current_collection_start_year, 4, 5)
+  end
+
   def form_name_from_start_year(year, type)
     form_mappings = { 0 => "current_#{type}", 1 => "previous_#{type}", -1 => "next_#{type}" }
     form_mappings[current_collection_start_year - year]

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -38,6 +38,7 @@ class LettingsLog < Log
   scope :filter_by_propcode, ->(propcode) { where("propcode ILIKE ?", "%#{propcode}%") }
   scope :filter_by_postcode, ->(postcode_full) { where("REPLACE(postcode_full, ' ', '') ILIKE ?", "%#{postcode_full.delete(' ')}%") }
   scope :filter_by_location_postcode, ->(postcode_full) { left_joins(:location).where("REPLACE(locations.postcode, ' ', '') ILIKE ?", "%#{postcode_full.delete(' ')}%") }
+  scope :filter_by_before_startdate, ->(date) { left_joins(:location).where("lettings_logs.startdate >= ?", date) }
   scope :search_by, lambda { |param|
                       filter_by_location_postcode(param)
                           .or(filter_by_tenant_code(param))

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -38,7 +38,6 @@ class LettingsLog < Log
   scope :filter_by_propcode, ->(propcode) { where("propcode ILIKE ?", "%#{propcode}%") }
   scope :filter_by_postcode, ->(postcode_full) { where("REPLACE(postcode_full, ' ', '') ILIKE ?", "%#{postcode_full.delete(' ')}%") }
   scope :filter_by_location_postcode, ->(postcode_full) { left_joins(:location).where("REPLACE(locations.postcode, ' ', '') ILIKE ?", "%#{postcode_full.delete(' ')}%") }
-  scope :filter_by_before_startdate, ->(date) { left_joins(:location).where("lettings_logs.startdate >= ?", date) }
   scope :search_by, lambda { |param|
                       filter_by_location_postcode(param)
                           .or(filter_by_tenant_code(param))

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -10,15 +10,13 @@ class Location < ApplicationRecord
 
   auto_strip_attributes :name
 
-  attr_accessor :add_another_location
+  attr_accessor :add_another_location, :deactivation_date_type
 
   scope :search_by_postcode, ->(postcode) { where("REPLACE(postcode, ' ', '') ILIKE ?", "%#{postcode.delete(' ')}%") }
   scope :search_by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }
   scope :search_by, ->(param) { search_by_name(param).or(search_by_postcode(param)) }
   scope :started, -> { where("startdate <= ?", Time.zone.today).or(where(startdate: nil)) }
   scope :active, -> { where(confirmed: true).and(started) }
-
-  attribute :deactivation_date_type
 
   LOCAL_AUTHORITIES = {
     "E07000223": "Adur",

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -18,6 +18,8 @@ class Location < ApplicationRecord
   scope :started, -> { where("startdate <= ?", Time.zone.today).or(where(startdate: nil)) }
   scope :active, -> { where(confirmed: true).and(started) }
 
+  attribute :deactivation_date_type
+
   LOCAL_AUTHORITIES = {
     "E07000223": "Adur",
     "E07000026": "Allerdale",

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -373,7 +373,9 @@ class Location < ApplicationRecord
   end
 
   def status
-    "active"
+    return :active if deactivation_date.blank?
+    return :deactivating_soon if Time.zone.now < deactivation_date
+    return :deactivated if Time.zone.now >= deactivation_date
   end
 
 private

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,6 +2,7 @@ class Location < ApplicationRecord
   validate :validate_postcode
   validates :units, :type_of_unit, :mobility_type, presence: true
   belongs_to :scheme
+  has_many :lettings_logs, class_name: "LettingsLog"
 
   has_paper_trail
 

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -24,5 +24,9 @@
     </div>
 </div>
 <% if FeatureToggle.location_toggle_enabled? %>
-    <%= govuk_button_link_to "Deactivate this location", scheme_location_deactivate_path(scheme_id: @scheme.id, location_id: @location.id), warning: true %>
+    <% if @location.status == :active %>
+        <%= govuk_button_link_to "Deactivate this location", scheme_location_deactivate_path(scheme_id: @scheme.id, location_id: @location.id), warning: true %>
+    <% else %>
+        <%= govuk_button_link_to "Reactivate this location", scheme_location_reactivate_path(scheme_id: @scheme.id, location_id: @location.id) %>
+    <% end%>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -28,5 +28,5 @@
         <%= govuk_button_link_to "Deactivate this location", scheme_location_deactivate_path(scheme_id: @scheme.id, location_id: @location.id), warning: true %>
     <% else %>
         <%= govuk_button_link_to "Reactivate this location", scheme_location_reactivate_path(scheme_id: @scheme.id, location_id: @location.id) %>
-    <% end%>
+    <% end %>
 <% end %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -18,12 +18,12 @@
                                             caption: { text: "Deactivate #{@location.postcode}" },
                                             hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date)) } do %>
             <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.existing_logs") %>
-            <%= f.govuk_radio_button :deactivation_date,
-                                        collection_start_date,
+            <%= f.govuk_radio_button :deactivation_date_type,
+                                        1,
                                         label: { text: "From the start of the current collection period (#{collection_start_date.to_formatted_s(:govuk_date)})" } %>
 
-            <%= f.govuk_radio_button :deactivation_date,
-                                        "other",
+            <%= f.govuk_radio_button :deactivation_date_type,
+                                        2,
                                         label: { text: "For tenancies starting after a certain date" },
                                         **basic_conditional_html_attributes({ "deactivation_date" => %w[other] }, "location") do %>
                                           <%= f.govuk_date_field :deactivation_date,

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -4,10 +4,9 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-        href: "/schemes/#{@location.scheme.id}/locations/#{@location.id}",
+    href: "/schemes/#{@location.scheme.id}/locations/#{@location.id}",
   ) %>
 <% end %>
-
 
 <%= form_with model: @location, url: scheme_location_deactivate_path(scheme_id: @location.scheme.id, location_id: @location.id), method: "patch", local: true do |f| %>
   <div class="govuk-grid-row">
@@ -15,9 +14,9 @@
     <% collection_start_date = FormHandler.instance.current_collection_start_date %>
     <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :deactivation_date,
-                                            legend: { text: I18n.t("questions.location.deactivation.apply_from")},
-                                            caption: { text: "Deactivate #{@location.postcode}"},
-                                            hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date))} do %>
+                                            legend: { text: I18n.t("questions.location.deactivation.apply_from") },
+                                            caption: { text: "Deactivate #{@location.postcode}" },
+                                            hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date)) } do %>
             <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.existing_logs") %>
             <%= f.govuk_radio_button :deactivation_date,
                                         collection_start_date,
@@ -26,9 +25,8 @@
             <%= f.govuk_radio_button :deactivation_date,
                                         "other",
                                         label: { text: "For tenancies starting after a certain date" },
-                                         **basic_conditional_html_attributes({
-                                            "deactivation_date" => ["other"]}, "location") do %>
-                                            <%= f.govuk_date_field :deactivation_date,
+                                        **basic_conditional_html_attributes({ "deactivation_date" => %w[other] }, "location") do %>
+                                          <%= f.govuk_date_field :deactivation_date,
                                                         legend: { text: "Date", size: "m" },
                                                         hint: { text: "For example, 27 3 2008" },
                                                         width: 20 %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -1,4 +1,4 @@
-<% title = "Deactivate #{@location.postcode}" %>
+<% title = "#{action.humanize} #{@location.postcode}" %>
 <% content_for :title, title %>
 
 <% content_for :before_content do %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds">
     <% collection_start_date = FormHandler.instance.current_collection_start_date %>
     <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset :deactivation_date,
+        <%= f.govuk_radio_buttons_fieldset :deactivation_date_type,
                                             legend: { text: I18n.t("questions.location.deactivation.apply_from") },
                                             caption: { text: "Deactivate #{@location.postcode}" },
                                             hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date)) } do %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -1,0 +1,40 @@
+<% title = "Deactivate #{@location.postcode}" %>
+<% content_for :title, title %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: "Back",
+        href: "/schemes/#{@scheme.id}/locations/#{@location.id}",
+  ) %>
+<% end %>
+
+
+<%= form_for(@location, method: :patch, url: location_deactivate_path(@location)) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <%= f.govuk_error_summary %>
+        <%= f.govuk_radio_buttons_fieldset :deactivation_date,
+                                            legend: { text: "When should this change apply?"},
+                                            caption: { text: "Deactivate #{@location.postcode}"},
+                                            hint: { text: "If the date is before 5 April 2022, select ‘From the start of the current collection period’ because the previous period has now closed."} do %>
+            <%= govuk_warning_text text: "It will not be possible to add logs with this scheme if their tenancy start date is on or after the date you enter. Any existing logs may be affected." %>
+            <%= f.govuk_radio_button :deactivation_date,
+                                        Time.now(),
+                                        label: { text: "From the start of the current collection period (5 April 2022)" } %>
+
+            <%= f.govuk_radio_button :deactivation_date,
+                                        "other",
+                                        label: { text: "For tenancies starting after a certain date" },
+                                         **basic_conditional_html_attributes({
+                                            "deactivation_date" => ["other"]}, "location") do %>
+                                            <%= f.govuk_date_field :deactivation_date,
+                                                        legend: { text: "Date", size: "m" },
+                                                        hint: { text: "For example, 27 3 2008" },
+                                                        width: 20 %>
+                                                        <% end %>
+        <% end %>
+
+        <%= f.govuk_submit "Continue" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -14,10 +14,10 @@
     <div class="govuk-grid-column-two-thirds">
     <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :deactivation_date,
-                                            legend: { text: "When should this change apply?"},
+                                            legend: { text: I18n.t("questions.location.deactivation.apply_from")},
                                             caption: { text: "Deactivate #{@location.postcode}"},
-                                            hint: { text: "If the date is before 5 April 2022, select ‘From the start of the current collection period’ because the previous period has now closed."} do %>
-            <%= govuk_warning_text text: "It will not be possible to add logs with this scheme if their tenancy start date is on or after the date you enter. Any existing logs may be affected." %>
+                                            hint: { text: I18n.t("hints.location.deactivation")} do %>
+            <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.existing_logs") %>
             <%= f.govuk_radio_button :deactivation_date,
                                         Time.now(),
                                         label: { text: "From the start of the current collection period (5 April 2022)" } %>

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -4,14 +4,15 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-        href: "/schemes/#{@scheme.id}/locations/#{@location.id}",
+        href: "/schemes/#{@location.scheme.id}/locations/#{@location.id}",
   ) %>
 <% end %>
 
 
-<%= form_with url: location_deactivate_path(@location), method: "patch", local: true do |f| %>
+<%= form_with model: @location, url: scheme_location_deactivate_path(scheme_id: @location.scheme.id, location_id: @location.id), method: "patch", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+    <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :deactivation_date,
                                             legend: { text: "When should this change apply?"},
                                             caption: { text: "Deactivate #{@location.postcode}"},

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -19,11 +19,11 @@
                                             hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date)) } do %>
             <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.existing_logs") %>
             <%= f.govuk_radio_button :deactivation_date_type,
-                                        1,
+                                        "default",
                                         label: { text: "From the start of the current collection period (#{collection_start_date.to_formatted_s(:govuk_date)})" } %>
 
             <%= f.govuk_radio_button :deactivation_date_type,
-                                        2,
+                                        "other",
                                         label: { text: "For tenancies starting after a certain date" },
                                         **basic_conditional_html_attributes({ "deactivation_date" => %w[other] }, "location") do %>
                                           <%= f.govuk_date_field :deactivation_date,

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -4,7 +4,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: "Back",
-    href: "/schemes/#{@location.scheme.id}/locations/#{@location.id}",
+    href: scheme_location_path(scheme_id: @location.scheme.id, id: @location.id),
   ) %>
 <% end %>
 

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -12,15 +12,16 @@
 <%= form_with model: @location, url: scheme_location_deactivate_path(scheme_id: @location.scheme.id, location_id: @location.id), method: "patch", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+    <% collection_start_date = FormHandler.instance.current_collection_start_date %>
     <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :deactivation_date,
                                             legend: { text: I18n.t("questions.location.deactivation.apply_from")},
                                             caption: { text: "Deactivate #{@location.postcode}"},
-                                            hint: { text: I18n.t("hints.location.deactivation")} do %>
+                                            hint: { text: I18n.t("hints.location.deactivation", date: collection_start_date.to_formatted_s(:govuk_date))} do %>
             <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.existing_logs") %>
             <%= f.govuk_radio_button :deactivation_date,
-                                        Time.now(),
-                                        label: { text: "From the start of the current collection period (5 April 2022)" } %>
+                                        collection_start_date,
+                                        label: { text: "From the start of the current collection period (#{collection_start_date.to_formatted_s(:govuk_date)})" } %>
 
             <%= f.govuk_radio_button :deactivation_date,
                                         "other",

--- a/app/views/locations/toggle_active.html.erb
+++ b/app/views/locations/toggle_active.html.erb
@@ -9,10 +9,9 @@
 <% end %>
 
 
-<%= form_for(@location, method: :patch, url: location_deactivate_path(@location)) do |f| %>
+<%= form_with url: location_deactivate_path(@location), method: "patch", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :deactivation_date,
                                             legend: { text: "When should this change apply?"},
                                             caption: { text: "Deactivate #{@location.postcode}"},

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -3,14 +3,14 @@
        <%= govuk_back_link(href: :back) %>
      <% end %>
    <h1 class="govuk-heading-l">
-     <span class="govuk-caption-l"><%= @scheme.service_name %></span>
+     <span class="govuk-caption-l"><%= @location.postcode %></span>
      <%= "This change will affect #{@location.lettings_logs.count} logs" %>
    </h1>
    <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.review_logs") %>
    <%= f.hidden_field :confirm, value: true %>
    <%= f.hidden_field :deactivation_date, value: deactivation_date %>
    <div class="govuk-button-group">
-     <%= f.govuk_submit "Deactivate this scheme" %>
+     <%= f.govuk_submit "Deactivate this location" %>
      <%= govuk_button_link_to "Cancel", scheme_location_path(scheme_id: @scheme, id: @location.id), html: { method: :get }, secondary: true %>
    </div>
  <% end %>

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -4,7 +4,7 @@
      <% end %>
    <h1 class="govuk-heading-l">
      <span class="govuk-caption-l"><%= @scheme.service_name %></span>
-     <%= "This change will affect SOME logs" %>
+     <%= "This change will affect #{@location.lettings_logs.count} logs" %>
    </h1>
    <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.review_logs") %>
    <%= f.hidden_field :confirm, :value => true %>

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: location_deactivate_path(@location), method: "patch", local: true do |f| %>
+<%= form_with model: @location, url: scheme_location_deactivate_path(@location), method: "patch", local: true do |f| %>
      <% content_for :before_content do %>
        <%= govuk_back_link(href: :back) %>
      <% end %>
@@ -11,7 +11,7 @@
    <%= f.hidden_field :deactivation_date, :value => deactivation_date %>
    <div class="govuk-button-group">
      <%= f.govuk_submit "Deactivate this scheme" %>
-     <%= govuk_button_link_to "Cancel", location_path, html: { method: :get }, secondary: true %>
+     <%= govuk_button_link_to "Cancel", scheme_location_path(scheme_id: @scheme, id: @location.id), html: { method: :get }, secondary: true %>
    </div>
  <% end %>
  

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -7,11 +7,10 @@
      <%= "This change will affect #{@location.lettings_logs.count} logs" %>
    </h1>
    <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.review_logs") %>
-   <%= f.hidden_field :confirm, :value => true %>
-   <%= f.hidden_field :deactivation_date, :value => deactivation_date %>
+   <%= f.hidden_field :confirm, value: true %>
+   <%= f.hidden_field :deactivation_date, value: deactivation_date %>
    <div class="govuk-button-group">
      <%= f.govuk_submit "Deactivate this scheme" %>
      <%= govuk_button_link_to "Cancel", scheme_location_path(scheme_id: @scheme, id: @location.id), html: { method: :get }, secondary: true %>
    </div>
  <% end %>
- 

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -6,7 +6,7 @@
      <span class="govuk-caption-l"><%= @scheme.service_name %></span>
      <%= "This change will affect SOME logs" %>
    </h1>
-   <%= govuk_warning_text text: "Your data providers will need to review these logs and answer a few questions again. We’ll email each log creator with a list of logs that need updating." %>
+   <%= govuk_warning_text text: I18n.t("warnings.location.deactivation.review_logs") %>
    <%= f.hidden_field :confirm, :value => true %>
    <%= f.hidden_field :deactivation_date, :value => deactivation_date %>
    <div class="govuk-button-group">

--- a/app/views/locations/toggle_active_confirm.html.erb
+++ b/app/views/locations/toggle_active_confirm.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: location_deactivate_path(@location), method: "patch", local: true do |f| %>
+     <% content_for :before_content do %>
+       <%= govuk_back_link(href: :back) %>
+     <% end %>
+   <h1 class="govuk-heading-l">
+     <span class="govuk-caption-l"><%= @scheme.service_name %></span>
+     <%= "This change will affect SOME logs" %>
+   </h1>
+   <%= govuk_warning_text text: "Your data providers will need to review these logs and answer a few questions again. We’ll email each log creator with a list of logs that need updating." %>
+   <%= f.hidden_field :confirm, :value => true %>
+   <%= f.hidden_field :deactivation_date, :value => deactivation_date %>
+   <div class="govuk-button-group">
+     <%= f.govuk_submit "Deactivate this scheme" %>
+     <%= govuk_button_link_to "Cancel", location_path, html: { method: :get }, secondary: true %>
+   </div>
+ <% end %>
+ 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,7 +382,7 @@ en:
       postcode: "For example, SW1P 4DF."
       name: "This is how you refer to this location within your organisation"
       units: "A unit can be a bedroom in a shared house or flat, or a house with 4 bedrooms. Do not include bedrooms used for wardens, managers, volunteers or sleep-in staff."
-      deactivation: "If the date is before 5 April 2022, select ‘From the start of the current collection period’ because the previous period has now closed."
+      deactivation: "If the date is before %{date}, select ‘From the start of the current collection period’ because the previous period has now closed."
   
   warnings:
     location:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,7 +388,7 @@ en:
   warnings:
     location:
       deactivation: 
-        existing_logs: "It will not be possible to add logs with this scheme if their tenancy start date is on or after the date you enter. Any existing logs may be affected."
+        existing_logs: "It will not be possible to add logs with this location if their tenancy start date is on or after the date you enter. Any existing logs may be affected."
         review_logs: "Your data providers will need to review these logs and answer a few questions again. We’ll email each log creator with a list of logs that need updating."
 
   test:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,6 +312,11 @@ en:
     declaration:
       missing: "You must show the DLUHC privacy notice to the tenant before you can submit this log."
 
+    location:
+      deactivation_date:
+        not_selected: "Select one of the options"
+        not_entered: "Enter a date"
+
   soft_validations:
     net_income:
       title_text: "Net income is outside the expected range based on the lead tenant’s working situation"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,7 +315,8 @@ en:
     location:
       deactivation_date:
         not_selected: "Select one of the options"
-        not_entered: "Enter a date"
+        not_entered: "Enter a %{period}"
+        invalid: "Enter a valid date"
 
   soft_validations:
     net_income:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
         not_selected: "Select one of the options"
         not_entered: "Enter a %{period}"
         invalid: "Enter a valid date"
+        out_of_range: "The date must be on or after the %{date}"
 
   soft_validations:
     net_income:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,8 @@ en:
       startdate: "When did the first property in this location become available under this scheme? (optional)"
       add_another_location: "Do you want to add another location?"
       mobility_type: "What are the mobility standards for the majority of units in this location?"
+      deactivation:
+        apply_from: "When should this change apply?"
     descriptions:
       location:
         mobility_type:
@@ -380,6 +382,13 @@ en:
       postcode: "For example, SW1P 4DF."
       name: "This is how you refer to this location within your organisation"
       units: "A unit can be a bedroom in a shared house or flat, or a house with 4 bedrooms. Do not include bedrooms used for wardens, managers, volunteers or sleep-in staff."
+      deactivation: "If the date is before 5 April 2022, select ‘From the start of the current collection period’ because the previous period has now closed."
+  
+  warnings:
+    location:
+      deactivation: 
+        existing_logs: "It will not be possible to add logs with this scheme if their tenancy start date is on or after the date you enter. Any existing logs may be affected."
+        review_logs: "Your data providers will need to review these logs and answer a few questions again. We’ll email each log creator with a list of logs that need updating."
 
   test:
     one_argument: "This is based on the tenant’s work situation: %{ecstat1}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       get "edit-name", to: "locations#edit_name"
       get "edit-local-authority", to: "locations#edit_local_authority"
       get "deactivate", to: "locations#deactivate"
+      get "reactivate", to: "locations#reactivate"
       patch "deactivate", to: "locations#deactivate"
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       get "edit-name", to: "locations#edit_name"
       get "edit-local-authority", to: "locations#edit_local_authority"
       get "deactivate", to: "locations#deactivate"
+      patch "deactivate", to: "locations#deactivate"
     end
   end
 

--- a/db/migrate/20221109122033_add_deactivation_date_to_locations.rb
+++ b/db/migrate/20221109122033_add_deactivation_date_to_locations.rb
@@ -1,0 +1,5 @@
+class AddDeactivationDateToLocations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :locations, :deactivation_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_19_082625) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_122033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -260,6 +260,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_19_082625) do
     t.datetime "startdate", precision: nil
     t.string "location_admin_district"
     t.boolean "confirmed"
+    t.datetime "deactivation_date"
     t.index ["old_id"], name: "index_locations_on_old_id", unique: true
     t.index ["scheme_id"], name: "index_locations_on_scheme_id"
   end

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe LocationsHelper do
         { name: "Mobility type", value: location.mobility_type },
         { name: "Code", value: location.location_code },
         { name: "Availability", value: "Available from 8 August 2022" },
-        { name: "Status", value: "active" },
+        { name: "Status", value: :active },
       ]
 
       expect(display_attributes(location)).to eq(attributes)

--- a/spec/helpers/question_attribute_helper_spec.rb
+++ b/spec/helpers/question_attribute_helper_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe QuestionAttributeHelper do
           "data-action": "input->numeric-question#calculateFields click->conditional-question#displayConditional",
           "data-target": "lettings-log-#{question.result_field.to_s.dasherize}-field",
           "data-calculated": question.fields_to_add.to_json,
-          "data-info": { conditional_questions: question.conditional_for, log_type: "lettings" }.to_json,
+          "data-info": { conditional_questions: question.conditional_for, type: "lettings-log" }.to_json,
         }
       end
 

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -118,6 +118,10 @@ RSpec.describe FormHandler do
       it "returns the correct next sales form name" do
         expect(form_handler.form_name_from_start_year(2023, "sales")).to eq("next_sales")
       end
+
+      it "returns the correct current start date" do
+        expect(form_handler.current_collection_start_date).to eq(Time.utc(2022, 4, 5))
+      end
     end
 
     context "with the date before 1st of April" do

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe FormHandler do
       end
 
       it "returns the correct current start date" do
-        expect(form_handler.current_collection_start_date).to eq(Time.utc(2022, 4, 5))
+        expect(form_handler.current_collection_start_date).to eq(Time.utc(2022, 4, 1))
       end
     end
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -111,4 +111,36 @@ RSpec.describe Location, type: :model do
       end
     end
   end
+
+  describe "status" do
+    let(:location) { FactoryBot.build(:location) }
+
+    before do
+      Timecop.freeze(2022, 6, 7)
+    end
+
+    it "returns active if the location is not deactivated" do
+      location.deactivation_date = nil
+      location.save!
+      expect(location.status).to eq(:active)
+    end
+
+    it "returns deactivating soon if deactivation_date is in the future" do
+      location.deactivation_date = Time.zone.local(2022, 8, 8)
+      location.save!
+      expect(location.status).to eq(:deactivating_soon)
+    end
+
+    it "returns deactivated if deactivation_date is in the past" do
+      location.deactivation_date = Time.zone.local(2022, 4, 8)
+      location.save!
+      expect(location.status).to eq(:deactivated)
+    end
+
+    it "returns deactivated if deactivation_date is today" do
+      location.deactivation_date = Time.zone.local(2022, 6, 7)
+      location.save!
+      expect(location.status).to eq(:deactivated)
+    end
+  end
 end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1249,7 +1249,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with default date" do
-        let(:params) { { location: { deactivation_date: } } }
+        let(:params) { { location: { deactivation_date_type: 1 } } }
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
@@ -1288,8 +1288,8 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when invalid date is entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
-
+        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
+        
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.invalid"))
@@ -1297,8 +1297,8 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the date is entered is before the beginning of current collection window" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
-
+        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
+        
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.out_of_range", date: "5 April 2022"))
@@ -1306,8 +1306,8 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the day is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
-
+        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
+        
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "day"))
@@ -1315,8 +1315,8 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the month is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
-
+        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
+        
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "month"))
@@ -1324,8 +1324,8 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the year is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
-
+        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
+        
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "year"))

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1296,6 +1296,15 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
+      context "when the date is entered is before the beginning of current collection window" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020"} }}
+
+        it "displays the new page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.out_of_range", date: "5 April 2022"))
+        end
+      end
+
       context "when the day is not entered" do
         let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022"} }}
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1253,7 +1253,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("This change will affect SOME logs")
+          expect(page).to have_content("This change will affect #{location.lettings_logs.count} logs")
         end
       end
 
@@ -1262,7 +1262,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("This change will affect SOME logs")
+          expect(page).to have_content("This change will affect #{location.lettings_logs.count} logs")
         end
       end
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1249,7 +1249,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with default date" do
-        let(:params) { { location: { deactivation_date_type: 1 } } }
+        let(:params) { { location: { deactivation_date_type: "default" } } }
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
@@ -1288,7 +1288,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when invalid date is entered" do
-        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
+        let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
         
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1297,7 +1297,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the date is entered is before the beginning of current collection window" do
-        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
+        let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
         
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1306,7 +1306,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the day is not entered" do
-        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
+        let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
         
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1315,7 +1315,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the month is not entered" do
-        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
+        let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
         
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1324,7 +1324,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the year is not entered" do
-        let(:params) { { location: { deactivation_date_type: 2, "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
+        let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
         
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1249,7 +1249,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "default date" do
-        let(:params) { { deactivation_date: deactivation_date } } 
+        let(:params) { {location:{ deactivation_date: deactivation_date } } }
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
@@ -1258,11 +1258,41 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "other date" do
-        let(:params) { { deactivation_date: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "10", "deactivation_date(1i)": "2022"} }
+        let(:params) { {location:{ deactivation_date: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "10", "deactivation_date(1i)": "2022"} }}
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
           expect(page).to have_content("This change will affect SOME logs")
+        end
+      end
+
+      context "when confirming deactivation" do
+        let(:params) { {location:{ deactivation_date: Time.new(2022, 10, 10), confirm: true } } }
+
+        it "updates existing location with valid deactivation date and renders location page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+          location.reload
+          expect(location.deactivation_date).to eq(deactivation_date)
+        end
+      end
+
+      context "when the date is not entered" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "", "deactivation_date(1i)": ""} }}
+
+        it "displays the new page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered"))
+        end
+      end
+
+      context "when the date is not selected" do
+        let(:params) { { location: { "deactivation_date": "" } }}
+
+        it "displays the new page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_selected"))
         end
       end
     end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1301,7 +1301,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(page).to have_content(I18n.t("validations.location.deactivation_date.out_of_range", date: "5 April 2022"))
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.out_of_range", date: "1 April 2022"))
         end
       end
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1267,7 +1267,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when confirming deactivation" do
-        let(:params) { { location: { deactivation_date: deactivation_date, confirm: true } } }
+        let(:params) { { location: { deactivation_date:, confirm: true } } }
 
         it "updates existing location with valid deactivation date and renders location page" do
           follow_redirect!
@@ -1289,7 +1289,7 @@ RSpec.describe LocationsController, type: :request do
 
       context "when invalid date is entered" do
         let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
-        
+
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.invalid"))
@@ -1298,7 +1298,7 @@ RSpec.describe LocationsController, type: :request do
 
       context "when the date is entered is before the beginning of current collection window" do
         let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
-        
+
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.out_of_range", date: "5 April 2022"))
@@ -1307,7 +1307,7 @@ RSpec.describe LocationsController, type: :request do
 
       context "when the day is not entered" do
         let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
-        
+
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "day"))
@@ -1316,7 +1316,7 @@ RSpec.describe LocationsController, type: :request do
 
       context "when the month is not entered" do
         let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
-        
+
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "month"))
@@ -1325,7 +1325,7 @@ RSpec.describe LocationsController, type: :request do
 
       context "when the year is not entered" do
         let(:params) { { location: { deactivation_date_type: "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
-        
+
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "year"))

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1239,8 +1239,6 @@ RSpec.describe LocationsController, type: :request do
       let(:user) { FactoryBot.create(:user, :data_coordinator) }
       let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
       let!(:location) { FactoryBot.create(:location, scheme:) }
-      let!(:lettings_log_to_deactivate) { FactoryBot.create(:lettings_log, scheme:, location:, startdate: Time.utc(2022, 10, 11) ) }
-      let!(:active_lettings_log) { FactoryBot.create(:lettings_log, scheme:, location:, startdate: Time.utc(2022, 10, 9) ) }
       let(:startdate) { Time.utc(2021, 1, 2) }
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
 
@@ -1277,16 +1275,6 @@ RSpec.describe LocationsController, type: :request do
           expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
           location.reload
           expect(location.deactivation_date).to eq(deactivation_date)
-        end
-
-        it "updates lettings logs with a startdate later than deactivation_date" do
-          lettings_log_to_deactivate.reload
-          expect(lettings_log_to_deactivate.location).to eq(nil)
-        end
-
-        it "does not update lettings logs with a startdate earlier than deactivation_date" do
-          active_lettings_log.reload
-          expect(active_lettings_log.location).to eq(location)
         end
       end
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1278,21 +1278,48 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
-      context "when the date is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "", "deactivation_date(1i)": ""} }}
-
-        it "displays the new page with an error message" do
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered"))
-        end
-      end
-
       context "when the date is not selected" do
         let(:params) { { location: { "deactivation_date": "" } }}
 
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_selected"))
+        end
+      end
+
+      context "when invalid date is entered" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022"} }}
+
+        it "displays the new page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.invalid"))
+        end
+      end
+
+      context "when the day is not entered" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022"} }}
+
+        it "displays page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "day"))
+        end
+      end
+
+      context "when the month is not entered" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022"} }}
+
+        it "displays page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "month"))
+        end
+      end
+
+      context "when the year is not entered" do
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": ""} }}
+
+        it "displays page with an error message" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.location.deactivation_date.not_entered", period: "year"))
         end
       end
     end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1240,7 +1240,7 @@ RSpec.describe LocationsController, type: :request do
       let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
       let!(:location) { FactoryBot.create(:location, scheme:) }
       let(:startdate) { Time.utc(2021, 1, 2) }
-      let(:deactivation_date) { Time.new(2022, 10, 10) }
+      let(:deactivation_date) { Time.utc(2022, 10, 10) }
 
       before do
         Timecop.freeze(Time.utc(2022, 10, 10))
@@ -1248,8 +1248,8 @@ RSpec.describe LocationsController, type: :request do
         patch "/schemes/#{scheme.id}/locations/#{location.id}/deactivate", params:
       end
 
-      context "default date" do
-        let(:params) { {location:{ deactivation_date: deactivation_date } } }
+      context "with default date" do
+        let(:params) { { location: { deactivation_date: } } }
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
@@ -1257,8 +1257,8 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
-      context "other date" do
-        let(:params) { {location:{ deactivation_date: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "10", "deactivation_date(1i)": "2022"} }}
+      context "with other date" do
+        let(:params) { { location: { deactivation_date: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "10", "deactivation_date(1i)": "2022" } } }
 
         it "renders the confirmation page" do
           expect(response).to have_http_status(:ok)
@@ -1267,7 +1267,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when confirming deactivation" do
-        let(:params) { {location:{ deactivation_date: Time.new(2022, 10, 10), confirm: true } } }
+        let(:params) { { location: { deactivation_date: Time.utc(2022, 10, 10), confirm: true } } }
 
         it "updates existing location with valid deactivation date and renders location page" do
           follow_redirect!
@@ -1279,7 +1279,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the date is not selected" do
-        let(:params) { { location: { "deactivation_date": "" } }}
+        let(:params) { { location: { "deactivation_date": "" } } }
 
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1288,7 +1288,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when invalid date is entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022"} }}
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "44", "deactivation_date(1i)": "2022" } } }
 
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1297,7 +1297,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the date is entered is before the beginning of current collection window" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020"} }}
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
 
         it "displays the new page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1306,7 +1306,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the day is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022"} }}
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "", "deactivation_date(2i)": "2", "deactivation_date(1i)": "2022" } } }
 
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1315,7 +1315,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the month is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022"} }}
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "", "deactivation_date(1i)": "2022" } } }
 
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1324,7 +1324,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when the year is not entered" do
-        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": ""} }}
+        let(:params) { { location: { "deactivation_date": "other", "deactivation_date(3i)": "2", "deactivation_date(2i)": "2", "deactivation_date(1i)": "" } } }
 
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
- [x] When the user clicks on the `Deactivate this location` button they are taken to a page where they can deactivate from the the beginning of the current collection period or from a specific date that's after the beginning of the current collection period
<img width="857" alt="image" src="https://user-images.githubusercontent.com/54268893/201302681-14fb3bc9-3a5a-4bd0-a851-417d0ee62b97.png">

- [x] It displays relevant errors
<img width="679" alt="image" src="https://user-images.githubusercontent.com/54268893/201302844-e5148101-5dcd-4e02-9563-b0cb059ae770.png">
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/54268893/201305823-bc290e7d-57d4-416b-83fd-c7693b82d0ba.png">

- [x] After confirming deactivation the user is taken to the location page 
- [x] After confirming deactivation the user can see a confirmation banner
- [x] `Reactivate this location` button is shown on deactivated or soon to deactivate locations

<img width="924" alt="image" src="https://user-images.githubusercontent.com/54268893/201301686-ab765924-5d93-4928-9730-d64f8e206b27.png">

- [x] The status tag in location page displays the correct status
<img width="957" alt="image" src="https://user-images.githubusercontent.com/54268893/201302482-043ba269-830d-46c6-bb92-833809343db6.png">
<img width="809" alt="image" src="https://user-images.githubusercontent.com/54268893/201302547-51370e8a-4d83-465a-833f-27e7277495f8.png">
<img width="877" alt="image" src="https://user-images.githubusercontent.com/54268893/201302635-26b64ba0-a797-4f45-9eb9-3a30a8d992ac.png">

- [x] Update the conditional question controller to work with all conditional questions and not just the log form ones
- [x] Add current_collection_start_date to the form handler

This PR does not update the logs or send the notifications to the users