### PR TITLE
Update deactivation tests

### DIFF
--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -909,6 +909,7 @@ RSpec.describe LettingsLogsController, type: :request do
       let(:headers) { { "Accept" => "text/html" } }
 
       before do
+        allow(affected_lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
       end


### PR DESCRIPTION
After closing 21/22 period some tests needed to be updated, because they now tested logs that were created during the closed collection periods.
The tests in this PR slipped past because I didn't rebase onto main before merging [#1044](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1044)