### PR TITLE
1628: a scheme's owning organisation must hold stock

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -213,7 +213,7 @@ class Scheme < ApplicationRecord
   end
 
   def validate_owning_organisation
-    if !owning_organisation.holds_own_stock?
+    unless owning_organisation.holds_own_stock?
       errors.add(:owning_organisation_id, :does_not_own_stock, message: I18n.t("validations.scheme.owning_organisation.does_not_own_stock"))
     end
   end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -215,7 +215,6 @@ class Scheme < ApplicationRecord
   def validate_owning_organisation
     if !owning_organisation.holds_own_stock?
       errors.add(:owning_organisation_id, :does_not_own_stock, message: I18n.t("validations.scheme.owning_organisation.does_not_own_stock"))
-      owning_organisation = nil
     end
   end
 

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -21,7 +21,7 @@ class Scheme < ApplicationRecord
   scope :order_by_completion, -> { order("confirmed ASC NULLS FIRST") }
   scope :order_by_service_name, -> { order(service_name: :asc) }
 
-  validate :validate_confirmed
+  validate :validate_confirmed, :validate_owning_organisation
 
   auto_strip_attributes :service_name
 
@@ -209,6 +209,13 @@ class Scheme < ApplicationRecord
           self.confirmed = false
         end
       end
+    end
+  end
+
+  def validate_owning_organisation
+    if !owning_organisation.holds_own_stock?
+      errors.add(:owning_organisation_id, :does_not_own_stock, message: I18n.t("validations.scheme.owning_organisation.does_not_own_stock"))
+      owning_organisation = nil
     end
   end
 

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -21,7 +21,8 @@ class Scheme < ApplicationRecord
   scope :order_by_completion, -> { order("confirmed ASC NULLS FIRST") }
   scope :order_by_service_name, -> { order(service_name: :asc) }
 
-  validate :validate_confirmed, :validate_owning_organisation
+  validate :validate_confirmed
+  validate :validate_owning_organisation
 
   auto_strip_attributes :service_name
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,8 @@ en:
         before_deactivation: "This scheme was deactivated on %{date}. The reactivation date must be on or after deactivation date"
       deactivation:
         during_deactivated_period: "The scheme is already deactivated during this date, please enter a different date"
+      owning_organisation:
+        does_not_own_stock: "Enter an organisation that owns housing stock"
 
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -186,7 +186,7 @@ unless Rails.env.test?
       address_line1: "Higher Kingston",
       address_line2: "Yeovil",
       postcode: "BA21 4AT",
-      holds_own_stock: false,
+      holds_own_stock: true,
       other_stock_owners: "None",
       managing_agents_label: "None",
       provider_type: "LA",

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Scheme, type: :model do
 
     context "when the owning organisation is set as a non-stock-owning organisation" do
       it "throws the correct validation error" do
-        expect { scheme.update!({ owning_organisation_id: non_stock_owning_org.id }) }.to raise_error(ActiveRecord::RecordInvalid, /#{I18n.t("validations.scheme.owning_organisation.does_not_own_stock")}/)
+        expect { scheme.update!({ owning_organisation_id: non_stock_owning_org.id }) }.to raise_error(ActiveRecord::RecordInvalid, /Enter an organisation that owns housing stock/)
       end
     end
   end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Scheme, type: :model do
 
     context "when the owning organisation is set as a non-stock-owning organisation" do
       it "throws the correct validation error" do
-        expect { scheme.update!({ owning_organisation_id: non_stock_owning_org.id }) }.to raise_error(ActiveRecord::RecordInvalid, /Enter an organisation that owns housing stock/)
+        expect { scheme.update!({ owning_organisation: non_stock_owning_org }) }.to raise_error(ActiveRecord::RecordInvalid, /Enter an organisation that owns housing stock/)
       end
     end
   end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -209,4 +209,16 @@ RSpec.describe Scheme, type: :model do
       end
     end
   end
+
+  describe "owning organisation" do
+    let(:stock_owning_org) { FactoryBot.create(:organisation, holds_own_stock: true) }
+    let(:non_stock_owning_org) { FactoryBot.create(:organisation, holds_own_stock: false) }
+    let(:scheme) { FactoryBot.create(:scheme, owning_organisation_id: stock_owning_org.id) }
+
+    context "when the owning organisation is set as a non-stock-owning organisation" do
+      it "throws the correct validation error" do
+        expect { scheme.update!({ owning_organisation_id: non_stock_owning_org.id }) }.to raise_error(ActiveRecord::RecordInvalid, /#{I18n.t("validations.scheme.owning_organisation.does_not_own_stock")}/)
+      end
+    end
+  end
 end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -941,7 +941,7 @@ RSpec.describe SchemesController, type: :request do
       end
     end
 
-    context "when signed in as a support" do
+    context "when signed in as a support user" do
       let(:user) { FactoryBot.create(:user, :support) }
       let(:scheme_to_update) { FactoryBot.create(:scheme, owning_organisation: user.organisation, confirmed: nil) }
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -674,7 +674,7 @@ RSpec.describe SchemesController, type: :request do
           } }
         end
 
