### PR TITLE
CLDC-1627 Enable multiple inferred answers

### DIFF
--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -53,10 +53,7 @@ class Form::Question
     answer = label_from_value(log[id]) if log[id].present?
     answer_label = [prefix, format_value(answer), suffix_label(log)].join("") if answer
 
-    inferred = inferred_answer_value(log)
-    return inferred if inferred.present?
-
-    answer_label
+    inferred_answer_value(log) || answer_label
   end
 
   def get_inferred_answers(log)
@@ -113,7 +110,7 @@ class Form::Question
     return unless inferred_check_answers_value
 
     inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
-    inferred_answer.present? ? inferred_answer["value"] : ""
+    inferred_answer["value"] if inferred_answer.present?
   end
 
   def displayed_answer_options(log, _current_user = nil)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -106,13 +106,6 @@ class Form::Question
     false
   end
 
-  def inferred_answer_value(log)
-    return unless inferred_check_answers_value
-
-    inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
-    inferred_answer["value"] if inferred_answer.present?
-  end
-
   def displayed_answer_options(log, _current_user = nil)
     answer_options.select do |_key, val|
       !val.is_a?(Hash) || !val["depends_on"] || form.depends_on_met(val["depends_on"], log)
@@ -311,6 +304,13 @@ private
 
   def enabled_inferred_answers(inferred_answers, log)
     inferred_answers.filter { |_key, value| value.all? { |condition_key, condition_value| log[condition_key] == condition_value } }
+  end
+
+  def inferred_answer_value(log)
+    return unless inferred_check_answers_value
+
+    inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
+    inferred_answer["value"] if inferred_answer.present?
   end
 
   RADIO_YES_VALUE = {

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -53,7 +53,7 @@ class Form::Question
     answer = label_from_value(log[id]) if log[id].present?
     answer_label = [prefix, format_value(answer), suffix_label(log)].join("") if answer
 
-    inferred = get_inferred_answer_value(log)
+    inferred = inferred_answer_value(log)
     return inferred if inferred.present?
 
     answer_label
@@ -109,7 +109,7 @@ class Form::Question
     false
   end
 
-  def get_inferred_answer_value(log)
+  def inferred_answer_value(log)
     return unless inferred_check_answers_value
 
     inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -53,7 +53,7 @@ class Form::Question
     answer = label_from_value(log[id]) if log[id].present?
     answer_label = [prefix, format_value(answer), suffix_label(log)].join("") if answer
 
-    inferred = inferred_check_answers_value["value"] if inferred_check_answers_value && has_inferred_check_answers_value?(log)
+    inferred = get_inferred_answer_value(log)
     return inferred if inferred.present?
 
     answer_label
@@ -104,9 +104,16 @@ class Form::Question
 
   def has_inferred_check_answers_value?(log)
     return true if selected_answer_option_is_derived?(log)
-    return inferred_check_answers_value["condition"].values[0] == log[inferred_check_answers_value["condition"].keys[0]] if inferred_check_answers_value.present?
+    return inferred_check_answers_value&.any? { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] } if inferred_check_answers_value.present?
 
     false
+  end
+
+  def get_inferred_answer_value(log)
+    return unless inferred_check_answers_value
+
+    inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
+    inferred_answer.present??  inferred_answer["value"] : ""
   end
 
   def displayed_answer_options(log, _current_user = nil)
@@ -271,7 +278,7 @@ private
   end
 
   def has_inferred_display_value?(log)
-    inferred_check_answers_value.present? && log[inferred_check_answers_value["condition"].keys.first] == inferred_check_answers_value["condition"].values.first
+    inferred_check_answers_value.present? && inferred_check_answers_value.any? { |inferred_value| log[inferred_value["condition"].keys.first] == inferred_value["condition"].values.first}
   end
 
   def checkbox_answer_label(log)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -113,7 +113,7 @@ class Form::Question
     return unless inferred_check_answers_value
 
     inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
-    inferred_answer.present??  inferred_answer["value"] : ""
+    inferred_answer.present? ? inferred_answer["value"] : ""
   end
 
   def displayed_answer_options(log, _current_user = nil)
@@ -278,7 +278,7 @@ private
   end
 
   def has_inferred_display_value?(log)
