### PR TITLE
Only hide created_by question for non support users

### DIFF
--- a/app/models/form/lettings/questions/created_by_id.rb
+++ b/app/models/form/lettings/questions/created_by_id.rb
@@ -35,8 +35,8 @@ class Form::Lettings::Questions::CreatedById < ::Form::Question
     answer_options[value]
   end
 
-  def hidden_in_check_answers?(_log, _current_user)
-    true
+  def hidden_in_check_answers?(_log, current_user)
+    !current_user.support?
   end
 
   def derived?

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Lettings Log Features" do
         log_id = page.current_path.scan(/\d/).join
         visit("lettings-logs/#{log_id}/setup/check-answers")
         expect(page).to have_content("Housing provider #{support_user.organisation.name}")
-        expect(page).to have_content("You have answered 2 of 8 questions")
+        expect(page).to have_content("You have answered 3 of 9 questions")
       end
     end
   end

--- a/spec/models/form/lettings/questions/created_by_id_spec.rb
+++ b/spec/models/form/lettings/questions/created_by_id_spec.rb
@@ -51,8 +51,20 @@ RSpec.describe Form::Lettings::Questions::CreatedById, type: :model do
     expect(question.derived?).to be true
   end
 
-  it "is not shown in check answers" do
-    expect(question.hidden_in_check_answers?(nil, user_1)).to be true
+  context "when the current user is support" do
+    let(:support_user) { FactoryBot.build(:user, :support) }
+
+    it "is shown in check answers" do
+      expect(question.hidden_in_check_answers?(nil, support_user)).to be false
+    end
+  end
+
+  context "when the current user is not support" do
+    let(:user) { FactoryBot.build(:user) }
+
+    it "is not shown in check answers" do
+      expect(question.hidden_in_check_answers?(nil, user)).to be true
+    end
   end
 
   context "when the owning organisation is already set" do


### PR DESCRIPTION
As a support user we need to be able to answer created_by question to mark the setup section as complete and unlock the rest of the sections.
We don't need to show this question to other users because the created_by value gets set to current user when the log is created by non support users and non support users should only be able to create logs as themselves.