### PR TITLE
CLDC-1842 Display correct price questions for discounted ownership sales

### DIFF
--- a/app/models/form/sales/pages/about_price_not_rtb.rb
+++ b/app/models/form/sales/pages/about_price_not_rtb.rb
@@ -5,6 +5,7 @@ class Form::Sales::Pages::AboutPriceNotRtb < ::Form::Page
     @header = "About the price of the property"
     @depends_on = [{
       "right_to_buy?" => false,
+      "rent_to_buy_full_ownership?" => false,
     }]
   end
 

--- a/app/models/form/sales/pages/purchase_price.rb
+++ b/app/models/form/sales/pages/purchase_price.rb
@@ -1,7 +1,12 @@
 class Form::Sales::Pages::PurchasePrice < ::Form::Page
   def initialize(id, hsh, subsection)
     super
-    @id = "purchase_price"
+    @depends_on = [{
+      "ownershipsch" => 3,
+    },
+                   {
+                     "rent_to_buy_full_ownership?" => true,
+                   }]
   end
 
   def questions

--- a/app/models/form/sales/pages/purchase_price.rb
+++ b/app/models/form/sales/pages/purchase_price.rb
@@ -1,12 +1,10 @@
 class Form::Sales::Pages::PurchasePrice < ::Form::Page
   def initialize(id, hsh, subsection)
     super
-    @depends_on = [{
-      "ownershipsch" => 3,
-    },
-                   {
-                     "rent_to_buy_full_ownership?" => true,
-                   }]
+    @depends_on = [
+      { "ownershipsch" => 3 },
+      { "rent_to_buy_full_ownership?" => true },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/subsections/discounted_ownership_scheme.rb
+++ b/app/models/form/sales/subsections/discounted_ownership_scheme.rb
@@ -11,6 +11,7 @@ class Form::Sales::Subsections::DiscountedOwnershipScheme < ::Form::Subsection
       Form::Sales::Pages::LivingBeforePurchase.new("living_before_purchase_discounted_ownership", nil, self),
       Form::Sales::Pages::AboutPriceRtb.new(nil, nil, self),
       Form::Sales::Pages::AboutPriceNotRtb.new(nil, nil, self),
+      Form::Sales::Pages::PurchasePrice.new("purchase_price_discounted_ownership", nil, self),
       Form::Sales::Pages::Mortgageused.new("mortgage_used_discounted_ownership", nil, self),
       Form::Sales::Pages::MortgageAmount.new("mortgage_amount_discounted_ownership", nil, self),
       Form::Sales::Pages::MortgageLender.new("mortgage_lender_discounted_ownership", nil, self),

--- a/app/models/form/sales/subsections/outright_sale.rb
+++ b/app/models/form/sales/subsections/outright_sale.rb
@@ -8,7 +8,7 @@ class Form::Sales::Subsections::OutrightSale < ::Form::Subsection
 
   def pages
     @pages ||= [
-      Form::Sales::Pages::PurchasePrice.new(nil, nil, self),
+      Form::Sales::Pages::PurchasePrice.new("purchase_price_outright_sale", nil, self),
       Form::Sales::Pages::Mortgageused.new("mortgage_used_outright_sale", nil, self),
       Form::Sales::Pages::MortgageAmount.new("mortgage_amount_outright_sale", nil, self),
       Form::Sales::Pages::MortgageLender.new("mortgage_lender_outright_sale", nil, self),

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -121,6 +121,10 @@ class SalesLog < Log
     [9, 14, 27].include?(type)
   end
 
+  def rent_to_buy_full_ownership?
+    type == 29
+  end
+
   def is_type_discount?
     type == 18
   end

--- a/spec/models/form/sales/pages/about_price_not_rtb_spec.rb
+++ b/spec/models/form/sales/pages/about_price_not_rtb_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Form::Sales::Pages::AboutPriceNotRtb, type: :model do
   it "has correct depends_on" do
     expect(page.depends_on).to eq([{
       "right_to_buy?" => false,
+      "rent_to_buy_full_ownership?" => false,
     }])
   end
 end

--- a/spec/models/form/sales/pages/purchase_price_spec.rb
+++ b/spec/models/form/sales/pages/purchase_price_spec.rb
@@ -28,11 +28,9 @@ RSpec.describe Form::Sales::Pages::PurchasePrice, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "ownershipsch" => 3,
-    },
-                                   {
-                                     "rent_to_buy_full_ownership?" => true,
-                                   }])
+    expect(page.depends_on).to eq([
+      { "ownershipsch" => 3 },
+      { "rent_to_buy_full_ownership?" => true },
+    ])
   end
 end

--- a/spec/models/form/sales/pages/purchase_price_spec.rb
+++ b/spec/models/form/sales/pages/purchase_price_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Form::Sales::Pages::PurchasePrice, type: :model do
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
-  let(:page_id) { nil }
+  let(:page_id) { "purchase_price" }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
 
@@ -28,6 +28,11 @@ RSpec.describe Form::Sales::Pages::PurchasePrice, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
+    expect(page.depends_on).to eq([{
+      "ownershipsch" => 3,
+    },
+                                   {
+                                     "rent_to_buy_full_ownership?" => true,
+                                   }])
   end
 end

--- a/spec/models/form/sales/subsections/discounted_ownership_scheme_spec.rb
+++ b/spec/models/form/sales/subsections/discounted_ownership_scheme_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Form::Sales::Subsections::DiscountedOwnershipScheme, type: :model
         living_before_purchase_discounted_ownership
         about_price_rtb
         about_price_not_rtb
+        purchase_price_discounted_ownership
         mortgage_used_discounted_ownership
         mortgage_amount_discounted_ownership
         mortgage_lender_discounted_ownership

--- a/spec/models/form/sales/subsections/outright_sale_spec.rb
+++ b/spec/models/form/sales/subsections/outright_sale_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Form::Sales::Subsections::OutrightSale, type: :model do
   it "has correct pages" do
     expect(outright_sale.pages.map(&:id)).to eq(
       %w[
-        purchase_price
+        purchase_price_outright_sale
         mortgage_used_outright_sale
         mortgage_amount_outright_sale
         mortgage_lender_outright_sale

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe FormHandler do
     it "is able to load a current sales form" do
       form = form_handler.get_form("current_sales")
       expect(form).to be_a(Form)
-      expect(form.pages.count).to eq(144)
+      expect(form.pages.count).to eq(145)
       expect(form.name).to eq("2022_2023_sales")
     end
 
     it "is able to load a previous sales form" do
       form = form_handler.get_form("previous_sales")
       expect(form).to be_a(Form)
-      expect(form.pages.count).to eq(144)
+      expect(form.pages.count).to eq(145)
       expect(form.name).to eq("2021_2022_sales")
     end
   end


### PR DESCRIPTION
In the discounted ownership routing, on the question "About the price of the property" we do not need to ask "What was the amount of any loan, grant, discount or subsidy given" (GRANT).
When type = 29, the only question should be "What was the full purchase price" (VALUE)

We have a page with just a VALUE question that we use in the outright sale section, we are now also reusing it for the discounted ownership question when type is 29.