### PR TITLE
CLDC-1844 Allow filtering by organisation if organisation has managing agents

### DIFF
--- a/app/components/log_summary_component.html.erb
+++ b/app/components/log_summary_component.html.erb
@@ -36,7 +36,7 @@
         </p>
       <% end %>
 
-      <% if current_user.support? %>
+      <% if current_user.support? || current_user.organisation.has_managing_agents? %>
         <% if log.owning_organisation or log.managing_organisation %>
           <dl class="app-metadata">
             <div class="app-metadata__item">

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -6,8 +6,8 @@ class OrganisationsController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource, except: %i[index new create]
   before_action :authenticate_scope!, except: [:index]
-  before_action -> { session_filters(specific_org: true) }, if: -> { current_user.support? }
-  before_action :set_session_filters, if: -> { current_user.support? }
+  before_action -> { session_filters(specific_org: true) }, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }
+  before_action :set_session_filters, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }
 
   def index
     redirect_to organisation_path(current_user.organisation) unless current_user.support?

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -22,4 +22,9 @@ module FiltersHelper
 
     JSON.parse(session[:logs_filters])[filter] || ""
   end
+
+  def organisations_filter_options(user)
+    organisation_options = user.support? ? Organisation.all : [user.organisation] + user.organisation.managing_agents
+    [OpenStruct.new(id: "", name: "Select an option")] + organisation_options.map { |org| OpenStruct.new(id: org.id, name: org.name) }
+  end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -92,4 +92,8 @@ class Organisation < ApplicationRecord
       { name: "Data protection agreement", value: data_protection_agreement_string, editable: false },
     ].compact
   end
+
+  def has_managing_agents?
+    managing_agents.count.positive?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ApplicationRecord
   end
 
   def logs_filters(specific_org: false)
-    if support? && !specific_org
+    if (support? && !specific_org) || organisation.has_managing_agents?
       %w[status years user organisation]
     else
       %w[status years user]

--- a/app/views/logs/_log_filters.erb
+++ b/app/views/logs/_log_filters.erb
@@ -10,7 +10,7 @@
         <%= render partial: "filters/checkbox_filter", locals: { f: f, options: years, label: "Collection year", category: "years" } %>
         <%= render partial: "filters/checkbox_filter", locals: { f: f, options: status_filters, label: "Status", category: "status" } %>
         <%= render partial: "filters/radio_filter", locals: { f: f, options: all_or_yours, label: "Logs", category: "user", } %>
-        <% if @current_user.support? && request.path == "/lettings-logs" %>
+        <% if (@current_user.support? || @current_user.organisation.has_managing_agents?) && request.path == "/lettings-logs" %>
           <%= render partial: "filters/radio_filter", locals: {
             f: f,
             options: {
@@ -21,7 +21,7 @@
                   type: "select",
                   label: "Organisation",
                   category: "organisation",
-                  options: [OpenStruct.new(id: "", name: "Select an option")] + Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) } 
+                  options: organisations_filter_options(@current_user)
                 }
               }
             },

--- a/spec/helpers/filters_helper_spec.rb
+++ b/spec/helpers/filters_helper_spec.rb
@@ -81,4 +81,39 @@ RSpec.describe FiltersHelper do
       end
     end
   end
+
+  describe "#organisations_filter_options" do
+    let(:parent_organisation) { FactoryBot.create(:organisation, name: "Parent organisation") }
+    let(:child_organisation) { FactoryBot.create(:organisation, name: "Child organisation") }
+
+    before do
+      FactoryBot.create(:organisation_relationship, parent_organisation:, child_organisation:)
+      FactoryBot.create(:organisation, name: "Other organisation", id: 99)
+    end
+
+    context "with a support user" do
+      let(:user) { FactoryBot.create(:user, :support, organisation: parent_organisation) }
+
+      it "returns a list of all organisations" do
+        expect(organisations_filter_options(user)).to eq([
+          OpenStruct.new(id: "", name: "Select an option"),
+          OpenStruct.new(id: parent_organisation.id, name: "Parent organisation"),
+          OpenStruct.new(id: child_organisation.id, name: "Child organisation"),
+          OpenStruct.new(id: 99, name: "Other organisation"),
+        ])
+      end
+    end
+
+    context "with a data coordinator user" do
+      let(:user) { FactoryBot.create(:user, :data_coordinator, organisation: parent_organisation) }
+
+      it "returns a list of managing agents and your own organisation" do
+        expect(organisations_filter_options(user)).to eq([
+          OpenStruct.new(id: "", name: "Select an option"),
+          OpenStruct.new(id: parent_organisation.id, name: "Parent organisation"),
+          OpenStruct.new(id: child_organisation.id, name: "Child organisation"),
+        ])
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe User, type: :model do
           FactoryBot.create(:organisation_relationship, parent_organisation: user.organisation)
         end
 
-        it "can filter lettings logs by user, year and status" do
+        it "can filter lettings logs by user, year, status and organisation" do
           expect(user.logs_filters).to eq(%w[status years user organisation])
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,8 +117,24 @@ RSpec.describe User, type: :model do
         })
       end
 
-      it "can filter lettings logs by user, year and status" do
-        expect(user.logs_filters).to eq(%w[status years user])
+      context "and their organisation does not have managing agents" do
+        before do
+          user.organisation.update(holds_own_stock: false)
+        end
+
+        it "can filter lettings logs by user, year and status" do
+          expect(user.logs_filters).to eq(%w[status years user])
+        end
+      end
+
+      context "and their organisation has managing agents" do
+        before do
+          FactoryBot.create(:organisation_relationship, parent_organisation: user.organisation)
+        end
+
+        it "can filter lettings logs by user, year and status" do
+          expect(user.logs_filters).to eq(%w[status years user organisation])
+        end
       end
     end
 


### PR DESCRIPTION
We already display all the logs managed by other organisations.
This PR also displays the organisation filter for all users if the organisation has managing agents