### PR TITLE
CLDC-1543 Route to mortgage questions only if mortgage is used

### DIFF
--- a/app/models/form/sales/pages/about_deposit_without_discount.rb
+++ b/app/models/form/sales/pages/about_deposit_without_discount.rb
@@ -2,7 +2,7 @@ class Form::Sales::Pages::AboutDepositWithoutDiscount < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @header = "About the deposit"
-    @depends_on = [{ "is_type_discount?" => false }]
+    @depends_on = [{ "is_type_discount?" => false, "mortgageused" => 1 }]
   end
 
   def questions

--- a/app/models/form/sales/pages/about_deposit_without_discount.rb
+++ b/app/models/form/sales/pages/about_deposit_without_discount.rb
@@ -2,7 +2,9 @@ class Form::Sales::Pages::AboutDepositWithoutDiscount < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @header = "About the deposit"
-    @depends_on = [{ "is_type_discount?" => false, "mortgageused" => 1 }]
+    @depends_on = [{ "is_type_discount?" => false, "ownershipsch" => 1 },
+                   { "ownershipsch" => 2 },
+                   { "ownershipsch" => 3, "mortgageused" => 1 }]
   end
 
   def questions

--- a/app/models/form/sales/pages/mortgage_lender.rb
+++ b/app/models/form/sales/pages/mortgage_lender.rb
@@ -4,6 +4,9 @@ class Form::Sales::Pages::MortgageLender < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
+    @depends_on = [{
+      "mortgageused" => 1,
+    }]
   end
 
   def questions

--- a/app/models/form/sales/pages/mortgage_length.rb
+++ b/app/models/form/sales/pages/mortgage_length.rb
@@ -1,4 +1,11 @@
 class Form::Sales::Pages::MortgageLength < ::Form::Page
+  def initialize(id, hsh, subsection)
+    super
+    @depends_on = [{
+      "mortgageused" => 1,
+    }]
+  end
+
   def questions
     @questions ||= [
       Form::Sales::Questions::MortgageLength.new(nil, nil, self),

--- a/app/models/form/sales/questions/deposit_amount.rb
+++ b/app/models/form/sales/questions/deposit_amount.rb
@@ -9,5 +9,6 @@ class Form::Sales::Questions::DepositAmount < ::Form::Question
     @width = 5
     @prefix = "£"
     @hint_text = "Enter the total cash sum paid by the buyer towards the property that was not funded by the mortgage"
+    @derived = true
   end
 end

--- a/app/models/form/sales/questions/deposit_amount.rb
+++ b/app/models/form/sales/questions/deposit_amount.rb
@@ -11,4 +11,8 @@ class Form::Sales::Questions::DepositAmount < ::Form::Question
     @hint_text = "Enter the total cash sum paid by the buyer towards the property that was not funded by the mortgage"
     @derived = true
   end
+
+  def selected_answer_option_is_derived?(_log)
+    true
+  end
 end

--- a/spec/models/form/sales/pages/about_deposit_without_discount_spec.rb
+++ b/spec/models/form/sales/pages/about_deposit_without_discount_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Form::Sales::Pages::AboutDepositWithoutDiscount, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [{ "is_type_discount?" => false, "mortgageused" => 1 }],
+      [{ "is_type_discount?" => false, "ownershipsch" => 1 },
+       { "ownershipsch" => 2 },
+       { "ownershipsch" => 3, "mortgageused" => 1 }],
     )
   end
 end

--- a/spec/models/form/sales/pages/about_deposit_without_discount_spec.rb
+++ b/spec/models/form/sales/pages/about_deposit_without_discount_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Form::Sales::Pages::AboutDepositWithoutDiscount, type: :model do
 
   it "has correct depends_on" do
     expect(page.depends_on).to eq(
-      [{ "is_type_discount?" => false }],
+      [{ "is_type_discount?" => false, "mortgageused" => 1 }],
     )
   end
 end

--- a/spec/models/form/sales/pages/mortgage_lender_spec.rb
+++ b/spec/models/form/sales/pages/mortgage_lender_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Form::Sales::Pages::MortgageLender, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
+    expect(page.depends_on).to eq([{
+      "mortgageused" => 1,
+    }])
   end
 end

--- a/spec/models/form/sales/pages/mortgage_length_spec.rb
+++ b/spec/models/form/sales/pages/mortgage_length_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Form::Sales::Pages::MortgageLength, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
+    expect(page.depends_on).to eq([{
+      "mortgageused" => 1,
+    }])
   end
 end

--- a/spec/models/form/sales/questions/deposit_amount_spec.rb
+++ b/spec/models/form/sales/questions/deposit_amount_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Form::Sales::Questions::DepositAmount, type: :model do
     expect(question.type).to eq("numeric")
   end
 
-  it "is not marked as derived" do
-    expect(question.derived?).to be false
+  it "is marked as derived" do
+    expect(question.derived?).to be true
   end
 
   it "has the correct hint" do


### PR DESCRIPTION
Some of the mortgage questions in the outright sale subsection only need to be routed to if the mortgage was used for the sale