### PR TITLE
CLDC-858 Add number of bedrooms validation

### DIFF
--- a/app/models/form/sales/questions/property_number_of_bedrooms.rb
+++ b/app/models/form/sales/questions/property_number_of_bedrooms.rb
@@ -5,7 +5,9 @@ class Form::Sales::Questions::PropertyNumberOfBedrooms < ::Form::Question
     @check_answer_label = "Number of bedrooms"
     @header = "How many bedrooms does the property have?"
     @hint_text = "A bedsit has 1 bedroom"
-    @type = "text"
+    @type = "numeric"
     @width = 10
+    @min = 1
+    @max = 9
   end
 end

--- a/spec/models/form/sales/questions/property_number_of_bedrooms_spec.rb
+++ b/spec/models/form/sales/questions/property_number_of_bedrooms_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Form::Sales::Questions::PropertyNumberOfBedrooms, type: :model do
   end
 
   it "has the correct type" do
-    expect(question.type).to eq("text")
+    expect(question.type).to eq("numeric")
   end
 
   it "is not marked as derived" do
@@ -33,5 +33,13 @@ RSpec.describe Form::Sales::Questions::PropertyNumberOfBedrooms, type: :model do
 
   it "has the correct hint_text" do
     expect(question.hint_text).to eq("A bedsit has 1 bedroom")
+  end
+
+  it "has the correct min" do
+    expect(question.min).to eq(1)
+  end
+
+  it "has the correct max" do
+    expect(question.max).to eq(9)
   end
 end


### PR DESCRIPTION
- [x] Number of bedrooms: Must be between 1 and 9
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/213996207-04ef71ef-ad42-4c82-b4c4-a548d9cce6b3.png">


- [ ] Property type | Cannot be 2 if BEDS is greater than 1 - covered by [CLDC-859](https://digital.dclg.gov.uk/jira/browse/CLDC-859).
- [ ] A soft minimum and maximum per Local Authority, per Number of bedrooms - should be covered by CLDC-1577


