### PR TITLE
Update error message wording

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,11 +144,11 @@ en:
         after_major_repair_date: "Enter a tenancy start date that is after the major repair date"
         location:
           deactivated: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered."
-          reactivating_soon: "The location %{postcode} was deactivated on %{deactivation_date} and is not available on the date you entered. It reactivates on %{date}"
+          reactivating_soon: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
           activating_soon: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
         scheme:
           deactivated: "%{name} was deactivated on %{date} and was not available on the day you entered"
-          reactivating_soon: "%{name} was deactivated on %{deactivation_date} and is not available on the date you entered. It reactivates on %{date}"
+          reactivating_soon: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
           activating_soon: "%{name} is not available until %{date}. Enter a tenancy start date after %{date}"
 
     property:

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022", deactivation_date: "4 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -150,7 +150,7 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 September 2022", deactivation_date: "1 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -194,7 +194,7 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 August 2022", deactivation_date: "4 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do
@@ -220,7 +220,7 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 September 2022", deactivation_date: "1 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Validations::SetupValidations do
         record.location = location
         setup_validator.validate_scheme(record)
         expect(record.errors["scheme_id"])
-        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022", deactivation_date: "4 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -115,7 +115,7 @@ RSpec.describe Validations::SetupValidations do
         record.scheme = scheme
         setup_validator.validate_scheme(record)
         expect(record.errors["scheme_id"])
-        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 August 2022", deactivation_date: "4 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do
@@ -141,7 +141,7 @@ RSpec.describe Validations::SetupValidations do
         record.scheme = scheme
         setup_validator.validate_scheme(record)
         expect(record.errors["scheme_id"])
-        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 September 2022", deactivation_date: "1 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do
@@ -193,7 +193,7 @@ RSpec.describe Validations::SetupValidations do
         record.location = location
         setup_validator.validate_location(record)
         expect(record.errors["location_id"])
-        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022", deactivation_date: "4 June 2022"))
+        .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do


### PR DESCRIPTION
Update error message wording for a scheme/location that is deactivated during the selected tenancy start date and has a reactivation date (CLDC-1769):
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/54268893/206448319-e9aafe7e-bf84-42d9-82f4-efcfe1ca5c05.png">

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/54268893/206449402-081af1fb-bb21-4514-a3e0-043e007f3ad9.png">
