### PR TITLE
Clear total charge when log is unresolved

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -555,6 +555,7 @@ private
       self.scharge = nil
       self.pscharge = nil
       self.supcharg = nil
+      self.tcharge = nil
     end
 
     errors.clear

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2073,6 +2073,7 @@ RSpec.describe LettingsLog do
           expect(lettings_log.scharge).to eq(nil)
           expect(lettings_log.pscharge).to eq(nil)
           expect(lettings_log.supcharg).to eq(nil)
+          expect(lettings_log.tcharge).to eq(nil)
         end
 
         it "does not impact other validations" do


### PR DESCRIPTION
When fixing an unresolved log we want to clear the charges, but that doesn't update the total charge, so that has to be manually reset as well, otherwise it shows up as complete in CYA:

<img width="855" alt="image" src="https://user-images.githubusercontent.com/54268893/207891212-b7fee2cc-d2a2-40a1-a59b-bea5695b7cb9.png">