### PR TITLE
CLDC-859 Sales validation - bedsits cannot have more than 1 bed

### DIFF
--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -223,6 +223,12 @@ class SalesLog < Log
     type == 24
   end
 
+  def is_bedsit?
+    return if proptype.nil?
+
+    proptype == 2
+  end
+
   def shared_ownership_scheme?
     ownershipsch == 1
   end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -224,8 +224,6 @@ class SalesLog < Log
   end
 
   def is_bedsit?
-    return if proptype.nil?
-
     proptype == 2
   end
 

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -9,9 +9,9 @@ module Validations::Sales::PropertyValidations
   end
 
   def validate_bedsit_number_of_beds(record)
-    return if record.proptype.blank? || record.beds.blank?
+    return if record.is_bedsit?.blank? || record.beds.blank?
 
-    if record.proptype == 2 && record.beds > 1
+    if record.is_bedsit? && record.beds > 1
       record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")
       record.errors.add :beds, I18n.t("validations.property.beds.bedsits_have_max_one_bedroom")
     end

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -15,4 +15,12 @@ module Validations::Sales::PropertyValidations
       record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")
     end
   end
+
+  def validate_property_number_of_bedrooms(record)
+    return if record.proptype.blank? || record.beds.blank?
+
+    unless record.proptype != 2 || record.beds <= 1
+      record.errors.add :beds, I18n.t("validations.property.beds.bedsits_have_max_one_bedroom")
+    end
+  end
 end

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -8,7 +8,7 @@ module Validations::Sales::PropertyValidations
     end
   end
 
-  def validate_propert_unit_type(record)
+  def validate_property_unit_type(record)
     return if record.proptype.blank? || record.beds.blank?
 
     unless record.proptype != 2 || record.beds <= 1

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -8,18 +8,11 @@ module Validations::Sales::PropertyValidations
     end
   end
 
-  def validate_property_unit_type(record)
+  def validate_bedsit_number_of_beds(record)
     return if record.proptype.blank? || record.beds.blank?
 
     unless record.proptype != 2 || record.beds <= 1
       record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")
-    end
-  end
-
-  def validate_property_number_of_bedrooms(record)
-    return if record.proptype.blank? || record.beds.blank?
-
-    unless record.proptype != 2 || record.beds <= 1
       record.errors.add :beds, I18n.t("validations.property.beds.bedsits_have_max_one_bedroom")
     end
   end

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -11,7 +11,7 @@ module Validations::Sales::PropertyValidations
   def validate_bedsit_number_of_beds(record)
     return if record.proptype.blank? || record.beds.blank?
 
-    unless record.proptype != 2 || record.beds <= 1
+    if record.proptype == 2 && record.beds > 1
       record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")
       record.errors.add :beds, I18n.t("validations.property.beds.bedsits_have_max_one_bedroom")
     end

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -7,4 +7,12 @@ module Validations::Sales::PropertyValidations
       record.errors.add :ppostcode_full, I18n.t("validations.property.postcode.must_match_previous")
     end
   end
+
+  def validate_propert_unit_type(record)
+    return if record.proptype.blank? || record.beds.blank?
+
+    unless record.proptype != 2 || record.beds <= 1
+      record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")
+    end
+  end
 end

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -9,7 +9,7 @@ module Validations::Sales::PropertyValidations
   end
 
   def validate_bedsit_number_of_beds(record)
-    return if record.is_bedsit?.blank? || record.beds.blank?
+    return unless record.proptype.present? && record.beds.present?
 
     if record.is_bedsit? && record.beds > 1
       record.errors.add :proptype, I18n.t("validations.property.proptype.bedsits_have_max_one_bedroom")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,9 +202,9 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
-        bedsits_have_max_one_bedroom: "Bedsits have at most one bedroom"
+        bedsits_have_max_one_bedroom: "Bedsit bedroom maximum 1"
       proptype:
-        bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
+        bedsits_have_max_one_bedroom: "Bedsit maximum 1 bedroom"
       postcode:
         must_match_previous: "Buyer's last accommodation and discounted ownership postcodes must match"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
+        bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
       proptype:
         bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
       postcode:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,8 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
+      proptype:
+        bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
       postcode:
         must_match_previous: "Buyer's last accommodation and discounted ownership postcodes must match"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
-        bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
+        bedsits_have_max_one_bedroom: "Bedsits have at most one bedroom"
       proptype:
         bedsits_have_max_one_bedroom: "Properties with 2 or more bedrooms cannot be bedsits"
       postcode:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,9 +202,9 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
-        bedsits_have_max_one_bedroom: "Bedsit bedroom maximum 1"
+        bedsits_have_max_one_bedroom: "Number of bedrooms must be 1 if the property is a bedsit"
       proptype:
-        bedsits_have_max_one_bedroom: "Bedsit maximum 1 bedroom"
+        bedsits_have_max_one_bedroom: "Answer cannot be 'Bedsit' if the property has 2 or more bedrooms"
       postcode:
         must_match_previous: "Buyer's last accommodation and discounted ownership postcodes must match"
 

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -55,27 +55,6 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does not add an error if it's a bedsit" do
         property_validator.validate_property_unit_type(record)
