### PR TITLE
Update enabled method

### DIFF
--- a/app/models/form/sales/subsections/household_characteristics.rb
+++ b/app/models/form/sales/subsections/household_characteristics.rb
@@ -4,7 +4,7 @@ class Form::Sales::Subsections::HouseholdCharacteristics < ::Form::Subsection
     @id = "household_characteristics"
     @label = "Household characteristics"
     @section = section
-    @depends_on = [{ "setup" => "completed" }]
+    @depends_on = [{ "setup_completed?" => true }]
   end
 
   def pages

--- a/app/models/form/sales/subsections/household_needs.rb
+++ b/app/models/form/sales/subsections/household_needs.rb
@@ -4,7 +4,7 @@ class Form::Sales::Subsections::HouseholdNeeds < ::Form::Subsection
     @id = "household_needs"
     @label = "Household needs"
     @section = section
-    @depends_on = [{ "setup" => "completed" }]
+    @depends_on = [{ "setup_completed?" => true }]
   end
 
   def pages

--- a/app/models/form/sales/subsections/income_benefits_and_outgoings.rb
+++ b/app/models/form/sales/subsections/income_benefits_and_outgoings.rb
@@ -4,7 +4,7 @@ class Form::Sales::Subsections::IncomeBenefitsAndOutgoings < ::Form::Subsection
     @id = "income_benefits_and_outgoings"
     @label = "Income, benefits and outgoings"
     @section = section
-    @depends_on = [{ "setup" => "completed" }]
+    @depends_on = [{ "setup_completed?" => true }]
   end
 
   def pages

--- a/app/models/form/sales/subsections/property_information.rb
+++ b/app/models/form/sales/subsections/property_information.rb
@@ -4,7 +4,7 @@ class Form::Sales::Subsections::PropertyInformation < ::Form::Subsection
     @id = "property_information"
     @label = "Property information"
     @section = section
-    @depends_on = [{ "setup" => "completed" }]
+    @depends_on = [{ "setup_completed?" => true }]
   end
 
   def pages

--- a/app/models/form/subsection.rb
+++ b/app/models/form/subsection.rb
@@ -20,11 +20,7 @@ class Form::Subsection
   def enabled?(log)
     return true unless depends_on
 
-    depends_on.any? do |conditions_set|
-      conditions_set.all? do |subsection_id, dependent_status|
-        form.get_subsection(subsection_id).status(log) == dependent_status.to_sym
-      end
-    end
+    form.depends_on_met(depends_on, log)
   end
 
   def status(log)

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -507,6 +507,10 @@ class LettingsLog < Log
     form.get_question("rent_type", self)&.label_from_value(rent_type)
   end
 
+  def non_location_setup_questions_completed?
+    [needstype, renewal, rent_type, startdate, owning_organisation_id, created_by_id].all?(&:present?)
+  end
+
 private
 
   PIO = PostcodeService.new

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -40,6 +40,10 @@ class Log < ApplicationRecord
     ethnic_group == 17
   end
 
+  def managing_organisation_provider_type
+    managing_organisation&.provider_type
+  end
+
 private
 
   def update_status!

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -47,4 +47,8 @@ class SalesLog < Log
   def completed?
     status == "completed"
   end
+
+  def setup_completed?
+    form.setup_sections.first.subsections.first.status(self) == :completed
+  end
 end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -49,6 +49,6 @@ class SalesLog < Log
   end
 
   def setup_completed?
