### PR TITLE
Update hidden_in_check_answers for managing organisation

### DIFF
--- a/app/models/form/lettings/questions/managing_organisation.rb
+++ b/app/models/form/lettings/questions/managing_organisation.rb
@@ -45,9 +45,9 @@ class Form::Lettings::Questions::ManagingOrganisation < ::Form::Question
     true
   end
 
-  def hidden_in_check_answers?(_log, user = nil)
+  def hidden_in_check_answers?(log, user = nil)
     @current_user = user
-    @current_user.nil?
+    @current_user.nil? || !@page.routed_to?(log, user)
   end
 
   def enabled

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -86,11 +86,11 @@ class Form::Question
     conditional_on.all? { |condition| evaluate_condition(condition, log) }
   end
 
-  def hidden_in_check_answers?(log, _current_user = nil)
+  def hidden_in_check_answers?(log, current_user = nil)
     if hidden_in_check_answers.is_a?(Hash)
       form.depends_on_met(hidden_in_check_answers["depends_on"], log)
     else
-      hidden_in_check_answers
+      hidden_in_check_answers || !page.routed_to?(log, current_user)
     end
   end
 

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Lettings Log Features" do
         log_id = page.current_path.scan(/\d/).join
         visit("lettings-logs/#{log_id}/setup/check-answers")
         expect(page).to have_content("Housing provider #{support_user.organisation.name}")
-        expect(page).to have_content("You have answered 3 of 9 questions")
+        expect(page).to have_content("You have answered 2 of 8 questions")
       end
     end
   end

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -142,6 +142,10 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
   end
 
   describe "#hidden_in_check_answers?" do
+    before do
+      allow(page).to receive(:routed_to?).and_return(true)
+    end
+
     context "when user present" do
       let(:user) { create(:user) }
 
@@ -151,10 +155,21 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
     end
 
     context "when user not provided" do
-      let(:user) { create(:user, :support) }
-
       it "is not hidden in check answers" do
         expect(question.hidden_in_check_answers?(nil)).to be true
+      end
+    end
+
+    context "when the page is not routed to" do
+      let(:user) { create(:user, :data_coordinator, organisation: create(:organisation, holds_own_stock: true)) }
+      let(:log) { create(:lettings_log, owning_organisation: user.organisation) }
+
+      before do
+        allow(page).to receive(:routed_to?).and_return(false)
+      end
+
+      it "is hidden in check answers" do
+        expect(question.hidden_in_check_answers?(log, user)).to be true
       end
     end
   end


### PR DESCRIPTION
Hide managing organisation question in check answers if it was not routed to.
This is because we cannot access the managing organisation page if it's not routed to (it gets redirected to tasklist) and the user has not answered the managing organisation question if it was not routed to, it was most likely inferred.