### PR TITLE
Run tests on draft PRs

### DIFF
--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -76,7 +76,6 @@ jobs:
 
   feature_test:
     name: Feature Tests
-    if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
 
     services:
@@ -135,7 +134,6 @@ jobs:
 
   lint:
     name: Lint
-    if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
 
     steps:
@@ -163,7 +161,6 @@ jobs:
 
   audit:
     name: Audit dependencies
-    if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -18,7 +18,6 @@ defaults:
 jobs:
   test:
     name: Tests
-    if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     types:
       - opened
-      - ready_for_review
       - synchronize
   workflow_dispatch:
 


### PR DESCRIPTION
Enable tests, lint and dependencies audit on draft PRs on GitHub actions.