### PR TITLE
Cldc 1793 update handover date routing

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -760,14 +760,6 @@
                 },
                 {
                   "renewal": 0,
-                  "rsnvac": 16
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 17
-                },
-                {
-                  "renewal": 0,
                   "rsnvac": 18
                 },
                 {
@@ -827,6 +819,14 @@
                 {
                   "renewal": 0,
                   "rsnvac": 15
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 16
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 17
                 }
               ]
             },
@@ -892,14 +892,6 @@
                 {
                   "renewal": 0,
                   "rsnvac": 13
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 16
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 17
                 },
                 {
                   "renewal": 0,

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -760,14 +760,6 @@
                 },
                 {
                   "renewal": 0,
-                  "rsnvac": 16
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 17
-                },
-                {
-                  "renewal": 0,
                   "rsnvac": 18
                 },
                 {
@@ -827,6 +819,14 @@
                 {
                   "renewal": 0,
                   "rsnvac": 15
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 16
+                },
+                {
+                  "renewal": 0,
+                  "rsnvac": 17
                 }
               ]
             },
@@ -892,14 +892,6 @@
                 {
                   "renewal": 0,
                   "rsnvac": 13
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 16
-                },
-                {
-                  "renewal": 0,
-                  "rsnvac": 17
                 },
                 {
                   "renewal": 0,


### PR DESCRIPTION
When RENEWAL= NO; 
TYPE = Supported Housing; 
NEWPROP = YES (First time let)

Then the voiddate question should be "What is the new build handover date" and we should not be asked "Were any major repairs carried out during the void period?"

Previously we were checking if the rsnvac was 15 and depending on that determining that the property is first let.
The property is also first let when the rsnvac question is answered 16, or 17, so those options are now added to the first let route for voiddate question and removed from majorrepairs date route.