### PR TITLE
Parse meta fields where namespace declarations aren't included

### DIFF
--- a/app/services/imports/import_service.rb
+++ b/app/services/imports/import_service.rb
@@ -19,8 +19,12 @@ module Imports
       end
     end
 
-    def field_value(xml_document, namespace, field)
-      xml_document.at_xpath("//#{namespace}:#{field}")&.text
+    def field_value(xml_document, namespace, field, *args)
+      xml_document.at_xpath("//#{namespace}:#{field}", *args)&.text
+    end
+
+    def meta_field_value(xml_document, field)
+      field_value(xml_document, "meta", field, { "meta" => "http://data.gov.uk/core/metadata" })
     end
 
     def overridden?(xml_document, namespace, field)

--- a/app/services/imports/lettings_logs_field_import_service.rb
+++ b/app/services/imports/lettings_logs_field_import_service.rb
@@ -16,8 +16,8 @@ module Imports
   private
 
     def update_lettings_allocation(xml_doc)
-      old_id = field_value(xml_doc, "meta", "document-id")
-      previous_status = field_value(xml_doc, "meta", "status")
+      old_id = meta_field_value(xml_doc, "document-id")
+      previous_status = meta_field_value(xml_doc, "status")
       record = LettingsLog.find_by(old_id:)
 
       if record.present? && previous_status.include?("submitted")
@@ -46,11 +46,11 @@ module Imports
     end
 
     def update_major_repairs(xml_doc)
-      old_id = field_value(xml_doc, "meta", "document-id")
+      old_id = meta_field_value(xml_doc, "document-id")
       record = LettingsLog.find_by(old_id:)
 
       if record.present?
-        previous_status = field_value(xml_doc, "meta", "status")
+        previous_status = meta_field_value(xml_doc, "status")
         major_repairs_date = compose_date(xml_doc, "MRCDAY", "MRCMONTH", "MRCYEAR")
         major_repairs = if major_repairs_date.present? && previous_status.include?("submitted")
                           1
@@ -69,7 +69,7 @@ module Imports
     end
 
     def update_tenant_code(xml_doc)
-      old_id = field_value(xml_doc, "meta", "document-id")
+      old_id = meta_field_value(xml_doc, "document-id")
       record = LettingsLog.find_by(old_id:)
 
       if record.present?

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -57,7 +57,7 @@ module Imports
     def create_log(xml_doc)
       attributes = {}
 
-      previous_status = field_value(xml_doc, "meta", "status")
+      previous_status = meta_field_value(xml_doc, "status")
 
       # Required fields for status complete or logic to work
       # Note: order matters when we derive from previous values (attributes parameter)
@@ -191,9 +191,9 @@ module Imports
 
       # Not specific to our form but required for consistency (present in import)
       attributes["old_form_id"] = safe_string_as_integer(xml_doc, "FORM")
-      attributes["created_at"] = Time.zone.parse(field_value(xml_doc, "meta", "created-date"))
-      attributes["updated_at"] = Time.zone.parse(field_value(xml_doc, "meta", "modified-date"))
-      attributes["old_id"] = field_value(xml_doc, "meta", "document-id")
+      attributes["created_at"] = Time.zone.parse(meta_field_value(xml_doc, "created-date"))
+      attributes["updated_at"] = Time.zone.parse(meta_field_value(xml_doc, "modified-date"))
+      attributes["old_id"] = meta_field_value(xml_doc, "document-id")
 
       # Required for our form invalidated questions (not present in import)
       attributes["previous_la_known"] = attributes["prevloc"].nil? ? 0 : 1
@@ -236,7 +236,7 @@ module Imports
       attributes["net_income_value_check"] = 0
 
       # Sets the log creator
-      owner_id = field_value(xml_doc, "meta", "owner-user-id").strip
+      owner_id = meta_field_value(xml_doc, "owner-user-id").strip
       if owner_id.present?
         user = LegacyUser.find_by(old_user_id: owner_id)&.user
         @logger.warn "Missing user! We expected to find a legacy user with old_user_id #{owner_id}" unless user
@@ -347,7 +347,7 @@ module Imports
     end
 
     def get_form_name_component(xml_doc, index)
-      form_name = field_value(xml_doc, "meta", "form-name")
+      form_name = meta_field_value(xml_doc, "form-name")
       form_type_components = form_name.split("-")
       form_type_components[index]
     end


### PR DESCRIPTION
We import XML files that define logs from the previous CORE service. For an unknown reason, some of these files don't include the required namespace declarations to parse `meta` values. Instead of changing the source, this change introduces a new method that forces the namespace declaration for meta fields.

This allows us to import documents regardless of whether they specify namespace bindings for `meta` or not.