### PR TITLE
Safely import schemes with empty `registered_under_care_act` values

### DIFF
--- a/app/services/imports/scheme_location_import_service.rb
+++ b/app/services/imports/scheme_location_import_service.rb
@@ -76,7 +76,7 @@ module Imports
       attributes = {}
       attributes["scheme_type"] = safe_string_as_integer(xml_doc, "scheme-type")
       registered_under_care_act = safe_string_as_integer(xml_doc, "reg-home-type")
-      attributes["registered_under_care_act"] = registered_under_care_act.zero? ? nil : registered_under_care_act
+      attributes["registered_under_care_act"] = registered_under_care_act&.zero? ? nil : registered_under_care_act
       attributes["support_type"] = safe_string_as_integer(xml_doc, "support-type")
       attributes["intended_stay"] = string_or_nil(xml_doc, "intended-stay")
       attributes["mobility_type"] = string_or_nil(xml_doc, "mobility-type")

--- a/spec/services/imports/scheme_location_import_service_spec.rb
+++ b/spec/services/imports/scheme_location_import_service_spec.rb
@@ -170,8 +170,22 @@ RSpec.describe Imports::SchemeLocationImportService do
       end
     end
 
-    context "and the registered under care act value is missing" do
+    context "and the registered under care act value is zero" do
       before { location_xml.at_xpath("//scheme:reg-home-type").content = "0" }
+
+      it "sets the registered under care act to nil" do
+        location = location_service.create_scheme_location(location_xml)
+        expect(location.scheme.registered_under_care_act).to be_nil
+      end
+
+      it "sets the confirmed status to false" do
+        location = location_service.create_scheme_location(location_xml)
+        expect(location.scheme.confirmed).to be_falsey
+      end
+    end
+
+    context "and the registered under care act value is missing" do
+      before { location_xml.at_xpath("//scheme:reg-home-type").content = "" }
 
       it "sets the registered under care act to nil" do
         location = location_service.create_scheme_location(location_xml)


### PR DESCRIPTION
Safely import schemes with empty `registered_under_care_act` values. As well as being zero, this field can also be empty, so we should handle that appropriately. 

This PR adds the safety operator:

```ruby
attributes["registered_under_care_act"] = registered_under_care_act&.zero? ? nil : registered_under_care_act
```