### PR TITLE
Add Parallel tests

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
   gem "pry-byebug"
+
+  gem "parallel_tests"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ GEM
       globalid
       paper_trail (>= 3.0.0)
     parallel (1.22.1)
+    parallel_tests (4.0.0)
+      parallel
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.3)
@@ -430,6 +432,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -456,6 +459,7 @@ DEPENDENCIES
   overcommit (>= 0.37.0)
   paper_trail
   paper_trail-globalid
+  parallel_tests
   pg (~> 1.1)
   possessive
   postcodes_io

--- a/config/database.yml
+++ b/config/database.yml
@@ -66,7 +66,7 @@ staging:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: data_collector_test
+  database: data_collector_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "faker"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,3 +15,19 @@ nav_order: 4
 - Feature specs are generally written sparingly as they’re also the slowest, where possible a request spec is preferred as this still tests a large surface area (route, controller, model, view) without the performance impact. They are not suitable for tests that need to run JavaScript or test that a specific set of interaction events that trigger a specific set of requests (with high confidence).
 
 - Test data is created with [FactoryBot](https://github.com/thoughtbot/factory_bot) where ever possible
+
+## Parallel testing
+
+- The RSpec test suite can be ran in parallel in local development for quicker turnaround times
+
+- Setup with the following:
+
+```sh
+bundle exec rake parallel:setup
+```
+
+- Run with:
+
+```sh
+RAILS_ENV=test bundle exec rake parallel:spec
+```


### PR DESCRIPTION
- This allows RSpec to be run in parallel in local development for faster turnaround times
- Updated the docs on how to setup and run