### PR TITLE
CLDC-867 Add previous bedrooms validations

### DIFF
--- a/app/models/form/sales/questions/previous_bedrooms.rb
+++ b/app/models/form/sales/questions/previous_bedrooms.rb
@@ -6,7 +6,8 @@ class Form::Sales::Questions::PreviousBedrooms < ::Form::Question
     @header = "How many bedrooms did the property have?"
     @type = "numeric"
     @width = 5
-    @min = 0
+    @min = 1
+    @max = 6
     @hint_text = "For bedsits enter 1"
   end
 end

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -14,4 +14,13 @@ module Validations::Sales::SaleInformationValidations
       record.errors.add :hodate, "Practical completion or handover date must be before exchange date"
     end
   end
+
+  def validate_previous_property_unit_type(record)
+    return unless record.fromprop && record.frombeds
+
+    if record.frombeds != 1 && record.fromprop == 2
+      record.errors.add :frombeds, I18n.t("validations.sale_information.previous_property_beds.property_type_bedsit")
+      record.errors.add :fromprop, I18n.t("validations.sale_information.previous_property_type.property_type_bedsit")
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,6 +408,11 @@ en:
         before_deactivation: "This location was deactivated on %{date}. The reactivation date must be on or after deactivation date"
       deactivation:
         during_deactivated_period: "The location is already deactivated during this date, please enter a different date"
+    sale_information:
+      previous_property_beds: 
+        property_type_bedsit: "Bedsit bedroom maximum 1"
+      previous_property_type: 
+        property_type_bedsit: "A bedsit can not have more than 1 bedroom"
 
   soft_validations:
     net_income:

--- a/spec/models/form/sales/questions/previous_bedrooms_spec.rb
+++ b/spec/models/form/sales/questions/previous_bedrooms_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Form::Sales::Questions::PreviousBedrooms, type: :model do
   end
 
   it "has correct min" do
-    expect(question.min).to eq(0)
+    expect(question.min).to eq(1)
+  end
+
+  it "has correct max" do
+    expect(question.max).to eq(6)
   end
 end

--- a/spec/models/validations/sales/sale_information_validations_spec.rb
+++ b/spec/models/validations/sales/sale_information_validations_spec.rb
@@ -108,4 +108,26 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
       end
     end
   end
+
+  describe "#validate_previous_property_unit_type" do
+    context "when number of bedrooms is <= 1" do
+      let(:record) { FactoryBot.build(:sales_log, frombeds: 1, fromprop: 2) }
+
+      it "does not add an error if it's a bedsit" do
+        sale_information_validator.validate_previous_property_unit_type(record)
+
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context "when number of bedrooms is > 1" do
+      let(:record) { FactoryBot.build(:sales_log, frombeds: 2, fromprop: 2) }
+
+      it "does add an error if it's a bedsit" do
+        sale_information_validator.validate_previous_property_unit_type(record)
+        expect(record.errors["fromprop"]).to include(I18n.t("validations.sale_information.previous_property_type.property_type_bedsit"))
+        expect(record.errors["frombeds"]).to include(I18n.t("validations.sale_information.previous_property_beds.property_type_bedsit"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Number of bedrooms in vacated property | Must be 6 or fewer

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/214089943-6473d4b0-70e6-402f-b69c-974ee05dbabc.png">

- [x] Previous property type	Cannot be 2 if FROMBEDS is greater than 1

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/214090024-300ca45f-5ce2-4d15-a654-36e87e8c8381.png">
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/54268893/214090107-461a8c03-da25-4835-8f17-f83cbb617a6a.png">
