### PR TITLE
Add mechanism to download bulk uploads

### DIFF
--- a/app/services/bulk_upload/downloader.rb
+++ b/app/services/bulk_upload/downloader.rb
@@ -1,0 +1,33 @@
+class BulkUpload::Downloader
+  attr_reader :bulk_upload
+
+  delegate :path, to: :file
+
+  def initialize(bulk_upload:)
+    @bulk_upload = bulk_upload
+  end
+
+  def call
+    download
+  end
+
+private
+
+  def download
+    io = storage_service.get_file_io(bulk_upload.identifier)
+    file.write(io.read)
+    io.close
+    file.close
+  end
+
+  def file
+    @file ||= Tempfile.new
+  end
+
+  def storage_service
+    @storage_service ||= Storage::S3Service.new(
+      Configuration::PaasConfigurationService.new,
+      ENV["CSV_DOWNLOAD_PAAS_INSTANCE"],
+    )
+  end
+end

--- a/spec/factories/bulk_upload.rb
+++ b/spec/factories/bulk_upload.rb
@@ -1,0 +1,10 @@
+require "securerandom"
+
+FactoryBot.define do
+  factory :bulk_upload do
+    user
+    log_type { BulkUpload.log_types.values.sample }
+    year { 2022 }
+    identifier { SecureRandom.uuid }
+  end
+end

--- a/spec/services/bulk_upload/downloader_spec.rb
+++ b/spec/services/bulk_upload/downloader_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe BulkUpload::Downloader do
+  subject(:downloader) { described_class.new(bulk_upload:) }
+
+  let(:bulk_upload) { build(:bulk_upload) }
+
+  let(:get_file_io) do
+    io = StringIO.new
+    io.write("hello")
+    io.rewind
+    io
+  end
+
+  # rubocop:disable RSpec/PredicateMatcher
+  describe "#call" do
+    let(:mock_storage_service) { instance_double(Storage::S3Service, get_file_io:) }
+
+    it "downloads the file as a temporary file" do
+      allow(Storage::S3Service).to receive(:new).and_return(mock_storage_service)
+
+      downloader.call
+
+      expect(mock_storage_service).to have_received(:get_file_io).with(bulk_upload.identifier)
+
+      expect(File.exist?(downloader.path)).to be_truthy
+      expect(File.read(downloader.path)).to eql("hello")
+    end
+  end
+  # rubocop:enable RSpec/PredicateMatcher
+end


### PR DESCRIPTION
# Context

- After bulk upload CSV files are uploaded to S3 we need a mechanism to download them again
- These changes will be needed soon for the remainder of the bulk upload journey so I have started adding tooling in this area

# Changes

- Add class to download the CSV uploaded from bulk upload for local processing