-    inferred_check_answers_value.present? && inferred_check_answers_value.any? { |inferred_value| log[inferred_value["condition"].keys.first] == inferred_value["condition"].values.first}
+    inferred_check_answers_value.present? && inferred_check_answers_value.any? { |inferred_value| log[inferred_value["condition"].keys.first] == inferred_value["condition"].values.first }
   end
 
   def checkbox_answer_label(log)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -101,7 +101,7 @@ class Form::Question
 
   def has_inferred_check_answers_value?(log)
     return true if selected_answer_option_is_derived?(log)
-    return inferred_check_answers_value&.any? { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] } if inferred_check_answers_value.present?
+    return inferred_check_answers_value&.any? { |inferred_value| inferred_value["condition"].values.first == log[inferred_value["condition"].keys.first] } if inferred_check_answers_value.present?
 
     false
   end

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -309,7 +309,7 @@ private
   def inferred_answer_value(log)
     return unless inferred_check_answers_value
 
-    inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values[0] == log[inferred_value["condition"].keys[0]] }
+    inferred_answer = inferred_check_answers_value.find { |inferred_value| inferred_value["condition"].values.first == log[inferred_value["condition"].keys.first] }
     inferred_answer["value"] if inferred_answer.present?
   end
 

--- a/app/models/form/sales/questions/age1.rb
+++ b/app/models/form/sales/questions/age1.rb
@@ -6,12 +6,12 @@ class Form::Sales::Questions::Age1 < ::Form::Question
     @header = "Age"
     @type = "numeric"
     @width = 2
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => {
         "age1_known" => 1,
       },
       "value" => "Not known",
-    }
+    }]
     @check_answers_card_number = 1
   end
 end

--- a/app/models/form/sales/questions/age1.rb
+++ b/app/models/form/sales/questions/age1.rb
@@ -6,12 +6,16 @@ class Form::Sales::Questions::Age1 < ::Form::Question
     @header = "Age"
     @type = "numeric"
     @width = 2
-    @inferred_check_answers_value = [{
-      "condition" => {
-        "age1_known" => 1,
+    @inferred_check_answers_value = [
+      {
+        "condition" => { "age1_known" => 1 },
+        "value" => "Not known",
       },
-      "value" => "Not known",
-    }]
+      {
+        "condition" => { "age1_known" => 2 },
+        "value" => "Prefers not to say",
+      },
+    ]
     @check_answers_card_number = 1
   end
 end

--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -6,10 +6,10 @@ class Form::Sales::Questions::Age2 < ::Form::Question
     @header = "Age"
     @type = "numeric"
     @width = 2
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => { "age2_known" => 1 },
       "value" => "Not known",
-    }
+    }]
     @check_answers_card_number = 2
   end
 end

--- a/app/models/form/sales/questions/buyer1_age_known.rb
+++ b/app/models/form/sales/questions/buyer1_age_known.rb
@@ -18,6 +18,9 @@ class Form::Sales::Questions::Buyer1AgeKnown < ::Form::Question
         {
           "age1_known" => 1,
         },
+        {
+          "age1_known" => 2,
+        },
       ],
     }
     @check_answers_card_number = 1

--- a/app/models/form/sales/questions/buyer1_ethnic_group.rb
+++ b/app/models/form/sales/questions/buyer1_ethnic_group.rb
@@ -7,12 +7,12 @@ class Form::Sales::Questions::Buyer1EthnicGroup < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => {
         "ethnic_group" => 17,
       },
       "value" => "Prefers not to say",
-    }
+    }]
     @check_answers_card_number = 1
   end
 

--- a/app/models/form/sales/questions/buyer1_working_situation.rb
+++ b/app/models/form/sales/questions/buyer1_working_situation.rb
@@ -8,6 +8,12 @@ class Form::Sales::Questions::Buyer1WorkingSituation < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @hint_text = "Buyer 1 is the person in the household who does the most paid work. If it's a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
     @check_answers_card_number = 1