-    form.setup_sections.first.subsections.first.status(self) == :completed
+    form.setup_sections.all? { |sections| sections.subsections.all? { |subsection| subsection.status(self) == :completed } }
   end
 end

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -10,7 +10,7 @@
           "label": "Property information",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -952,7 +952,7 @@
           "label": "Tenancy information",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -1133,7 +1133,7 @@
           "label": "Household characteristics",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -5671,7 +5671,7 @@
           "label": "Household needs",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -6060,7 +6060,7 @@
           "label": "Household situation",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -7302,7 +7302,7 @@
           "label": "Income, benefits and outgoings",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -10,7 +10,7 @@
           "label": "Property information",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -952,7 +952,7 @@
           "label": "Tenancy information",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -1168,7 +1168,7 @@
           "label": "Household characteristics",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -5670,7 +5670,7 @@
           "label": "Household needs",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -6062,7 +6062,7 @@
           "label": "Household situation",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {
@@ -7070,7 +7070,7 @@
               },
               "depends_on": [
                 {
-                  "managing_organisation.provider_type": "LA",
+                  "managing_organisation_provider_type": "LA",
                   "needstype": 1,
                   "renewal": 0
                 }
@@ -7127,7 +7127,7 @@
               },
               "depends_on": [
                 {
-                  "managing_organisation.provider_type": "PRP",
+                  "managing_organisation_provider_type": "PRP",
                   "needstype": 1,
                   "renewal": 0
                 }
@@ -7184,7 +7184,7 @@
               },
               "depends_on": [
                 {
-                  "managing_organisation.provider_type": "LA",
+                  "managing_organisation_provider_type": "LA",
                   "needstype": 2,
                   "renewal": 0
                 }
@@ -7244,7 +7244,7 @@
               },
               "depends_on": [
                 {
-                  "managing_organisation.provider_type": "PRP",
+                  "managing_organisation_provider_type": "PRP",
                   "needstype": 2,
                   "renewal": 0
                 }
@@ -7261,7 +7261,7 @@
           "label": "Income, benefits and outgoings",
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ],
           "pages": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -1099,9 +1099,10 @@
           "label": "Declaration",
           "depends_on": [
             {
-              "household_characteristics": "completed",
-              "household_needs": "completed",
-              "property_information": "completed"
+              "armedforces": 1
+            },
+            {
+              "armedforces": 3
             }
           ],
           "pages": {

--- a/spec/fixtures/forms/2022_2023.json
+++ b/spec/fixtures/forms/2022_2023.json
@@ -47,7 +47,7 @@
           },
           "depends_on": [
             {
-              "setup": "completed"
+              "non_location_setup_questions_completed?": true
             }
           ]
         }

--- a/spec/models/form/sales/subsections/household_characteristics_spec.rb
+++ b/spec/models/form/sales/subsections/household_characteristics_spec.rb
@@ -53,6 +53,6 @@ RSpec.describe Form::Sales::Subsections::HouseholdCharacteristics, type: :model 
   end
 
   it "has correct depends on" do
-    expect(household_characteristics.depends_on).to eq([{ "setup" => "completed" }])
+    expect(household_characteristics.depends_on).to eq([{ "setup_completed?" => true }])
   end
 end

--- a/spec/models/form/sales/subsections/income_benefits_and_outgoings_spec.rb
+++ b/spec/models/form/sales/subsections/income_benefits_and_outgoings_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe Form::Sales::Subsections::IncomeBenefitsAndOutgoings, type: :mode
   end
 
   it "has correct depends on" do
-    expect(subsection.depends_on).to eq([{ "setup" => "completed" }])
+    expect(subsection.depends_on).to eq([{ "setup_completed?" => true }])
   end
 end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -832,6 +832,11 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_rent_amount(record)
           expect(record.errors["brent"])
             .to include(match I18n.t("validations.financial.brent.below_hard_min"))
+
+          %w[beds la postcode_known scheme_id location_id rent_type needstype period].each do |field|
+            expect(record.errors[field])
+              .to include(match I18n.t("validations.financial.brent.#{field}.below_hard_min"))
+          end
         end
 
         it "validates hard max for general needs" do
@@ -846,22 +851,11 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_rent_amount(record)
           expect(record.errors["brent"])
             .to include(match I18n.t("validations.financial.brent.above_hard_max"))
