### PR TITLE
CLDC-848 Add household details validations

### DIFF
--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -11,5 +11,7 @@ class Form::Sales::Questions::Age2 < ::Form::Question
       "value" => "Not known",
     }]
     @check_answers_card_number = 2
+    @max = 110
+    @min = 0
   end
 end

--- a/app/models/form/sales/questions/person_age.rb
+++ b/app/models/form/sales/questions/person_age.rb
@@ -10,5 +10,7 @@ class Form::Sales::Questions::PersonAge < Form::Sales::Questions::Person
       "value" => "Not known",
     }]
     @check_answers_card_number = person_index
+    @min = 0
+    @max = 110
   end
 end

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -40,10 +40,26 @@ private
     relationship = record.public_send("relat#{person_num}")
     return unless age && economic_status && relationship
 
-    if age >= 16 && age <= 19 && person_is_fulltime_student?(economic_status) && !person_is_child?(relationship)
-      record.errors.add "age#{person_num}", I18n.t("validations.household.age.student_16_19")
-      record.errors.add "ecstat#{person_num}", I18n.t("validations.household.ecstat.student_16_19")
-      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.student_16_19")
+    age_between_16_19 = age.between?(16, 19)
+    student = person_is_fulltime_student?(economic_status)
+    child = person_is_child?(relationship)
+
+    if age_between_16_19 && student && !child
+      record.errors.add "age#{person_num}", I18n.t("validations.household.age.student_16_19.cannot_be_16_19.student_not_child")
+      record.errors.add "ecstat#{person_num}", I18n.t("validations.household.ecstat.student_16_19.cannot_be_student.16_19_not_child")
+      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.student_16_19.must_be_child")
+    end
+
+    if age_between_16_19 && !student && child
+      record.errors.add "age#{person_num}", I18n.t("validations.household.age.student_16_19.cannot_be_16_19.child_not_student")
+      record.errors.add "ecstat#{person_num}", I18n.t("validations.household.ecstat.student_16_19.must_be_student")
+      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.student_16_19.cannot_be_child.16_19_not_student")
+    end
+
+    if !age_between_16_19 && student && child
+      record.errors.add "age#{person_num}", I18n.t("validations.household.age.student_16_19.must_be_16_19")
+      record.errors.add "ecstat#{person_num}", I18n.t("validations.household.ecstat.student_16_19.cannot_be_student.child_not_16_19")
+      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.student_16_19.cannot_be_child.student_not_16_19")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,7 +297,11 @@ en:
         child_over_16: "Answer cannot be over 16 as person’s %{person_num} working situation is ‘child under 16‘"
         child_over_20: "Answer cannot be 20 or over as the relationship is ‘child’"
         not_student_16_19: "Answer cannot be between 16 and 19 as person %{person_num} is a child of the lead tenant but is not a full-time student"
-        student_16_19: "Person cannot be aged 16-19 if they are a student but don't have relationship ‘child’"
+        student_16_19:
+          cannot_be_16_19: 
+            student_not_child: "Person cannot be aged 16-19 if they are a student but don't have relationship ‘child’"
+            child_not_student: "Person cannot be aged 16-19 if they have relationship ‘child’ but are not a student"
+          must_be_16_19: "Person must be aged 16-19 if they are a student and have relationship ‘child’"
         partner_under_16: "Cannot be under 16 if the relationship is partner"
         lead:
           over_20: "The lead tenant must be under 20 as you told us their housing situation immediately before this letting was a children’s home or foster care"
@@ -306,7 +310,11 @@ en:
         child_under_16: "Person’s %{person_num} working situation must be ’child under 16‘ as you told us they’re under 16"
         child_over_16: "Answer cannot be ‘child under 16’ as you told us the person %{person_num} is older than 16"
         not_student_16_19: "Person’s %{person_num} working situation must be full-time student or prefers not to say as you told us they’re between 16 and 19."