+    @inferred_check_answers_value = [{
+      "condition" => {
+        "ecstat1" => 10,
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_relationship_to_buyer1.rb
+++ b/app/models/form/sales/questions/buyer2_relationship_to_buyer1.rb
@@ -7,6 +7,12 @@ class Form::Sales::Questions::Buyer2RelationshipToBuyer1 < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = 2
+    @inferred_check_answers_value = [{
+      "condition" => {
+        "relat2" => "R",
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/buyer2_working_situation.rb
+++ b/app/models/form/sales/questions/buyer2_working_situation.rb
@@ -7,6 +7,12 @@ class Form::Sales::Questions::Buyer2WorkingSituation < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = 2
+    @inferred_check_answers_value = [{
+      "condition" => {
+        "ecstat2" => 10,
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/gender_identity2.rb
+++ b/app/models/form/sales/questions/gender_identity2.rb
@@ -7,6 +7,12 @@ class Form::Sales::Questions::GenderIdentity2 < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = 2
+    @inferred_check_answers_value = [{
+      "condition" => {
+        "sex2" => "R",
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/nationality1.rb
+++ b/app/models/form/sales/questions/nationality1.rb
@@ -18,6 +18,12 @@ class Form::Sales::Questions::Nationality1 < ::Form::Question
       ],
     }
     @check_answers_card_number = 1
+    @inferred_check_answers_value = [{
+      "condition" => {
+        "national" => 13,
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person_age.rb
+++ b/app/models/form/sales/questions/person_age.rb
@@ -5,10 +5,10 @@ class Form::Sales::Questions::PersonAge < Form::Sales::Questions::Person
     @header = "Age"
     @type = "numeric"
     @width = 3
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => { field_for_person("age", "_known") => 1 },
       "value" => "Not known",
-    }
+    }]
     @check_answers_card_number = person_index
   end
 end

--- a/app/models/form/sales/questions/person_gender_identity.rb
+++ b/app/models/form/sales/questions/person_gender_identity.rb
@@ -6,6 +6,12 @@ class Form::Sales::Questions::PersonGenderIdentity < ::Form::Sales::Questions::P
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = person_index
+    @inferred_check_answers_value = [{
+      "condition" => {
+        id => "R",
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person_relationship_to_buyer_1.rb
+++ b/app/models/form/sales/questions/person_relationship_to_buyer_1.rb
@@ -6,6 +6,12 @@ class Form::Sales::Questions::PersonRelationshipToBuyer1 < ::Form::Sales::Questi
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = person_index
+    @inferred_check_answers_value = [{
+      "condition" => {
+        id => "R",
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/person_working_situation.rb
+++ b/app/models/form/sales/questions/person_working_situation.rb
@@ -6,6 +6,12 @@ class Form::Sales::Questions::PersonWorkingSituation < ::Form::Sales::Questions:
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @check_answers_card_number = person_index
+    @inferred_check_answers_value = [{
+      "condition" => {
+        id => 10,
+      },
+      "value" => "Prefers not to say",
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/postcode.rb
+++ b/app/models/form/sales/questions/postcode.rb
@@ -6,12 +6,12 @@ class Form::Sales::Questions::Postcode < ::Form::Question
     @header = "Postcode"
     @type = "text"
     @width = 5
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => {
         "pcodenk" => 1,
       },
       "value" => "Not known",
-    }
+    }]
     @inferred_answers = {
       "la" => {
         "is_la_inferred" => true,

--- a/app/models/form/sales/questions/previous_postcode.rb
+++ b/app/models/form/sales/questions/previous_postcode.rb
@@ -6,12 +6,12 @@ class Form::Sales::Questions::PreviousPostcode < ::Form::Question
     @header = "Postcode"
     @type = "text"
     @width = 5
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => {
         "ppcodenk" => 1,
       },
       "value" => "Not known",
-    }
+    }]
     @inferred_answers = {
       "prevloc" => {
         "is_previous_la_inferred" => true,

--- a/app/models/form/sales/questions/prevloc.rb
+++ b/app/models/form/sales/questions/prevloc.rb
@@ -6,12 +6,12 @@ class Form::Sales::Questions::Prevloc < ::Form::Question
     @header = "Select a local authority"
     @type = "select"
     @answer_options = ANSWER_OPTIONS
-    @inferred_check_answers_value = {
+    @inferred_check_answers_value = [{
       "condition" => {
         "previous_la_known" => 0,
       },
       "value" => "Not known",
-    }
+    }]
   end
 
   ANSWER_OPTIONS = {

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -59,12 +59,12 @@
                       "is_la_inferred": true
                     }
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "postcode_known": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -1298,12 +1298,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age1_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -2077,12 +2077,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age2_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -2612,12 +2612,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age3_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -3144,12 +3144,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age4_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -3673,12 +3673,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age5_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -4199,12 +4199,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age6_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -4722,12 +4722,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age7_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -5242,12 +5242,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age8_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -6517,12 +6517,12 @@
                       "is_previous_la_inferred": true
                     }
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "ppcodenk": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               }
             },
@@ -6950,12 +6950,12 @@
                     "W92000004": "Wales",
                     "9300000XX": "Outside UK"
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "previous_la_known": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -59,12 +59,12 @@
                       "is_la_inferred": true
                     }
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "postcode_known": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -1333,12 +1333,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age1_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -2076,12 +2076,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age2_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -2611,12 +2611,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age3_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -3143,12 +3143,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age4_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -3672,12 +3672,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age5_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -4198,12 +4198,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age6_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -4721,12 +4721,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age7_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -5241,12 +5241,12 @@
                   "max": 120,
                   "step": 1,
                   "width": 2,
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "age8_known": 1
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [
@@ -6482,12 +6482,12 @@
                       "is_previous_la_inferred": true
                     }
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "ppcodenk": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               }
             },
@@ -6915,12 +6915,12 @@
                     "W92000004": "Wales",
                     "9300000XX": "Outside UK"
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "previous_la_known": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               },
               "depends_on": [

--- a/config/forms/schema/generic.json
+++ b/config/forms/schema/generic.json
@@ -115,7 +115,7 @@
                                       "description": "fields that get inferred based on the value of the current field",
                                       "type": "object"
                                     },
-                                    "inferred_check_answers_value": {
+                                    "inferred_check_answers_value": [{
                                       "description": "value that gets displayed in the check answers for this field if the given condition is met",
                                       "type": "object",
                                       "properties": {
@@ -128,7 +128,7 @@
                                           "type": "object"
                                         }
                                       }
-                                    }
+                                    }]
                                   },
                                   "minProperties": 1
                                 }

--- a/docs/form/builder.md
+++ b/docs/form/builder.md
@@ -82,10 +82,10 @@ The JSON should follow the structure:
                     "[snake_case_question_to_enable_2_name_string]": ["condition-that-enables"]
                   },
                   "inferred_answers": { "field_that_gets_inferred_from_current_field": { "is_that_field_inferred": true } },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": { "field_name_for_inferred_check_answers_condition": "field_value_for_inferred_check_answers_condition" },
                     "value": "Inferred value that gets displayed if condition is met"
-                  }
+                  }]
                 }
               },
               "depends_on": [{ "question_key": "answer_value_required_for_this_page_to_be_shown" }]

