### PR TITLE
Add validation to dependent earnings and incfreq fields

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -34,10 +34,12 @@ module Validations::FinancialValidations
 
     if record.earnings.present? && record.incfreq.blank?
       record.errors.add :incfreq, I18n.t("validations.financial.earnings.freq_missing")
+      record.errors.add :earnings, I18n.t("validations.financial.earnings.freq_missing")
     end
 
     if record.incfreq.present? && record.earnings.blank?
       record.errors.add :earnings, I18n.t("validations.financial.earnings.earnings_missing")
+      record.errors.add :incfreq, I18n.t("validations.financial.earnings.earnings_missing")
     end
   end
 

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Validations::FinancialValidations do
       financial_validator.validate_net_income(record)
       expect(record.errors["incfreq"])
         .to include(match I18n.t("validations.financial.earnings.freq_missing"))
+      expect(record.errors["earnings"])
+        .to include(match I18n.t("validations.financial.earnings.freq_missing"))
     end
 
     it "when income frequency is provided it validates that earnings must be provided" do
@@ -25,6 +27,8 @@ RSpec.describe Validations::FinancialValidations do
       record.incfreq = 1
       financial_validator.validate_net_income(record)
       expect(record.errors["earnings"])
+        .to include(match I18n.t("validations.financial.earnings.earnings_missing"))
+      expect(record.errors["incfreq"])
         .to include(match I18n.t("validations.financial.earnings.earnings_missing"))
     end
   end


### PR DESCRIPTION
We need to add a validation here so that we can clear both values on import. If we don't do this then the validation will continue to trigger and the importer will get stuck in an endless loop.

Note this is identical to https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/979 but for a different set of fields.