### PR TITLE
CLDC-1461 add validation ensure postcodes match if discounted ownership purchase

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -1,5 +1,6 @@
 class SalesLogValidator < ActiveModel::Validator
   include Validations::Sales::HouseholdValidations
+  include Validations::Sales::PropertyValidations
   include Validations::SharedValidations
   include Validations::Sales::FinancialValidations
   include Validations::LocalAuthorityValidations
@@ -164,6 +165,10 @@ class SalesLog < Log
 
   def outright_sale?
     ownershipsch == 3
+  end
+
+  def discounted_ownership_sale?
+    ownershipsch == 2
   end
 
   def mortgage_not_used?

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -1,0 +1,10 @@
+module Validations::Sales::PropertyValidations
+  def validate_postcodes_match_if_discounted_ownership(record)
+    return unless record.ppostcode_full.present? && record.postcode_full.present?
+
+    if record.discounted_ownership_sale? && record.ppostcode_full != record.postcode_full
+      record.errors.add :postcode_full, I18n.t("validations.property.postcode.must_match_previous")
+      record.errors.add :ppostcode_full, I18n.t("validations.property.postcode.must_match_previous")
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
       beds:
         non_positive: "Number of bedrooms has to be greater than 0"
         over_max: "Number of bedrooms cannot be more than 12"
+      postcode:
+        must_match_previous: "Buyer's last accommodation and discounted ownership postcodes must match"
 
     financial:
       tshortfall:

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Validations::Sales::PropertyValidations do
   subject(:property_validator) { property_validator_class.new }
+
   let(:property_validator_class) { Class.new { include Validations::Sales::PropertyValidations } }
 
   describe "#validate_postcodes_match_if_discounted_ownership" do

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Validations::Sales::PropertyValidations do
+  subject(:property_validator) { property_validator_class.new }
+  let(:property_validator_class) { Class.new { include Validations::Sales::PropertyValidations } }
+
+  describe "#validate_postcodes_match_if_discounted_ownership" do
+    context "when ownership scheme is not discounted ownership" do
+      let(:record) { FactoryBot.build(:sales_log, ownershipsch: 1) }
+
+      it "when postcodes match no error is added" do
+        record.postcode_full = "SW1A 1AA"
+        record.ppostcode_full = "SW1A 1AA"
+
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to be_empty
+      end
+    end
+
+    context "when ownership scheme is discounted ownership" do
+      let(:record) { FactoryBot.build(:sales_log, ownershipsch: 2) }
+
+      it "when ppostcode_full is not present no error is added" do
+        record.postcode_full = "SW1A 1AA"
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to be_empty
+      end
+
+      it "when postcode_full is not present no error is added" do
+        record.ppostcode_full = "SW1A 1AA"
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to be_empty
+      end
+
+      it "when postcodes match no error is added" do
+        record.postcode_full = "SW1A 1AA"
+        record.ppostcode_full = "SW1A 1AA"
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to be_empty
+      end
+
+      it "when postcodes do not match an error is added" do
+        record.postcode_full = "SW1A 1AA"
+        record.ppostcode_full = "SW1A 0AA"
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to include(match I18n.t("validations.property.postcode.must_match_previous"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-1461

If log type is discounted ownership, their current postcode and last postcode should match.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/51094020/213512564-16b6c3f5-ef5a-4df4-a6e6-ce1f509910c5.png">
