### PR TITLE
Wait for binding when deploying review apps

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -126,21 +126,21 @@ jobs:
           APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}
           SERVICE_NAME: dluhc-core-review-${{ github.event.pull_request.number }}-postgres
         run: |
-          cf bind-service $APP_NAME $SERVICE_NAME
+          cf bind-service $APP_NAME $SERVICE_NAME --wait
 
       - name: Bind redis service
         env:
           APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}
           SERVICE_NAME: dluhc-core-review-${{ github.event.pull_request.number }}-redis
         run: |
-          cf bind-service $APP_NAME $SERVICE_NAME
+          cf bind-service $APP_NAME $SERVICE_NAME --wait
 
       - name: Bind logit drain service
         env:
           APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}
           SERVICE_NAME: logit-ssl-drain
         run: |
-          cf bind-service $APP_NAME $SERVICE_NAME
+          cf bind-service $APP_NAME $SERVICE_NAME --wait
 
       - name: Start review app
         env:


### PR DESCRIPTION
# Context

- there seems to be a race condition without this and there is a chance next command will fail as it needs to wait for any existing operations to complete first

# The change

- wait for bindings to complete before executing next command