### PR TITLE
Cldc 1627 update age in check answers and put persons on different check answers cards

### DIFF
--- a/app/models/form/sales/pages/buyer2_live_in_property.rb
+++ b/app/models/form/sales/pages/buyer2_live_in_property.rb
@@ -5,6 +5,9 @@ class Form::Sales::Pages::Buyer2LiveInProperty < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
+    @depends_on = [{
+      "jointpur" => 1,
+    }]
   end
 
   def questions

--- a/app/models/form/sales/pages/buyer2_working_situation.rb
+++ b/app/models/form/sales/pages/buyer2_working_situation.rb
@@ -5,6 +5,9 @@ class Form::Sales::Pages::Buyer2WorkingSituation < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
+    @depends_on = [{
+      "jointpur" => 1,
+    }]
   end
 
   def questions

--- a/app/models/form/sales/pages/person1_gender_identity.rb
+++ b/app/models/form/sales/pages/person1_gender_identity.rb
@@ -5,9 +5,12 @@ class Form::Sales::Pages::Person1GenderIdentity < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
-    @depends_on = [{
-      "jointpur" => 2,
-    }]
+    @depends_on = [
+      { "hholdcount" => 1, "jointpur" => 2 },
+      { "hholdcount" => 2, "jointpur" => 2 },
+      { "hholdcount" => 3, "jointpur" => 2 },
+      { "hholdcount" => 4, "jointpur" => 2 },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/pages/person1_gender_identity.rb
+++ b/app/models/form/sales/pages/person1_gender_identity.rb
@@ -7,7 +7,6 @@ class Form::Sales::Pages::Person1GenderIdentity < ::Form::Page
     @subsection = subsection
     @depends_on = [{
       "jointpur" => 2,
-      "details_known_2" => 1,
     }]
   end
 

--- a/app/models/form/sales/pages/person1_gender_identity_joint_purchase.rb
+++ b/app/models/form/sales/pages/person1_gender_identity_joint_purchase.rb
@@ -5,10 +5,12 @@ class Form::Sales::Pages::Person1GenderIdentityJointPurchase < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
-    @depends_on = [{
-      "jointpur" => 1,
-      "details_known_3" => 1,
-    }]
+    @depends_on = [
+      { "hholdcount" => 1, "jointpur" => 1 },
+      { "hholdcount" => 2, "jointpur" => 1 },
+      { "hholdcount" => 3, "jointpur" => 1 },
+      { "hholdcount" => 4, "jointpur" => 1 },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/pages/person2_age.rb
+++ b/app/models/form/sales/pages/person2_age.rb
@@ -6,7 +6,7 @@ class Form::Sales::Pages::Person2Age < ::Form::Page
     @description = ""
     @subsection = subsection
     @depends_on = [
-      { "details_known_2" => 1}
+      { "details_known_2" => 1 },
     ]
   end
 

--- a/app/models/form/sales/pages/person2_age.rb
+++ b/app/models/form/sales/pages/person2_age.rb
@@ -6,9 +6,7 @@ class Form::Sales::Pages::Person2Age < ::Form::Page
     @description = ""
     @subsection = subsection
     @depends_on = [
-      { "hholdcount" => 2, "details_known_2" => 1 },
-      { "hholdcount" => 3, "details_known_2" => 1 },
-      { "hholdcount" => 4, "details_known_2" => 1 },
+      { "details_known_2" => 1}
     ]
   end
 

--- a/app/models/form/sales/pages/person3_age.rb
+++ b/app/models/form/sales/pages/person3_age.rb
@@ -6,8 +6,7 @@ class Form::Sales::Pages::Person3Age < ::Form::Page
     @description = ""
     @subsection = subsection
     @depends_on = [
-      { "hholdcount" => 3, "details_known_3" => 1 },
-      { "hholdcount" => 4, "details_known_3" => 1 },
+      { "details_known_3" => 1}
     ]
   end
 

--- a/app/models/form/sales/pages/person3_age.rb
+++ b/app/models/form/sales/pages/person3_age.rb
@@ -6,7 +6,7 @@ class Form::Sales::Pages::Person3Age < ::Form::Page
     @description = ""
     @subsection = subsection
     @depends_on = [
-      { "details_known_3" => 1}
+      { "details_known_3" => 1 },
     ]
   end
 

--- a/app/models/form/sales/pages/person4_age.rb
+++ b/app/models/form/sales/pages/person4_age.rb
@@ -6,7 +6,7 @@ class Form::Sales::Pages::Person4Age < ::Form::Page
     @description = ""
     @subsection = subsection
     @depends_on = [
-      { "hholdcount" => 4, "details_known_4" => 1 },
+      { "details_known_4" => 1 },
     ]
   end
 

--- a/app/models/form/sales/questions/age1.rb
+++ b/app/models/form/sales/questions/age1.rb
@@ -9,9 +9,9 @@ class Form::Sales::Questions::Age1 < ::Form::Question
     @width = 2
     @inferred_check_answers_value = {
       "condition" => {
-        "age1_known" => 1
+        "age1_known" => 1,
       },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 1
   end

--- a/app/models/form/sales/questions/age1.rb
+++ b/app/models/form/sales/questions/age1.rb
@@ -7,5 +7,11 @@ class Form::Sales::Questions::Age1 < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 2
+    @inferred_check_answers_value = {
+      "condition" => {
+        "age1_known" => 1
+      },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/age1.rb
+++ b/app/models/form/sales/questions/age1.rb
@@ -13,5 +13,6 @@ class Form::Sales::Questions::Age1 < ::Form::Question
       },
       "value" => "Not known"
     }
+    @check_answers_card_number = 1
   end
 end

--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -9,7 +9,7 @@ class Form::Sales::Questions::Age2 < ::Form::Question
     @width = 2
     @inferred_check_answers_value = {
       "condition" => { "age2_known" => 1 },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 2
   end

--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -11,5 +11,6 @@ class Form::Sales::Questions::Age2 < ::Form::Question
       "condition" => { "age2_known" => 1 },
       "value" => "Not known"
     }
+    @check_answers_card_number = 2
   end
 end

--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -7,5 +7,9 @@ class Form::Sales::Questions::Age2 < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 2
+    @inferred_check_answers_value = {
+      "condition" => { "age2_known" => 1 },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/buyer1_age_known.rb
+++ b/app/models/form/sales/questions/buyer1_age_known.rb
@@ -2,7 +2,7 @@ class Form::Sales::Questions::Buyer1AgeKnown < ::Form::Question
   def initialize(id, hsh, page)
     super
     @id = "age1_known"
-    @check_answer_label = "Buyer 1’s age"
+    @check_answer_label = "Lead buyer’s age"
     @header = "Do you know buyer 1’s age?"
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
@@ -10,6 +10,16 @@ class Form::Sales::Questions::Buyer1AgeKnown < ::Form::Question
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
     @conditional_for = {
       "age1" => [0],
+    }
+    @hidden_in_check_answers = {
+      "depends_on" => [
+        {
+          "age1_known" => 0,
+        },
+        {
+          "age1_known" => 1,
+        }
+      ],
     }
   end
 

--- a/app/models/form/sales/questions/buyer1_age_known.rb
+++ b/app/models/form/sales/questions/buyer1_age_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::Buyer1AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_age_known.rb
+++ b/app/models/form/sales/questions/buyer1_age_known.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Buyer1AgeKnown < ::Form::Question
         },
         {
           "age1_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 1

--- a/app/models/form/sales/questions/buyer1_ethnic_background_arab.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_background_arab.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1EthnicBackgroundArab < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_ethnic_background_asian.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_background_asian.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1EthnicBackgroundAsian < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_ethnic_background_black.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_background_black.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1EthnicBackgroundBlack < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_ethnic_background_mixed.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_background_mixed.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1EthnicBackgroundMixed < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_ethnic_background_white.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_background_white.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1EthnicBackgroundWhite < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_ethnic_group.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_group.rb
@@ -14,6 +14,7 @@ class Form::Sales::Questions::Buyer1EthnicGroup < ::Form::Question
       },
       "value" => "Prefers not to say",
     }
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_income.rb
+++ b/app/models/form/sales/questions/buyer1_income.rb
@@ -10,5 +10,6 @@ class Form::Sales::Questions::Buyer1Income < ::Form::Question
     @step = 1
     @width = 5
     @prefix = "£"
+    @check_answers_card_number = 1
   end
 end

--- a/app/models/form/sales/questions/buyer1_income_known.rb
+++ b/app/models/form/sales/questions/buyer1_income_known.rb
@@ -12,6 +12,7 @@ class Form::Sales::Questions::Buyer1IncomeKnown < ::Form::Question
     @conditional_for = {
       "income1" => [0],
     }
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_live_in_property.rb
+++ b/app/models/form/sales/questions/buyer1_live_in_property.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1LiveInProperty < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_mortgage.rb
+++ b/app/models/form/sales/questions/buyer1_mortgage.rb
@@ -7,6 +7,7 @@ class Form::Sales::Questions::Buyer1Mortgage < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @page = page
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer1_working_situation.rb
+++ b/app/models/form/sales/questions/buyer1_working_situation.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer1WorkingSituation < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @page = page
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it's a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_age_known.rb
+++ b/app/models/form/sales/questions/buyer2_age_known.rb
@@ -17,7 +17,7 @@ class Form::Sales::Questions::Buyer2AgeKnown < ::Form::Question
         },
         {
           "age2_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 2

--- a/app/models/form/sales/questions/buyer2_age_known.rb
+++ b/app/models/form/sales/questions/buyer2_age_known.rb
@@ -10,6 +10,16 @@ class Form::Sales::Questions::Buyer2AgeKnown < ::Form::Question
     @conditional_for = {
       "age2" => [0],
     }
+    @hidden_in_check_answers = {
+      "depends_on" => [
+        {
+          "age2_known" => 0,
+        },
+        {
+          "age2_known" => 1,
+        }
+      ],
+    }
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_age_known.rb
+++ b/app/models/form/sales/questions/buyer2_age_known.rb
@@ -20,6 +20,7 @@ class Form::Sales::Questions::Buyer2AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_income.rb
+++ b/app/models/form/sales/questions/buyer2_income.rb
@@ -10,5 +10,6 @@ class Form::Sales::Questions::Buyer2Income < ::Form::Question
     @step = 1
     @width = 5
     @prefix = "£"
+    @check_answers_card_number = 2
   end
 end

--- a/app/models/form/sales/questions/buyer2_income_known.rb
+++ b/app/models/form/sales/questions/buyer2_income_known.rb
@@ -12,6 +12,7 @@ class Form::Sales::Questions::Buyer2IncomeKnown < ::Form::Question
     @conditional_for = {
       "income2" => [0],
     }
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_live_in_property.rb
+++ b/app/models/form/sales/questions/buyer2_live_in_property.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer2LiveInProperty < ::Form::Question
     @hint_text = ""
     @answer_options = ANSWER_OPTIONS
     @page = page
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_relationship_to_buyer1.rb
+++ b/app/models/form/sales/questions/buyer2_relationship_to_buyer1.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer2RelationshipToBuyer1 < ::Form::Question
     @hint_text = ""
     @page = page
     @answer_options = ANSWER_OPTIONS
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_working_situation.rb
+++ b/app/models/form/sales/questions/buyer2_working_situation.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::Buyer2WorkingSituation < ::Form::Question
     @hint_text = ""
     @page = page
     @answer_options = ANSWER_OPTIONS
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/gender_identity1.rb
+++ b/app/models/form/sales/questions/gender_identity1.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::GenderIdentity1 < ::Form::Question
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
     @page = page
     @answer_options = ANSWER_OPTIONS
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/gender_identity2.rb
+++ b/app/models/form/sales/questions/gender_identity2.rb
@@ -7,6 +7,7 @@ class Form::Sales::Questions::GenderIdentity2 < ::Form::Question
     @type = "radio"
     @page = page
     @answer_options = ANSWER_OPTIONS
+    @check_answers_card_number = 2
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/nationality1.rb
+++ b/app/models/form/sales/questions/nationality1.rb
@@ -18,6 +18,7 @@ class Form::Sales::Questions::Nationality1 < ::Form::Question
         },
       ],
     }
