### PR TITLE
Update toggle scheme/location button

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -53,6 +53,11 @@ module LocationsHelper
     availability.strip
   end
 
+  def toggle_location_link(location)
+    return govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(location.scheme, location), warning: true if location.active?
+    return govuk_button_link_to "Reactivate this location", scheme_location_new_reactivation_path(location.scheme, location) if location.deactivated?
+  end
+
 private
 
   ActivePeriod = Struct.new(:from, :to)

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -42,6 +42,11 @@ module SchemesHelper
     availability.strip
   end
 
+  def toggle_scheme_link(scheme)
+    return govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(scheme), warning: true if scheme.active?
+    return govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(scheme) if scheme.deactivated?
+  end
+
 private
 
   ActivePeriod = Struct.new(:from, :to)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -383,7 +383,11 @@ class Location < ApplicationRecord
     location_deactivation_periods.order("created_at").last
   end
 
-  def status(date = Time.zone.now)
+  def status
+    @status ||= status_at(Time.zone.now)
+  end
+
+  def status_at(date)
     return :incomplete unless confirmed
     return :deactivated if open_deactivation&.deactivation_date.present? && date >= open_deactivation.deactivation_date
     return :deactivating_soon if open_deactivation&.deactivation_date.present? && date < open_deactivation.deactivation_date
@@ -392,7 +396,6 @@ class Location < ApplicationRecord
 
     :active
   end
-  alias_method :status_at, :status
 
   def active?
     status == :active

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -398,6 +398,10 @@ class Location < ApplicationRecord
     status == :active
   end
 
+  def deactivated?
+    status == :deactivated
+  end
+
   def reactivating_soon?
     status == :reactivating_soon
   end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -241,4 +241,8 @@ class Scheme < ApplicationRecord
   def reactivating_soon?
     status == :reactivating_soon
   end
+
+  def deactivated?
+    status == :deactivated
+  end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -224,7 +224,11 @@ class Scheme < ApplicationRecord
     scheme_deactivation_periods.order("created_at").last
   end
 
-  def status(date = Time.zone.now)
+  def status
+    @status ||= status_at(Time.zone.now)
+  end
+
+  def status_at(date)
     return :incomplete unless confirmed
     return :deactivated if open_deactivation&.deactivation_date.present? && date >= open_deactivation.deactivation_date
     return :deactivating_soon if open_deactivation&.deactivation_date.present? && date < open_deactivation.deactivation_date
@@ -232,7 +236,6 @@ class Scheme < ApplicationRecord
 
     :active
   end
-  alias_method :status_at, :status
 
   def active?
     status == :active

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -24,9 +24,5 @@
     </div>
 </div>
 <% if FeatureToggle.location_toggle_enabled? %>
-    <% if @location.active? || @location.reactivating_soon? %>
-        <%= govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(@scheme, @location), warning: true %>
-    <% else %>
-        <%= govuk_button_link_to "Reactivate this location", scheme_location_new_reactivation_path(@scheme, @location) %>
-    <% end %>
+    <%= toggle_location_link(@location) %>
 <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -34,9 +34,5 @@
 <% end %>
 
 <% if FeatureToggle.scheme_toggle_enabled? %>
-  <% if @scheme.active? || @scheme.reactivating_soon? %>
-    <%= govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(@scheme), warning: true %>
-  <% else %>
-    <%= govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(@scheme) %>
-  <% end %>
+  <%= toggle_scheme_link(@scheme) %>
 <% end %>

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1519,18 +1519,20 @@ RSpec.describe LocationsController, type: :request do
       context "with location that's deactivating soon" do
         let(:location_deactivation_period) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 12), location:) }
 
-        it "renders reactivate this location" do
+        it "does not render toggle location link" do
           expect(response).to have_http_status(:ok)
-          expect(page).to have_link("Reactivate this location", href: "/schemes/#{scheme.id}/locations/#{location.id}/new-reactivation")
+          expect(page).not_to have_link("Reactivate this location")
+          expect(page).not_to have_link("Deactivate this location")
         end
       end
 
       context "with location that's reactivating soon" do
         let(:location_deactivation_period) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 4, 12), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
 
-        it "renders reactivate this location" do
+        it "does not render toggle location link" do
           expect(response).to have_http_status(:ok)
-          expect(page).to have_link("Deactivate this location", href: "/schemes/#{scheme.id}/locations/#{location.id}/new-deactivation")
+          expect(page).not_to have_link("Reactivate this location")
+          expect(page).not_to have_link("Deactivate this location")
         end
       end
     end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -292,9 +292,10 @@ RSpec.describe SchemesController, type: :request do
         context "with scheme that's deactivating soon" do
           let(:scheme_deactivation_period) { FactoryBot.create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 12), scheme:) }
 
-          it "renders reactivate this scheme" do
+          it "does not render toggle scheme link" do
             expect(response).to have_http_status(:ok)
-            expect(page).to have_link("Reactivate this scheme", href: "/schemes/#{scheme.id}/new-reactivation")
+            expect(page).not_to have_link("Reactivate this scheme")
+            expect(page).not_to have_link("Deactivate this scheme")
           end
         end
       end


### PR DESCRIPTION
Only display deactivate/reactivate this scheme/location button for active and deactivated schemes.
The "reactivate" or "deactivate" button should not be present, until the date where change takes place, in order to stop the scheduling of more than one change at a time.

Buttons displayed for deactivated and active:
<img width="1558" alt="image" src="https://user-images.githubusercontent.com/54268893/205888839-58021d22-6f7f-46cb-ac86-f91a694676c1.png">
<img width="1619" alt="image" src="https://user-images.githubusercontent.com/54268893/205888897-0bd4f10b-280d-4533-b57d-dda2fc111a12.png">

Buttons not displayed for reactivating soon, deactivating soon, activating soon
<img width="1523" alt="image" src="https://user-images.githubusercontent.com/54268893/205888969-32638480-7e19-4e64-a412-218c761928f6.png">
<img width="1478" alt="image" src="https://user-images.githubusercontent.com/54268893/205889014-aa677bce-fc37-450e-a4c4-6e8e13d2f9f2.png">
<img width="1457" alt="image" src="https://user-images.githubusercontent.com/54268893/205889057-2acafd46-567d-4285-b871-21c8291c135d.png">
