### PR TITLE
Add a default ordering for schemes

### DIFF
--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -9,7 +9,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.all
+    all_schemes = Scheme.all.order(confirmed: :asc, service_name: :asc)
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -9,7 +9,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.all.order("service_name ASC")
+    all_schemes = Scheme.all
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -9,7 +9,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.all.order(confirmed: :asc, service_name: :asc)
+    all_schemes = Scheme.order(confirmed: :asc, service_name: :asc)
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -21,7 +21,6 @@ class Scheme < ApplicationRecord
   validate :validate_confirmed
 
   auto_strip_attributes :service_name
-  default_scope { order(confirmed: :asc, service_name: :asc) }
 
   SENSITIVE = {
     No: 0,

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -21,6 +21,7 @@ class Scheme < ApplicationRecord
   validate :validate_confirmed
 
   auto_strip_attributes :service_name
+  default_scope { order(confirmed: :asc, service_name: :asc) }
 
   SENSITIVE = {
     No: 0,

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -175,4 +175,19 @@ RSpec.describe Scheme, type: :model do
       end
     end
   end
+
+  describe "all schemes" do
+    before do
+      FactoryBot.create_list(:scheme, 4)
+      FactoryBot.create_list(:scheme, 3, confirmed: false)
+    end
+
+    it "sorts the schemes by status" do
+      all_schemes = described_class.all
+      expect(all_schemes.count).to eq(7)
+      expect(all_schemes[0].status).to eq(:incomplete)
+      expect(all_schemes[1].status).to eq(:incomplete)
+      expect(all_schemes[2].status).to eq(:incomplete)
+    end
+  end
 end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe Scheme, type: :model do
       FactoryBot.create_list(:scheme, 3, confirmed: false)
     end
 
-    it "sorts the schemes by status" do
-      all_schemes = described_class.all
+    it "can sort the schemes by status" do
+      all_schemes = described_class.all.order(confirmed: :asc, service_name: :asc)
       expect(all_schemes.count).to eq(7)
       expect(all_schemes[0].status).to eq(:incomplete)
       expect(all_schemes[1].status).to eq(:incomplete)


### PR DESCRIPTION
Add order for schemes that puts incomplete schemes first and keeps the service name ordering within that.
<img width="977" alt="image" src="https://user-images.githubusercontent.com/54268893/203945825-e617baaf-bdf9-4a77-b07b-55947949d134.png">
