### PR TITLE
Parse user fields where namespace declarations aren't included

### DIFF
--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -45,7 +45,7 @@ module Imports
     end
 
     def user_field_value(xml_document, field)
-      field_value(xml_document, "user", field)
+      field_value(xml_document, "user", field, { "user" => "dclg:user" })
     end
 
     def role(field_value)

--- a/spec/fixtures/imports/user/80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb.xml
+++ b/spec/fixtures/imports/user/80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb.xml
@@ -1,0 +1,19 @@
+<user xmlns="dclg:user">
+  <id>80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb</id>
+  <user-name>Jane Doe</user-name>
+  <institution>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</institution>
+  <user-stamp>1158 1158</user-stamp>
+  <active>true</active>
+  <user-type>Data Provider</user-type>
+  <association-site-id />
+  <e-core-download>false</e-core-download>
+  <raw-data-download>false</raw-data-download>
+  <licence>false</licence>
+  <contact-priority-id>None</contact-priority-id>
+  <email>jane.doe@gov.uk</email>
+  <password>REDACTED</password>
+  <full-name>Jane Doe</full-name>
+  <telephone-no>01111 000000</telephone-no>
+  <deleted>false</deleted>
+  <date-deactivated>2021-09-28Z</date-deactivated>
+</user>

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe Imports::UserImportService do
       end
     end
 
+    context "when the user does not have namespace bindings" do
+      let(:old_user_id) { "80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb" }
+
+      it "imports them succesfully" do
+        FactoryBot.create(:organisation, old_org_id:)
+        import_service.create_users("user_directory")
+
+        user = LegacyUser.find_by(old_user_id:)&.user
+        expect(user.name).to eq("Jane Doe")
+        expect(user.email).to eq("jane.doe@gov.uk")
+      end
+    end
+
     context "when a user has already been imported with that email" do
       let!(:org) { FactoryBot.create(:organisation, old_org_id:) }
       let!(:user) { FactoryBot.create(:user, :data_provider, organisation: org, email: "john.doe@gov.uk") }


### PR DESCRIPTION
This is the same as https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/983 but for users instead of logs.

We import XML files that define logs from the previous CORE service. For an unknown reason, some of these files don't include the required namespace declarations to parse `user` values. Instead of changing the source, this change introduces a new method that forces the namespace declaration for user fields.

This allows us to import users regardless of whether they specify namespace bindings or not.