### PR TITLE
Import locations that belong to now inactive schemes

### DIFF
--- a/app/services/imports/scheme_location_import_service.rb
+++ b/app/services/imports/scheme_location_import_service.rb
@@ -97,25 +97,19 @@ module Imports
     end
 
     def add_location(scheme, attributes)
-      if attributes["end_date"].nil? || attributes["end_date"] >= Time.zone.now
-        begin
-          Location.create!(
-            name: attributes["location_name"],
-            postcode: attributes["postcode"],
-            mobility_type: attributes["mobility_type"],
-            units: attributes["units"],
-            type_of_unit: attributes["type_of_unit"],
-            old_visible_id: attributes["location_old_visible_id"],
-            old_id: attributes["location_old_id"],
-            startdate: attributes["start_date"],
-            scheme:,
-          )
-        rescue ActiveRecord::RecordNotUnique
-          @logger.warn("Location is already present with legacy ID #{attributes['location_old_id']}, skipping")
-        end
-      else
-        @logger.warn("Location with legacy ID #{attributes['location_old_id']} is expired (#{attributes['end_date']}), skipping")
-      end
+      Location.create!(
+        name: attributes["location_name"],
+        postcode: attributes["postcode"],
+        mobility_type: attributes["mobility_type"],
+        units: attributes["units"],
+        type_of_unit: attributes["type_of_unit"],
+        old_visible_id: attributes["location_old_visible_id"],
+        old_id: attributes["location_old_id"],
+        startdate: attributes["start_date"],
+        scheme:,
+      )
+    rescue ActiveRecord::RecordNotUnique
+      @logger.warn("Location is already present with legacy ID #{attributes['location_old_id']}, skipping")
     end
 
     def find_scheme_to_merge(attributes)

--- a/spec/services/imports/scheme_location_import_service_spec.rb
+++ b/spec/services/imports/scheme_location_import_service_spec.rb
@@ -160,21 +160,6 @@ RSpec.describe Imports::SchemeLocationImportService do
       expect(location.scheme.confirmed).to be_truthy
     end
 
-    context "and the end date is before the current date" do
-      before do
-        Timecop.freeze(2022, 6, 1)
-        location_xml.at_xpath("//scheme:end-date").content = "2022-05-01"
-      end
-
-      after { Timecop.unfreeze }
-
-      it "does not create the location" do
-        expect(logger).to receive(:warn).with("Location with legacy ID 0ae7ad6dc0f1cf7ef33c18cc8c108bebc1b4923e is expired (2022-05-01 00:00:00 +0100), skipping")
-        expect { location_service.create_scheme_location(location_xml) }
-          .not_to change(Location, :count)
-      end
-    end
-
     context "and we import the same location twice" do
       before { location_service.create_scheme_location(location_xml) }
 


### PR DESCRIPTION
We were previously blocking the import of locations that belonged to schemes where the end date was before the current date. This meant that we were unable to import logs that are associated with schemes that _were_ valid in relation to when they were created, but have since expired.

This PR relaxes that constraint so that we can import logs, schemes and locations that have an `end_date` in the past but a `startdate` before that.