-
-        expect(record.errors).not_to be_present
-      end
-    end
-
-    context "when number of bedrooms is > 1" do
-      let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
-
-      it "does add an error if it's a bedsit" do
-        property_validator.validate_property_unit_type(record)
-
-        expect(record.errors).to be_present
-      end
-    end
-  end  
-
-  describe "#validate_property_number_of_bedrooms" do
-    context "when number of bedrooms is <= 1" do
-      let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
-
-      it "does not add an error if it's a bedsit" do
         property_validator.validate_property_number_of_bedrooms(record)
 
         expect(record.errors).not_to be_present
@@ -86,6 +65,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
       let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
 
       it "does add an error if it's a bedsit" do
+        property_validator.validate_property_unit_type(record)
         property_validator.validate_property_number_of_bedrooms(record)
 
         expect(record.errors).to be_present

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does not add an error if it's a bedsit" do
         property_validator.validate_bedsit_number_of_beds(record)
-
         expect(record.errors).not_to be_present
       end
     end
@@ -67,6 +66,21 @@ RSpec.describe Validations::Sales::PropertyValidations do
         property_validator.validate_bedsit_number_of_beds(record)
         expect(record.errors.added?(:proptype, "Bedsit maximum 1 bedroom")).to be true
         expect(record.errors.added?(:beds, "Bedsit bedroom maximum 1")).to be true
+      end
+
+      it "does not add an error if proptype is undefined" do
+        record.update(proptype: nil)
+        property_validator.validate_bedsit_number_of_beds(record)
+        expect(record.errors).not_to be_present
+      end
+    end
+
+    context "when number of bedrooms is undefined" do
+      let(:record) { FactoryBot.build(:sales_log, beds: nil, proptype: 2) }
+
+      it "does not add an error if it's a bedsit" do
+        property_validator.validate_bedsit_number_of_beds(record)
+        expect(record.errors).not_to be_present
       end
     end
   end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
       let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
 
       it "does not add an error if it's a bedsit" do
-        property_validator.validate_property_unit_type(record)
-        property_validator.validate_property_number_of_bedrooms(record)
+        property_validator.validate_bedsit_number_of_beds(record)
 
         expect(record.errors).not_to be_present
       end
@@ -65,10 +64,8 @@ RSpec.describe Validations::Sales::PropertyValidations do
       let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
 
       it "does add an error if it's a bedsit" do
-        property_validator.validate_property_unit_type(record)
+        property_validator.validate_bedsit_number_of_beds(record)
         expect(record.errors.added? :proptype, "Properties with 2 or more bedrooms cannot be bedsits").to be true
-
-        property_validator.validate_property_number_of_bedrooms(record)
         expect(record.errors.added? :beds, "Bedsits have at most one bedroom").to be true
       end
     end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does add an error if it's a bedsit" do
         property_validator.validate_bedsit_number_of_beds(record)
-        expect(record.errors.added? :proptype, "Bedsit maximum 1 bedroom").to be true
-        expect(record.errors.added? :beds, "Bedsit bedroom maximum 1").to be true
+        expect(record.errors.added?(:proptype, "Bedsit maximum 1 bedroom")).to be true
+        expect(record.errors.added?(:beds, "Bedsit bedroom maximum 1")).to be true
       end
     end
   end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does add an error if it's a bedsit" do
         property_validator.validate_bedsit_number_of_beds(record)
-        expect(record.errors.added? :proptype, "Properties with 2 or more bedrooms cannot be bedsits").to be true
-        expect(record.errors.added? :beds, "Bedsits have at most one bedroom").to be true
+        expect(record.errors.added? :proptype, "Bedsit maximum 1 bedroom").to be true
+        expect(record.errors.added? :beds, "Bedsit bedroom maximum 1").to be true
       end
     end
   end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -66,9 +66,10 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does add an error if it's a bedsit" do
         property_validator.validate_property_unit_type(record)
-        property_validator.validate_property_number_of_bedrooms(record)
+        expect(record.errors.added? :proptype, "Properties with 2 or more bedrooms cannot be bedsits").to be true
 
-        expect(record.errors).to be_present
+        property_validator.validate_property_number_of_bedrooms(record)
+        expect(record.errors.added? :beds, "Bedsits have at most one bedroom").to be true
       end
     end
   end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -48,4 +48,26 @@ RSpec.describe Validations::Sales::PropertyValidations do
       end
     end
   end
+
+  describe "#validate_propert_unit_type" do
+    context "when number of bedrooms is <= 1" do
+      let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
+
+      it "does not add an error if it's a bedsit" do
+        property_validator.validate_propert_unit_type(record)
+
+        expect(record.errors).not_to be_present
+      end
+    end
+
+    context "when number of bedrooms is > 1" do
+      let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
+
+      it "does add an error if it's a bedsit" do
+        property_validator.validate_propert_unit_type(record)
+
+        expect(record.errors).to be_present
+      end
+    end
+  end  
 end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
       end
 
       it "does not add an error if proptype is undefined" do
