### PR TITLE
CLDC-1798 Update household before letting question for 22/23 form

### DIFF
--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -6339,7 +6339,7 @@
                       "value": "Sheltered accommodation"
                     },
                     "6": {
-                      "value": "Supported housing"
+                      "value": "Other supported housing"
                     },
                     "3": {
                       "value": "Private sector tenancy"
@@ -6421,7 +6421,7 @@
                       "value": "Sheltered accommodation"
                     },
                     "6": {
-                      "value": "Supported housing"
+                      "value": "Other supported housing"
                     }
                   }
                 }

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -6329,6 +6329,12 @@
                     "33": {
                       "value": "Lifetime private registered provider (PRP) general needs tenancy"
                     },
+                    "34": {
+                      "value": "Specialist retirement housing"
+                    },
+                    "35": {
+                      "value": "Extra care housing"
+                    },
                     "8": {
                       "value": "Sheltered accommodation"
                     },
@@ -6405,6 +6411,12 @@
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
+                    "34": {
+                      "value": "Specialist retirement housing"
+                    },
+                    "35": {
+                      "value": "Extra care housing"
+                    },
                     "8": {
                       "value": "Sheltered accommodation"
                     },

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -6335,9 +6335,6 @@
                     "35": {
                       "value": "Extra care housing"
                     },
-                    "8": {
-                      "value": "Sheltered accommodation"
-                    },
                     "6": {
                       "value": "Other supported housing"
                     },
@@ -6416,9 +6413,6 @@
                     },
                     "35": {
                       "value": "Extra care housing"
-                    },
-                    "8": {
-                      "value": "Sheltered accommodation"
                     },
                     "6": {
                       "value": "Other supported housing"


### PR DESCRIPTION
Update 22/23 prevten question because it should be different in the 22/23 form.
This will need some records in production to be updated as option 8 for this question is no longer available.

- [x] Add "Specialist retirement housing", number 34 in DB, placed after "Lifetime private registered provider (PRP) general needs tenancy"
- [x] Add "Extra care housing", number 35 in DB, placed after "Specialist retirement housing"
- [x] Rename "Supported housing" to "Other supported housing". Keep DB number 6. Keep place in list (will now be after "extra care housing"
- [x] Remove Sheltered accommodation (option 8)

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/54268893/211524185-c04a4863-94eb-4886-a1d0-312e7a9c9917.png">
<img width="1735" alt="image" src="https://user-images.githubusercontent.com/54268893/211524300-df83c022-5d3d-4cac-9f3a-45289a0ae8b7.png">
