### PR TITLE
Cldc 1771 Blank invalidated unresolved log fields

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -544,7 +544,7 @@ private
     return unless startdate && voiddate
 
     validate_property_void_date(self)
-    if errors[:voiddate].present?
+    if errors[:voiddate].present? && unresolved?
       self.voiddate = nil
       errors.clear
     end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -541,8 +541,6 @@ private
   end
 
   def reset_voiddate
-    return unless startdate && voiddate
-
     validate_property_void_date(self)
     if errors[:voiddate].present? && unresolved?
       self.voiddate = nil

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -17,6 +17,7 @@ end
 class LettingsLog < Log
   include Validations::SoftValidations
   include DerivedVariables::LettingsLogVariables
+  include Validations::DateValidations
 
   has_paper_trail
 
@@ -25,6 +26,7 @@ class LettingsLog < Log
   before_validation :reset_scheme_location!, if: :scheme_changed?, unless: :location_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
+  before_validation :reset_voiddate, if: :startdate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :reset_location_fields!, unless: :postcode_known?
   before_validation :reset_previous_location_fields!, unless: :previous_postcode_known?
@@ -535,6 +537,16 @@ private
         Rails.logger.debug("Cleared derived #{dependent} value")
         self[dependent] = nil
       end
+    end
+  end
+
+  def reset_voiddate
+    return unless startdate && voiddate
+
+    validate_property_void_date(self)
+    if errors[:voiddate].present?
+      self.voiddate = nil
+      errors.clear
     end
   end
 

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -18,6 +18,7 @@ class LettingsLog < Log
   include Validations::SoftValidations
   include DerivedVariables::LettingsLogVariables
   include Validations::DateValidations
+  include Validations::FinancialValidations
 
   has_paper_trail
 
@@ -547,6 +548,14 @@ private
 
     validate_property_major_repairs(self)
     self.mrcdate = nil if errors[:mrcdate].present?
+
+    validate_rent_range(self)
+    if errors[:brent].present?
+      self.brent = nil 
+      self.scharge = nil
+      self.pscharge = nil
+      self.supcharg = nil
+    end
 
     errors.clear
   end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -26,7 +26,7 @@ class LettingsLog < Log
   before_validation :reset_scheme_location!, if: :scheme_changed?, unless: :location_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
-  before_validation :reset_voiddate, if: :startdate_changed?
+  before_validation :reset_voiddate!, if: :startdate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :reset_location_fields!, unless: :postcode_known?
   before_validation :reset_previous_location_fields!, unless: :previous_postcode_known?
@@ -540,7 +540,7 @@ private
     end
   end
 
-  def reset_voiddate
+  def reset_voiddate!
     validate_property_void_date(self)
     if errors[:voiddate].present? && unresolved?
       self.voiddate = nil

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -27,6 +27,7 @@ class LettingsLog < Log
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
   before_validation :reset_voiddate!, if: :startdate_changed?
+  before_validation :reset_mrcdate!, if: :startdate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :reset_location_fields!, unless: :postcode_known?
   before_validation :reset_previous_location_fields!, unless: :previous_postcode_known?
@@ -544,6 +545,14 @@ private
     validate_property_void_date(self)
     if errors[:voiddate].present? && unresolved?
       self.voiddate = nil
+      errors.clear
+    end
+  end
+
+  def reset_mrcdate!
+    validate_property_major_repairs(self)
+    if errors[:mrcdate].present? && unresolved?
+      self.mrcdate = nil
       errors.clear
     end
   end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -551,7 +551,7 @@ private
 
     validate_rent_range(self)
     if errors[:brent].present?
-      self.brent = nil 
+      self.brent = nil
       self.scharge = nil
       self.pscharge = nil
       self.supcharg = nil

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2003,6 +2003,29 @@ RSpec.describe LettingsLog do
         end
       end
     end
+
+    context "when the log is unresolved" do
+      let(:lettings_log) do
+        FactoryBot.create(
+          :lettings_log,
+          renewal: 0,
+          rsnvac: 5,
+          first_time_property_let_as_social_housing: 0,
+          startdate: Time.zone.tomorrow,
+          voiddate: Time.zone.today,
+          unresolved: true,
+        )
+      end
+
+      context "and the new startdate triggers void date validation" do
+        it "clears void date value" do
+          lettings_log.update!(startdate: Time.zone.yesterday)
+          lettings_log.reload
+          expect(lettings_log.startdate).to eq(Time.zone.yesterday)
+          expect(lettings_log.voiddate).to eq(nil)
+        end
+      end
+    end
   end
 
   describe "tshortfall_unknown?" do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2013,6 +2013,7 @@ RSpec.describe LettingsLog do
           first_time_property_let_as_social_housing: 0,
           startdate: Time.zone.tomorrow,
           voiddate: Time.zone.today,
+          mrcdate: Time.zone.today,
           unresolved: true,
         )
       end
