### PR TITLE
WIP CLDC-1688 Update logs page + banner

### DIFF
--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -13,6 +13,7 @@ class LettingsLogsController < LogsController
         @pagy, @logs = pagy(unpaginated_filtered_logs)
         @searched = search_term.presence
         @total_count = all_logs.size
+        @logs_to_update = LettingsLog.where(created_by: current_user, impacted_by_scheme_deactivation: true).count
         render "logs/index"
       end
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -43,8 +43,16 @@ class LocationsController < ApplicationController
   end
 
   def deactivate
-    if @location.location_deactivation_periods.create!(deactivation_date: params[:deactivation_date]) && reset_location_and_scheme_for_logs!
+    if @location.location_deactivation_periods.create!(deactivation_date: params[:deactivation_date])
+      logs = reset_location_and_scheme_for_logs!
+
       flash[:notice] = deactivate_success_notice
+      LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
+        logs.to_a,
+        url_for(controller: "update_logs", action: "show"),
+        @location.scheme.service_name,
+        @location.postcode,
+      )
     end
     redirect_to scheme_location_path(@scheme, @location)
   end
@@ -214,7 +222,9 @@ private
   end
 
   def reset_location_and_scheme_for_logs!
-    @location.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time).update!(location: nil, scheme: nil)
+    logs = @location.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time)
+    logs.update!(location: nil, scheme: nil, impacted_by_scheme_deactivation: true)
+    logs
   end
 
   def toggle_date(key)

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -344,6 +344,7 @@ private
   end
 
   def reset_location_and_scheme_for_logs!
-    @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time).update!(location: nil, scheme: nil)
+    @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time).update!(location: nil, scheme: nil, impacted_by_scheme_deactivation: true)
+    # TODO: E-mail users
   end
 end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -44,8 +44,15 @@ class SchemesController < ApplicationController
   end
 
   def deactivate
-    if @scheme.scheme_deactivation_periods.create!(deactivation_date: params[:deactivation_date]) && reset_location_and_scheme_for_logs!
+    if @scheme.scheme_deactivation_periods.create!(deactivation_date: params[:deactivation_date])
+      logs = reset_location_and_scheme_for_logs!
+
       flash[:notice] = deactivate_success_notice
+      LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
+        logs.to_a,
+        url_for(controller: "update_logs", action: "show"),
+        @scheme.service_name,
+      )
     end
     redirect_to scheme_details_path(@scheme)
   end
@@ -344,7 +351,8 @@ private
   end
 
   def reset_location_and_scheme_for_logs!
-    @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time).update!(location: nil, scheme: nil, impacted_by_scheme_deactivation: true)
-    # TODO: E-mail users
+    logs = @scheme.lettings_logs.filter_by_before_startdate(params[:deactivation_date].to_time)
+    logs.update!(location: nil, scheme: nil, impacted_by_scheme_deactivation: true)
+    logs
   end
 end

--- a/app/controllers/update_logs_controller.rb
+++ b/app/controllers/update_logs_controller.rb
@@ -1,0 +1,8 @@
+class UpdateLogsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @logs = LettingsLog.where(created_by: current_user, impacted_by_scheme_deactivation: true)
+    render "logs/update_logs"
+  end
+end

--- a/app/mailers/location_or_scheme_deactivation_mailer.rb
+++ b/app/mailers/location_or_scheme_deactivation_mailer.rb
@@ -1,0 +1,38 @@
+class LocationOrSchemeDeactivationMailer < NotifyMailer
+  DEACTIVATION_TEMPLATE_ID = "8d07a8c3-a4e3-4102-8be7-4ee79e4183fd".freeze
+
+  def send_deactivation_mail(user, log_count, update_logs_url, scheme_name, postcode = nil)
+    send_email(
+      user.email,
+      DEACTIVATION_TEMPLATE_ID,
+      {
+        log_count:,
+        log_or_logs: log_count == 1 ? "log" : "logs",
+        update_logs_url:,
+        location_or_scheme_description: description(scheme_name, postcode),
+      },
+    )
+  end
+
+  def send_deactivation_mails(logs, update_logs_url, scheme_name, postcode = nil)
+    counts_by_user(logs).each do |user, count|
+      send_deactivation_mail(user, count, update_logs_url, scheme_name, postcode) if user
+    end
+  end
+
+private
+
+  def counts_by_user(logs)
+    logs.each_with_object(Hash.new(0)) do |log, counts|
+      counts[log.created_by] += 1
+    end
+  end
+
+  def description(scheme_name, postcode)
+    if postcode
+      "the #{postcode} location from the #{scheme_name} scheme"
+    else
+      "the #{scheme_name} scheme"
+    end
+  end
+end

