### PR TITLE
Tweak blank error message for bulk upload

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -205,7 +205,7 @@ private
       next if log.optional_fields.include?(question.id)
       next if question.completed?(log)
 
-      fields.each { |field| errors.add(field, :blank) }
+      fields.each { |field| errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase)) }
     end
   end
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -279,6 +279,10 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         it "returns an error" do
           expect(parser.errors[:field_103]).to be_present
         end
+
+        it "populates with correct error message" do
+          expect(parser.errors[:field_103]).to eql(["You must answer type of building"])
+        end
       end
 
       context "when unpermitted values" do


### PR DESCRIPTION
# Context

- Placeholder for bulk upload error message for blank field was not implemented

# Changes

- Improve bulk upload error message when required field is blank

# Screenshots

![Screenshot 2023-01-20 at 15 50 46](https://user-images.githubusercontent.com/92580/213746204-11c135bc-704b-443e-82db-d7a6919c6230.png)