### PR TITLE
[1711] Orgs parent-child relationship now atomic

### DIFF
--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -39,7 +39,6 @@ class OrganisationRelationshipsController < ApplicationController
 
   def create_housing_provider
     child_organisation = @organisation
-    relationship_type = OrganisationRelationship::OWNING
     if params[:organisation][:related_organisation_id].empty?
       @organisation.errors.add :related_organisation_id, "You must choose a housing provider"
       @organisations = Organisation.where.not(id: child_organisation.id).pluck(:id, :name)
@@ -47,21 +46,20 @@ class OrganisationRelationshipsController < ApplicationController
       return
     else
       parent_organisation = related_organisation
-      if OrganisationRelationship.exists?(child_organisation:, parent_organisation:, relationship_type:)
+      if OrganisationRelationship.exists?(child_organisation:, parent_organisation:)
         @organisation.errors.add :related_organisation_id, "You have already added this housing provider"
         @organisations = Organisation.where.not(id: child_organisation.id).pluck(:id, :name)
         render "organisation_relationships/add_housing_provider"
         return
       end
     end
-    create!(child_organisation:, parent_organisation:, relationship_type:)
+    create!(child_organisation:, parent_organisation:)
     flash[:notice] = "#{related_organisation.name} is now one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} housing providers"
     redirect_to housing_providers_organisation_path
   end
 
   def create_managing_agent
     parent_organisation = @organisation
-    relationship_type = OrganisationRelationship::MANAGING
     if params[:organisation][:related_organisation_id].empty?
       @organisation.errors.add :related_organisation_id, "You must choose a managing agent"
       @organisations = Organisation.where.not(id: parent_organisation.id).pluck(:id, :name)
@@ -69,14 +67,14 @@ class OrganisationRelationshipsController < ApplicationController
       return
     else
       child_organisation = related_organisation
-      if OrganisationRelationship.exists?(child_organisation:, parent_organisation:, relationship_type:)
+      if OrganisationRelationship.exists?(child_organisation:, parent_organisation:)
         @organisation.errors.add :related_organisation_id, "You have already added this managing agent"
         @organisations = Organisation.where.not(id: parent_organisation.id).pluck(:id, :name)
         render "organisation_relationships/add_managing_agent"
         return
       end
     end
-    create!(child_organisation:, parent_organisation:, relationship_type:)
+    create!(child_organisation:, parent_organisation:)
     flash[:notice] = "#{related_organisation.name} is now one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} managing agents"
     redirect_to managing_agents_organisation_path
   end
@@ -89,7 +87,6 @@ class OrganisationRelationshipsController < ApplicationController
     relationship = OrganisationRelationship.find_by!(
       child_organisation: @organisation,
       parent_organisation: target_organisation,
-      relationship_type: OrganisationRelationship::OWNING,
     )
     relationship.destroy!
     flash[:notice] = "#{target_organisation.name} is no longer one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} housing providers"
@@ -104,7 +101,6 @@ class OrganisationRelationshipsController < ApplicationController
     relationship = OrganisationRelationship.find_by!(
       parent_organisation: @organisation,
       child_organisation: target_organisation,
-      relationship_type: OrganisationRelationship::MANAGING,
     )
     relationship.destroy!
     flash[:notice] = "#{target_organisation.name} is no longer one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} managing agents"
@@ -113,8 +109,8 @@ class OrganisationRelationshipsController < ApplicationController
 
 private
 
-  def create!(child_organisation:, parent_organisation:, relationship_type:)
-    @resource = OrganisationRelationship.new(child_organisation:, parent_organisation:, relationship_type:)
+  def create!(child_organisation:, parent_organisation:)
+    @resource = OrganisationRelationship.new(child_organisation:, parent_organisation:)
     @resource.save!
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   include Devise::Controllers::SignInOut
   include Helpers::Email
   include Modules::SearchFilter
+
   before_action :authenticate_user!
   before_action :find_resource, except: %i[new create]
   before_action :authenticate_scope!, except: %i[new]

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -13,9 +13,10 @@ class Organisation < ApplicationRecord
   has_many :child_organisation_relationships, foreign_key: :parent_organisation_id, class_name: "OrganisationRelationship"
   has_many :child_organisations, through: :child_organisation_relationships
 
