### PR TITLE
CLDC 877 add validation on value of cash discount

### DIFF
--- a/app/models/form/sales/questions/deposit_discount.rb
+++ b/app/models/form/sales/questions/deposit_discount.rb
@@ -6,6 +6,7 @@ class Form::Sales::Questions::DepositDiscount < ::Form::Question
     @header = "How much cash discount was given through Social HomeBuy?"
     @type = "numeric"
     @min = 0
+    @max = 999_999
     @width = 5
     @prefix = "£"
     @hint_text = "Enter the total cash discount given on the property being purchased through the Social HomeBuy scheme"

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -11,4 +11,12 @@ module Validations::Sales::FinancialValidations
       end
     end
   end
+
+  def validate_cash_discount(record)
+    return unless record.cashdis
+
+    unless record.cashdis.between?(0, 999_999)
+      record.errors.add :cashdis, I18n.t("validations.financial.cash_discount_invalid")
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,6 +274,7 @@ en:
       carehome:
         out_of_range: "Household rent and other charges must be between %{min_chcharge} and %{max_chcharge} if paying %{period}"
         not_provided: "Enter how much rent and other charges the household pays %{period}"
+      cash_discount_invalid: "Cash discount must be £0 - £999,999"
     household:
       reasonpref:
         not_homeless: "Answer cannot be ‘homeless or about to lose their home’ as the tenant was not homeless immediately prior to this letting"

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -53,4 +53,26 @@ RSpec.describe Validations::Sales::FinancialValidations do
       end
     end
   end
+
+  describe "#validate_cash_discount" do
+    let(:record) { FactoryBot.create(:sales_log) }
+
+    it "adds an error if the cash discount is below zero" do
+      record.cashdis = -1
+      financial_validator.validate_cash_discount(record)
+      expect(record.errors["cashdis"]).to include(match I18n.t("validations.financial.cash_discount_invalid"))
+    end
+
+    it "adds an error if the cash discount is one million or more" do
+      record.cashdis = 1_000_000
+      financial_validator.validate_cash_discount(record)
+      expect(record.errors["cashdis"]).to include(match I18n.t("validations.financial.cash_discount_invalid"))
+    end
+
+    it "does not add an error if the cash discount is in the expected range" do
+      record.cashdis = 10_000
+      financial_validator.validate_cash_discount(record)
+      expect(record.errors["cashdis"]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
<img width="805" alt="image" src="https://user-images.githubusercontent.com/51094020/214248520-547d7431-5db3-4494-a92b-914c18c580de.png">

as in the notes on the [ticket](https://digital.dclg.gov.uk/jira/browse/CLDC-877), Kat has covered the compound soft validation in another ticket