+    @check_answers_card_number = 1
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/other_nationality1.rb
+++ b/app/models/form/sales/questions/other_nationality1.rb
@@ -6,5 +6,6 @@ class Form::Sales::Questions::OtherNationality1 < ::Form::Question
     @header = "Nationality"
     @type = "text"
     @page = page
+    @check_answers_card_number = 1
   end
 end

--- a/app/models/form/sales/questions/person1_age.rb
+++ b/app/models/form/sales/questions/person1_age.rb
@@ -11,5 +11,6 @@ class Form::Sales::Questions::Person1Age < ::Form::Question
       "condition" => { "age3_known" => 1 },
       "value" => "Not known"
     }
+    @check_answers_card_number = 3
   end
 end

--- a/app/models/form/sales/questions/person1_age.rb
+++ b/app/models/form/sales/questions/person1_age.rb
@@ -9,7 +9,7 @@ class Form::Sales::Questions::Person1Age < ::Form::Question
     @width = 3
     @inferred_check_answers_value = {
       "condition" => { "age3_known" => 1 },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 3
   end

--- a/app/models/form/sales/questions/person1_age.rb
+++ b/app/models/form/sales/questions/person1_age.rb
@@ -7,5 +7,9 @@ class Form::Sales::Questions::Person1Age < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 3
+    @inferred_check_answers_value = {
+      "condition" => { "age3_known" => 1 },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/person1_age_known.rb
+++ b/app/models/form/sales/questions/person1_age_known.rb
@@ -16,6 +16,9 @@ class Form::Sales::Questions::Person1AgeKnown < ::Form::Question
         {
           "age3_known" => 0,
         },
+        {
+          "age3_known" => 1,
+        }
       ],
     }
   end