-        it "renders primary client group after successful update" do
+        it "renders the same page with error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content("Create a new supported housing scheme")
           expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.service_name.invalid"))
@@ -970,7 +970,7 @@ RSpec.describe SchemesController, type: :request do
           } }
         end
 
-        it "renders primary client group after successful update" do
+        it "renders the same page with error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content("Create a new supported housing scheme")
           expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.owning_organisation_id.invalid"))

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -611,7 +611,7 @@ RSpec.describe SchemesController, type: :request do
         it "displays the new page with an error message" do
           post "/schemes", params: params
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(page).to have_content(I18n.t("validations.scheme.owning_organisation.does_not_own_stock"))
+          expect(page).to have_content("Enter an organisation that owns housing stock")
         end
       end
     end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -585,16 +585,6 @@ RSpec.describe SchemesController, type: :request do
           expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.owning_organisation_id.invalid"))
         end
       end
-
-      context "when required organisation id param is missing" do
-        let(:params) { { "scheme" => { "service_name" => "qweqwer", "sensitive" => "Yes", "owning_organisation_id" => "", "scheme_type" => "Foyer", "registered_under_care_act" => "Yes – part registered as a care home" } } }
-
-        it "displays the new page with an error message" do
-          post "/schemes", params: params
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.owning_organisation_id.invalid"))
-        end
-      end
     end
   end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -585,6 +585,21 @@ RSpec.describe SchemesController, type: :request do
           expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.owning_organisation_id.invalid"))
         end
       end
