### PR TITLE
CLDC-1688 scheme change mailer

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -54,7 +54,7 @@ class LocationsController < ApplicationController
       flash[:notice] = deactivate_success_notice
       LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
         logs.to_a,
-        url_for(controller: "update_logs", action: "show"),
+        url_for(controller: "lettings_logs", action: "update_logs"),
         @location.scheme.service_name,
         @location.postcode,
       )

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -53,7 +53,7 @@ class LocationsController < ApplicationController
 
       flash[:notice] = deactivate_success_notice
       LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
-        logs.to_a,
+        logs,
         url_for(controller: "lettings_logs", action: "update_logs"),
         @location.scheme.service_name,
         @location.postcode,

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -55,7 +55,7 @@ class SchemesController < ApplicationController
       flash[:notice] = deactivate_success_notice
       LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
         logs.to_a,
-        url_for(controller: "update_logs", action: "show"),
+        url_for(controller: "lettings_logs", action: "update_logs"),
         @scheme.service_name,
       )
     end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -53,11 +53,12 @@ class SchemesController < ApplicationController
       logs = reset_location_and_scheme_for_logs!
 
       flash[:notice] = deactivate_success_notice
-      LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
-        logs,
-        url_for(controller: "lettings_logs", action: "update_logs"),
-        @scheme.service_name,
-      )
+      logs.group_by(&:created_by).transform_values(&:count).compact.each do |user, count|
+        LocationOrSchemeDeactivationMailer.send_deactivation_mail(user,
+                                                                  count,
+                                                                  url_for(controller: "lettings_logs", action: "update_logs"),
+                                                                  @scheme.service_name).deliver_later
+      end
     end
     redirect_to scheme_details_path(@scheme)
   end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -54,7 +54,7 @@ class SchemesController < ApplicationController
 
       flash[:notice] = deactivate_success_notice
       LocationOrSchemeDeactivationMailer.new.send_deactivation_mails(
-        logs.to_a,
+        logs,
         url_for(controller: "lettings_logs", action: "update_logs"),
         @scheme.service_name,
       )

--- a/app/mailers/location_or_scheme_deactivation_mailer.rb
+++ b/app/mailers/location_or_scheme_deactivation_mailer.rb
@@ -14,12 +14,6 @@ class LocationOrSchemeDeactivationMailer < NotifyMailer
     )
   end
 
-  def send_deactivation_mails(logs, update_logs_url, scheme_name, postcode = nil)
-    logs.group_by(&:created_by).transform_values(&:count).compact.each do |user, count|
-      send_deactivation_mail(user, count, update_logs_url, scheme_name, postcode)
-    end
-  end
-
 private
 
   def description(scheme_name, postcode)

--- a/app/mailers/location_or_scheme_deactivation_mailer.rb
+++ b/app/mailers/location_or_scheme_deactivation_mailer.rb
@@ -15,18 +15,12 @@ class LocationOrSchemeDeactivationMailer < NotifyMailer
   end
 
   def send_deactivation_mails(logs, update_logs_url, scheme_name, postcode = nil)
-    counts_by_user(logs).each do |user, count|
-      send_deactivation_mail(user, count, update_logs_url, scheme_name, postcode) if user
+    logs.group_by(&:created_by).transform_values(&:count).compact.each do |user, count|
+      send_deactivation_mail(user, count, update_logs_url, scheme_name, postcode)
     end
   end
 
 private
-
-  def counts_by_user(logs)
-    logs.each_with_object(Hash.new(0)) do |log, counts|
-      counts[log.created_by] += 1
-    end
-  end
 
   def description(scheme_name, postcode)
     if postcode

--- a/app/mailers/location_or_scheme_deactivation_mailer.rb
+++ b/app/mailers/location_or_scheme_deactivation_mailer.rb
@@ -1,0 +1,38 @@
+class LocationOrSchemeDeactivationMailer < NotifyMailer
+  DEACTIVATION_TEMPLATE_ID = "8d07a8c3-a4e3-4102-8be7-4ee79e4183fd".freeze
+
+  def send_deactivation_mail(user, log_count, update_logs_url, scheme_name, postcode = nil)
+    send_email(
+      user.email,
+      DEACTIVATION_TEMPLATE_ID,
+      {
+        log_count:,
+        log_or_logs: log_count == 1 ? "log" : "logs",
+        update_logs_url:,
+        location_or_scheme_description: description(scheme_name, postcode),
+      },
+    )
+  end
+
+  def send_deactivation_mails(logs, update_logs_url, scheme_name, postcode = nil)
+    counts_by_user(logs).each do |user, count|
+      send_deactivation_mail(user, count, update_logs_url, scheme_name, postcode) if user
+    end
+  end
+
+private
+
+  def counts_by_user(logs)
+    logs.each_with_object(Hash.new(0)) do |log, counts|
+      counts[log.created_by] += 1
+    end
+  end
+
+  def description(scheme_name, postcode)
+    if postcode
+      "the #{postcode} location from the #{scheme_name} scheme"
+    else
+      "the #{scheme_name} scheme"
+    end
+  end
+end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,4 +1,4 @@
-class NotifyMailer
+class NotifyMailer < ApplicationMailer
   require "notifications/client"
 
   def notify_client

