### PR TITLE
Order bulk upload errors by cell

### DIFF
--- a/app/components/bulk_upload_error_row_component.rb
+++ b/app/components/bulk_upload_error_row_component.rb
@@ -2,7 +2,7 @@ class BulkUploadErrorRowComponent < ViewComponent::Base
   attr_reader :bulk_upload_errors
 
   def initialize(bulk_upload_errors:)
-    @bulk_upload_errors = bulk_upload_errors
+    @bulk_upload_errors = sorted_errors(bulk_upload_errors)
 
     super
   end
@@ -44,5 +44,11 @@ class BulkUploadErrorRowComponent < ViewComponent::Base
 
   def sales?
     bulk_upload.log_type == "sales"
+  end
+
+private
+
+  def sorted_errors(errors)
+    errors.sort_by { |e| e.cell.rjust(3, "0") }
   end
 end

--- a/spec/components/bulk_upload_error_row_component_spec.rb
+++ b/spec/components/bulk_upload_error_row_component_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe BulkUploadErrorRowComponent, type: :component do
       expect(result).to have_content(expected)
     end
 
+    context "when multiple errors for a row" do
+      subject(:component) { described_class.new(bulk_upload_errors:) }
+
+      let(:bulk_upload_errors) do
+        [
+          build(:bulk_upload_error, cell: "Z1"),
+          build(:bulk_upload_error, cell: "AB1"),
+          build(:bulk_upload_error, cell: "A1"),
+        ]
+      end
+
+      it "is sorted by cell" do
+        expect(component.bulk_upload_errors.map(&:cell)).to eql(%w[A1 Z1 AB1])
+      end
+    end
+
     context "when a sales bulk upload" do
       let(:bulk_upload) { create(:bulk_upload, :sales) }
       let(:field) { :field_87 }


### PR DESCRIPTION
# Context

- Bulk upload errors are not presented in cell order which makes it hard to follow along with the uploaded spreadsheet

# Changes

- Order bulk upload errors by cells so they are more comprehendible for users rather that in an hodgepodge order. This now matches the order of the uploaded spreadsheet 

# Screenshots

![Screenshot 2023-01-17 at 09 40 51](https://user-images.githubusercontent.com/92580/212863552-844792b2-feaa-4a96-bce3-52d3ac46d40b.png)