--- a/app/models/form/sales/questions/person1_age_known.rb
+++ b/app/models/form/sales/questions/person1_age_known.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Person1AgeKnown < ::Form::Question
         },
         {
           "age3_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 3

--- a/app/models/form/sales/questions/person1_age_known.rb
+++ b/app/models/form/sales/questions/person1_age_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::Person1AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 3
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person2_age.rb
+++ b/app/models/form/sales/questions/person2_age.rb
@@ -7,5 +7,9 @@ class Form::Sales::Questions::Person2Age < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 3
+    @inferred_check_answers_value = {
+      "condition" => { "age4_known" => 1 },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/person2_age.rb
+++ b/app/models/form/sales/questions/person2_age.rb
@@ -9,7 +9,7 @@ class Form::Sales::Questions::Person2Age < ::Form::Question
     @width = 3
     @inferred_check_answers_value = {
       "condition" => { "age4_known" => 1 },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 4
   end

--- a/app/models/form/sales/questions/person2_age.rb
+++ b/app/models/form/sales/questions/person2_age.rb
@@ -11,5 +11,6 @@ class Form::Sales::Questions::Person2Age < ::Form::Question
       "condition" => { "age4_known" => 1 },
       "value" => "Not known"
     }
+    @check_answers_card_number = 4
   end
 end

--- a/app/models/form/sales/questions/person2_age_known.rb
+++ b/app/models/form/sales/questions/person2_age_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::Person2AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 4
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person2_age_known.rb
+++ b/app/models/form/sales/questions/person2_age_known.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Person2AgeKnown < ::Form::Question
         },
         {
           "age4_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 4

--- a/app/models/form/sales/questions/person2_age_known.rb
+++ b/app/models/form/sales/questions/person2_age_known.rb
@@ -17,11 +17,8 @@ class Form::Sales::Questions::Person2AgeKnown < ::Form::Question
           "age4_known" => 0,
         },
         {
-          "details_known_2" => nil,
-        },
-        {
-          "details_known_2" => 2,
-        },
+          "age4_known" => 1,
+        }
       ],
     }
   end

