### PR TITLE
CLDC-1734 Use managing_organisation for rent period validations

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -98,11 +98,11 @@ module Validations::FinancialValidations
   end
 
   def validate_rent_period(record)
-    if record.owning_organisation.present? && record.owning_organisation.rent_periods.present? &&
-        record.period && !record.owning_organisation.rent_periods.include?(record.period)
+    if record.managing_organisation.present? && record.managing_organisation.rent_periods.present? &&
+        record.period && !record.managing_organisation.rent_periods.include?(record.period)
       record.errors.add :period, I18n.t(
         "validations.financial.rent_period.invalid_for_org",
-        org_name: record.owning_organisation.name,
+        org_name: record.managing_organisation.name,
         rent_period: record.form.get_question("period", record).label_from_value(record.period).downcase,
       )
     end

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -126,14 +126,16 @@ RSpec.describe Validations::FinancialValidations do
 
   describe "rent period validations" do
     let(:organisation) { FactoryBot.create(:organisation) }
-    let(:record) { FactoryBot.create(:lettings_log, owning_organisation: organisation) }
+    let(:user) { FactoryBot.create(:user) }
+    let(:record) { FactoryBot.create(:lettings_log, owning_organisation: user.organisation, managing_organisation: organisation, created_by: user) }
 
     before do
+      FactoryBot.create(:organisation_relationship, parent_organisation: user.organisation, child_organisation: organisation)
       FactoryBot.create(:organisation_rent_period, organisation:, rent_period: 2)
     end
 
     context "when the organisation only uses specific rent periods" do
-      it "validates that the selected rent period is used by the organisation" do
+      it "validates that the selected rent period is used by the managing organisation" do
         record.period = 3
         financial_validator.validate_rent_period(record)
         expect(record.errors["period"])


### PR DESCRIPTION
Currently, there is a validation for "How often does the household pay rent and other charges?"
The validation triggers if the user selects a rent period which is not listed in the owning organisation's listed rent periods on the "about your organisation" page.
For organisations in parent/child relationships, the validation should use the managing agents' rent periods.