-  has_many :housing_provider_relationships, -> { where(relationship_type: OrganisationRelationship::OWNING) }, foreign_key: :child_organisation_id, class_name: "OrganisationRelationship"
+  has_many :housing_provider_relationships, foreign_key: :child_organisation_id, class_name: "OrganisationRelationship"
   has_many :housing_providers, through: :housing_provider_relationships, source: :parent_organisation
-  has_many :managing_agent_relationships, -> { where(relationship_type: OrganisationRelationship::MANAGING) }, foreign_key: :parent_organisation_id, class_name: "OrganisationRelationship"
+
+  has_many :managing_agent_relationships, foreign_key: :parent_organisation_id, class_name: "OrganisationRelationship"
   has_many :managing_agents, through: :managing_agent_relationships, source: :child_organisation
 
   scope :search_by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }

--- a/app/models/organisation_relationship.rb
+++ b/app/models/organisation_relationship.rb
@@ -1,16 +1,4 @@
 class OrganisationRelationship < ApplicationRecord
   belongs_to :child_organisation, class_name: "Organisation"
   belongs_to :parent_organisation, class_name: "Organisation"
-
-  scope :owning, -> { where(relationship_type: OWNING) }
-  scope :managing, -> { where(relationship_type: MANAGING) }
-
-  OWNING = "owning".freeze
-  MANAGING = "managing".freeze
-  RELATIONSHIP_TYPE = {
-    OWNING => 0,
-    MANAGING => 1,
-  }.freeze
-
-  enum relationship_type: RELATIONSHIP_TYPE
 end

--- a/db/migrate/20221122122311_delete_relationship_type.rb
+++ b/db/migrate/20221122122311_delete_relationship_type.rb
@@ -1,0 +1,5 @@
+class DeleteRelationshipType < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :organisation_relationships, :relationship_type, :integer, null: false
+  end
+end

--- a/db/migrate/20221122130928_add_org_relation_indexes.rb
+++ b/db/migrate/20221122130928_add_org_relation_indexes.rb
@@ -1,0 +1,10 @@
+class AddOrgRelationIndexes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :organisation_relationships, :child_organisation_id
+    add_index :organisation_relationships, :parent_organisation_id
+    add_index :organisation_relationships, %i[parent_organisation_id child_organisation_id], unique: true, name: "index_org_rel_parent_child_uniq"
+
+    add_foreign_key :organisation_relationships, :organisations, column: :parent_organisation_id
+    add_foreign_key :organisation_relationships, :organisations, column: :child_organisation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_103855) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_22_122311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -286,7 +286,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_17_103855) do
     t.integer "parent_organisation_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "relationship_type", null: false
   end
 
   create_table "organisation_rent_periods", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_22_122311) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -286,6 +286,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_122311) do
     t.integer "parent_organisation_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["child_organisation_id"], name: "index_organisation_relationships_on_child_organisation_id"
+    t.index ["parent_organisation_id", "child_organisation_id"], name: "index_org_rel_parent_child_uniq", unique: true
+    t.index ["parent_organisation_id"], name: "index_organisation_relationships_on_parent_organisation_id"
   end
 
   create_table "organisation_rent_periods", force: :cascade do |t|
@@ -476,6 +479,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_122311) do
   add_foreign_key "lettings_logs", "organisations", column: "owning_organisation_id", on_delete: :cascade
   add_foreign_key "lettings_logs", "schemes"
   add_foreign_key "locations", "schemes"