--- a/app/models/form/sales/questions/person2_known.rb
+++ b/app/models/form/sales/questions/person2_known.rb
@@ -15,6 +15,7 @@ class Form::Sales::Questions::Person2Known < ::Form::Question
         },
       ],
     }
+    @check_answers_card_number = 4
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person3_age.rb
+++ b/app/models/form/sales/questions/person3_age.rb
@@ -11,5 +11,6 @@ class Form::Sales::Questions::Person3Age < ::Form::Question
       "condition" => { "age5_known" => 1 },
       "value" => "Not known"
     }
+    @check_answers_card_number = 5
   end
 end

--- a/app/models/form/sales/questions/person3_age.rb
+++ b/app/models/form/sales/questions/person3_age.rb
@@ -7,5 +7,9 @@ class Form::Sales::Questions::Person3Age < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 3
+    @inferred_check_answers_value = {
+      "condition" => { "age5_known" => 1 },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/person3_age.rb
+++ b/app/models/form/sales/questions/person3_age.rb
@@ -9,7 +9,7 @@ class Form::Sales::Questions::Person3Age < ::Form::Question
     @width = 3
     @inferred_check_answers_value = {
       "condition" => { "age5_known" => 1 },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 5
   end

--- a/app/models/form/sales/questions/person3_age_known.rb
+++ b/app/models/form/sales/questions/person3_age_known.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Person3AgeKnown < ::Form::Question
         },
         {
           "age5_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 5

--- a/app/models/form/sales/questions/person3_age_known.rb
+++ b/app/models/form/sales/questions/person3_age_known.rb
@@ -17,11 +17,8 @@ class Form::Sales::Questions::Person3AgeKnown < ::Form::Question
           "age5_known" => 0,
         },
         {
-          "details_known_3" => nil,
-        },
-        {
-          "details_known_3" => 2,
-        },
+          "age5_known" => 1,
+        }
       ],
     }
   end

--- a/app/models/form/sales/questions/person3_age_known.rb
+++ b/app/models/form/sales/questions/person3_age_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::Person3AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 5
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person3_known.rb
+++ b/app/models/form/sales/questions/person3_known.rb
@@ -15,6 +15,7 @@ class Form::Sales::Questions::Person3Known < ::Form::Question
         },
       ],
     }
+    @check_answers_card_number = 5
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person4_age.rb
+++ b/app/models/form/sales/questions/person4_age.rb
@@ -7,5 +7,9 @@ class Form::Sales::Questions::Person4Age < ::Form::Question
     @type = "numeric"
     @page = page
     @width = 3
+    @inferred_check_answers_value = {
+      "condition" => { "age6_known" => 1 },
+      "value" => "Not known"
+    }
   end
 end

--- a/app/models/form/sales/questions/person4_age.rb
+++ b/app/models/form/sales/questions/person4_age.rb
@@ -9,7 +9,7 @@ class Form::Sales::Questions::Person4Age < ::Form::Question
     @width = 3
     @inferred_check_answers_value = {
       "condition" => { "age6_known" => 1 },
-      "value" => "Not known"
+      "value" => "Not known",
     }
     @check_answers_card_number = 6
   end

--- a/app/models/form/sales/questions/person4_age.rb
+++ b/app/models/form/sales/questions/person4_age.rb
@@ -11,5 +11,6 @@ class Form::Sales::Questions::Person4Age < ::Form::Question
       "condition" => { "age6_known" => 1 },
       "value" => "Not known"
     }
+    @check_answers_card_number = 6
   end
 end

--- a/app/models/form/sales/questions/person4_age_known.rb
+++ b/app/models/form/sales/questions/person4_age_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::Person4AgeKnown < ::Form::Question
         }
       ],
     }
+    @check_answers_card_number = 6
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person4_age_known.rb
+++ b/app/models/form/sales/questions/person4_age_known.rb
@@ -17,11 +17,8 @@ class Form::Sales::Questions::Person4AgeKnown < ::Form::Question
           "age6_known" => 0,
         },
         {
-          "details_known_4" => nil,
-        },
-        {
-          "details_known_4" => 2,
-        },
+          "age6_known" => 1,
+        }
       ],
     }
   end

--- a/app/models/form/sales/questions/person4_age_known.rb
+++ b/app/models/form/sales/questions/person4_age_known.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Person4AgeKnown < ::Form::Question
         },
         {
           "age6_known" => 1,
-        }
+        },
       ],
     }
     @check_answers_card_number = 6

