### PR TITLE
Log errors when logs, organisations, schemes and locations fail to import

### DIFF
--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -288,6 +288,7 @@ module Imports
         attributes.delete("referral")
         save_lettings_log(attributes, previous_status)
       else
+        @logger.error("Log #{lettings_log.old_id}: Failed to import")
         raise exception
       end
     end

--- a/app/services/imports/organisation_import_service.rb
+++ b/app/services/imports/organisation_import_service.rb
@@ -12,6 +12,8 @@ module Imports
     }.freeze
 
     def create_organisation(xml_document)
+      old_visible_id = organisation_field_value(xml_document, "visible-id")
+
       Organisation.create!(
         name: organisation_field_value(xml_document, "name"),
         provider_type: PROVIDER_TYPE[organisation_field_value(xml_document, "institution-type")],
@@ -32,12 +34,14 @@ module Imports
         supported_housing_units: organisation_field_value(xml_document, "supported-housing-units"),
         unspecified_units: organisation_field_value(xml_document, "unspecified-units"),
         old_org_id: organisation_field_value(xml_document, "id"),
-        old_visible_id: organisation_field_value(xml_document, "visible-id"),
+        old_visible_id:,
       )
     rescue ActiveRecord::RecordNotUnique
       name = organisation_field_value(xml_document, "name")
-      old_visible_id = organisation_field_value(xml_document, "visible-id")
       @logger.warn("Organisation #{name} is already present with old visible ID #{old_visible_id}, skipping.")
+    rescue ActiveRecord::RecordInvalid
+      @logger.error("Organisation #{old_visible_id}: Failed to import")
+      raise
     end
 
     def organisation_field_value(xml_document, field)

--- a/app/services/imports/scheme_import_service.rb
+++ b/app/services/imports/scheme_import_service.rb
@@ -18,6 +18,9 @@ module Imports
       else
         @logger.warn("Scheme with legacy ID #{attributes['old_id']} is not approved (#{attributes['status']}), skipping")
       end
+    rescue ActiveRecord::RecordInvalid
+      @logger.error("Scheme #{attributes['old_visible_id']}: Failed to import")
+      raise
     end
 
   private

--- a/app/services/imports/scheme_location_import_service.rb
+++ b/app/services/imports/scheme_location_import_service.rb
@@ -46,6 +46,9 @@ module Imports
       )
       confirm_scheme(scheme)
       scheme.save! && scheme
+    rescue ActiveRecord::RecordInvalid
+      @logger.error("Scheme #{source_scheme.old_visible_id}: Failed to import")
+      raise
     end
 
     def update_scheme(scheme, attributes)
@@ -110,6 +113,9 @@ module Imports
       )
     rescue ActiveRecord::RecordNotUnique
       @logger.warn("Location is already present with legacy ID #{attributes['location_old_id']}, skipping")
+    rescue ActiveRecord::RecordInvalid
+      @logger.error("Location #{attributes['location_old_id']}: Failed to import")
+      raise
     end
 
     def find_scheme_to_merge(attributes)


### PR DESCRIPTION
It's helpful to have the `old_id` for each resource so that we know which resource to re-import later.