### PR TITLE
Store filename on bulk upload

### DIFF
--- a/app/models/forms/bulk_upload_lettings/upload_your_file.rb
+++ b/app/models/forms/bulk_upload_lettings/upload_your_file.rb
@@ -35,6 +35,7 @@ module Forms
           user: current_user,
           log_type: BulkUpload.log_types[:lettings],
           year:,
+          filename: file.original_filename,
         )
 
         if upload_enabled?

--- a/app/models/forms/bulk_upload_sales/upload_your_file.rb
+++ b/app/models/forms/bulk_upload_sales/upload_your_file.rb
@@ -35,6 +35,7 @@ module Forms
           user: current_user,
           log_type: BulkUpload.log_types[:sales],
           year:,
+          filename: file.original_filename,
         )
 
         if upload_enabled?

--- a/db/migrate/20221207113235_add_bulk_upload_filename.rb
+++ b/db/migrate/20221207113235_add_bulk_upload_filename.rb
@@ -1,0 +1,5 @@
+class AddBulkUploadFilename < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_uploads, :filename, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_06_081127) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_07_113235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_06_081127) do
     t.uuid "identifier", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "filename"
     t.index ["identifier"], name: "index_bulk_uploads_on_identifier", unique: true
     t.index ["user_id"], name: "index_bulk_uploads_on_user_id"
   end

--- a/spec/models/forms/bulk_upload_lettings/upload_your_file_spec.rb
+++ b/spec/models/forms/bulk_upload_lettings/upload_your_file_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe Forms::BulkUploadLettings::UploadYourFile do
 
   let(:year) { 2022 }
   let(:actual_file) { File.open(file_fixture("blank_bulk_upload_sales.csv")) }
-  let(:file) { ActionDispatch::Http::UploadedFile.new(tempfile: actual_file) }
+  let(:file) do
+    ActionDispatch::Http::UploadedFile.new(
+      tempfile: actual_file,
+      filename: "my-file.csv",
+    )
+  end
   let(:current_user) { create(:user) }
   let(:mock_storage_service) { instance_double("S3Service") }
 
@@ -32,6 +37,7 @@ RSpec.describe Forms::BulkUploadLettings::UploadYourFile do
       expect(bulk_upload.user).to eql(current_user)
       expect(bulk_upload.log_type).to eql("lettings")
       expect(bulk_upload.year).to eql(year)
+      expect(bulk_upload.filename).to eql("my-file.csv")
       expect(bulk_upload.identifier).to be_present
     end
 

--- a/spec/models/forms/bulk_upload_sales/upload_your_file_spec.rb
+++ b/spec/models/forms/bulk_upload_sales/upload_your_file_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe Forms::BulkUploadSales::UploadYourFile do
 
   let(:year) { 2022 }
   let(:actual_file) { File.open(file_fixture("blank_bulk_upload_sales.csv")) }
-  let(:file) { ActionDispatch::Http::UploadedFile.new(tempfile: actual_file) }
+  let(:file) do
+    ActionDispatch::Http::UploadedFile.new(
+      tempfile: actual_file,
+      filename: "my-file.csv",
+    )
+  end
   let(:current_user) { create(:user) }
   let(:mock_storage_service) { instance_double("S3Service") }
 
@@ -32,6 +37,7 @@ RSpec.describe Forms::BulkUploadSales::UploadYourFile do
       expect(bulk_upload.user).to eql(current_user)
       expect(bulk_upload.log_type).to eql("sales")
       expect(bulk_upload.year).to eql(year)
+      expect(bulk_upload.filename).to eql("my-file.csv")
       expect(bulk_upload.identifier).to be_present
     end
 


### PR DESCRIPTION
# Context

- At the moment we are not storing the filename when using bulk upload
- It will be needed later to playback back to the user

# Changes

- Store the filename of the file the user uploaded for bulk upload