### PR TITLE
Deactivation does not affect logs

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -38,8 +38,12 @@ class LocationsController < ApplicationController
   end
 
   def deactivate_confirm
-    @deactivation_date = params[:deactivation_date]
-    @deactivation_date_type = params[:deactivation_date_type]
+    if @location.lettings_logs.filter_by_before_startdate(params[:deactivation_date]).count.zero?
+      deactivate
+    else
+      @deactivation_date = params[:deactivation_date]
+      @deactivation_date_type = params[:deactivation_date_type]
+    end
   end
 
   def deactivate

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -38,7 +38,8 @@ class LocationsController < ApplicationController
   end
 
   def deactivate_confirm
-    if @location.lettings_logs.filter_by_before_startdate(params[:deactivation_date]).count.zero?
+    @affected_logs = @location.lettings_logs.filter_by_before_startdate(params[:deactivation_date])
+    if @affected_logs.count.zero?
       deactivate
     else
       @deactivation_date = params[:deactivation_date]

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -39,7 +39,8 @@ class SchemesController < ApplicationController
   end
 
   def deactivate_confirm
-    if @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date]).count.zero?
+    @affected_logs = @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date])
+    if @affected_logs.count.zero?
       deactivate
     else
       @deactivation_date = params[:deactivation_date]

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -39,8 +39,12 @@ class SchemesController < ApplicationController
   end
 
   def deactivate_confirm
-    @deactivation_date = params[:deactivation_date]
-    @deactivation_date_type = params[:deactivation_date_type]
+    if @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date]).count.zero?
+      deactivate
+    else
+      @deactivation_date = params[:deactivation_date]
+      @deactivation_date_type = params[:deactivation_date_type]
+    end
   end
 
   def deactivate

--- a/app/views/locations/deactivate_confirm.html.erb
+++ b/app/views/locations/deactivate_confirm.html.erb
@@ -4,7 +4,7 @@
      <% end %>
    <h1 class="govuk-heading-l">
      <span class="govuk-caption-l"><%= @location.postcode %></span>
-     This change will affect <%= @location.lettings_logs.filter_by_before_startdate(@deactivation_date).count %> logs
+     This change will affect <%= @affected_logs.count %> logs
    </h1>
    <%= govuk_warning_text text: I18n.t("warnings.location.deactivate.review_logs") %>
    <%= f.hidden_field :confirm, value: true %>

--- a/app/views/locations/deactivate_confirm.html.erb
+++ b/app/views/locations/deactivate_confirm.html.erb
@@ -4,7 +4,7 @@
      <% end %>
    <h1 class="govuk-heading-l">
      <span class="govuk-caption-l"><%= @location.postcode %></span>
-     This change will affect <%= @location.lettings_logs.count %> logs
+     This change will affect <%= @location.lettings_logs.filter_by_before_startdate(@deactivation_date).count %> logs
    </h1>
    <%= govuk_warning_text text: I18n.t("warnings.location.deactivate.review_logs") %>
    <%= f.hidden_field :confirm, value: true %>

--- a/app/views/schemes/deactivate_confirm.html.erb
+++ b/app/views/schemes/deactivate_confirm.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-l"><%= @scheme.service_name %></span>
-    This change will affect <%= @scheme.lettings_logs.count %> logs
+    This change will affect <%= @scheme.lettings_logs.filter_by_before_startdate(@deactivation_date).count %> logs
   </h1>
   <%= govuk_warning_text text: I18n.t("warnings.scheme.deactivation.review_logs") %>
   <%= f.hidden_field :confirm, value: true %>

--- a/app/views/schemes/deactivate_confirm.html.erb
+++ b/app/views/schemes/deactivate_confirm.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-l"><%= @scheme.service_name %></span>
-    This change will affect <%= @scheme.lettings_logs.filter_by_before_startdate(@deactivation_date).count %> logs
+    This change will affect <%= @affected_logs.count %> logs
   </h1>
   <%= govuk_warning_text text: I18n.t("warnings.scheme.deactivation.review_logs") %>
   <%= f.hidden_field :confirm, value: true %>

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1773,10 +1773,12 @@ RSpec.describe SchemesController, type: :request do
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
       let!(:lettings_log) { FactoryBot.create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
       let(:startdate) { Time.utc(2022, 10, 11) }
+      let(:setup_schemes) { nil }
 
       before do
         Timecop.freeze(Time.utc(2022, 10, 10))
         sign_in user
+        setup_schemes
         patch "/schemes/#{scheme.id}/new-deactivation", params:
       end
 
@@ -1787,20 +1789,54 @@ RSpec.describe SchemesController, type: :request do
       context "with default date" do
         let(:params) { { scheme_deactivation_period: { deactivation_date_type: "default", deactivation_date: } } }
 
-        it "redirects to the confirmation page" do
-          follow_redirect!
-          expect(response).to have_http_status(:ok)
-          expect(page).to have_content("This change will affect #{scheme.lettings_logs.count} logs")
+        context "and affected logs" do
+          it "redirects to the confirmation page" do
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_content("This change will affect #{scheme.lettings_logs.count} logs")
+          end
+        end
+
+        context "and no affected logs" do
+          let(:setup_schemes) { scheme.lettings_logs.update(scheme: nil) }
+
+          it "redirects to the location page and updates the deactivation period" do
+            follow_redirect!
+            follow_redirect!
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+            scheme.reload
+            expect(scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2022, 4, 1))
+          end
         end
       end
 
       context "with other date" do
         let(:params) { { scheme_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "10", "deactivation_date(1i)": "2022" } } }
 
-        it "redirects to the confirmation page" do
-          follow_redirect!
-          expect(response).to have_http_status(:ok)
-          expect(page).to have_content("This change will affect #{scheme.lettings_logs.count} logs")
+        context "and affected logs" do
+          it "redirects to the confirmation page" do
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_content("This change will affect #{scheme.lettings_logs.count} logs")
+          end
+        end
+
+        context "and no affected logs" do
+          let(:setup_schemes) { scheme.lettings_logs.update(scheme: nil) }
+
+          it "redirects to the location page and updates the deactivation period" do
+            follow_redirect!
+            follow_redirect!
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+            scheme.reload
+            expect(scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2022, 10, 10))
+          end
         end
       end
 


### PR DESCRIPTION
Only show confirm deactivation page when a location or scheme gets deactivated if it affects at least 1 log (base on designs).
Otherwise deactivate the scheme/location and route to the following page with a success banner