-        student_16_19: "Person cannot be a student if they are aged 16-19 and but don't have relationship ‘child’"
+        student_16_19: 
+          cannot_be_student: 
+            child_not_16_19: "Person cannot be a student if they are not aged 16-19 but have relationship ‘child’"
+            16_19_not_child: "Person cannot be a student if they are aged 16-19 but don‘t have relationship ‘child’"
+          must_be_student: "Person must be a student if they are aged 16-19 and have relationship ‘child’"
         retired_male: "Answer cannot be ‘retired’ as the male tenant is under 65"
         retired_female: "Answer cannot be ‘retired’ as the female tenant is under 60"
       relat:
@@ -315,7 +323,11 @@ en:
         child_over_20: "Answer cannot be ‘child’ if the person's age is 20 or over"
         one_partner: "Number of partners cannot be greater than 1"
         not_student_16_19: "Answer cannot be ‘child’ as you told us the person %{person_num} is between 16 and 19 and is not a full-time student"
-        student_16_19: "Answer must be ‘child’ if the person is aged 16-19 and a student"
+        student_16_19: 
+          cannot_be_child: 
+            student_not_16_19: "Answer cannot be ‘child’ if the person is a student but not aged 16-19"
+            16_19_not_student:  "Answer cannot be ‘child’ if the person is aged 16-19 but not a student"
+          must_be_child: "Answer must be ‘child’ if the person is aged 16-19 and a student"
       housingneeds_a:
         one_or_two_choices: "You can only select one option or ‘other disabled access needs’ plus ‘wheelchair-accessible housing’, ‘wheelchair access to essential rooms’ or ‘level access housing’"
       prevten:

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -66,7 +66,7 @@ FactoryBot.define do
       sex5 { "X" }
       sex6 { "X" }
       mortgage { 20_000 }
-      ecstat3 { 10 }
+      ecstat3 { 9 }
       ecstat4 { 3 }
       ecstat5 { 2 }
       ecstat6 { 1 }

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -51,4 +51,12 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(2)
   end
+
+  it "has the correct min" do
+    expect(question.min).to eq(0)
+  end
+
+  it "has the correct max" do
+    expect(question.max).to eq(110)
+  end
 end

--- a/spec/models/form/sales/questions/person_age_spec.rb
+++ b/spec/models/form/sales/questions/person_age_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
     expect(question.hint_text).to be_nil
   end
 
+  it "has the correct min" do
+    expect(question.min).to eq(0)
+  end
+
+  it "has the correct max" do
+    expect(question.max).to eq(110)
+  end
+
   context "with not a joint purchase" do
     context "and person 1" do
       let(:person_index) { 2 }

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -86,6 +86,35 @@ RSpec.describe Validations::Sales::HouseholdValidations do
         expect(record.errors["age2"])
           .to include(match I18n.t("validations.household.age.partner_under_16"))
       end
+
+      it "validates that person's economic status must be Child" do
+        record.age2 = 14
+        record.ecstat2 = 1
+        household_validator.validate_household_number_of_other_members(record)
+        expect(record.errors["ecstat2"])
+          .to include(match I18n.t("validations.household.ecstat.child_under_16", person_num: 2))
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.household.age.child_under_16", person_num: 2))
+      end
+
+      it "expects that person's economic status is Child" do
+        record.age2 = 14
+        record.ecstat2 = 9
+        household_validator.validate_household_number_of_other_members(record)
+        expect(record.errors["ecstat2"]).to be_empty
+        expect(record.errors["age2"]).to be_empty
+      end
+
+      it "validates that a person with economic status 'child' must be under 16" do
+        record.age2 = 21
+        record.relat2 = "C"
+        record.ecstat2 = 9
+        household_validator.validate_household_number_of_other_members(record)
+        expect(record.errors["ecstat2"])
+          .to include(match I18n.t("validations.household.ecstat.child_over_16", person_num: 2))
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.household.age.child_over_16", person_num: 2))
+      end
     end
 
     it "validates that a person over 20 must not be a child of the buyer" do

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe Validations::Sales::HouseholdValidations do
 
       it "validates that a person with economic status 'child' must be under 16" do
         record.age2 = 21
