### PR TITLE
Limit review pipeline to single concurrency

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -1,5 +1,7 @@
 name: Review app pipeline
 
+concurrency: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
# Context

- There are occasional errors in the review pipeline. I have yet to pinpoint the problem, one theory is a race condition

# The change

- Ensure that review pipeline cannot run concurrently per pull request