### PR TITLE
Use collection_start_year instead of the startdate

### DIFF
--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1888,7 +1888,7 @@ RSpec.describe LettingsLog do
         soft_max: 89.54,
         hard_min: 10.87,
         hard_max: 100.99,
-        start_year: lettings_log.startdate&.year,
+        start_year: lettings_log.collection_start_year,
       )
     end
 


### PR DESCRIPTION
We were using startdate.year for LaRentRange in one of the tests, which would be a different year from the collection_start_year now that it's 2023.
This PR fixes that test