### PR TITLE
bind S3 buckets for review apps

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -145,6 +145,14 @@ jobs:
         run: |
           cf bind-service $APP_NAME $SERVICE_NAME --wait
 
+      - name: Bind S3 buckets services
+        env:
+          APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}
+        run: |
+          cf bind-service $APP_NAME dluhc-core-review-csv-bucket --wait
+          cf bind-service $APP_NAME dluhc-core-review-export-bucket --wait
+          cf bind-service $APP_NAME dluhc-core-review-import-bucket --wait
+
       - name: Start review app
         env:
           APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Context

- Review apps do not connect to any S3 buckets at the moment and need to do so in order to test certain features

# The changes

- On deploy of review apps, bind long lived shared S3 buckets 