--- a/app/models/form/sales/questions/person4_known.rb
+++ b/app/models/form/sales/questions/person4_known.rb
@@ -15,6 +15,7 @@ class Form::Sales::Questions::Person4Known < ::Form::Question
         },
       ],
     }
+    @check_answers_card_number = 6
   end
 
   ANSWER_OPTIONS = {

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -59,6 +59,7 @@ FactoryBot.define do
       la { "E09000003" }
       savingsnk { 1 }
       prevown { 1 }
+      sex3 { "X" }
     end
   end
 end

--- a/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe Form::Sales::Pages::Buyer2LiveInProperty, type: :model do
   it "has the correct description" do
     expect(page.description).to eq("")
   end
+
+  it "has correct depends_on" do
+    expect(page.depends_on).to eq([{ "jointpur" => 1 }])
+  end
 end

--- a/spec/models/form/sales/pages/buyer2_working_situation_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_working_situation_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe Form::Sales::Pages::Buyer2WorkingSituation, type: :model do
   it "has the correct description" do
     expect(page.description).to eq("")
   end
+
+  it "has correct depends_on" do
+    expect(page.depends_on).to eq([{ "jointpur" => 1 }])
+  end
 end

--- a/spec/models/form/sales/pages/person1_gender_identity_joint_purchase_spec.rb
+++ b/spec/models/form/sales/pages/person1_gender_identity_joint_purchase_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Form::Sales::Pages::Person1GenderIdentityJointPurchase, type: :mo
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "jointpur" => 1,
-      "details_known_3" => 1,
-    }])
+    expect(page.depends_on).to eq([{ "hholdcount" => 1, "jointpur" => 1 },
+                                   { "hholdcount" => 2, "jointpur" => 1 },
+                                   { "hholdcount" => 3, "jointpur" => 1 },
+                                   { "hholdcount" => 4, "jointpur" => 1 }])
   end
 end

--- a/spec/models/form/sales/pages/person1_gender_identity_spec.rb
+++ b/spec/models/form/sales/pages/person1_gender_identity_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Form::Sales::Pages::Person1GenderIdentity, type: :model do
   it "has correct depends_on" do
     expect(page.depends_on).to eq([{
       "jointpur" => 2,
-      "details_known_2" => 1,
     }])
   end
 end

--- a/spec/models/form/sales/pages/person1_gender_identity_spec.rb
+++ b/spec/models/form/sales/pages/person1_gender_identity_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe Form::Sales::Pages::Person1GenderIdentity, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "jointpur" => 2,
-    }])
+    expect(page.depends_on).to eq([
+      { "hholdcount" => 1, "jointpur" => 2 },
+      { "hholdcount" => 2, "jointpur" => 2 },
+      { "hholdcount" => 3, "jointpur" => 2 },
+      { "hholdcount" => 4, "jointpur" => 2 },
+    ])
   end
 end

--- a/spec/models/form/sales/pages/person2_age_spec.rb
+++ b/spec/models/form/sales/pages/person2_age_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::Person2Age, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [{ "details_known_2" => 1, "hholdcount" => 2 }, { "details_known_2" => 1, "hholdcount" => 3 }, { "details_known_2" => 1, "hholdcount" => 4 }],
+      [ { "details_known_2" => 1}],
     )
   end
 end

--- a/spec/models/form/sales/pages/person2_age_spec.rb
+++ b/spec/models/form/sales/pages/person2_age_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::Person2Age, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [ { "details_known_2" => 1}],
+      [{ "details_known_2" => 1 }],
     )
   end
 end

--- a/spec/models/form/sales/pages/person3_age_spec.rb
+++ b/spec/models/form/sales/pages/person3_age_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::Person3Age, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [ { "details_known_3" => 1}],
+      [{ "details_known_3" => 1 }],
     )
   end
 end

--- a/spec/models/form/sales/pages/person3_age_spec.rb
+++ b/spec/models/form/sales/pages/person3_age_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::Person3Age, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [{ "details_known_3" => 1, "hholdcount" => 3 }, { "details_known_3" => 1, "hholdcount" => 4 }],
+      [ { "details_known_3" => 1}],
     )
   end
 end

--- a/spec/models/form/sales/pages/person4_age_spec.rb
+++ b/spec/models/form/sales/pages/person4_age_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::Person4Age, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [{ "details_known_4" => 1, "hholdcount" => 4 }],
+      [{ "details_known_4" => 1 }],
     )
   end
 end

--- a/spec/models/form/sales/questions/age1_spec.rb
+++ b/spec/models/form/sales/questions/age1_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Form::Sales::Questions::Age1, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(2)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => { "age1_known" => 1},
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/age1_spec.rb
+++ b/spec/models/form/sales/questions/age1_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Form::Sales::Questions::Age1, type: :model do
 
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
-      "condition" => { "age1_known" => 1},
-      "value" => "Not known"
+      "condition" => { "age1_known" => 1 },
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/age1_spec.rb
+++ b/spec/models/form/sales/questions/age1_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Age1, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(2)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => {
+        "age2_known" => 1
+      },
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -47,4 +47,8 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
       "condition" => {
-        "age2_known" => 1
+        "age2_known" => 1,
       },