--- a/app/services/csv/lettings_log_csv_service.rb
+++ b/app/services/csv/lettings_log_csv_service.rb
@@ -1,6 +1,6 @@
 module Csv
   class LettingsLogCsvService
-    CSV_FIELDS_TO_OMIT = %w[hhmemb net_income_value_check first_time_property_let_as_social_housing renttype needstype postcode_known is_la_inferred totchild totelder totadult net_income_known is_carehome previous_la_known is_previous_la_inferred age1_known age2_known age3_known age4_known age5_known age6_known age7_known age8_known letting_allocation_unknown details_known_2 details_known_3 details_known_4 details_known_5 details_known_6 details_known_7 details_known_8 rent_type_detail wrent wscharge wpschrge wsupchrg wtcharge wtshortfall rent_value_check old_form_id old_id retirement_value_check tshortfall_known pregnancy_value_check hhtype new_old vacdays la prevloc].freeze
+    CSV_FIELDS_TO_OMIT = %w[hhmemb net_income_value_check first_time_property_let_as_social_housing renttype needstype postcode_known is_la_inferred totchild totelder totadult net_income_known is_carehome previous_la_known is_previous_la_inferred age1_known age2_known age3_known age4_known age5_known age6_known age7_known age8_known letting_allocation_unknown details_known_2 details_known_3 details_known_4 details_known_5 details_known_6 details_known_7 details_known_8 rent_type_detail wrent wscharge wpschrge wsupchrg wtcharge wtshortfall rent_value_check old_form_id old_id retirement_value_check tshortfall_known pregnancy_value_check hhtype new_old vacdays la prevloc impacted_by_scheme_deactivation].freeze
 
     def initialize(user)
       @user = user

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -4,6 +4,18 @@
 <% content_for :title, title %>
 
 <% if current_page?(controller: 'lettings_logs', action: 'index') %>
+  <% if @logs_to_update > 0 %>
+    <%= govuk_notification_banner(
+      title_text: "Important",
+      title_heading_level: 3,
+      title_id: "impacted-logs-banner",
+    ) do |notification_banner| %>
+      <% notification_banner.heading(text: "A scheme has changed and it has affected #{@logs_to_update} #{@logs_to_update > 1 ? 'logs' : 'log'}") %>
+      <div class="govuk-notification-banner__heading">
+        <a class="govuk-notification-banner__link" href="./lettings-logs/update-logs">Update logs</a>
+      </div>
+    <% end %>
+  <% end %>
   <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Lettings logs", sub: nil } : { main: "Lettings logs", sub: current_user.organisation.name } %>
 <% elsif current_page?(controller: 'sales_logs', action: 'index') %>
   <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Sales logs", sub: nil } : { main: "Sales logs", sub: current_user.organisation.name } %>

--- a/app/views/logs/update_logs.html.erb
+++ b/app/views/logs/update_logs.html.erb
@@ -1,0 +1,38 @@
+<% content_for :title, "Update logs" %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
+  <h1 class="govuk-heading-xl">You need to update <%= @logs.count %> logs</h1>
+
+  <p class="govuk-body">
+    Some scheme details have changed, and now the following <%= @logs.count %> logs need updating.
+  </p>
+  <p class="govuk-body">
+    You'll have to answer a few questions for each log.
+  </p>
+</div>
+
+<div class="govuk-grid-row">
+  <%= govuk_table do |table|
+        table.head do |head|
+          head.row do |row|
+            row.cell(header: true, text: "Log ID")
+            row.cell(header: true, text: "Tenancy code")
+            row.cell(header: true, text: "Property reference")
+            row.cell(header: true, text: "Status")
+            row.cell # "Update now" column has no heading
+          end
+        end
+
+        table.body do |body|
+          @logs.each do |log|
+            body.row do |row|
+              row.cell(header: true, text: log.id)
+              row.cell(text: log.tenancycode)
+              row.cell(text: log.propcode)
+              row.cell { status_tag(log.status) }
+              row.cell(numeric: true) { govuk_link_to("Update now", "#") } # "numeric" to right-align
+            end
+          end
+        end
+      end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
       get "csv-download", to: "lettings_logs#download_csv"
       post "email-csv", to: "lettings_logs#email_csv"
       get "csv-confirmation", to: "lettings_logs#csv_confirmation"
