### PR TITLE
Cldc 1488 fixes

### DIFF
--- a/app/models/form/sales/questions/previous_la_known.rb
+++ b/app/models/form/sales/questions/previous_la_known.rb
@@ -7,7 +7,7 @@ class Form::Sales::Questions::PreviousLaKnown < ::Form::Question
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
     @page = page
-    @hint_text = ""
+    @hint_text = "This is also known as the household’s 'last settled home'"
     @hidden_in_check_answers = {
       "depends_on" => [
         {

--- a/app/models/form/sales/questions/previous_postcode.rb
+++ b/app/models/form/sales/questions/previous_postcode.rb
@@ -7,7 +7,7 @@ class Form::Sales::Questions::PreviousPostcode < ::Form::Question
     @page = page
     @type = "text"
     @width = 5
-    @hint_text = "This is also known as the household’s 'last settled home'"
+    @hint_text = ""
     @inferred_check_answers_value = {
       "condition" => {
         "ppcodenk" => 1,

--- a/app/models/form/sales/questions/previous_postcode_known.rb
+++ b/app/models/form/sales/questions/previous_postcode_known.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::PreviousPostcodeKnown < ::Form::Question
     @conditional_for = {
       "ppostcode_full" => [0],
     }
+    @hint_text = "This is also known as the household’s 'last settled home'"
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/prevloc.rb
+++ b/app/models/form/sales/questions/prevloc.rb
@@ -7,7 +7,7 @@ class Form::Sales::Questions::Prevloc < ::Form::Question
     @type = "select"
     @answer_options = ANSWER_OPTIONS
     @page = page
-    @hint_text = "This is also known as the household’s 'last settled home'"
+    @hint_text = ""
     @inferred_check_answers_value = {
       "condition" => {
         "previous_la_known" => 0,

--- a/spec/models/form/sales/questions/previous_la_known_spec.rb
+++ b/spec/models/form/sales/questions/previous_la_known_spec.rb
@@ -58,4 +58,8 @@ RSpec.describe Form::Sales::Questions::PreviousLaKnown, type: :model do
       "prevloc" => [1],
     })
   end
+
+  it "has the correct hint" do
+    expect(question.hint_text).to eq("This is also known as the household’s 'last settled home'")
+  end
 end

--- a/spec/models/form/sales/questions/previous_postcode_known_spec.rb
+++ b/spec/models/form/sales/questions/previous_postcode_known_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe Form::Sales::Questions::PreviousPostcodeKnown, type: :model do
       "ppostcode_full" => [0],
     })
   end
+
+  it "has the correct hint" do
+    expect(question.hint_text).to eq("This is also known as the household’s 'last settled home'")
+  end
 end

--- a/spec/models/form/sales/questions/previous_postcode_spec.rb
+++ b/spec/models/form/sales/questions/previous_postcode_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Form::Sales::Questions::PreviousPostcode, type: :model do
   end
 
   it "has the correct hint" do
-    expect(question.hint_text).to eq("This is also known as the household’s 'last settled home'")
+    expect(question.hint_text).to eq("")
   end
 
   it "has the correct width" do


### PR DESCRIPTION
Move hint text.
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/210770255-5784ce51-e9bd-4996-b659-760138cd123d.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/210770319-92373f31-7820-43d6-a77d-c0b1173d0c1d.png">

After:
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/54268893/210770130-6931f294-ea99-4bbd-9084-6e92b9a91c51.png">
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/54268893/210770181-b2d5d1f2-8a43-41c3-a276-96c1fb0e9936.png">