-      "value" => "Not known"
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/buyer1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_age_known_spec.rb
@@ -59,4 +59,8 @@ RSpec.describe Form::Sales::Questions::Buyer1AgeKnown, type: :model do
     }],
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_age_known_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Form::Sales::Questions::Buyer1AgeKnown, type: :model do
   end
 
   it "has the correct check_answer_label" do
-    expect(question.check_answer_label).to eq("Buyer 1’s age")
+    expect(question.check_answer_label).to eq("Lead buyer’s age")
   end
 
   it "has the correct type" do
@@ -47,5 +47,16 @@ RSpec.describe Form::Sales::Questions::Buyer1AgeKnown, type: :model do
 
   it "has the correct hint" do
     expect(question.hint_text).to eq("Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest.")
+  end
+
+  it "has correct conditional for" do
+    expect(question.hidden_in_check_answers).to eq({
+      "depends_on" => [{
+        "age1_known" => 0,
+      },
+    {
+      "age1_known" => 1,
+    }],
+    })
   end
 end

--- a/spec/models/form/sales/questions/buyer1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_age_known_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Form::Sales::Questions::Buyer1AgeKnown, type: :model do
     expect(question.hint_text).to eq("Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest.")
   end
 
-  it "has correct conditional for" do
+  it "has correct hidden_in_check_answers for" do
     expect(question.hidden_in_check_answers).to eq({
       "depends_on" => [{
         "age1_known" => 0,
       },
-    {
-      "age1_known" => 1,
-    }],
+                       {
+                         "age1_known" => 1,
+                       }],
     })
   end
 

--- a/spec/models/form/sales/questions/buyer1_ethnic_background_arab_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_background_arab_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicBackgroundArab, type: :model 
       "19" => { "value" => "Arab" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_ethnic_background_asian_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_background_asian_spec.rb
@@ -44,4 +44,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicBackgroundAsian, type: :model
       "9" => { "value" => "Pakistani" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_ethnic_background_black_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_background_black_spec.rb
@@ -42,4 +42,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicBackgroundBlack, type: :model
       "14" => { "value" => "Any other Black, African or Caribbean background" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_ethnic_background_mixed_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_background_mixed_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicBackgroundMixed, type: :model
       "7" => { "value" => "Any other Mixed or Multiple ethnic background" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_ethnic_background_white_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_background_white_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicBackgroundWhite, type: :model
       "3" => { "value" => "Any other White background" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_ethnic_group_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_group_spec.rb
@@ -46,4 +46,8 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicGroup, type: :model do
       "divider" => { "value" => true },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_income_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_known_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Form::Sales::Questions::Buyer1IncomeKnown, type: :model do
     expect(question.bottom_guidance?).to eq(true)
     expect(question.top_guidance?).to eq(false)
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_income_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_spec.rb
@@ -50,4 +50,8 @@ RSpec.describe Form::Sales::Questions::Buyer1Income, type: :model do
   it "has correct min" do
     expect(question.min).to eq(0)
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_live_in_property_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_live_in_property_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Buyer1LiveInProperty, type: :model do
   it "has the correct hint" do
     expect(question.hint_text).to eq("Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest.")
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_mortgage_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_mortgage_spec.rb
@@ -37,4 +37,8 @@ RSpec.describe Form::Sales::Questions::Buyer1Mortgage, type: :model do
       "2" => { "value" => "No" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Buyer1WorkingSituation, type: :model do
       "7" => { "value" => "Full-time student" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_age_known_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Form::Sales::Questions::Buyer2AgeKnown, type: :model do
   it "has correct hidden in check answers" do
     expect(question.hidden_in_check_answers).to eq({
       "depends_on" => [{
-        "age2_known" => 0
+        "age2_known" => 0,
       },
-      {"age2_known" => 1}]
+                       { "age2_known" => 1 }],
     })
   end
 

--- a/spec/models/form/sales/questions/buyer2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_age_known_spec.rb
@@ -43,4 +43,13 @@ RSpec.describe Form::Sales::Questions::Buyer2AgeKnown, type: :model do
       "age2" => [0],
     })
   end
+
+  it "has correct hidden in check answers" do
+    expect(question.hidden_in_check_answers).to eq({
+      "depends_on" => [{
+        "age2_known" => 0
+      },
+      {"age2_known" => 1}]
+    })
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_age_known_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Form::Sales::Questions::Buyer2AgeKnown, type: :model do
       {"age2_known" => 1}]
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_income_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_income_known_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Form::Sales::Questions::Buyer2IncomeKnown, type: :model do
     expect(question.bottom_guidance?).to eq(true)
     expect(question.top_guidance?).to eq(false)
   end
-  
+
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end

--- a/spec/models/form/sales/questions/buyer2_income_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_income_known_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Form::Sales::Questions::Buyer2IncomeKnown, type: :model do
     expect(question.bottom_guidance?).to eq(true)
     expect(question.top_guidance?).to eq(false)
   end
+  
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_income_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_income_spec.rb
@@ -50,4 +50,8 @@ RSpec.describe Form::Sales::Questions::Buyer2Income, type: :model do
   it "has correct min" do
     expect(question.min).to eq(0)
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_live_in_property_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_live_in_property_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Form::Sales::Questions::Buyer2LiveInProperty, type: :model do
       "2" => { "value" => "No" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_relationship_to_buyer1_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_relationship_to_buyer1_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe Form::Sales::Questions::Buyer2RelationshipToBuyer1, type: :model 
       "R" => { "value" => "Buyer prefers not to say" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_working_situation_spec.rb
@@ -50,4 +50,8 @@ RSpec.describe Form::Sales::Questions::Buyer2WorkingSituation, type: :model do
       "9" => { "value" => "Child under 16" },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/gender_identity1_spec.rb
+++ b/spec/models/form/sales/questions/gender_identity1_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe Form::Sales::Questions::GenderIdentity1, type: :model do
       "R" => { "value" => "Prefers not to say " },
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/gender_identity2_spec.rb
+++ b/spec/models/form/sales/questions/gender_identity2_spec.rb
@@ -39,4 +39,8 @@ RSpec.describe Form::Sales::Questions::GenderIdentity2, type: :model do
       "R" => { "value" => "Buyer prefers not to say" },
     })
   end
+  
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(2)
+  end
 end

--- a/spec/models/form/sales/questions/gender_identity2_spec.rb
+++ b/spec/models/form/sales/questions/gender_identity2_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Form::Sales::Questions::GenderIdentity2, type: :model do
       "R" => { "value" => "Buyer prefers not to say" },
     })
   end
-  
+
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end

--- a/spec/models/form/sales/questions/nationality1_spec.rb
+++ b/spec/models/form/sales/questions/nationality1_spec.rb
@@ -60,4 +60,8 @@ RSpec.describe Form::Sales::Questions::Nationality1, type: :model do
       ],
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/other_nationality1_spec.rb
+++ b/spec/models/form/sales/questions/other_nationality1_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Sales::Questions::OtherNationality1, type: :model do
   it "has the correct hint" do
     expect(question.hint_text).to be_nil
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(1)
+  end
 end

