### PR TITLE
Enable editing schemes on production

### DIFF
--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -12,11 +12,11 @@ class FeatureToggle
   end
 
   def self.scheme_toggle_enabled?
-    !Rails.env.production?
+    true
   end
 
   def self.location_toggle_enabled?
-    !Rails.env.production?
+    true
   end
 
   def self.managing_for_other_user_enabled?


### PR DESCRIPTION
This PR toggles `location_toggle_enabled?` and `scheme_toggle_enabled?` to true in all environments, enabling editing schemes on all environments.