### PR TITLE
Unfreeze time

### DIFF
--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2396,6 +2396,10 @@ RSpec.describe LettingsLog do
       expected_content.sub!(/\{location_id\}/, location["id"].to_s)
     end
 
+    after do
+      Timecop.unfreeze
+    end
+
     context "with a support user" do
       let(:csv_export_file) { File.open("spec/fixtures/files/lettings_logs_download.csv", "r:UTF-8") }
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Location, type: :model do
     after do
       Timecop.unfreeze
     end
-    
+
     context "when there have not been any previous deactivations" do
       it "returns active if the location has no deactivation records" do
         expect(location.status).to eq(:active)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe Location, type: :model do
       Timecop.freeze(2022, 6, 7)
     end
 
+    after do
+      Timecop.unfreeze
+    end
+    
     context "when there have not been any previous deactivations" do
       it "returns active if the location has no deactivation records" do
         expect(location.status).to eq(:active)

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe Scheme, type: :model do
       Timecop.freeze(2022, 6, 7)
     end
 
+    after do
+      Timecop.unfreeze
+    end
+
     context "when there have not been any previous deactivations" do
       it "returns active if the scheme is not deactivated" do
         expect(scheme.status).to eq(:active)

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1251,7 +1251,7 @@ RSpec.describe LocationsController, type: :request do
 
       after do
         Timecop.unfreeze
-      end  
+      end
 
       context "with default date" do
         let(:params) { { location: { deactivation_date_type: "default", deactivation_date: } } }
@@ -1284,7 +1284,7 @@ RSpec.describe LocationsController, type: :request do
 
         after do
           Timecop.unfreeze
-        end    
+        end
 
         it "updates existing location with valid deactivation date and renders location page" do
           follow_redirect!
@@ -1412,7 +1412,7 @@ RSpec.describe LocationsController, type: :request do
 
       after do
         Timecop.unfreeze
-      end  
+      end
 
       context "with active location" do
         let(:add_deactivations) {}

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1249,6 +1249,10 @@ RSpec.describe LocationsController, type: :request do
         patch "/schemes/#{scheme.id}/locations/#{location.id}/new-deactivation", params:
       end
 
+      after do
+        Timecop.unfreeze
+      end  
+
       context "with default date" do
         let(:params) { { location: { deactivation_date_type: "default", deactivation_date: } } }
 
@@ -1277,6 +1281,10 @@ RSpec.describe LocationsController, type: :request do
           sign_in user
           patch "/schemes/#{scheme.id}/locations/#{location.id}/deactivate", params:
         end
+
+        after do
+          Timecop.unfreeze
+        end    
 
         it "updates existing location with valid deactivation date and renders location page" do
           follow_redirect!
@@ -1401,6 +1409,10 @@ RSpec.describe LocationsController, type: :request do
         location.save!
         get "/schemes/#{scheme.id}/locations/#{location.id}"
       end
+
+      after do
+        Timecop.unfreeze
+      end  
 
       context "with active location" do
         let(:add_deactivations) {}

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe SchemesController, type: :request do
 
         after do
           Timecop.unfreeze
-        end    
+        end
 
         context "with active scheme" do
           let(:add_deactivations) {}
@@ -1782,7 +1782,7 @@ RSpec.describe SchemesController, type: :request do
 
       after do
         Timecop.unfreeze
-      end  
+      end
 
       context "with default date" do
         let(:params) { { scheme: { deactivation_date_type: "default", deactivation_date: } } }
@@ -1815,7 +1815,7 @@ RSpec.describe SchemesController, type: :request do
 
         after do
           Timecop.unfreeze
-        end    
+        end
 
         it "updates existing scheme with valid deactivation date and renders scheme page" do
           follow_redirect!

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -256,6 +256,10 @@ RSpec.describe SchemesController, type: :request do
           get "/schemes/#{scheme.id}"
         end
 
+        after do
+          Timecop.unfreeze
+        end    
+
         context "with active scheme" do
           let(:add_deactivations) {}
 
@@ -1776,6 +1780,10 @@ RSpec.describe SchemesController, type: :request do
         patch "/schemes/#{scheme.id}/new-deactivation", params:
       end
 
+      after do
+        Timecop.unfreeze
+      end  
+
       context "with default date" do
         let(:params) { { scheme: { deactivation_date_type: "default", deactivation_date: } } }
 
@@ -1804,6 +1812,10 @@ RSpec.describe SchemesController, type: :request do
           sign_in user
           patch "/schemes/#{scheme.id}/deactivate", params:
         end
+
+        after do
+          Timecop.unfreeze
+        end    
 
         it "updates existing scheme with valid deactivation date and renders scheme page" do
           follow_redirect!

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Exports::LettingsLogExportService do
     allow(FormHandler.instance).to receive(:get_form).with("current_lettings").and_return(real_2022_2023_form)
   end
 
+  after do
+    Timecop.unfreeze
+  end
+
   context "when exporting daily lettings logs in XML" do
     context "and no lettings logs is available for export" do
       it "generates a master manifest with the correct name" do


### PR DESCRIPTION
Some non related tests started to fail because we didn't reset time after freezing it.
This unfreezes all the frozen time that were missed after tests to prevent that