--- a/spec/models/form/sales/questions/person1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person1_age_known_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe Form::Sales::Questions::Person1AgeKnown, type: :model do
           {
             "age3_known" => 0,
           },
+          {
+            "age3_known" => 1,
+          },
         ],
       },
     )

--- a/spec/models/form/sales/questions/person1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person1_age_known_spec.rb
@@ -62,4 +62,8 @@ RSpec.describe Form::Sales::Questions::Person1AgeKnown, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(3)
+  end
 end

--- a/spec/models/form/sales/questions/person1_age_spec.rb
+++ b/spec/models/form/sales/questions/person1_age_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Form::Sales::Questions::Person1Age, type: :model do
 
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
-      "condition" => {"age3_known" => 1},
-      "value" => "Not known"
+      "condition" => { "age3_known" => 1 },
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/person1_age_spec.rb
+++ b/spec/models/form/sales/questions/person1_age_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Form::Sales::Questions::Person1Age, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(3)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => {"age3_known" => 1},
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/person1_age_spec.rb
+++ b/spec/models/form/sales/questions/person1_age_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Person1Age, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(3)
+  end
 end

--- a/spec/models/form/sales/questions/person2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person2AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age4_known" => 0 }, { "details_known_2" => nil }, { "details_known_2" => 2 }],
+        "depends_on" => [{ "age4_known" => 0 }, {"age4_known" => 1}],
       },
     )
   end

--- a/spec/models/form/sales/questions/person2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_known_spec.rb
@@ -55,4 +55,8 @@ RSpec.describe Form::Sales::Questions::Person2AgeKnown, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(4)
+  end
 end

--- a/spec/models/form/sales/questions/person2_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person2AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age4_known" => 0 }, {"age4_known" => 1}],
+        "depends_on" => [{ "age4_known" => 0 }, { "age4_known" => 1 }],
       },
     )
   end

--- a/spec/models/form/sales/questions/person2_age_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Person2Age, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(4)
+  end
 end

--- a/spec/models/form/sales/questions/person2_age_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Form::Sales::Questions::Person2Age, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(3)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => {"age4_known" => 1},
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/person2_age_spec.rb
+++ b/spec/models/form/sales/questions/person2_age_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Form::Sales::Questions::Person2Age, type: :model do
 
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
-      "condition" => {"age4_known" => 1},
-      "value" => "Not known"
+      "condition" => { "age4_known" => 1 },
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/person2_known_spec.rb
+++ b/spec/models/form/sales/questions/person2_known_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Form::Sales::Questions::Person2Known, type: :model do
       },
     )
   end
-  
+
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(4)
   end

--- a/spec/models/form/sales/questions/person2_known_spec.rb
+++ b/spec/models/form/sales/questions/person2_known_spec.rb
@@ -57,4 +57,8 @@ RSpec.describe Form::Sales::Questions::Person2Known, type: :model do
       },
     )
   end
+  
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(4)
+  end
 end