@@ -2023,6 +2024,15 @@ RSpec.describe LettingsLog do
           lettings_log.reload
           expect(lettings_log.startdate).to eq(Time.zone.yesterday)
           expect(lettings_log.voiddate).to eq(nil)
+        end
+      end
+
+      context "and the new startdate triggers major repairs date validation" do
+        it "clears major repairs date value" do
+          lettings_log.update!(startdate: Time.zone.yesterday)
+          lettings_log.reload
+          expect(lettings_log.startdate).to eq(Time.zone.yesterday)
+          expect(lettings_log.mrcdate).to eq(nil)
         end
       end
     end
@@ -2036,6 +2046,7 @@ RSpec.describe LettingsLog do
           first_time_property_let_as_social_housing: 0,
           startdate: Time.zone.tomorrow,
           voiddate: Time.zone.today,
+          mrcdate: Time.zone.today,
           unresolved: nil,
         )
       end
@@ -2045,6 +2056,14 @@ RSpec.describe LettingsLog do
           expect { lettings_log.update!(startdate: Time.zone.yesterday) }.to raise_error(ActiveRecord::RecordInvalid, /Enter a void date that is before the tenancy start date/)
           expect(lettings_log.startdate).to eq(Time.zone.yesterday)
           expect(lettings_log.voiddate).to eq(Time.zone.today)
+        end
+      end
+
+      context "and the new startdate triggers major repairs date validation" do
+        it "doesn't clear major repairs date value" do
+          expect { lettings_log.update!(startdate: Time.zone.yesterday) }.to raise_error(ActiveRecord::RecordInvalid, /Enter a major repairs date that is before the tenancy start date/)
+          expect(lettings_log.startdate).to eq(Time.zone.yesterday)
+          expect(lettings_log.mrcdate).to eq(Time.zone.today)
         end
       end
     end

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2026,6 +2026,28 @@ RSpec.describe LettingsLog do
         end
       end
     end
+
+    context "when the log is resolved" do
+      let(:lettings_log) do
+        FactoryBot.create(
+          :lettings_log,
+          renewal: 0,
+          rsnvac: 5,
+          first_time_property_let_as_social_housing: 0,
+          startdate: Time.zone.tomorrow,
+          voiddate: Time.zone.today,
+          unresolved: nil,
+        )
+      end
+
+      context "and the new startdate triggers void date validation" do
+        it "doesn't clear void date value" do
+          expect { lettings_log.update!(startdate: Time.zone.yesterday) }.to raise_error(ActiveRecord::RecordInvalid, /Enter a void date that is before the tenancy start date/)
+          expect(lettings_log.startdate).to eq(Time.zone.yesterday)
+          expect(lettings_log.voiddate).to eq(Time.zone.today)
+        end
+      end
+    end
   end
 
   describe "tshortfall_unknown?" do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2053,6 +2053,11 @@ RSpec.describe LettingsLog do
           expect(lettings_log.startdate).to eq(Time.zone.yesterday)
           expect(lettings_log.voiddate).to eq(nil)
         end
+
+        it "does not impact other validations" do
+          expect { lettings_log.update!(startdate: Time.zone.yesterday, first_time_property_let_as_social_housing: 0, rsnvac: 16) }
+            .to raise_error(ActiveRecord::RecordInvalid, /Enter a reason for vacancy that is not 'first let' if unit has been previously let as social housing/)
+        end
       end
 
       context "and the new startdate triggers major repairs date validation" do
@@ -2073,6 +2078,11 @@ RSpec.describe LettingsLog do
           expect(lettings_log.scharge).to eq(nil)
           expect(lettings_log.pscharge).to eq(nil)
           expect(lettings_log.supcharg).to eq(nil)
+        end
+
+        it "does not impact other validations" do
+          expect { lettings_log.update!(location:, scheme:, first_time_property_let_as_social_housing: 0, rsnvac: 16) }
+            .to raise_error(ActiveRecord::RecordInvalid, /Enter a reason for vacancy that is not 'first let' if unit has been previously let as social housing/)
         end
       end
     end


### PR DESCRIPTION
When updating a log that is marked as unresolved as a consequence of a scheme or location deactivation, we can get stuck if the new data triggers a validation elsewhere, as we can not access that data to correct it until the log is resolved.

When editing unresolved logs:
- If a new tenancy start date is entered, and when the user clicks "save and continue" it triggers the void date or major repairs date validation, then we clear the voiddate or mrcdate
- If a new scheme or location triggers the rent range validation when the user clicks "save and continue", we clear the rent amount fields

---

We clear the fields by running `reset_invalid_unresolved_log_fields!` before the validation and as part of `reset_invalidated_dependent_fields` for lettings logs only.

We run the specific validations and check if they'd fail and clear relevant fields if they would.
We didn't use `.invalid?` method because running it in the `before validation` method would get stuck in a loop and we don't need to run all of the validations.
We are running validations to check if the fields need to be reset instead of checking them manually in case the validations change.
We clear the errors from validations after resetting the values because the logs wouldn't save otherwise.