### PR TITLE
[1644] Validate head count

### DIFF
--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -1,5 +1,10 @@
 class SalesLogValidator < ActiveModel::Validator
-  def validate(record); end
+  include Validations::Sales::HouseholdValidations
+
+  def validate(record)
+    validation_methods = public_methods.select { |method| method.starts_with?("validate_") }
+    validation_methods.each { |meth| public_send(meth, record) }
+  end
 end
 
 class SalesLog < Log

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -1,0 +1,9 @@
+module Validations::Sales::HouseholdValidations
+  def validate_number_of_other_people_living_in_the_property(record)
+    return if record.hholdcount.blank?
+
+    unless record.hholdcount >= 0 && record.hholdcount <= 4
+      record.errors.add :hholdcount, I18n.t("validations.numeric.valid", field: "Number of other people living in the property", min: 0, max: 4)
+    end
+  end
+end

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Validations::Sales::HouseholdValidations do
+  subject(:household_validator) { validator_class.new }
+
+  let(:validator_class) { Class.new { include Validations::Sales::HouseholdValidations } }
+
+  describe "#validate_number_of_other_people_living_in_the_property" do
+    context "when within permitted bounds" do
+      let(:record) { FactoryBot.build(:sales_log, hholdcount: 2) }
+
+      it "does not add an error" do
+        household_validator.validate_number_of_other_people_living_in_the_property(record)
+
+        expect(record.errors).not_to be_present
+      end
+    end
+
+    context "when blank" do
+      let(:record) { FactoryBot.build(:sales_log, hholdcount: nil) }
+
+      it "does not add an error" do
+        household_validator.validate_number_of_other_people_living_in_the_property(record)
+
+        expect(record.errors).not_to be_present
+      end
+    end
+
+    context "when below lower bound" do
+      let(:record) { FactoryBot.build(:sales_log, hholdcount: -1) }
+
+      it "adds an error" do
+        household_validator.validate_number_of_other_people_living_in_the_property(record)
+
+        expect(record.errors).to be_present
+      end
+    end
+
+    context "when higher than upper bound" do
+      let(:record) { FactoryBot.build(:sales_log, hholdcount: 5) }
+
+      it "adds an error" do
+        household_validator.validate_number_of_other_people_living_in_the_property(record)
+
+        expect(record.errors).to be_present
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,13 +62,14 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
-  #
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1644
- There is missing validation for sales logs when question `Besides the buyers, how many other people live in the property?` is asked

# What's changed

- Add validation when on a sales log where number of permitted additional occupants is limited to between 0 and 4

# Screenshots

![Screenshot 2022-11-21 at 11 31 35](https://user-images.githubusercontent.com/92580/203040458-16515d02-5344-4c9c-8709-a5c9233e201d.png)