+      get "update-logs", to: "update_logs#show"
     end
 
     member do

--- a/db/migrate/20221124171430_add_impacted_by_scheme_deactivation.rb
+++ b/db/migrate/20221124171430_add_impacted_by_scheme_deactivation.rb
@@ -1,0 +1,13 @@
+class AddImpactedBySchemeDeactivation < ActiveRecord::Migration[7.0]
+  def up
+    change_table :lettings_logs, bulk: true do |t|
+      t.column :impacted_by_scheme_deactivation, :boolean
+    end
+  end
+
+  def down
+    change_table :lettings_logs, bulk: true do |t|
+      t.remove :impacted_by_scheme_deactivation
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_24_171430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -237,6 +237,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
     t.integer "void_date_value_check"
     t.integer "housingneeds_type"
     t.integer "housingneeds_other"
+    t.boolean "impacted_by_scheme_deactivation"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"
     t.index ["managing_organisation_id"], name: "index_lettings_logs_on_managing_organisation_id"
@@ -345,12 +346,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
     t.integer "jointmore"
     t.integer "jointpur"
     t.integer "beds"
-    t.integer "companybuy"
     t.integer "age1"
     t.integer "age1_known"
+    t.integer "companybuy"
     t.string "sex1"
-    t.integer "national"
-    t.string "othernational"
     t.integer "ethnic"
     t.integer "ethnic_group"
     t.integer "buy1livein"
@@ -364,8 +363,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
     t.integer "noint"
     t.integer "buy2livein"
     t.integer "ecstat2"
-    t.integer "privacynotice"
     t.integer "ecstat1"
+    t.integer "national"
+    t.string "othernational"
+    t.integer "privacynotice"
     t.integer "wheel"
     t.integer "hholdcount"
     t.integer "age3"
@@ -374,15 +375,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_130928) do
     t.integer "la_known"
     t.integer "income1"
     t.integer "income1nk"
-    t.integer "details_known_2"
-    t.integer "details_known_3"
-    t.integer "details_known_4"
     t.integer "age4"
     t.integer "age4_known"
     t.integer "age5"
     t.integer "age5_known"
     t.integer "age6"
     t.integer "age6_known"
+    t.integer "details_known_2"
+    t.integer "details_known_3"
+    t.integer "details_known_4"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["managing_organisation_id"], name: "index_sales_logs_on_managing_organisation_id"
     t.index ["owning_organisation_id"], name: "index_sales_logs_on_owning_organisation_id"

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -134,4 +134,34 @@ RSpec.describe "Lettings Log Features" do
       end
     end
   end
+
+  context "when logs the user created have been affected by a scheme deactivation" do
+    let(:user) { create(:user, last_sign_in_at: Time.zone.now) }
+    let!(:my_impacted_logs) do
+      [
+        create(:lettings_log, created_by: user, impacted_by_scheme_deactivation: true),
+        create(:lettings_log, created_by: user, impacted_by_scheme_deactivation: true),
+      ]
+    end
+
+    before do
+      # Non-impacted log
+      create(:lettings_log, created_by: user)
+      # Impacted log for a different user user
+      create(:lettings_log, impacted_by_scheme_deactivation: true)
+
+      visit("/lettings-logs")
+      fill_in("user[email]", with: user.email)
+      fill_in("user[password]", with: user.password)
+      click_button("Sign in")
+    end
+
+    it "displays a banner" do
+      expect(page).to have_content("A scheme has changed")
+    end
+
+    it "displays the count of affected logs" do
+      expect(page).to have_content("it has affected #{my_impacted_logs.count} logs")
+    end
+  end
 end

