### PR TITLE
Fix which row bulk upload error belongs to

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -154,7 +154,7 @@ class BulkUpload::Lettings::Validator
     row_parsers.each_with_index do |row_parser, index|
       row_parser.valid?
 
-      row = index + row_offset
+      row = index + row_offset + 1
 
       row_parser.errors.each do |error|
         bulk_upload.bulk_upload_errors.create!(
@@ -163,7 +163,7 @@ class BulkUpload::Lettings::Validator
           tenant_code: row_parser.field_7,
           property_ref: row_parser.field_100,
           row:,
-          cell: "#{cols[field_number_for_attribute(error.attribute) - col_offset + 1]}#{row + 1}",
+          cell: "#{cols[field_number_for_attribute(error.attribute) - col_offset + 1]}#{row}",
         )
       end
     end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -32,8 +32,15 @@ RSpec.describe BulkUpload::Lettings::Validator do
   context "when a valid csv" do
     let(:path) { file_fixture("2022_23_lettings_bulk_upload.csv") }
 
-    it do
+    it "creates validation errors" do
+      expect { validator.call }.to change(BulkUploadError, :count)
+    end
+
+    it "create validation error with correct values" do
       validator.call
+
+      error = BulkUploadError.first
+      expect(error.row).to eq("6")
     end
   end
 end


### PR DESCRIPTION
# Context

- When viewing bulk upload errors there is an offset by one error for the row being displayed back to the user

# Change

- Update so that row number is correct and matches up with cell row

# Screenshots

![Screenshot 2023-01-16 at 17 40 18](https://user-images.githubusercontent.com/92580/212738381-0131ca27-4e70-4c96-92ab-9f39b2829b0f.png)