+  add_foreign_key "organisation_relationships", "organisations", column: "child_organisation_id"
+  add_foreign_key "organisation_relationships", "organisations", column: "parent_organisation_id"
   add_foreign_key "sales_logs", "organisations", column: "owning_organisation_id", on_delete: :cascade
   add_foreign_key "schemes", "organisations", column: "managing_organisation_id"
   add_foreign_key "schemes", "organisations", column: "owning_organisation_id", on_delete: :cascade

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,22 +70,18 @@ unless Rails.env.test?
   OrganisationRelationship.create!(
     child_organisation: org,
     parent_organisation: housing_provider1,
-    relationship_type: OrganisationRelationship::OWNING,
   )
   OrganisationRelationship.create!(
     child_organisation: org,
     parent_organisation: housing_provider2,
-    relationship_type: OrganisationRelationship::OWNING,
   )
   OrganisationRelationship.create!(
     child_organisation: managing_agent1,
     parent_organisation: org,
-    relationship_type: OrganisationRelationship::MANAGING,
   )
   OrganisationRelationship.create!(
     child_organisation: managing_agent2,
     parent_organisation: org,
-    relationship_type: OrganisationRelationship::MANAGING,
   )
 
   if (Rails.env.development? || Rails.env.review?) && User.count.zero?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,19 +67,19 @@ unless Rails.env.test?
     end
   end
 