--- a/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
+++ b/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe LocationOrSchemeDeactivationMailer do
+  let(:notify_client) { instance_double(Notifications::Client) }
+
+  before do
+    allow(Notifications::Client).to receive(:new).and_return(notify_client)
+    allow(notify_client).to receive(:send_email).and_return(true)
+  end
+
+  describe "#send_deactivation_mail" do
+    let(:user) { FactoryBot.create(:user, email: "user@example.com") }
+
+    it "sends a deactivation E-mail via notify" do
+      update_logs_url = :update_logs_url
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user.email,
+        template_id: described_class::DEACTIVATION_TEMPLATE_ID,
+        personalisation: hash_including({ update_logs_url: }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, update_logs_url, "Test Scheme Name", "test postcode")
+    end
+
+    it "singularises 'logs' correctly" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          log_count: 1,
+          log_or_logs: "log",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 1, :update_logs_url, :scheme_name)
+    end
+
+    it "pluralises 'logs' correctly" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          log_count: 2,
+          log_or_logs: "logs",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 2, :update_logs_url, :scheme_name)
+    end
+
+    it "describes a scheme" do
+      scheme_name = "Test Scheme"
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          location_or_scheme_description: "the #{scheme_name} scheme",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, :update_logs_url, scheme_name)
+    end
+
+    it "describes a location within a scheme" do
+      scheme_name = "Test Scheme"
+      postcode = "test postcode"
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          location_or_scheme_description: "the #{postcode} location from the #{scheme_name} scheme",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, :update_logs_url, scheme_name, postcode)
+    end
+  end
+
+  describe "#send_deactivation_mails" do
+    let(:user_a) { FactoryBot.create(:user, email: "user_a@example.com") }
+    let(:user_a_logs) { FactoryBot.create_list(:lettings_log, 1, created_by: user_a) }
+
+    let(:user_b) { FactoryBot.create(:user, email: "user_b@example.com") }
+    let(:user_b_logs) { FactoryBot.create_list(:lettings_log, 3, created_by: user_b) }
+
+    let(:logs) { user_a_logs + user_b_logs }
+
+    it "sends E-mails to the creators of affected logs with counts" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user_a.email,
+        personalisation: hash_including({ log_count: user_a_logs.count }),
+      }))
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user_b.email,
+        personalisation: hash_including({ log_count: user_b_logs.count }),
+      }))
+
+      described_class.new.send_deactivation_mails(logs, :update_logs_url, "Test Scheme", "test postcode")
+    end
+  end
+end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1805,8 +1805,12 @@ RSpec.describe SchemesController, type: :request do
 
       context "when confirming deactivation" do
         let(:params) { { deactivation_date:, confirm: true, deactivation_date_type: "other" } }
+        let(:mailer) { instance_double(LocationOrSchemeDeactivationMailer) }
 
         before do
+          allow(LocationOrSchemeDeactivationMailer).to receive(:new).and_return(mailer)
+          allow(mailer).to receive(:send_deactivation_mails)
+
           Timecop.freeze(Time.utc(2022, 10, 10))
           sign_in user
           patch "/schemes/#{scheme.id}/deactivate", params:
@@ -1833,6 +1837,10 @@ RSpec.describe SchemesController, type: :request do
             lettings_log.reload
             expect(lettings_log.scheme).to eq(nil)
             expect(lettings_log.scheme).to eq(nil)
+          end
+
+          it "sends update E-mails for affected logs" do
+            expect(mailer).to have_received(:send_deactivation_mails).with([lettings_log], "http://www.example.com/lettings-logs/update-logs", scheme.service_name)
           end
         end
 

--- a/spec/services/csv/lettings_log_csv_service_spec.rb
+++ b/spec/services/csv/lettings_log_csv_service_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe Csv::LettingsLogCsvService do
                                    hhtype
                                    new_old
                                    vacdays
+                                   impacted_by_scheme_deactivation
                                    unittype_sh
                                    scheme_code
                                    scheme_service_name


### PR DESCRIPTION
E-mails, banner and update logs page, along with the column to mark the affected logs.

E-mail template is already configured in Notify :)

Approach for the actual questions when they click through to update is up in the air - probably wants to share behaviour with existing form, but the unusual flow (specific subset of questions, flash notice to return to Update logs when done) means we can't just deep link into the normal flow. Haven't found a good way to do that yet.