### PR TITLE
Add sorting per org

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -19,7 +19,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    all_schemes = Scheme.where(owning_organisation: @organisation).order("confirmed ASC NULLS FIRST", service_name: :asc)
+    all_schemes = Scheme.where(owning_organisation: @organisation).order_by_completion.order_by_service_name
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -19,7 +19,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    all_schemes = Scheme.where(owning_organisation: @organisation)
+    all_schemes = Scheme.where(owning_organisation: @organisation).order(confirmed: :asc, service_name: :asc)
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -19,7 +19,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    all_schemes = Scheme.where(owning_organisation: @organisation).order(confirmed: :asc, service_name: :asc)
+    all_schemes = Scheme.where(owning_organisation: @organisation).order("confirmed ASC NULLS FIRST", service_name: :asc)
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -9,7 +9,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.order("confirmed ASC NULLS FIRST", service_name: :asc)
+    all_schemes = Scheme.order_by_completion.order_by_service_name
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -9,7 +9,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.order(confirmed: :asc, service_name: :asc)
+    all_schemes = Scheme.order("confirmed ASC NULLS FIRST", service_name: :asc)
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -18,6 +18,9 @@ class Scheme < ApplicationRecord
                         .or(filter_by_id(param)).distinct
                     }
 
+  scope :order_by_completion, -> { order("confirmed ASC NULLS FIRST") }
+  scope :order_by_service_name, -> { order(service_name: :asc) }
+
   validate :validate_confirmed
 
   auto_strip_attributes :service_name

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -176,24 +176,6 @@ RSpec.describe Scheme, type: :model do
     end
   end
 
-  describe "all schemes" do
-    before do
-      FactoryBot.create_list(:scheme, 4)
-      FactoryBot.create_list(:scheme, 3, confirmed: false)
-      FactoryBot.create_list(:scheme, 2, confirmed: nil)
-    end
-
-    it "can sort the schemes by status" do
-      all_schemes = described_class.all.order("confirmed ASC NULLS FIRST", service_name: :asc)
-      expect(all_schemes.count).to eq(9)
-      expect(all_schemes[0].status).to eq(:incomplete)
-      expect(all_schemes[1].status).to eq(:incomplete)
-      expect(all_schemes[2].status).to eq(:incomplete)
-      expect(all_schemes[3].status).to eq(:incomplete)
-      expect(all_schemes[4].status).to eq(:incomplete)
-    end
-  end
-
   describe "available_from" do
     context "when the scheme was created at the start of the 2022/23 collection window" do
       let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2022, 4, 6)) }

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -180,14 +180,17 @@ RSpec.describe Scheme, type: :model do
     before do
       FactoryBot.create_list(:scheme, 4)
       FactoryBot.create_list(:scheme, 3, confirmed: false)
+      FactoryBot.create_list(:scheme, 2, confirmed: nil)
     end
 
     it "can sort the schemes by status" do
-      all_schemes = described_class.all.order(confirmed: :asc, service_name: :asc)
-      expect(all_schemes.count).to eq(7)
+      all_schemes = described_class.all.order("confirmed ASC NULLS FIRST", service_name: :asc)
+      expect(all_schemes.count).to eq(9)
       expect(all_schemes[0].status).to eq(:incomplete)
       expect(all_schemes[1].status).to eq(:incomplete)
       expect(all_schemes[2].status).to eq(:incomplete)
+      expect(all_schemes[3].status).to eq(:incomplete)
+      expect(all_schemes[4].status).to eq(:incomplete)
     end
   end
 

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe OrganisationsController, type: :request do
           end
         end
 
+        it "shows incomplete schemes at the top" do
+          schemes[0].update!(confirmed: nil, owning_organisation: user.organisation)
+          schemes[2].update!(confirmed: false, owning_organisation: user.organisation)
+          schemes[4].update!(confirmed: false, owning_organisation: user.organisation)
+          get "/organisations/#{organisation.id}/schemes", headers:, params: {}
+
+          expect(page.all(".govuk-tag")[1].text).to eq("Incomplete")
+          expect(page.all(".govuk-tag")[2].text).to eq("Incomplete")
+          expect(page.all(".govuk-tag")[3].text).to eq("Incomplete")
+        end
+
         context "with schemes that are not in scope for the user, i.e. that they do not belong to" do
           let!(:unauthorised_organisation) { FactoryBot.create(:organisation) }
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe SchemesController, type: :request do
         assert_select ".govuk-tag", text: /Incomplete/, count: 1
       end
 
+      it "shows incomplete schemes at the top" do
+        schemes[0].update!(confirmed: nil)
+        schemes[2].update!(confirmed: false)
+        schemes[4].update!(confirmed: false)
+        get "/schemes"
+
+        expect(page.all(".govuk-tag")[1].text).to eq("Incomplete")
+        expect(page.all(".govuk-tag")[2].text).to eq("Incomplete")
+        expect(page.all(".govuk-tag")[3].text).to eq("Incomplete")
+      end
+
       it "displays a link to check answers page if the scheme is incomplete" do
         scheme = schemes[0]
         scheme.update!(confirmed: nil)


### PR DESCRIPTION
Pull incomplete schemes to the top for specific organisations: 
￼
![](https://user-images.githubusercontent.com/54268893/204533288-1fa315fe-49eb-4017-96a3-3847d04cddac.png)

So far we're only doing that for support user view (all schemes) and not for specific orgs, this should fix it
Also pull schemes with confirmed nil values to the top as they are also incomplete
