### PR TITLE
[1018] Make cookies secure for production like envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,11 @@ module DataCollector
     config.exceptions_app = routes
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.session_store(
+      :cookie_store,
+      key: "_data_collector_session",
+      secure: (Rails.env.production? || Rails.env.staging? || Rails.env.review?)
+    )
   end
 end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1018
- Cookies were not set with the `secure` flag. This means they would continue to work if downgraded from `https` to `http`

# The changes

- Set the cookie to have `secure` flag for production like envs
- I tested this with a few deploys and appears to not log you out and just upgrade the cookie