### PR TITLE
Ignore unmapped rent period labels

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -60,8 +60,8 @@ class Organisation < ApplicationRecord
   end
 
   def rent_period_labels
-    labels = rent_periods.map { |period| RentPeriod.rent_period_mappings[period.to_s]["value"] }
-    labels.presence || %w[All]
+    labels = rent_periods.map { |period| RentPeriod.rent_period_mappings.dig(period.to_s, "value") }
+    labels.compact.presence || %w[All]
   end
 
   def data_protection_confirmed?

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -124,11 +124,14 @@ RSpec.describe Organisation, type: :model do
       before do
         FactoryBot.create(:organisation_rent_period, organisation:, rent_period: 2)
         FactoryBot.create(:organisation_rent_period, organisation:, rent_period: 3)
+
+        # Unmapped and ignored by `rent_period_labels`
+        FactoryBot.create(:organisation_rent_period, organisation:, rent_period: 10)
         allow(RentPeriod).to receive(:rent_period_mappings).and_return(rent_period_mappings)
       end
 
       it "has rent periods associated" do
-        expect(organisation.rent_periods).to eq([2, 3])
+        expect(organisation.rent_periods).to eq([2, 3, 10])
       end
 
       it "maps the rent periods to display values" do


### PR DESCRIPTION
- It's possible that we import rent periods for an organisation that we haven't yet defined on the new service
- In this instance an organisation as `rent_period` of 10, which corresponds to 'Weekly for 53' in the previous service
- Until we decide how to manage that rent period we should safely generate the rent labels

Fixes: https://sentry.io/organizations/dluhc-core/issues/3802912826/?referrer=slack