### PR TITLE
Update routing to go back to location page

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -98,7 +98,11 @@ class LocationsController < ApplicationController
             redirect_to(scheme_check_answers_path(@scheme, anchor: "locations"))
           end
         when "edit-name"
-          redirect_to(scheme_check_answers_path(@scheme, anchor: "locations"))
+          if @scheme.locations.count == @scheme.locations.active.count
+            redirect_to(scheme_location_path(@scheme, @location))
+          else
+            redirect_to(scheme_check_answers_path(@scheme, anchor: "locations"))
+          end
         when "edit-local-authority"
           if params[:add_another_location] == "Yes"
             redirect_to(new_scheme_location_path(@location.scheme))

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -18,7 +18,7 @@ module CheckAnswersHelper
 
   def get_location_change_link_href_postcode(scheme, location)
     if location.confirmed?
-      scheme_location_edit_name_path(scheme_id: scheme.id, location_id: location.id)
+      scheme_location_path(scheme_id: scheme.id, id: location.id)
     else
       edit_scheme_location_path(scheme_id: scheme.id, id: location.id)
     end

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -801,9 +801,9 @@ RSpec.describe "Schemes scheme Features" do
                 it "returns to locations check your answers page and shows the new name" do
                   fill_in "location-name-field", with: "NewName"
                   click_button "Save and continue"
-                  expect(page).to have_content location.id
+                  expect(page).to have_content location.postcode
                   expect(page).to have_content "NewName"
-                  expect(page.current_url.split("/").last).to eq("check-answers#locations")
+                  expect(page).to have_current_path("/schemes/#{scheme.id}/locations/#{location.id}")
                 end
 
                 context "when I press the back button" do

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -597,7 +597,7 @@ RSpec.describe LocationsController, type: :request do
         it "updates existing location for scheme with valid params and redirects to correct page" do
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("Locations")
+          expect(page).to have_content("Test")
         end
 
         it "updates existing location for scheme with valid params" do
@@ -736,7 +736,7 @@ RSpec.describe LocationsController, type: :request do
         it "updates existing location for scheme with valid params and redirects to correct page" do
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(page).to have_content("Locations")
+          expect(page).to have_content("Test")
         end
 
         it "updates existing location for scheme with valid params" do


### PR DESCRIPTION
Route back to view location page after changing the name:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/54268893/201379695-84e84ce6-f109-4dd9-be22-3933e516bdd3.png">


Unless you have originally come from check your answers, in which case route back to check your answers, so that unconfirmed locations could be saved/confirmed:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/54268893/201380614-9c275c45-dfd6-4bfc-978b-7d708b19243b.png">
