### PR TITLE
Fix flaky seed test

### DIFF
--- a/app/services/imports/rent_ranges_service.rb
+++ b/app/services/imports/rent_ranges_service.rb
@@ -1,0 +1,33 @@
+module Imports
+  class RentRangesService
+    attr_reader :start_year, :path, :count
+
+    def initialize(start_year:, path:)
+      @start_year = start_year
+      @path = path
+      @count = 0
+    end
+
+    def call
+      CSV.foreach(path, headers: true) do |row|
+        LaRentRange.upsert(
+          { ranges_rent_id: row["ranges_rent_id"],
+            lettype: row["lettype"],
+            beds: row["beds"],
+            start_year:,
+            la: row["la"],
+            soft_min: row["soft_min"],
+            soft_max: row["soft_max"],
+            hard_min: row["hard_min"],
+            hard_max: row["hard_max"] },
+          unique_by: %i[start_year lettype beds la],
+        )
+        self.count = count + 1
+      end
+    end
+
+  private
+
+    attr_writer :count
+  end
+end

--- a/app/services/imports/rent_ranges_service.rb
+++ b/app/services/imports/rent_ranges_service.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 module Imports
   class RentRangesService
     attr_reader :start_year, :path, :count

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -279,8 +279,8 @@ unless Rails.env.test?
   if LaRentRange.count.zero?
     Dir.glob("config/rent_range_data/*.csv").each do |path|
       start_year = File.basename(path, ".csv")
-      Rake::Task["data_import:rent_ranges"].invoke(start_year, path)
-      Rake::Task["data_import:rent_ranges"].reenable
+      service = Imports::RentRangesService.new(start_year:, path:)
+      service.call
     end
   end
 end

--- a/lib/tasks/rent_ranges.rake
+++ b/lib/tasks/rent_ranges.rake
@@ -1,5 +1,3 @@
-require "csv"
-
 namespace :data_import do
   desc "Import annual rent range data"
   task :rent_ranges, %i[start_year path] => :environment do |_task, args|

--- a/lib/tasks/rent_ranges.rake
+++ b/lib/tasks/rent_ranges.rake
@@ -5,25 +5,12 @@ namespace :data_import do
   task :rent_ranges, %i[start_year path] => :environment do |_task, args|
     start_year = args[:start_year]
     path = args[:path]
-    count = 0
 
     raise "Usage: rake data_import:rent_ranges[start_year,'path/to/csv_file']" if path.blank? || start_year.blank?
 
-    CSV.foreach(path, headers: true) do |row|
-      LaRentRange.upsert(
-        { ranges_rent_id: row["ranges_rent_id"],
-          lettype: row["lettype"],
-          beds: row["beds"],
-          start_year:,
-          la: row["la"],
-          soft_min: row["soft_min"],
-          soft_max: row["soft_max"],
-          hard_min: row["hard_min"],
-          hard_max: row["hard_max"] },
-        unique_by: %i[start_year lettype beds la],
-      )
-      count += 1
-    end
-    pp "Created/updated #{count} LA Rent Range records for #{start_year}" unless Rails.env.test?
+    service = Imports::RentRangesService.new(start_year:, path:)
+    service.call
+
+    pp "Created/updated #{service.count} LA Rent Range records for #{start_year}" unless Rails.env.test?
   end
 end


### PR DESCRIPTION
# Context

- There is a flaky test when testing the seeding process
- The theory is that by invoking rake tasks in the seeds it is able to break out of the transaction which does not get rolled back
- This may or may not cause a failure depending on the running ordering of test execution

# Changes

- Extract importing of rent ranges to a class
- Start using that class in relevant places instead of invoking as a rake task