### PR TITLE
Update available_from methods

### DIFF
--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -49,6 +49,11 @@ class FormHandler
     today < window_end_date ? today.year - 1 : today.year
   end
 
+  def collection_start_date(date)
+    window_end_date = Time.zone.local(date.year, 4, 1)
+    date < window_end_date ? Time.zone.local(date.year - 1, 4, 1) : Time.zone.local(date.year, 4, 1)
+  end
+
   def current_collection_start_date
     Time.zone.local(current_collection_start_year, 4, 1)
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -372,8 +372,7 @@ class Location < ApplicationRecord
   def available_from
     return startdate if startdate.present?
 
-    window_end_date = Time.zone.local(created_at.year, 4, 1)
-    created_at < window_end_date ? Time.zone.local(created_at.year - 1, 4, 1) : Time.zone.local(created_at.year, 4, 1)
+    FormHandler.instance.collection_start_date(created_at)
   end
 
   def status

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -370,7 +370,10 @@ class Location < ApplicationRecord
   end
 
   def available_from
-    startdate || [created_at, FormHandler.instance.current_collection_start_date].min
+    return startdate if startdate.present?
+
+    window_end_date = Time.zone.local(created_at.year, 4, 1)
+    created_at < window_end_date ? Time.zone.local(created_at.year - 1, 4, 1) : Time.zone.local(created_at.year, 4, 1)
   end
 
   def status

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -210,7 +210,8 @@ class Scheme < ApplicationRecord
   end
 
   def available_from
-    [created_at, FormHandler.instance.current_collection_start_date].min
+    window_end_date = Time.zone.local(created_at.year, 4, 1)
+    created_at < window_end_date ? Time.zone.local(created_at.year - 1, 4, 1) : Time.zone.local(created_at.year, 4, 1)
   end
 
   def status

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -210,8 +210,7 @@ class Scheme < ApplicationRecord
   end
 
   def available_from
-    window_end_date = Time.zone.local(created_at.year, 4, 1)
-    created_at < window_end_date ? Time.zone.local(created_at.year - 1, 4, 1) : Time.zone.local(created_at.year, 4, 1)
+    FormHandler.instance.collection_start_date(created_at)
   end
 
   def status

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -154,11 +154,11 @@ RSpec.describe LocationsHelper do
 
     context "when viewing availability" do
       context "with no deactivations" do
-        it "displays created_at as availability date if startdate is not present" do
+        it "displays previous collection start date as availability date if created_at is earlier than collection start date" do
           location.update!(startdate: nil)
           availability_attribute = display_location_attributes(location).find { |x| x[:name] == "Availability" }[:value]
 
-          expect(availability_attribute).to eq("Active from #{location.created_at.to_formatted_s(:govuk_date)}")
+          expect(availability_attribute).to eq("Active from 1 April 2021")
         end
 
         it "displays current collection start date as availability date if created_at is later than collection start date" do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -208,4 +208,48 @@ RSpec.describe Location, type: :model do
       end
     end
   end
+
+  describe "available_from" do
+    context "when there is a startdate" do
+      let(:location) { FactoryBot.build(:location, startdate: Time.zone.local(2022, 4, 6)) }
+
+      it "returns the startdate" do
+        expect(location.available_from).to eq(Time.zone.local(2022, 4, 6))
+      end
+    end
+
+    context "when there is no start date" do
+      context "and the location was created at the start of the 2022/23 collection window" do
+        let(:location) { FactoryBot.build(:location, created_at: Time.zone.local(2022, 4, 6), startdate: nil) }
+
+        it "returns the beginning of 22/23 collection window" do
+          expect(location.available_from).to eq(Time.zone.local(2022, 4, 1))
+        end
+      end
+
+      context "and the location was created at the end of the 2022/23 collection window" do
+        let(:location) { FactoryBot.build(:location, created_at: Time.zone.local(2023, 2, 6), startdate: nil) }
+
+        it "returns the beginning of 22/23 collection window" do
+          expect(location.available_from).to eq(Time.zone.local(2022, 4, 1))
+        end
+      end
+
+      context "and the location was created at the start of the 2021/22 collection window" do
+        let(:location) { FactoryBot.build(:location, created_at: Time.zone.local(2021, 4, 6), startdate: nil) }
+
+        it "returns the beginning of 21/22 collection window" do
+          expect(location.available_from).to eq(Time.zone.local(2021, 4, 1))
+        end
+      end
+
+      context "and the location was created at the end of the 2021/22 collection window" do
+        let(:location) { FactoryBot.build(:location, created_at: Time.zone.local(2022, 2, 6), startdate: nil) }
+
+        it "returns the beginning of 21/22 collection window" do
+          expect(location.available_from).to eq(Time.zone.local(2021, 4, 1))
+        end
+      end
+    end
+  end
 end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -190,4 +190,38 @@ RSpec.describe Scheme, type: :model do
       expect(all_schemes[2].status).to eq(:incomplete)
     end
   end
+
+  describe "available_from" do
+    context "when the scheme was created at the start of the 2022/23 collection window" do
+      let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2022, 4, 6)) }
+
+      it "returns the beginning of 22/23 collection window" do
+        expect(scheme.available_from).to eq(Time.zone.local(2022, 4, 1))
+      end
+    end
+
+    context "when the scheme was created at the end of the 2022/23 collection window" do
+      let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2023, 2, 6)) }
+
+      it "returns the beginning of 22/23 collection window" do
+        expect(scheme.available_from).to eq(Time.zone.local(2022, 4, 1))
+      end
+    end
+
+    context "when the scheme was created at the start of the 2021/22 collection window" do
+      let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2021, 4, 6)) }
+
+      it "returns the beginning of 21/22 collection window" do
+        expect(scheme.available_from).to eq(Time.zone.local(2021, 4, 1))
+      end
+    end
+
+    context "when the scheme was created at the end of the 2021/22 collection window" do
+      let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2022, 2, 6)) }
+
+      it "returns the beginning of 21/22 collection window" do
+        expect(scheme.available_from).to eq(Time.zone.local(2021, 4, 1))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sets the `available_from` date to the beginning of the collection period in which the location or scheme have been created.

Before (if no `startdate` exists) it was setting it to the beginning of the current collection window if it was created later than the beginning of the collection window.

However if it was created before the current collection window start date, it was being set to creation date.

This would become an issue when we reach the next collection year, because all of the locations that were created after the current collection year start date will have their `available_from` dates changed to a year later.