### PR TITLE
CLDC-1694 Fix issue with non-renewal lettings allowing 'renewal' for vacancy reason

### DIFF
--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -39,7 +39,7 @@ module Validations::PropertyValidations
       record.errors.add :referral, I18n.t("validations.household.referral.rsnvac_non_temp")
     end
 
-    if record.renewal == 0 && record.rsnvac == 14
+    if record.renewal && record.renewal.zero? && record.rsnvac == 14
       record.errors.add :rsnvac, I18n.t("validations.property.rsnvac.not_a_renewal")
     end
   end

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -38,6 +38,10 @@ module Validations::PropertyValidations
       record.errors.add :rsnvac, I18n.t("validations.property.rsnvac.referral_invalid")
       record.errors.add :referral, I18n.t("validations.household.referral.rsnvac_non_temp")
     end
+
+    if record.renewal == 0 && record.rsnvac == 14
+      record.errors.add :rsnvac, I18n.t("validations.property.rsnvac.not_a_renewal")
+    end
   end
 
   def validate_unitletas(record)

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -39,7 +39,7 @@ module Validations::PropertyValidations
       record.errors.add :referral, I18n.t("validations.household.referral.rsnvac_non_temp")
     end
 
-    if record.renewal && record.renewal.zero? && record.rsnvac == 14
+    if record.renewal.present? && record.renewal.zero? && record.rsnvac == 14
       record.errors.add :rsnvac, I18n.t("validations.property.rsnvac.not_a_renewal")
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
         previous_let_social: "Property cannot have a previous let type if being let as social housing for the first time"
         non_temp_accommodation: "Answer cannot be re-let to tenant who occupied the same property as temporary accommodation as this accommodation is not temporary"
         referral_invalid: "Answer cannot be re-let to tenant who occupied the same property as temporary accommodation as a different source of referral for this letting"
+        not_a_renewal: "Reason for vacancy cannot be 'Renewal of fixed-term tenancy' if letting is not a renewal"
       unittype_gn:
         one_bedroom_bedsit: "A bedsit can only have one bedroom"
         one_seven_bedroom_shared: "A shared house must have 1 to 7 bedrooms"

--- a/spec/models/validations/property_validations_spec.rb
+++ b/spec/models/validations/property_validations_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Validations::PropertyValidations do
           record.rsnvac = 14
           property_validator.validate_rsnvac(record)
           expect(record.errors["rsnvac"])
-                .to include(match I18n.t("Reason for vacancy cannot be 'Renewal of fixed-term tenancy' if letting is not a renewal"))
+                .to include(match I18n.t("validations.property.rsnvac.not_a_renewal"))
         end
       end
     end

--- a/spec/models/validations/property_validations_spec.rb
+++ b/spec/models/validations/property_validations_spec.rb
@@ -233,6 +233,17 @@ RSpec.describe Validations::PropertyValidations do
         property_validator.validate_rsnvac(record)
         expect(record.errors["rsnvac"]).to be_empty
       end
+
+      context "when the letting is not a renewal" do
+        it "validates that the reason for vacancy is not renewal" do
+          record.first_time_property_let_as_social_housing = 0 
+          record.renewal = 0
+          record.rsnvac = 14
+          property_validator.validate_rsnvac(record)
+          expect(record.errors["rsnvac"])
+                .to include(match I18n.t("Reason for vacancy cannot be 'Renewal of fixed-term tenancy' if letting is not a renewal"))
+        end
+      end
     end
 
     context "when the property has been let before" do

--- a/spec/models/validations/property_validations_spec.rb
+++ b/spec/models/validations/property_validations_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Validations::PropertyValidations do
 
       context "when the letting is not a renewal" do
         it "validates that the reason for vacancy is not renewal" do
-          record.first_time_property_let_as_social_housing = 0 
+          record.first_time_property_let_as_social_housing = 0
           record.renewal = 0
           record.rsnvac = 14
           property_validator.validate_rsnvac(record)


### PR DESCRIPTION
Would it make sense to also write a test to check that no errors are seen when the letting is not a renewal but a different vacancy reason is chosen? Presumably that would be might be overkill?

As well as reviewing my code, I wouldn't mind feedback on my commit messages if they could be improved!