-  OrganisationRelationship.create!(
+  OrganisationRelationship.find_or_create_by!(
     child_organisation: org,
     parent_organisation: housing_provider1,
   )
-  OrganisationRelationship.create!(
+  OrganisationRelationship.find_or_create_by!(
     child_organisation: org,
     parent_organisation: housing_provider2,
   )
-  OrganisationRelationship.create!(
+  OrganisationRelationship.find_or_create_by!(
     child_organisation: managing_agent1,
     parent_organisation: org,
   )
-  OrganisationRelationship.create!(
+  OrganisationRelationship.find_or_create_by!(
     child_organisation: managing_agent2,
     parent_organisation: org,
   )

--- a/spec/factories/organisation_relationship.rb
+++ b/spec/factories/organisation_relationship.rb
@@ -2,13 +2,5 @@ FactoryBot.define do
   factory :organisation_relationship do
     child_organisation { FactoryBot.create(:organisation) }
     parent_organisation { FactoryBot.create(:organisation) }
-
-    trait :owning do
-      relationship_type { OrganisationRelationship::OWNING }
-    end
-
-    trait :managing do
-      relationship_type { OrganisationRelationship::MANAGING }
-    end
   end
 end

--- a/spec/models/form/lettings/pages/housing_provider_spec.rb
+++ b/spec/models/form/lettings/pages/housing_provider_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe Form::Lettings::Pages::HousingProvider, type: :model do
           before do
             create(
               :organisation_relationship,
-              :owning,
               child_organisation: user.organisation,
               parent_organisation: housing_provider,
             )
@@ -101,13 +100,11 @@ RSpec.describe Form::Lettings::Pages::HousingProvider, type: :model do
           before do
             create(
               :organisation_relationship,
-              :owning,
               child_organisation: user.organisation,
               parent_organisation: housing_provider1,
             )
             create(
               :organisation_relationship,
-              :owning,
               child_organisation: user.organisation,
               parent_organisation: housing_provider2,
             )
@@ -140,8 +137,8 @@ RSpec.describe Form::Lettings::Pages::HousingProvider, type: :model do
 
         context "with >0 housing_providers" do
           before do
-            create(:organisation_relationship, :owning, child_organisation: user.organisation)
-            create(:organisation_relationship, :owning, child_organisation: user.organisation)
+            create(:organisation_relationship, child_organisation: user.organisation)
+            create(:organisation_relationship, child_organisation: user.organisation)
           end
 
           it "is shown" do

--- a/spec/models/form/lettings/pages/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/pages/managing_organisation_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Form::Lettings::Pages::ManagingOrganisation, type: :model do
 
         context "with >1 managing_agents" do
           before do
-            create(:organisation_relationship, :managing, parent_organisation: log.owning_organisation)
-            create(:organisation_relationship, :managing, parent_organisation: log.owning_organisation)
+            create(:organisation_relationship, parent_organisation: log.owning_organisation)
+            create(:organisation_relationship, parent_organisation: log.owning_organisation)
           end
 
           it "is shown" do
@@ -91,7 +91,6 @@ RSpec.describe Form::Lettings::Pages::ManagingOrganisation, type: :model do
           before do
             create(
               :organisation_relationship,
-              :managing,
               child_organisation: managing_agent,
               parent_organisation: log.owning_organisation,
             )
@@ -128,8 +127,8 @@ RSpec.describe Form::Lettings::Pages::ManagingOrganisation, type: :model do
 
         context "with >1 managing_agents" do
           before do
-            create(:organisation_relationship, :managing, parent_organisation: user.organisation)
-            create(:organisation_relationship, :managing, parent_organisation: user.organisation)
+            create(:organisation_relationship, parent_organisation: user.organisation)
+            create(:organisation_relationship, parent_organisation: user.organisation)
           end
 
           it "is shown" do
@@ -143,7 +142,6 @@ RSpec.describe Form::Lettings::Pages::ManagingOrganisation, type: :model do
           before do
             create(
               :organisation_relationship,
-              :managing,
               child_organisation: managing_agent,
               parent_organisation: user.organisation,
             )

--- a/spec/models/form/lettings/questions/housing_provider_spec.rb
+++ b/spec/models/form/lettings/questions/housing_provider_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Form::Lettings::Questions::HousingProvider, type: :model do
 
       context "when housing providers != 0" do
         before do
-          create(:organisation_relationship, :owning, child_organisation: user.organisation)
+          create(:organisation_relationship, child_organisation: user.organisation)
         end
 
         it "is visible in check answers" do
@@ -122,7 +122,7 @@ RSpec.describe Form::Lettings::Questions::HousingProvider, type: :model do
 
       context "when housing providers <= 1" do
         before do
-          create(:organisation_relationship, :owning, child_organisation: user.organisation)
+          create(:organisation_relationship, child_organisation: user.organisation)
         end
 
         it "is hidden in check answers" do
@@ -133,8 +133,8 @@ RSpec.describe Form::Lettings::Questions::HousingProvider, type: :model do
 
       context "when housing providers >= 2" do
         before do
-          create(:organisation_relationship, :owning, child_organisation: user.organisation)
-          create(:organisation_relationship, :owning, child_organisation: user.organisation)
+          create(:organisation_relationship, child_organisation: user.organisation)
+          create(:organisation_relationship, child_organisation: user.organisation)
         end
 
         it "is visible in check answers" do

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       let(:user) { create(:user, :data_coordinator, organisation: create(:organisation, holds_own_stock: true)) }
 
       let(:log) { create(:lettings_log) }
-      let!(:org_rel1) { create(:organisation_relationship, :managing, parent_organisation: user.organisation) }
-      let!(:org_rel2) { create(:organisation_relationship, :managing, parent_organisation: user.organisation) }
+      let!(:org_rel1) { create(:organisation_relationship, parent_organisation: user.organisation) }
+      let!(:org_rel2) { create(:organisation_relationship, parent_organisation: user.organisation) }
 
       let(:options) do
         {
@@ -77,8 +77,8 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       let(:user) { create(:user, :data_coordinator, organisation: create(:organisation, holds_own_stock: false)) }
 
       let(:log) { create(:lettings_log) }
-      let!(:org_rel1) { create(:organisation_relationship, :managing, parent_organisation: user.organisation) }
-      let!(:org_rel2) { create(:organisation_relationship, :managing, parent_organisation: user.organisation) }
+      let!(:org_rel1) { create(:organisation_relationship, parent_organisation: user.organisation) }
+      let!(:org_rel2) { create(:organisation_relationship, parent_organisation: user.organisation) }
 
       let(:options) do
         {
@@ -98,8 +98,8 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       let(:user) { create(:user, :support) }
       let(:log_owning_org) { create(:organisation, holds_own_stock: false) }
       let(:log) { create(:lettings_log, owning_organisation: log_owning_org) }
-      let!(:org_rel1) { create(:organisation_relationship, :managing, parent_organisation: log_owning_org) }
-      let!(:org_rel2) { create(:organisation_relationship, :managing, parent_organisation: log_owning_org) }
+      let!(:org_rel1) { create(:organisation_relationship, parent_organisation: log_owning_org) }
+      let!(:org_rel2) { create(:organisation_relationship, parent_organisation: log_owning_org) }
 
       let(:options) do
         {
@@ -118,8 +118,8 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       let(:user) { create(:user, :support) }
       let(:log_owning_org) { create(:organisation, holds_own_stock: true) }
       let(:log) { create(:lettings_log, owning_organisation: log_owning_org) }
-      let!(:org_rel1) { create(:organisation_relationship, :managing, parent_organisation: log_owning_org) }
-      let!(:org_rel2) { create(:organisation_relationship, :managing, parent_organisation: log_owning_org) }
+      let!(:org_rel1) { create(:organisation_relationship, parent_organisation: log_owning_org) }
+      let!(:org_rel2) { create(:organisation_relationship, parent_organisation: log_owning_org) }
 
       let(:options) do
         {

--- a/spec/models/organisation_relationship_spec.rb
+++ b/spec/models/organisation_relationship_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe OrganisationRelationship do
+  let(:parent_organisation) { create(:organisation) }
+  let(:child_organisation) { create(:organisation) }
+
+  context "when a relationship exists" do
+    subject!(:relationship) do
+      described_class.create!(parent_organisation:,
+                              child_organisation:)
+    end
+
+    describe "parent#managing_agents" do
+      it "includes child" do
+        expect(parent_organisation.managing_agents).to include(child_organisation)
+      end
+    end
+
+    describe "child#housing_providers" do
+      it "includes parent" do
+        expect(child_organisation.housing_providers).to include(parent_organisation)
+      end
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -34,14 +34,12 @@ RSpec.describe Organisation, type: :model do
       before do
         FactoryBot.create(
           :organisation_relationship,
-          :owning,
           child_organisation:,
           parent_organisation: organisation,
         )
 
         FactoryBot.create(
           :organisation_relationship,
-          :owning,
           child_organisation: grandchild_organisation,
           parent_organisation: child_organisation,
         )
@@ -65,21 +63,12 @@ RSpec.describe Organisation, type: :model do
       before do
         FactoryBot.create(
           :organisation_relationship,
-          :managing,
           child_organisation:,
           parent_organisation: organisation,
         )
 
         FactoryBot.create(
           :organisation_relationship,
-          :owning,
-          child_organisation:,
-          parent_organisation: organisation,
-        )
-
-        FactoryBot.create(
-          :organisation_relationship,
-          :owning,
           child_organisation: grandchild_organisation,
           parent_organisation: child_organisation,
         )
@@ -98,21 +87,12 @@ RSpec.describe Organisation, type: :model do
       before do
         FactoryBot.create(
           :organisation_relationship,
-          :managing,
           child_organisation:,
           parent_organisation: organisation,
         )
 
         FactoryBot.create(
           :organisation_relationship,
-          :owning,
-          child_organisation:,
-          parent_organisation: organisation,
-        )
-
-        FactoryBot.create(
-          :organisation_relationship,
-          :managing,
           child_organisation: grandchild_organisation,
           parent_organisation: child_organisation,
         )

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD 2") }
 
           before do
-            FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
-            FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
+            FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider)
+            FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider)
             get "/organisations/#{organisation.id}/housing-providers", headers:, params: {}
           end
 
@@ -83,8 +83,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD") }
 
           before do
-            FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
-            FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
+            FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+            FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent)
             get "/organisations/#{organisation.id}/managing-agents", headers:, params: {}
           end
 
@@ -153,7 +153,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
         it "sets the organisation relationship attributes correctly" do
           request
-          expect(OrganisationRelationship).to exist(child_organisation_id: organisation.id, parent_organisation_id: housing_provider.id, relationship_type: OrganisationRelationship::OWNING)
+          expect(OrganisationRelationship).to exist(child_organisation_id: organisation.id, parent_organisation_id: housing_provider.id)
         end
 
         it "redirects to the organisation list" do
@@ -181,7 +181,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
         it "sets the organisation relationship attributes correctly" do
           request
-          expect(OrganisationRelationship).to exist(parent_organisation_id: organisation.id, child_organisation_id: managing_agent.id, relationship_type: OrganisationRelationship::MANAGING)
+          expect(OrganisationRelationship).to exist(parent_organisation_id: organisation.id, child_organisation_id: managing_agent.id)
         end
 
         it "redirects to the organisation list" do
@@ -200,7 +200,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         let(:request) { delete "/organisations/#{organisation.id}/housing-providers", headers:, params: }
 
         before do
-          FactoryBot.create(:organisation_relationship, :owning, child_organisation: organisation, parent_organisation: housing_provider)
+          FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider)
         end
 
         it "deletes the new organisation relationship" do
@@ -225,7 +225,6 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         before do
           FactoryBot.create(
             :organisation_relationship,
-            :managing,
             parent_organisation: organisation,
             child_organisation: managing_agent,
           )
@@ -256,8 +255,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD") }
 
           before do
-            FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
-            FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
+            FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider)
+            FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider)
             get "/organisations/#{organisation.id}/housing-providers", headers:, params: {}
           end
 
@@ -304,8 +303,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD") }
 
           before do
-            FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
-            FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
+            FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+            FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent)
             get "/organisations/#{organisation.id}/managing-agents", headers:, params: {}
           end
 
@@ -383,7 +382,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
         it "sets the organisation relationship attributes correctly" do
           request
-          expect(OrganisationRelationship).to exist(child_organisation_id: organisation.id, parent_organisation_id: housing_provider.id, relationship_type: OrganisationRelationship::OWNING)
+          expect(OrganisationRelationship).to exist(child_organisation_id: organisation.id, parent_organisation_id: housing_provider.id)
         end
 
         it "redirects to the organisation list" do
@@ -411,7 +410,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
         it "sets the organisation relationship attributes correctly" do
           request
-          expect(OrganisationRelationship).to exist(parent_organisation_id: organisation.id, child_organisation_id: managing_agent.id, relationship_type: OrganisationRelationship::MANAGING)
+          expect(OrganisationRelationship).to exist(parent_organisation_id: organisation.id, child_organisation_id: managing_agent.id)
         end
 
         it "redirects to the organisation list" do
@@ -430,7 +429,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         let(:request) { delete "/organisations/#{organisation.id}/housing-providers", headers:, params: }
 
         before do
-          FactoryBot.create(:organisation_relationship, :owning, child_organisation: organisation, parent_organisation: housing_provider)
+          FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider)
         end
 
         it "deletes the new organisation relationship" do
