### PR TITLE
Remove rolling deployment from review apps

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           APP_NAME: dluhc-core-review-${{ github.event.pull_request.number }}
         run: |
-          cf restage $APP_NAME --strategy rolling
+          cf restage $APP_NAME
 
       - name: Comment on PR with URL
         uses: unsplash/comment-on-pr@v1.3.0


### PR DESCRIPTION
- the following error seems to occur fairly frequently
```
Cannot cancel a deployment with status: FINALIZED and reason: DEGENERATE
```
- removing rolling deployments to see if this can resolve that
- I don't feel rolling deployments will be missed from review apps