-        record.update(proptype: nil)
+        record.update!(proptype: nil)
         property_validator.validate_bedsit_number_of_beds(record)
         expect(record.errors).not_to be_present
       end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -70,4 +70,26 @@ RSpec.describe Validations::Sales::PropertyValidations do
       end
     end
   end  
+
+  describe "#validate_property_number_of_bedrooms" do
+    context "when number of bedrooms is <= 1" do
+      let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
+
+      it "does not add an error if it's a bedsit" do
+        property_validator.validate_property_number_of_bedrooms(record)
+
+        expect(record.errors).not_to be_present
+      end
+    end
+
+    context "when number of bedrooms is > 1" do
+      let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
+
+      it "does add an error if it's a bedsit" do
+        property_validator.validate_property_number_of_bedrooms(record)
+
+        expect(record.errors).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
   end
 
   describe "#validate_property_unit_type" do
-    context "when number of bedrooms is <= 1" do
+    context "when number of bedrooms is 1" do
       let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
 
       it "does not add an error if it's a bedsit" do
@@ -64,8 +64,8 @@ RSpec.describe Validations::Sales::PropertyValidations do
 
       it "does add an error if it's a bedsit" do
         property_validator.validate_bedsit_number_of_beds(record)
-        expect(record.errors.added?(:proptype, "Bedsit maximum 1 bedroom")).to be true
-        expect(record.errors.added?(:beds, "Bedsit bedroom maximum 1")).to be true
+        expect(record.errors.added?(:proptype, "Answer cannot be 'Bedsit' if the property has 2 or more bedrooms")).to be true
+        expect(record.errors.added?(:beds, "Number of bedrooms must be 1 if the property is a bedsit")).to be true
       end
 
       it "does not add an error if proptype is undefined" do

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe Validations::Sales::PropertyValidations do
     end
   end
 
-  describe "#validate_propert_unit_type" do
+  describe "#validate_property_unit_type" do
     context "when number of bedrooms is <= 1" do
       let(:record) { FactoryBot.build(:sales_log, beds: 1, proptype: 2) }
 
       it "does not add an error if it's a bedsit" do
-        property_validator.validate_propert_unit_type(record)
+        property_validator.validate_property_unit_type(record)
 
         expect(record.errors).not_to be_present
       end
@@ -64,7 +64,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
       let(:record) { FactoryBot.build(:sales_log, beds: 2, proptype: 2) }
 
       it "does add an error if it's a bedsit" do
-        property_validator.validate_propert_unit_type(record)
+        property_validator.validate_property_unit_type(record)
 
         expect(record.errors).to be_present
       end

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SalesLogsController, type: :request do
         it "validates sales log parameters" do
           json_response = JSON.parse(response.body)
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(json_response["errors"]).to match_array([["beds", ["Bedsit bedroom maximum 1"]], ["proptype", ["Bedsit maximum 1 bedroom"]]])
+          expect(json_response["errors"]).to match_array([["beds", ["Number of bedrooms must be 1 if the property is a bedsit"]], ["proptype", ["Answer cannot be 'Bedsit' if the property has 2 or more bedrooms"]]])
         end
       end
     end

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SalesLogsController, type: :request do
       context "with a request containing invalid json parameters" do
         let(:params) do
           {
-            "saledate": Date.new(1, 1, 1),
+            "saledate": Date.new(2022, 4, 1),
             "purchid": "1",
             "ownershipsch": 1,
             "type": 2,

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe SalesLogsController, type: :request do
           expect(response).to have_http_status(:unauthorized)
         end
       end
+
+      context "with a request containing invalid json parameters" do
+        let(:params) do
+          {
+            "saledate": Date.new(1, 1, 1),
+            "purchid": "1",
+            "ownershipsch": 1,
+            "type": 2,
+            "jointpur": 1,
+            "jointmore": 1,
+            "beds": 2,
+            "proptype": 2,
+          }
+        end
+
+        before do
+          post "/sales-logs", headers:, params: params.to_json
+        end
+
+        it "validates sales log parameters" do
+          json_response = JSON.parse(response.body)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json_response["errors"]).to match_array([["beds", ["Bedsit bedroom maximum 1"]], ["proptype", ["Bedsit maximum 1 bedroom"]]])
+        end
+      end
     end
 
     context "when UI" do


### PR DESCRIPTION
## Context
- https://digital.dclg.gov.uk/jira/browse/CLDC-859
- Adding a sales validation to ensure bedsits have at most one bedroom.

## The changes
- Added a validation to the property type page, so that if the number of bedrooms is >1 and then bedsit (proptype = 2) is selected as the property type, then the following message is displayed: "Bedsit maximum 1 bedroom".
<img width="748" alt="image" src="https://user-images.githubusercontent.com/63662292/213765454-8fdf84cc-79b4-4aa7-b1f8-1579b97ebb31.png">

- Added a validation to the 'number of bedrooms' page, so that if the property type is selected (as bedsit) and then the number of beds is entered as >1 then the following message is displayed: "Bedsit bedroom maximum 1".
<img width="745" alt="image" src="https://user-images.githubusercontent.com/63662292/213765374-62028d76-eede-405a-9a1e-1a9cd3ef2049.png">