### PR TITLE
Correct no-stock user names + update emails to prevent duplicates

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -110,8 +110,8 @@ unless Rails.env.test?
   )
 
   User.find_or_create_by!(
-    name: "Provider Owns Stock",
-    email: "provider.nostock1@example.com",
+    name: "Provider No Stock",
+    email: "provider.nostock@example.com",
     organisation: standalone_no_stock,
     role: "data_provider",
   ) do |user|
@@ -120,8 +120,8 @@ unless Rails.env.test?
   end
 
   User.find_or_create_by!(
-    name: "Coordinator Owns Stock",
-    email: "coordinator.nostock1@example.com",
+    name: "Coordinator No Stock",
+    email: "coordinator.nostock@example.com",
     organisation: standalone_no_stock,
     role: "data_coordinator",
   ) do |user|


### PR DESCRIPTION
There are a couple of users in the `seeds.rb` file which have non-stock-owning organisations. The names of the users suggested that their orgs _did_ own stock though, which was confusing. This PR simply updates their names to be more sensible. It also updates their email addresses (in a completely trivial way) to ensure that duplicate email alerts aren't triggered.

This PR is not related to a ticket in Jira - it's just something I noticed whilst doing some testing.