--- a/spec/models/form/sales/questions/person3_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person3AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age5_known" => 0 }, {"age5_known" => 1}],
+        "depends_on" => [{ "age5_known" => 0 }, { "age5_known" => 1 }],
       },
     )
   end

--- a/spec/models/form/sales/questions/person3_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person3AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age5_known" => 0 }, { "details_known_3" => nil }, { "details_known_3" => 2 }],
+        "depends_on" => [{ "age5_known" => 0 }, {"age5_known" => 1}],
       },
     )
   end

--- a/spec/models/form/sales/questions/person3_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_known_spec.rb
@@ -55,4 +55,8 @@ RSpec.describe Form::Sales::Questions::Person3AgeKnown, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(5)
+  end
 end

--- a/spec/models/form/sales/questions/person3_age_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Form::Sales::Questions::Person3Age, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(3)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => {"age5_known" => 1},
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/person3_age_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Person3Age, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(5)
+  end
 end

--- a/spec/models/form/sales/questions/person3_age_spec.rb
+++ b/spec/models/form/sales/questions/person3_age_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Form::Sales::Questions::Person3Age, type: :model do
 
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
-      "condition" => {"age5_known" => 1},
-      "value" => "Not known"
+      "condition" => { "age5_known" => 1 },
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/person3_known_spec.rb
+++ b/spec/models/form/sales/questions/person3_known_spec.rb
@@ -57,4 +57,8 @@ RSpec.describe Form::Sales::Questions::Person3Known, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(5)
+  end
 end

--- a/spec/models/form/sales/questions/person4_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person4AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age6_known" => 0 }, { "details_known_4" => nil }, { "details_known_4" => 2 }],
+        "depends_on" => [{ "age6_known" => 0 }, {"age6_known" => 1}],
       },
     )
   end

--- a/spec/models/form/sales/questions/person4_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_known_spec.rb
@@ -55,4 +55,8 @@ RSpec.describe Form::Sales::Questions::Person4AgeKnown, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(6)
+  end
 end

--- a/spec/models/form/sales/questions/person4_age_known_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_known_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Questions::Person4AgeKnown, type: :model do
   it "has the correct hidden_in_check_answers" do
     expect(question.hidden_in_check_answers).to eq(
       {
-        "depends_on" => [{ "age6_known" => 0 }, {"age6_known" => 1}],
+        "depends_on" => [{ "age6_known" => 0 }, { "age6_known" => 1 }],
       },
     )
   end

--- a/spec/models/form/sales/questions/person4_age_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Questions::Person4Age, type: :model do
       "value" => "Not known"
     })
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(6)
+  end
 end

--- a/spec/models/form/sales/questions/person4_age_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Form::Sales::Questions::Person4Age, type: :model do
 
   it "has the correct inferred check answers value" do
     expect(question.inferred_check_answers_value).to eq({
-      "condition" => {"age6_known" => 1},
-      "value" => "Not known"
+      "condition" => { "age6_known" => 1 },
+      "value" => "Not known",
     })
   end
 

--- a/spec/models/form/sales/questions/person4_age_spec.rb
+++ b/spec/models/form/sales/questions/person4_age_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Form::Sales::Questions::Person4Age, type: :model do
   it "has the correct width" do
     expect(question.width).to eq(3)
   end
+
+  it "has the correct inferred check answers value" do
+    expect(question.inferred_check_answers_value).to eq({
+      "condition" => {"age6_known" => 1},
+      "value" => "Not known"
+    })
+  end
 end

--- a/spec/models/form/sales/questions/person4_known_spec.rb
+++ b/spec/models/form/sales/questions/person4_known_spec.rb
@@ -57,4 +57,8 @@ RSpec.describe Form::Sales::Questions::Person4Known, type: :model do
       },
     )
   end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(6)
+  end
 end


### PR DESCRIPTION
## Part of the ticket
- Change the "Buyer 1's age" label in check your answers to "Lead buyer's age" and only display one label for `age known` and `age` questions.
<img width="661" alt="image" src="https://user-images.githubusercontent.com/54268893/206411530-044d2b2d-e6f4-4e3c-9887-161239d4c373.png">

- When lead buyer's age is known display the age in check your answers:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/54268893/206411220-6ae35448-bcf8-412b-b3de-e605801300a0.png">

- When lead buyer's age is not known display the `Not known` label in check your answers:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/54268893/206411081-eed6c87c-5dff-489a-a227-7d084390ea16.png">

- When lead buyer's prefers not to say the age display `Prefers not to say` label in check your answers (wording updated in #1077):
<img width="667" alt="image" src="https://user-images.githubusercontent.com/54268893/206410988-3b2b1ce6-e92d-431a-8a05-ef15e1bce065.png">

## General clean up
- Update the form to work the same way for the age questions for the rest of the people.
- Add `check_answers_card number` to the questions in household characteristics section in order to display different people on different cards (there's a different ticket to update the card labels):
<img width="1493" alt="image" src="https://user-images.githubusercontent.com/54268893/206416225-28b060f4-9a11-4ff2-a776-de5444f71f75.png">

- Update some buyer 2 questions to only be routed to if it is a joint purchase
