### PR TITLE
Cldc 1211 close collection period

### DIFF
--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -25,11 +25,13 @@
               <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
             <% end %>
           <% end %>
-          <% row.action(
-            text: question.action_text(log),
-            href: question.action_href(log, question.page.id),
-            visually_hidden_text: question.check_answer_label.to_s.downcase,
-          ) %>
+          <% if @log.form.end_date > Time.zone.today %>
+            <% row.action(
+              text: question.action_text(log),
+              href: question.action_href(log, question.page.id),
+              visually_hidden_text: question.check_answer_label.to_s.downcase,
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -25,7 +25,7 @@
               <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
             <% end %>
           <% end %>
-          <% if @log.form.end_date > Time.zone.today %>
+          <% if @log.collection_period_open? %>
             <% row.action(
               text: question.action_text(log),
               href: question.action_href(log, question.page.id),

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -50,7 +50,7 @@ class FormController < ApplicationController
       page_id = request.path.split("/")[-1].underscore
       @page = @log.form.get_page(page_id)
       @subsection = @log.form.subsection_for_page(@page)
-      if @page.routed_to?(@log, current_user)
+      if @page.routed_to?(@log, current_user) && @log.collection_period_open?
         render "form/page"
       else
         redirect_to lettings_log_path(@log)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -2,6 +2,7 @@ class FormController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource, only: %i[submit_form review]
   before_action :find_resource_by_named_id, except: %i[submit_form review]
+  before_action :check_collection_period, only: %i[submit_form show_page]
 
   def submit_form
     if @log
@@ -50,7 +51,7 @@ class FormController < ApplicationController
       page_id = request.path.split("/")[-1].underscore
       @page = @log.form.get_page(page_id)
       @subsection = @log.form.subsection_for_page(@page)
-      if @page.routed_to?(@log, current_user) && @log.collection_period_open?
+      if @page.routed_to?(@log, current_user)
         render "form/page"
       else
         redirect_to lettings_log_path(@log)
@@ -175,5 +176,11 @@ private
       session["fields"][question.id] = @log[question.id] = responses_for_page[question.id]
       responses_for_page[question.id].nil? || responses_for_page[question.id].blank?
     end
+  end
+
+  def check_collection_period
+    return unless @log
+
+    redirect_to lettings_log_path(@log) unless @log.collection_period_open?
   end
 end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -39,7 +39,7 @@ module TasklistHelper
 
   def review_log_text(log)
     if log.collection_period_open?
-      "You can #{govuk_link_to 'review and make changes to this log', "/lettings-logs/#{log.id}/review"} until #{(log.form.end_date + 1.day).to_formatted_s(:govuk_date)}.".html_safe
+      "You can #{govuk_link_to 'review and make changes to this log', review_lettings_log_path(log)} until #{(log.form.end_date + 1.day).to_formatted_s(:govuk_date)}.".html_safe
     else
       "This log is from the #{log.form.start_date.year}/#{log.form.start_date.year + 1} collection window, which is now closed."
     end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -39,7 +39,7 @@ module TasklistHelper
 
   def review_log_text(log)
     if log.collection_period_open?
-      "You can #{govuk_link_to 'review and make changes to this log', review_lettings_log_path(log)} until #{(log.form.end_date + 1.day).to_formatted_s(:govuk_date)}.".html_safe
+      "You can #{govuk_link_to 'review and make changes to this log', review_lettings_log_path(log)} until #{(log.form.end_date).to_formatted_s(:govuk_date)}.".html_safe
     else
       "This log is from the #{log.form.start_date.year}/#{log.form.start_date.year + 1} collection window, which is now closed."
     end

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -38,7 +38,7 @@ module TasklistHelper
   end
 
   def review_log_text(log)
-    if log.form.end_date > Time.zone.today
+    if log.collection_period_open?
       "You can #{govuk_link_to 'review and make changes to this log', "/lettings-logs/#{log.id}/review"} until #{(log.form.end_date + 1.day).to_formatted_s(:govuk_date)}.".html_safe
     else
       "This log is from the #{log.form.start_date.year}/#{log.form.start_date.year + 1} collection window, which is now closed."

--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -36,4 +36,12 @@ module TasklistHelper
       subsection.label
     end
   end
+
+  def review_log_text(log)
+    if log.form.end_date > Time.zone.today
+      "You can #{govuk_link_to 'review and make changes to this log', "/lettings-logs/#{log.id}/review"} until #{(log.form.end_date + 1.day).to_formatted_s(:govuk_date)}.".html_safe
+    else
+      "This log is from the #{log.form.start_date.year}/#{log.form.start_date.year + 1} collection window, which is now closed."
+    end
+  end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -44,6 +44,10 @@ class Log < ApplicationRecord
     managing_organisation&.provider_type
   end
 
+  def collection_period_open?
+    form.end_date > Time.zone.today
+  end
+
 private
 
   def update_status!

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -13,11 +13,13 @@
           <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
         <% end %>
       <% end %>
-      <% row.action(
-        text: question.action_text(@log),
-        href: question.action_href(@log, question.page.id),
-        visually_hidden_text: question.check_answer_label.to_s.downcase,
-      ) %>
+      <% if @log.form.end_date > Time.zone.today %>
+        <% row.action(
+          text: question.action_text(@log),
+          href: question.action_href(@log, question.page.id),
+          visually_hidden_text: question.check_answer_label.to_s.downcase,
+        ) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -13,7 +13,7 @@
           <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
         <% end %>
       <% end %>
-      <% if @log.form.end_date > Time.zone.today %>
+      <% if @log.collection_period_open? %>
         <% row.action(
           text: question.action_text(@log),
           href: question.action_href(@log, question.page.id),

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -11,7 +11,7 @@
       <%= content_for(:title) %>
     </h1>
     <p class="govuk-body">
-      You can review and make changes to this log until 2nd June <%= @log.collection_start_year.present? ? @log.collection_start_year + 1 : "" %>.
+      <%= review_log_text(@log) %>
     </p>
     <% @log.form.sections.map do |section| %>
       <h2 class="govuk-heading-m"><%= section.label %></h2>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -29,7 +29,7 @@
         <%= status_tag(@log.status) %>
       </p>
       <p class="govuk-body">
-        You can <%= govuk_link_to "review and make changes to this log", "/lettings-logs/#{@log.id}/review" %> until 2nd June <%= @log.collection_start_year.present? ? @log.collection_start_year + 1 : "" %>.
+        <%= review_log_text(@log) %>
       </p>
     <% end %>
     <%= render "tasklist" %>

--- a/docs/form/definition.md
+++ b/docs/form/definition.md
@@ -55,6 +55,9 @@ A form has the following attributes:
 - `start_date`: The start date of the form, in ISO 8601 format
 - `end_date`: The end date of the form, in ISO 8601 format
 
+Each form has an `end_date` which for JSON forms is defined in the form definition JSON file and for code defined forms it is set to 1st July, 1 year after the start year.
+Logs with a form that has `end_date` in the past can no longer be edited through the UI.
+
 ## Form views
 
 The main view used for rendering the form is the `app/views/form/page.html.erb` view as the Form contains multiple pages (which live in subsections within sections). This page view then renders the appropriate partials for the question types of the questions on the current page.
@@ -79,3 +82,6 @@ The form controller handles the form submission as well as the rendering of the 
 ## FormHandler helper class
 
 The FormHandler helper is a helper that loads all of the defined forms and initialises them as Form objects. It can also be used to get specific forms if needed.
+When the log type is chosen and the date is entered in the setup section of the form, an appropriate form for that log is selected and associated with the log.
+
+The current collection window gets incremented automatically in `FormHandler` and is determined within the `form_name_from_start_year`by looking at `current_collection_start_year` method which would increment the collection window on the 1st of April each year.

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Accessible Automcomplete" do
   end
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/check_answers_page_spec.rb
+++ b/spec/features/form/check_answers_page_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe "Form Check Answers Page" do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/features/form/checkboxes_spec.rb
+++ b/spec/features/form/checkboxes_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Checkboxes" do
   let(:id) { lettings_log.id }
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     RequestHelper.stub_http_requests
     sign_in user
   end

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe "Form Conditional Questions" do
 
   before do
     sign_in user
+    allow(sales_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe "Form Navigation" do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/features/form/page_routing_spec.rb
+++ b/spec/features/form/page_routing_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Form Page Routing" do
   let(:validator) { lettings_log._validators[nil].first }
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     allow(validator).to receive(:validate_pregnancy).and_return(true)
     sign_in user
   end

--- a/spec/features/form/progressive_total_field_spec.rb
+++ b/spec/features/form/progressive_total_field_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Accessible Automcomplete" do
   end
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/saving_data_spec.rb
+++ b/spec/features/form/saving_data_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Form Saving Data" do
   end
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Task List" do
   let(:status) { lettings_log.status }
 
   before do
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "validations" do
   let(:id) { lettings_log.id }
 
   before do
+    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -509,6 +509,7 @@ RSpec.describe FormController, type: :request do
           before do
             completed_lettings_log.update!(ecstat1: 1, earnings: 130, hhmemb: 1) # we're not routing to that page, so it gets cleared?§
             allow(completed_lettings_log).to receive(:net_income_soft_validation_triggered?).and_return(true)
+            allow(completed_lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
             post "/lettings-logs/#{completed_lettings_log.id}/form", params: interrupt_params, headers: headers.merge({ "HTTP_REFERER" => referrer })
           end
 

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe FormController, type: :request do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
+    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 
@@ -85,6 +86,10 @@ RSpec.describe FormController, type: :request do
         context "when forms exist for multiple years" do
           let(:lettings_log_year_1) { create(:lettings_log, startdate: Time.zone.local(2021, 5, 1), owning_organisation: organisation, created_by: user) }
           let(:lettings_log_year_2) { create(:lettings_log, :about_completed, startdate: Time.zone.local(2022, 5, 1), owning_organisation: organisation, created_by: user) }
+
+          before do
+            allow(lettings_log_year_1.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+          end
 
           it "displays the correct question details for each lettings log based on form year" do
             get "/lettings-logs/#{lettings_log_year_1.id}/tenant-code-test", headers: headers, params: {}

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -782,6 +782,11 @@ RSpec.describe LettingsLogsController, type: :request do
         expect(page).not_to have_link("Change")
         expect(page).not_to have_link("Answer")
       end
+
+      it "does not let the user navigate to questions for previous collection year logs" do
+        get "/lettings-logs/#{completed_lettings_log.id}/needs-type", headers: { "Accept" => "text/html" }, params: {}
+        expect(response).to redirect_to("/lettings-logs/#{completed_lettings_log.id}")
+      end
     end
 
     context "when requesting CSV download" do


### PR DESCRIPTION
Display a different text if collection window is closed. Use `end_date` form attribute to determine if the logs can still be edited for that collection. 
<img width="620" alt="image" src="https://user-images.githubusercontent.com/54268893/204762459-304d9287-7fc1-48c6-819b-ac4074fc015f.png">
<img width="625" alt="image" src="https://user-images.githubusercontent.com/54268893/204762537-3211218a-82f2-48e2-aaa9-bb4694623fa4.png">
Do not display change links in review and check your answers paged for logs with closed collection windows. Redirect to the tasklist if the user navigates directly to the question for such log.
<img width="610" alt="image" src="https://user-images.githubusercontent.com/54268893/204762710-4435399e-647a-40a3-a0ff-a9e903d842fc.png">

Stub `end_date ` for forms in failing tests so that the collection period is returned as open.