@@ -455,7 +454,6 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         before do
           FactoryBot.create(
             :organisation_relationship,
-            :managing,
             parent_organisation: organisation,
             child_organisation: managing_agent,
           )
@@ -477,8 +475,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD 2") }
 
         before do
-          FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
-          FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider, relationship_type: OrganisationRelationship.relationship_types[:owning])
+          FactoryBot.create(:organisation_relationship, child_organisation: organisation, parent_organisation: housing_provider)
+          FactoryBot.create(:organisation_relationship, child_organisation: other_organisation, parent_organisation: other_org_housing_provider)
           get "/organisations/#{organisation.id}/housing-providers", headers:, params: {}
         end
 
@@ -531,8 +529,8 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         let!(:other_organisation) { FactoryBot.create(:organisation, name: "Foobar LTD 2") }
 
         before do
-          FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
-          FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent, relationship_type: OrganisationRelationship.relationship_types[:managing])
+          FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+          FactoryBot.create(:organisation_relationship, parent_organisation: other_organisation, child_organisation: other_org_managing_agent)
           get "/organisations/#{organisation.id}/managing-agents", headers:, params: {}
         end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1711
- Prior to this change a relation between 2 organisations was represented by 2 independent `OrganisationRelationship` records. One for each side of the relationship
- We were not creating both sides of the relationship therefore only one party would see the relationship
- This has now been simplified so only one `OrganisationRelationship` record is needed as we do not need each way of the relationship to be independent of the other

# The changes

- The column `OrganisationRelationship#relationship_type` has been removed
- A single `OrganisationRelationship` record now represents the 2 way relationship between 2 orgs
- Therefore there is no need to create 2 records to represent the relationship
- Therefore when deleting the relationship only one `OrganisationRelationship` record will need to be deleted
- Added missing database indexes to `OrganisationRelationship` which should reduce the need for full table scans
- Added a unique index to prevent duplicate relationships from entering the system
- Added foreign key constraints to prevent bad data integrity between relationships and orgs
- Seeding of relationships is now idempotent so review apps can run the seeding process over and over without issue