### PR TITLE
Ignore `created_by` when computing differences between imported logs

### DIFF
--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -307,7 +307,7 @@ module Imports
     end
 
     def fields_not_present_in_softwire_data
-      %w[majorrepairs illness_type_0 tshortfall_known pregnancy_value_check retirement_value_check rent_value_check net_income_value_check major_repairs_date_value_check void_date_value_check housingneeds_type housingneeds_other]
+      %w[majorrepairs illness_type_0 tshortfall_known pregnancy_value_check retirement_value_check rent_value_check net_income_value_check major_repairs_date_value_check void_date_value_check housingneeds_type housingneeds_other created_by]
     end
 
     def check_status_completed(lettings_log, previous_status)


### PR DESCRIPTION
This field is not set on the previous service. If we don't do this then the importer will complain that the value has changed, where in fact it _is_ always nil.