-          expect(record.errors["beds"])
-            .to include(match I18n.t("validations.financial.brent.beds.above_hard_max"))
-          expect(record.errors["la"])
-            .to include(match I18n.t("validations.financial.brent.la.above_hard_max"))
-          expect(record.errors["postcode_known"])
-            .to include(match I18n.t("validations.financial.brent.postcode_known.above_hard_max"))
-          expect(record.errors["scheme_id"])
-            .to include(match I18n.t("validations.financial.brent.scheme_id.above_hard_max"))
-          expect(record.errors["location_id"])
-            .to include(match I18n.t("validations.financial.brent.location_id.above_hard_max"))
-          expect(record.errors["rent_type"])
-            .to include(match I18n.t("validations.financial.brent.rent_type.above_hard_max"))
-          expect(record.errors["needstype"])
-            .to include(match I18n.t("validations.financial.brent.needstype.above_hard_max"))
-          expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.brent.period.above_hard_max"))
+
+          %w[beds la postcode_known scheme_id location_id rent_type needstype period].each do |field|
+            expect(record.errors[field])
+              .to include(match I18n.t("validations.financial.brent.#{field}.above_hard_max"))
+          end
         end
 
         it "validates hard max for supported housing" do
@@ -875,22 +869,11 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_rent_amount(record)
           expect(record.errors["brent"])
             .to include(match I18n.t("validations.financial.brent.above_hard_max"))
-          expect(record.errors["beds"])
-            .to include(match I18n.t("validations.financial.brent.beds.above_hard_max"))
-          expect(record.errors["la"])
-            .to include(match I18n.t("validations.financial.brent.la.above_hard_max"))
-          expect(record.errors["postcode_known"])
-            .to include(match I18n.t("validations.financial.brent.postcode_known.above_hard_max"))
-          expect(record.errors["scheme_id"])
-            .to include(match I18n.t("validations.financial.brent.scheme_id.above_hard_max"))
-          expect(record.errors["location_id"])
-            .to include(match I18n.t("validations.financial.brent.location_id.above_hard_max"))
-          expect(record.errors["rent_type"])
-            .to include(match I18n.t("validations.financial.brent.rent_type.above_hard_max"))
-          expect(record.errors["needstype"])
-            .to include(match I18n.t("validations.financial.brent.needstype.above_hard_max"))
-          expect(record.errors["period"])
-            .to include(match I18n.t("validations.financial.brent.period.above_hard_max"))
+
+          %w[beds la postcode_known scheme_id location_id rent_type needstype period].each do |field|
+            expect(record.errors[field])
+              .to include(match I18n.t("validations.financial.brent.#{field}.above_hard_max"))
+          end
         end
 
         it "validates hard max for correct collection year" do
@@ -904,14 +887,11 @@ RSpec.describe Validations::FinancialValidations do
           financial_validator.validate_rent_amount(record)
           expect(record.errors["brent"])
             .to include(match I18n.t("validations.financial.brent.above_hard_max"))
-          expect(record.errors["beds"])
-            .to include(match I18n.t("validations.financial.brent.beds.above_hard_max"))
-          expect(record.errors["la"])
-            .to include(match I18n.t("validations.financial.brent.la.above_hard_max"))
-          expect(record.errors["rent_type"])
-            .to include(match I18n.t("validations.financial.brent.rent_type.above_hard_max"))
-          expect(record.errors["needstype"])
-            .to include(match I18n.t("validations.financial.brent.needstype.above_hard_max"))
+
+          %w[beds la postcode_known scheme_id location_id rent_type needstype period].each do |field|
+            expect(record.errors[field])
+              .to include(match I18n.t("validations.financial.brent.#{field}.above_hard_max"))
+          end
         end
 
         it "does not error if some of the fields are missing" do


### PR DESCRIPTION
Update enabled method to work the same way routed_to? works. 
Instead of checking the status of other subsections to determine whether the subsection is enabled, we can now check individual questions and call methods.

For lettings logs instead of checking that the setup section is completed we check that all the answers except for scheme and location are answered. That is to prevent the rest of the fields from clearing if scheme and location is missing.

For sales logs we check that all the questions in the setup section are answered