### PR TITLE
fix the buildpack to previous version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 defaults: &defaults
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.59
   processes:
     - type: web
       command: bundle exec rake cf:on_first_instance db:migrate && bin/rails server


### PR DESCRIPTION
Buildpack bumped their version to 18.12.1 and removed 16 https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.60
We cannot upgrade to node 18 because of this dependency https://www.npmjs.com/package/govuk-eleventy-plugin

This fixes the build pack we're using to the previous version (compatible with node 16)