-        record.relat2 = "C"
         record.ecstat2 = 9
         household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["ecstat2"])

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -126,17 +126,43 @@ RSpec.describe Validations::Sales::HouseholdValidations do
         .to include(match I18n.t("validations.household.age.child_over_20"))
     end
 
-    it "validates that a person aged 16-19 who is a student must be a child of the buyer" do
+    it "adds errors for a person aged 16-19 who is a student but not a child of the buyer" do
       record.age2 = 18
       record.ecstat2 = "7"
       record.relat2 = "P"
       household_validator.validate_household_number_of_other_members(record)
       expect(record.errors["relat2"])
-        .to include(match I18n.t("validations.household.relat.student_16_19"))
+        .to include(match I18n.t("validations.household.relat.student_16_19.must_be_child"))
       expect(record.errors["age2"])
-        .to include(match I18n.t("validations.household.age.student_16_19"))
+        .to include(match I18n.t("validations.household.age.student_16_19.cannot_be_16_19.student_not_child"))
       expect(record.errors["ecstat2"])
-        .to include(match I18n.t("validations.household.ecstat.student_16_19"))
+        .to include(match I18n.t("validations.household.ecstat.student_16_19.cannot_be_student.16_19_not_child"))
+    end
+
+    it "adds errors for a person aged 16-19 who is a child of the buyer but not a student" do
+      record.age2 = 17
+      record.ecstat2 = "1"
+      record.relat2 = "C"
+      household_validator.validate_household_number_of_other_members(record)
+      expect(record.errors["relat2"])
+        .to include(match I18n.t("validations.household.relat.student_16_19.cannot_be_child.16_19_not_student"))
+      expect(record.errors["age2"])
+        .to include(match I18n.t("validations.household.age.student_16_19.cannot_be_16_19.child_not_student"))
+      expect(record.errors["ecstat2"])
+        .to include(match I18n.t("validations.household.ecstat.student_16_19.must_be_student"))
+    end
+
+    it "adds errors for a person who is a child of the buyer and a student but not aged 16-19" do
+      record.age2 = 14
+      record.ecstat2 = "7"
+      record.relat2 = "C"
+      household_validator.validate_household_number_of_other_members(record)
+      expect(record.errors["relat2"])
+        .to include(match I18n.t("validations.household.relat.student_16_19.cannot_be_child.student_not_16_19"))
+      expect(record.errors["age2"])
+        .to include(match I18n.t("validations.household.age.student_16_19.must_be_16_19"))
+      expect(record.errors["ecstat2"])
+        .to include(match I18n.t("validations.household.ecstat.student_16_19.cannot_be_student.child_not_16_19"))
     end
   end
 end


### PR DESCRIPTION
- [x]  Buyer 2's age must be below 110 [person 2's age / person 3's age etc etc] 
<img width="1781" alt="image" src="https://user-images.githubusercontent.com/54268893/213232807-b4727f16-1922-455f-8d84-e6438922eeb5.png">

- [ ] If male and ECSTAT2, (ECSTAT3 etc) is 5, AGE2  (AGE3, etc) must be 65 or over - covered in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1191

- [ ] If female and ECSTAT2, (ECSTAT3 etc), AGE2 (AGE3 etc) must be 60 or over - covered in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1191
- [x] Must be under 16 if RELAT2 is "Child" - covered in CLDC-850

- [x] If 16-19 and ECSTAT2 is 7, RELAT2 must be child - covered in CLDC-850

- [x] RELAT2 cannot be child if AGE2 is 20 or over  - covered in CLDC-850


- [x] ECSTAT2 Must be 9 if AGE2 is under 16
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/213486064-8d519494-92ec-4bbb-b60d-094f102d0304.png">

- [x] ECSTAT2 cannot be 9 if Age2 is 16 or over
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/54268893/213486288-8cc1941d-66d1-4082-b026-e1c9769a5b98.png">

- [ ] TYPE cannot be 24 if no purchasers are over 64 - covered in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1191
