### PR TITLE
Add buyer 2 mortgage question

### DIFF
--- a/app/models/form/sales/pages/buyer2_mortgage.rb
+++ b/app/models/form/sales/pages/buyer2_mortgage.rb
@@ -1,0 +1,16 @@
+class Form::Sales::Pages::Buyer2Mortgage < ::Form::Page
+  def initialize(id, hsh, subsection)
+    super
+    @id = "buyer_2_mortgage"
+    @header = ""
+    @description = ""
+    @subsection = subsection
+    @depends_on = [{ "jointpur" => 1 }]
+  end
+
+  def questions
+    @questions ||= [
+      Form::Sales::Questions::Buyer2Mortgage.new(nil, nil, self),
+    ]
+  end
+end

--- a/app/models/form/sales/questions/buyer1_mortgage.rb
+++ b/app/models/form/sales/questions/buyer1_mortgage.rb
@@ -3,7 +3,7 @@ class Form::Sales::Questions::Buyer1Mortgage < ::Form::Question
     super
     @id = "inc1mort"
     @check_answer_label = "Buyer 1's income used for mortgage application"
-    @header = "Was buyer 1's income used for a mortgage application"
+    @header = "Was buyer 1's income used for a mortgage application?"
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @page = page

--- a/app/models/form/sales/questions/buyer2_mortgage.rb
+++ b/app/models/form/sales/questions/buyer2_mortgage.rb
@@ -1,0 +1,17 @@
+class Form::Sales::Questions::Buyer2Mortgage < ::Form::Question
+  def initialize(id, hsh, page)
+    super
+    @id = "inc2mort"
+    @check_answer_label = "Buyer 2's income used for mortgage application"
+    @header = "Was buyer 2's income used for a mortgage application?"
+    @type = "radio"
+    @answer_options = ANSWER_OPTIONS
+    @page = page
+    @check_answers_card_number = 2
+  end
+
+  ANSWER_OPTIONS = {
+    "1" => { "value" => "Yes" },
+    "2" => { "value" => "No" },
+  }.freeze
+end

--- a/app/models/form/sales/subsections/income_benefits_and_savings.rb
+++ b/app/models/form/sales/subsections/income_benefits_and_savings.rb
@@ -16,6 +16,8 @@ class Form::Sales::Subsections::IncomeBenefitsAndSavings < ::Form::Subsection
       Form::Sales::Pages::MortgageValueCheck.new("buyer_1_mortgage_value_check", nil, self),
       Form::Sales::Pages::Buyer2Income.new(nil, nil, self),
       Form::Sales::Pages::MortgageValueCheck.new("buyer_2_income_mortgage_value_check", nil, self),
+      Form::Sales::Pages::Buyer2Mortgage.new(nil, nil, self),
+      Form::Sales::Pages::MortgageValueCheck.new("buyer_2_mortgage_value_check", nil, self),
       Form::Sales::Pages::Savings.new(nil, nil, self),
       Form::Sales::Pages::PreviousOwnership.new(nil, nil, self),
     ]

--- a/spec/models/form/sales/pages/buyer2_mortgage_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_mortgage_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Form::Sales::Pages::Buyer2Mortgage, type: :model do
+  subject(:page) { described_class.new(page_id, page_definition, subsection) }
+
+  let(:page_id) { nil }
+  let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection) }
+
+  it "has correct subsection" do
+    expect(page.subsection).to eq(subsection)
+  end
+
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(%w[inc2mort])
+  end
+
+  it "has the correct id" do
+    expect(page.id).to eq("buyer_2_mortgage")
+  end
+
+  it "has the correct header" do
+    expect(page.header).to eq("")
+  end
+
+  it "has the correct description" do
+    expect(page.description).to eq("")
+  end
+
+  it "has correct depends_on" do
+    expect(page.depends_on).to eq([{ "jointpur" => 1 }])
+  end
+end

--- a/spec/models/form/sales/questions/buyer2_mortgage_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_mortgage_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Form::Sales::Questions::Buyer1Mortgage, type: :model do
+RSpec.describe Form::Sales::Questions::Buyer2Mortgage, type: :model do
   subject(:question) { described_class.new(question_id, question_definition, page) }
 
   let(:question_id) { nil }
@@ -12,15 +12,15 @@ RSpec.describe Form::Sales::Questions::Buyer1Mortgage, type: :model do
   end
 
   it "has the correct id" do
-    expect(question.id).to eq("inc1mort")
+    expect(question.id).to eq("inc2mort")
   end
 
   it "has the correct header" do
-    expect(question.header).to eq("Was buyer 1's income used for a mortgage application?")
+    expect(question.header).to eq("Was buyer 2's income used for a mortgage application?")
   end
 
   it "has the correct check_answer_label" do
-    expect(question.check_answer_label).to eq("Buyer 1's income used for mortgage application")
+    expect(question.check_answer_label).to eq("Buyer 2's income used for mortgage application")
   end
 
   it "has the correct type" do
@@ -39,6 +39,6 @@ RSpec.describe Form::Sales::Questions::Buyer1Mortgage, type: :model do
   end
 
   it "has the correct check_answers_card_number" do
-    expect(question.check_answers_card_number).to eq(1)
+    expect(question.check_answers_card_number).to eq(2)
   end
 end

--- a/spec/models/form/sales/subsections/income_benefits_and_savings_spec.rb
+++ b/spec/models/form/sales/subsections/income_benefits_and_savings_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Form::Sales::Subsections::IncomeBenefitsAndSavings, type: :model 
         buyer_1_mortgage_value_check
         buyer_2_income
         buyer_2_income_mortgage_value_check
+        buyer_2_mortgage
+        buyer_2_mortgage_value_check
         savings
         previous_ownership
       ],

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe FormHandler do
     it "is able to load a current sales form" do
       form = form_handler.get_form("current_sales")
       expect(form).to be_a(Form)
-      expect(form.pages.count).to eq(105)
+      expect(form.pages.count).to eq(107)
       expect(form.name).to eq("2022_2023_sales")
     end
 
     it "is able to load a previous sales form" do
       form = form_handler.get_form("previous_sales")
       expect(form).to be_a(Form)
-      expect(form.pages.count).to eq(105)
+      expect(form.pages.count).to eq(107)
       expect(form.name).to eq("2021_2022_sales")
     end
   end


### PR DESCRIPTION
Add a `inc2mort` question to income and benefits section.
<img width="1459" alt="image" src="https://user-images.githubusercontent.com/54268893/208060480-f93f6bad-e5ab-4831-8f6f-6f7149d3f077.png">

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/54268893/208060413-281543c1-a74d-4368-8c1e-ae2fbd18c70b.png">

Add an interruption screen after this question (soft validation), because we want the soft validation screen to show up if this is the last question that is answered from the set of questions that impact `mortgage_over_soft_max?` validation.