+
+      context "when organisation id param refers to a non-stock-owning organisation" do
+        let(:organisation_which_does_not_own_stock) { FactoryBot.create(:organisation, holds_own_stock: false) }
+        let(:params) do
+          { scheme: {
+            owning_organisation_id: organisation_which_does_not_own_stock.id,
+          } }
+        end
+
+        it "displays the new page with an error message" do
+          post "/schemes", params: params
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.scheme.owning_organisation.does_not_own_stock"))
+        end
+      end
     end
   end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -662,7 +662,6 @@ RSpec.describe SchemesController, type: :request do
           { scheme: {
             service_name: "",
             managing_organisation_id: "",
-            owning_organisation_id: "",
             primary_client_group: "",
             secondary_client_group: "",
             scheme_type: "",

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -494,7 +494,7 @@ RSpec.describe SchemesController, type: :request do
         let(:organisation) { FactoryBot.create(:organisation) }
         let(:params) do
           { scheme: {
-            owning_organisation_id: organisation.id,
+            owning_organisation: organisation,
           } }
         end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
-      context "when missing required scheme params" do
+      context "when required params are missing" do
         let(:params) do
           { scheme: { service_name: "",
                       scheme_type: "",
@@ -580,7 +580,7 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
-      context "when missing required scheme params" do
+      context "when required params are missing" do
         let(:params) do
           { scheme: { service_name: "",
                       scheme_type: "",
@@ -657,7 +657,7 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
-      context "when params are missing" do
+      context "when required params are missing" do
         let(:params) do
           { scheme: {
             service_name: "",
@@ -953,7 +953,7 @@ RSpec.describe SchemesController, type: :request do
         patch "/schemes/#{scheme_to_update.id}", params:
       end
 
-      context "when params are missing" do
+      context "when required params are missing" do
         let(:params) do
           { scheme: {
             service_name: "",

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -492,11 +492,7 @@ RSpec.describe SchemesController, type: :request do
 
       context "when the organisation id param is included" do
         let(:organisation) { FactoryBot.create(:organisation) }
-        let(:params) do
-          { scheme: {
-            owning_organisation: organisation,
-          } }
-        end
+        let(:params) { { scheme: { owning_organisation: organisation } } }
 
         it "sets the owning organisation correctly" do
           post "/schemes", params: params
@@ -602,11 +598,7 @@ RSpec.describe SchemesController, type: :request do
 
       context "when organisation id param refers to a non-stock-owning organisation" do
         let(:organisation_which_does_not_own_stock) { FactoryBot.create(:organisation, holds_own_stock: false) }
-        let(:params) do
-          { scheme: {
-            owning_organisation_id: organisation_which_does_not_own_stock.id,
-          } }
-        end
+        let(:params) { { scheme: { owning_organisation_id: organisation_which_does_not_own_stock.id } } }
 
         it "displays the new page with an error message" do
           post "/schemes", params: params

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -489,6 +489,20 @@ RSpec.describe SchemesController, type: :request do
           expect(page).to have_content(I18n.t("activerecord.errors.models.scheme.attributes.service_name.invalid"))
         end
       end
+
+      context "when the organisation id param is included" do
+        let(:organisation) { FactoryBot.create(:organisation) }
+        let(:params) do
+          { scheme: {
+            owning_organisation_id: organisation.id,
+          } }
+        end
+
+        it "sets the owning organisation correctly" do
+          post "/schemes", params: params
+          expect(Scheme.last.owning_organisation_id).to eq(user.organisation_id)
+        end
+      end
     end
 
     context "when signed in as a support user" do


### PR DESCRIPTION
## Context

* https://digital.dclg.gov.uk/jira/browse/CLDC-1628
* Steer from Jemma: this ticket should **only cover** adding validation such that users should be presented with an error if they select a non-stock-owning org for the "Which organisation owns the housing stock for this scheme?" question.

## The changes
* Added a `validate_owning_organisation` method onto the `Scheme` model (which uses new validation text added to `config/locales/en.yml`).
* Tests (all in `spec/requests/schemes_controller_spec.rb`)
  * Test to check that entering an invalid owning org should trigger the validation error mentioned above.
  * Test to check that when the user is a data coordinator, the owning org of a scheme is set as the user's org even if when creating the scheme a different owning org was specified.
  * Removed a test for `owning_organisation_id` being missing for support users, because the test above it already covered that case.
  * Removed `owning_organisation_id` from a 'missing required params' test for data coordinators, since it is not a required param for data coordinators.
  * Minor improvements to some test names/descriptions.

## Screenshots
<img width="745" alt="image" src="https://user-images.githubusercontent.com/63662292/205112537-b638ca3d-003f-40fa-b964-8235f05ebdfc.png">
<img width="706" alt="image" src="https://user-images.githubusercontent.com/63662292/205112643-d8c26a09-2ab7-43a3-ac9f-504c09619873.png">

## Questions / things I wasn't sure about
* Does it make sense to also add a test in `spec/models/scheme_spec.rb`? I tried to write one which created a scheme with an invalid owning org and then checked the contents of `errors`, but this didn't work because the creation failed due to the validation I'd written! So my guess is that the only test which makes sense is the one I've already written in `spec/requests/schemes_controller_spec.rb'. Shout if I'm wrong though!
* Some other places I thought it **might** make sense to add tests (all in `spec/requests/schemes_controller_spec.rb`) were as follows. Interested to know if these sound sensible or not (I couldn't work out how to check the contents of an accessible autocomplete box, so thought I'd wait to see if it was even a good idea before spending more time on this).
  * describe "#edit_name"
    * When signed in as a data coordinator, a test could check that the scheme's owning org (i.e. the user's organisation) is displayed in the accessible autocomplete box.
    * When signed in as a support user, a test could check that the scheme's owning org  is displayed in the accessible autocomplete box.

Thanks for reviewing!