--- a/docs/form/question.md
+++ b/docs/form/question.md
@@ -74,12 +74,12 @@ The answer the data inputter provides to some questions allows us to infer the v
       "is_la_inferred": true
     }
   },
-  "inferred_check_answers_value": {
+  "inferred_check_answers_value": [{
     "condition": {
       "postcode_known": 0
     },
     "value": "Not known"
-  }
+  }]
 }
 ```
 

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -342,12 +342,12 @@
                       1
                     ]
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "armedforces": 3
                     },
                     "value": "Prefers not to say"
-                  }
+                  }]
                 },
                 "leftreg": {
                   "header": "Are they still serving?",
@@ -526,12 +526,12 @@
                       "is_la_inferred": true
                     }
                   },
-                  "inferred_check_answers_value": {
+                  "inferred_check_answers_value": [{
                     "condition": {
                       "postcode_known": 0
                     },
                     "value": "Not known"
-                  }
+                  }]
                 }
               }
             },

--- a/spec/models/form/sales/questions/age1_spec.rb
+++ b/spec/models/form/sales/questions/age1_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe Form::Sales::Questions::Age1, type: :model do
   end
 
   it "has the correct inferred check answers value" do
-    expect(question.inferred_check_answers_value).to eq({
+    expect(question.inferred_check_answers_value).to eq([{
       "condition" => { "age1_known" => 1 },
       "value" => "Not known",
-    })
+    }])
   end
 
   it "has the correct check_answers_card_number" do

--- a/spec/models/form/sales/questions/age1_spec.rb
+++ b/spec/models/form/sales/questions/age1_spec.rb
@@ -40,10 +40,16 @@ RSpec.describe Form::Sales::Questions::Age1, type: :model do
   end
 
   it "has the correct inferred check answers value" do
-    expect(question.inferred_check_answers_value).to eq([{
-      "condition" => { "age1_known" => 1 },
-      "value" => "Not known",
-    }])
+    expect(question.inferred_check_answers_value).to eq([
+      {
+        "condition" => { "age1_known" => 1 },
+        "value" => "Not known",
+      },
+      {
+        "condition" => { "age1_known" => 2 },
+        "value" => "Prefers not to say",
+      },
+    ])
   end
 
   it "has the correct check_answers_card_number" do

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
   end
 
   it "has the correct inferred check answers value" do
-    expect(question.inferred_check_answers_value).to eq({
+    expect(question.inferred_check_answers_value).to eq([{
       "condition" => {
         "age2_known" => 1,
       },
       "value" => "Not known",
-    })
+    }])
   end
 
   it "has the correct check_answers_card_number" do

--- a/spec/models/form/sales/questions/buyer1_age_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_age_known_spec.rb
@@ -51,12 +51,17 @@ RSpec.describe Form::Sales::Questions::Buyer1AgeKnown, type: :model do
 
   it "has correct hidden_in_check_answers for" do
     expect(question.hidden_in_check_answers).to eq({
-      "depends_on" => [{
-        "age1_known" => 0,
-      },
-                       {
-                         "age1_known" => 1,
-                       }],
+      "depends_on" => [
+        {
+          "age1_known" => 0,
+        },
+        {
+          "age1_known" => 1,
+        },
+        {
+          "age1_known" => 2,
+        },
+      ],
     })
   end
 

--- a/spec/models/form/sales/questions/buyer1_ethnic_group_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_ethnic_group_spec.rb
@@ -50,4 +50,13 @@ RSpec.describe Form::Sales::Questions::Buyer1EthnicGroup, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(1)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([{
+      "condition" => {
+        "ethnic_group" => 17,
+      },
+      "value" => "Prefers not to say",
+    }])
+  end
 end

--- a/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_working_situation_spec.rb
@@ -49,4 +49,10 @@ RSpec.describe Form::Sales::Questions::Buyer1WorkingSituation, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(1)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([
+      { "condition" => { "ecstat1" => 10 }, "value" => "Prefers not to say" },
+    ])
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_relationship_to_buyer1_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_relationship_to_buyer1_spec.rb
@@ -47,4 +47,10 @@ RSpec.describe Form::Sales::Questions::Buyer2RelationshipToBuyer1, type: :model 
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([
+      { "condition" => { "relat2" => "R" }, "value" => "Prefers not to say" },
+    ])
+  end
 end

--- a/spec/models/form/sales/questions/buyer2_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_working_situation_spec.rb
@@ -54,4 +54,10 @@ RSpec.describe Form::Sales::Questions::Buyer2WorkingSituation, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([
+      { "condition" => { "ecstat2" => 10 }, "value" => "Prefers not to say" },
+    ])
+  end
 end

--- a/spec/models/form/sales/questions/gender_identity2_spec.rb
+++ b/spec/models/form/sales/questions/gender_identity2_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe Form::Sales::Questions::GenderIdentity2, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([
+      { "condition" => { "sex2" => "R" }, "value" => "Prefers not to say" },
+    ])
+  end
 end

--- a/spec/models/form/sales/questions/nationality1_spec.rb
+++ b/spec/models/form/sales/questions/nationality1_spec.rb
@@ -64,4 +64,10 @@ RSpec.describe Form::Sales::Questions::Nationality1, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(1)
   end
+
+  it "has the correct inferred_check_answers_value" do
+    expect(question.inferred_check_answers_value).to eq([
+      { "condition" => { "national" => 13 }, "value" => "Prefers not to say" },
+    ])
+  end
 end

--- a/spec/models/form/sales/questions/person_age_spec.rb
+++ b/spec/models/form/sales/questions/person_age_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age2_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -86,10 +86,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age3_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -118,10 +118,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age4_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -150,10 +150,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age5_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -184,10 +184,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age3_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -216,10 +216,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age4_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -248,10 +248,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age5_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do
@@ -280,10 +280,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
       end
 
       it "has the correct inferred check answers value" do
-        expect(question.inferred_check_answers_value).to eq({
+        expect(question.inferred_check_answers_value).to eq([{
           "condition" => { "age6_known" => 1 },
           "value" => "Not known",
-        })
+        }])
       end
 
       it "has the correct check_answers_card_number" do

--- a/spec/models/form/sales/questions/person_gender_identity_spec.rb
+++ b/spec/models/form/sales/questions/person_gender_identity_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(2)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex2" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -85,6 +91,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex3" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -113,6 +125,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex3" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -137,6 +155,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex4" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -165,6 +189,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex4" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -189,6 +219,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex5" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -217,6 +253,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex5" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -241,6 +283,12 @@ RSpec.describe Form::Sales::Questions::PersonGenderIdentity, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(6)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "sex6" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end

--- a/spec/models/form/sales/questions/person_relationship_to_buyer1_spec.rb
+++ b/spec/models/form/sales/questions/person_relationship_to_buyer1_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(2)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat2" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -85,6 +91,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat3" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -113,6 +125,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat3" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -137,6 +155,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat4" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -165,6 +189,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat4" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -189,6 +219,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat5" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -217,6 +253,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat5" => "R" }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -241,6 +283,12 @@ RSpec.describe Form::Sales::Questions::PersonRelationshipToBuyer1, type: :model 
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(6)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "relat6" => "R" }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end

--- a/spec/models/form/sales/questions/person_working_situation_spec.rb
+++ b/spec/models/form/sales/questions/person_working_situation_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(2)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat2" => 10 }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -92,6 +98,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat3" => 10 }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -120,6 +132,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(3)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat3" => 10 }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -144,6 +162,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat4" => 10 }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -172,6 +196,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(4)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat4" => 10 }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -196,6 +226,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat5" => 10 }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end
@@ -224,6 +260,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(5)
       end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat5" => 10 }, "value" => "Prefers not to say" },
+        ])
+      end
     end
 
     context "and joint purchase" do
@@ -248,6 +290,12 @@ RSpec.describe Form::Sales::Questions::PersonWorkingSituation, type: :model do
 
       it "has expected check answers card number" do
         expect(question.check_answers_card_number).to eq(6)
+      end
+
+      it "has the correct inferred_check_answers_value" do
+        expect(question.inferred_check_answers_value).to eq([
+          { "condition" => { "ecstat6" => 10 }, "value" => "Prefers not to say" },
+        ])
       end
     end
   end

--- a/spec/models/form/sales/questions/postcode_spec.rb
+++ b/spec/models/form/sales/questions/postcode_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe Form::Sales::Questions::Postcode, type: :model do
   end
 
   it "has the correct inferred_check_answers_value" do
-    expect(question.inferred_check_answers_value).to eq({
+    expect(question.inferred_check_answers_value).to eq([{
       "condition" => {
         "pcodenk" => 1,
       },
       "value" => "Not known",
-    })
+    }])
   end
 end

--- a/spec/models/form/sales/questions/previous_postcode_spec.rb
+++ b/spec/models/form/sales/questions/previous_postcode_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe Form::Sales::Questions::PreviousPostcode, type: :model do
   end
 
   it "has the correct inferred_check_answers_value" do
-    expect(question.inferred_check_answers_value).to eq({
+    expect(question.inferred_check_answers_value).to eq([{
       "condition" => {
         "ppcodenk" => 1,
       },
       "value" => "Not known",
-    })
+    }])
   end
 end

--- a/spec/models/form/sales/questions/prevloc_spec.rb
+++ b/spec/models/form/sales/questions/prevloc_spec.rb
@@ -422,12 +422,12 @@ RSpec.describe Form::Sales::Questions::Prevloc, type: :model do
 
   it "has the correct inferred_check_answers_value" do
     expect(question.inferred_check_answers_value).to eq(
-      {
+      [{
         "condition" => {
           "previous_la_known" => 0,
         },
         "value" => "Not known",
-      },
+      }],
     )
   end
 end


### PR DESCRIPTION
Builds on top of #1068 

This enables different inferred check answers values to be displayed based on a different condition.
Previously we were only able to set a single inferred value with one condition per question.

This is because for the lead tenant's age question we want to display an inferred `Not known` when age known is answered as `No`, and `Prefers not to say` when the question is answered `Buyer prefers not to say`
<img width="665" alt="image" src="https://user-images.githubusercontent.com/54268893/206995496-29626f14-641d-4421-979f-7162cae20673.png">
<img width="666" alt="image" src="https://user-images.githubusercontent.com/54268893/206996412-21962b7f-a2f2-4040-8d04-5c938714d30b.png">

We also want to display `Prefers not to say` instead of `Buyer prefers not to say` in check your answers for all the other tenant questions, because the text wraps better on mobile screens:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/54268893/212960857-6f616625-c5db-47d3-897c-894e18e42b75.png">