--- a/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
+++ b/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe LocationOrSchemeDeactivationMailer do
+  let(:notify_client) { instance_double(Notifications::Client) }
+
+  before do
+    allow(Notifications::Client).to receive(:new).and_return(notify_client)
+    allow(notify_client).to receive(:send_email).and_return(true)
+  end
+
+  describe "#send_deactivation_mail" do
+    let(:user) { FactoryBot.create(:user, email: "user@example.com") }
+
+    it "sends a deactivation E-mail via notify" do
+      update_logs_url = :update_logs_url
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user.email,
+        template_id: described_class::DEACTIVATION_TEMPLATE_ID,
+        personalisation: hash_including({ update_logs_url: }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, update_logs_url, "Test Scheme Name", "test postcode")
+    end
+
+    it "singularises 'logs' correctly" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          log_count: 1,
+          log_or_logs: "log",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 1, :update_logs_url, :scheme_name)
+    end
+
+    it "pluralises 'logs' correctly" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          log_count: 2,
+          log_or_logs: "logs",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 2, :update_logs_url, :scheme_name)
+    end
+
+    it "describes a scheme" do
+      scheme_name = "Test Scheme"
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          location_or_scheme_description: "the #{scheme_name} scheme",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, :update_logs_url, scheme_name)
+    end
+
+    it "describes a location within a scheme" do
+      scheme_name = "Test Scheme"
+      postcode = "test postcode"
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        personalisation: hash_including({
+          location_or_scheme_description: "the #{postcode} location from the #{scheme_name} scheme",
+        }),
+      }))
+
+      described_class.new.send_deactivation_mail(user, 3, :update_logs_url, scheme_name, postcode)
+    end
+  end
+
+  describe "#send_deactivation_mails" do
+    let(:user_a) { FactoryBot.create(:user, email: "user_a@example.com") }
+    let(:user_a_logs) { FactoryBot.create_list(:lettings_log, 1, created_by: user_a) }
+
+    let(:user_b) { FactoryBot.create(:user, email: "user_b@example.com") }
+    let(:user_b_logs) { FactoryBot.create_list(:lettings_log, 3, created_by: user_b) }
+
+    let(:logs) { user_a_logs + user_b_logs }
+
+    it "sends E-mails to the creators of affected logs with counts" do
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user_a.email,
+        personalisation: hash_including({ log_count: user_a_logs.count }),
+      }))
+
+      expect(notify_client).to receive(:send_email).with(hash_including({
+        email_address: user_b.email,
+        personalisation: hash_including({ log_count: user_b_logs.count }),
+      }))
+
+      described_class.new.send_deactivation_mails(logs, :update_logs_url, "Test Scheme", "test postcode")
+    end
+  end
+end

--- a/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
+++ b/spec/mailers/location_or_scheme_deactivation_mailer_spec.rb
@@ -70,28 +70,4 @@ RSpec.describe LocationOrSchemeDeactivationMailer do
       described_class.new.send_deactivation_mail(user, 3, :update_logs_url, scheme_name, postcode)
     end
   end
-
-  describe "#send_deactivation_mails" do
-    let(:user_a) { FactoryBot.create(:user, email: "user_a@example.com") }
-    let(:user_a_logs) { FactoryBot.create_list(:lettings_log, 1, created_by: user_a) }
-
-    let(:user_b) { FactoryBot.create(:user, email: "user_b@example.com") }
-    let(:user_b_logs) { FactoryBot.create_list(:lettings_log, 3, created_by: user_b) }
-
-    let(:logs) { user_a_logs + user_b_logs }
-
-    it "sends E-mails to the creators of affected logs with counts" do
-      expect(notify_client).to receive(:send_email).with(hash_including({
-        email_address: user_a.email,
-        personalisation: hash_including({ log_count: user_a_logs.count }),
-      }))
-
-      expect(notify_client).to receive(:send_email).with(hash_including({
-        email_address: user_b.email,
-        personalisation: hash_including({ log_count: user_b_logs.count }),
-      }))
-
-      described_class.new.send_deactivation_mails(logs, :update_logs_url, "Test Scheme", "test postcode")
-    end
-  end
 end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1336,8 +1336,12 @@ RSpec.describe LocationsController, type: :request do
 
       context "when confirming deactivation" do
         let(:params) { { deactivation_date:, confirm: true, deactivation_date_type: "other" } }
+        let(:mailer) { instance_double(LocationOrSchemeDeactivationMailer) }
 
         before do
+          allow(LocationOrSchemeDeactivationMailer).to receive(:new).and_return(mailer)
+          allow(mailer).to receive(:send_deactivation_mails)
+
           Timecop.freeze(Time.utc(2022, 10, 10))
           sign_in user
           patch "/schemes/#{scheme.id}/locations/#{location.id}/deactivate", params:
@@ -1369,6 +1373,10 @@ RSpec.describe LocationsController, type: :request do
             expect(lettings_log.unresolved).to eq(nil)
             lettings_log.reload
             expect(lettings_log.unresolved).to eq(true)
+          end
+
+          it "sends update E-mails for affected logs" do
+            expect(mailer).to have_received(:send_deactivation_mails).with([lettings_log], "http://www.example.com/lettings-logs/update-logs", scheme.service_name, location.postcode)
           end
         end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1865,8 +1865,6 @@ RSpec.describe SchemesController, type: :request do
         let(:mailer) { instance_double(LocationOrSchemeDeactivationMailer) }
 
         before do
-          allow(LocationOrSchemeDeactivationMailer).to receive_message_chain(:send_deactivation_mail, :deliver_later).and_return(true)
-
           Timecop.freeze(Time.utc(2022, 10, 10))
           sign_in user
         end
@@ -1925,12 +1923,9 @@ RSpec.describe SchemesController, type: :request do
 
         context "and the users need to be notified" do
           it "sends E-mails to the creators of affected logs with counts" do
-            expect(LocationOrSchemeDeactivationMailer).to receive(:send_deactivation_mail).with(user,
-                                                                                                1,
-                                                                                                url_for(controller: "lettings_logs", action: "update_logs"),
-                                                                                                scheme.service_name)
-
-            patch "/schemes/#{scheme.id}/deactivate", params:
+            expect {
+              patch "/schemes/#{scheme.id}/deactivate", params:
+            }.to enqueue_job(ActionMailer::MailDeliveryJob)
           end
         end
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1791,7 +1791,7 @@ RSpec.describe SchemesController, type: :request do
       let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation, created_at: Time.zone.today) }
       let!(:location) { FactoryBot.create(:location, scheme:) }
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
-      let!(:lettings_log) { FactoryBot.create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
+      let!(:lettings_log) { FactoryBot.create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation, created_by: user) }
       let(:startdate) { Time.utc(2022, 10, 11) }
       let(:setup_schemes) { nil }
 
@@ -1865,29 +1865,31 @@ RSpec.describe SchemesController, type: :request do
         let(:mailer) { instance_double(LocationOrSchemeDeactivationMailer) }
 
         before do
-          allow(LocationOrSchemeDeactivationMailer).to receive(:new).and_return(mailer)
-          allow(mailer).to receive(:send_deactivation_mails)
+          allow(LocationOrSchemeDeactivationMailer).to receive_message_chain(:send_deactivation_mail, :deliver_later).and_return(true)
 
           Timecop.freeze(Time.utc(2022, 10, 10))
           sign_in user
-          patch "/schemes/#{scheme.id}/deactivate", params:
         end
 
         after do
           Timecop.unfreeze
         end
 
-        it "updates existing scheme with valid deactivation date and renders scheme page" do
-          follow_redirect!
-          follow_redirect!
-          expect(response).to have_http_status(:ok)
-          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-          scheme.reload
-          expect(scheme.scheme_deactivation_periods.count).to eq(1)
-          expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivation_date)
-        end
-
         context "and a log startdate is after scheme deactivation date" do
+          before do
+            patch "/schemes/#{scheme.id}/deactivate", params:
+          end
+
+          it "updates existing scheme with valid deactivation date and renders scheme page" do
+            follow_redirect!
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+            scheme.reload
+            expect(scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivation_date)
+          end
+
           it "clears the scheme and scheme answers" do
             expect(lettings_log.scheme).to eq(scheme)
             expect(lettings_log.scheme).to eq(scheme)
@@ -1900,10 +1902,6 @@ RSpec.describe SchemesController, type: :request do
             expect(lettings_log.unresolved).to eq(nil)
             lettings_log.reload
             expect(lettings_log.unresolved).to eq(true)
-          end
-
-          it "sends update E-mails for affected logs" do
-            expect(mailer).to have_received(:send_deactivation_mails).with([lettings_log], "http://www.example.com/lettings-logs/update-logs", scheme.service_name)
           end
         end
 
@@ -1922,6 +1920,17 @@ RSpec.describe SchemesController, type: :request do
             expect(lettings_log.unresolved).to eq(nil)
             lettings_log.reload
             expect(lettings_log.unresolved).to eq(nil)
+          end
+        end
+
+        context "and the users need to be notified" do
+          it "sends E-mails to the creators of affected logs with counts" do
+            expect(LocationOrSchemeDeactivationMailer).to receive(:send_deactivation_mail).with(user,
+                                                                                                1,
+                                                                                                url_for(controller: "lettings_logs", action: "update_logs"),
+                                                                                                scheme.service_name)
+
+            patch "/schemes/#{scheme.id}/deactivate", params:
           end
         end
       end


### PR DESCRIPTION
Extracted just the E-mail parts of #1029, updated URL to match #1035.

As per #1029, E-mail template exists and is configured to match designs 🙂 