### PR TITLE
CLDC-1764 Bulk upload filter

### DIFF
--- a/app/controllers/bulk_upload_lettings_results_controller.rb
+++ b/app/controllers/bulk_upload_lettings_results_controller.rb
@@ -6,4 +6,24 @@ class BulkUploadLettingsResultsController < ApplicationController
   def show
     @bulk_upload = current_user.bulk_uploads.lettings.find(params[:id])
   end
+
+  def resume
+    @bulk_upload = current_user.bulk_uploads.lettings.find(params[:id])
+
+    set_bulk_upload_logs_filters
+
+    redirect_to(lettings_logs_path(bulk_upload_id: [@bulk_upload.id]))
+  end
+
+private
+
+  def set_bulk_upload_logs_filters
+    hash = {
+      years: [""],
+      status: ["", "in_progress"],
+      user: "all",
+    }
+
+    session["logs_filters"] = hash.to_json
+  end
 end

--- a/app/controllers/bulk_upload_lettings_results_controller.rb
+++ b/app/controllers/bulk_upload_lettings_results_controller.rb
@@ -10,12 +10,20 @@ class BulkUploadLettingsResultsController < ApplicationController
   def resume
     @bulk_upload = current_user.bulk_uploads.lettings.find(params[:id])
 
-    set_bulk_upload_logs_filters
+    if @bulk_upload.lettings_logs.in_progress.count.positive?
+      set_bulk_upload_logs_filters
 
-    redirect_to(lettings_logs_path(bulk_upload_id: [@bulk_upload.id]))
+      redirect_to(lettings_logs_path(bulk_upload_id: [@bulk_upload.id]))
+    else
+      reset_logs_filters
+    end
   end
 
 private
+
+  def reset_logs_filters
+    session["logs_filters"] = {}.to_json
+  end
 
   def set_bulk_upload_logs_filters
     hash = {

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -4,6 +4,8 @@ class LettingsLogsController < LogsController
   before_action :set_session_filters, if: :current_user
 
   def index
+    extract_bulk_upload_from_session_filters
+
     respond_to do |format|
       format.html do
         all_logs = current_user.lettings_logs
@@ -108,6 +110,11 @@ class LettingsLogsController < LogsController
   end
 
 private
+
+  def extract_bulk_upload_from_session_filters
+    id = ((@session_filters["bulk_upload_id"] || []).reject(&:blank?))[0]
+    @bulk_upload = current_user.bulk_uploads.find_by(id:)
+  end
 
   def permitted_log_params
     params.require(:lettings_log).permit(LettingsLog.editable_fields)

--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -3,9 +3,10 @@ class LettingsLogsController < LogsController
   before_action :session_filters, if: :current_user
   before_action :set_session_filters, if: :current_user
 
-  def index
-    extract_bulk_upload_from_session_filters
+  before_action :extract_bulk_upload_from_session_filters, only: [:index]
+  before_action :redirect_if_bulk_upload_resolved, only: [:index]
 
+  def index
     respond_to do |format|
       format.html do
         all_logs = current_user.lettings_logs
@@ -110,6 +111,12 @@ class LettingsLogsController < LogsController
   end
 
 private
+
+  def redirect_if_bulk_upload_resolved
+    if @bulk_upload && @bulk_upload.lettings_logs.in_progress.count.zero?
+      redirect_to resume_bulk_upload_lettings_result_path(@bulk_upload)
+    end
+  end
 
   def extract_bulk_upload_from_session_filters
     id = ((@session_filters["bulk_upload_id"] || []).reject(&:blank?))[0]

--- a/app/controllers/modules/logs_filter.rb
+++ b/app/controllers/modules/logs_filter.rb
@@ -7,7 +7,9 @@ module Modules::LogsFilter
   def load_session_filters(specific_org: false)
     current_filters = session[:logs_filters]
     new_filters = current_filters.present? ? JSON.parse(current_filters) : {}
-    current_user.logs_filters(specific_org:).each { |filter| new_filters[filter] = params[filter] if params[filter].present? }
+    current_user.logs_filters(specific_org:).each do |filter|
+      new_filters[filter] = params[filter] if params[filter].present?
+    end
     params["organisation_select"] == "all" ? new_filters.except("organisation") : new_filters
   end
 

--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -18,4 +18,9 @@ module LogsHelper
       bulk_upload_sales_log_path(id:)
     end
   end
+
+  def bulk_upload_options(bulk_upload)
+    array = bulk_upload ? [bulk_upload.id] : []
+    array.index_with { |_bulk_upload_id| "With logs from bulk upload" }
+  end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -24,6 +24,10 @@ class Log < ApplicationRecord
       where(created_by: user)
     end
   }
+  scope :filter_by_bulk_upload_id, lambda { |bulk_upload_id, user|
+    joins(:bulk_upload)
+      .where(bulk_upload: { id: bulk_upload_id, user: })
+  }
   scope :created_by, ->(user) { where(created_by: user) }
 
   def collection_start_year

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,9 +145,9 @@ class User < ApplicationRecord
 
   def logs_filters(specific_org: false)
     if (support? && !specific_org) || organisation.has_managing_agents?
-      %w[status years user organisation]
+      %w[status years user organisation bulk_upload_id]
     else
-      %w[status years user]
+      %w[status years user bulk_upload_id]
     end
   end
 

--- a/app/views/bulk_upload_lettings_results/resume.html.erb
+++ b/app/views/bulk_upload_lettings_results/resume.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">There are no more logs that need updating</h1>
+  </div>
+</div>
+
+<p class="govuk-body-l">
+  You’ve completed all the logs that had errors from your bulk upload.
+</p>
+
+<%= govuk_button_link_to "Back to all logs", lettings_logs_path, button: true %>

--- a/app/views/logs/_log_filters.erb
+++ b/app/views/logs/_log_filters.erb
@@ -3,13 +3,21 @@
     <div class="app-filter__header">
       <h2 class="govuk-heading-m">Filters</h2>
     </div>
+
     <div class="app-filter__content">
       <%= form_with html: { method: :get } do |f| %>
-        <% years = {"2021": "2021/22", "2022": "2022/23"} %>
-        <% all_or_yours = {"all": { label: "All" }, "yours": { label: "Yours" } } %>
+        <% years = { "2021": "2021/22", "2022": "2022/23" } %>
+        <% all_or_yours = { "all": { label: "All" }, "yours": { label: "Yours" } } %>
+        <% bulk_upload_options = (@session_filters["bulk_upload_id"] || []).reject(&:blank?).index_with { |_bulk_upload_id| "With logs from bulk upload" } %>
+
+        <% if bulk_upload_options.present? %>
+          <%= render partial: "filters/checkbox_filter", locals: { f: f, options: bulk_upload_options, label: "Bulk upload", category: "bulk_upload_id" } %>
+        <% end %>
+
         <%= render partial: "filters/checkbox_filter", locals: { f: f, options: years, label: "Collection year", category: "years" } %>
         <%= render partial: "filters/checkbox_filter", locals: { f: f, options: status_filters, label: "Status", category: "status" } %>
-        <%= render partial: "filters/radio_filter", locals: { f: f, options: all_or_yours, label: "Logs", category: "user", } %>
+        <%= render partial: "filters/radio_filter", locals: { f: f, options: all_or_yours, label: "Logs", category: "user" } %>
+
         <% if (@current_user.support? || @current_user.organisation.has_managing_agents?) && request.path == "/lettings-logs" %>
           <%= render partial: "filters/radio_filter", locals: {
             f: f,
@@ -21,14 +29,15 @@
                   type: "select",
                   label: "Organisation",
                   category: "organisation",
-                  options: organisations_filter_options(@current_user)
-                }
-              }
+                  options: organisations_filter_options(@current_user),
+                },
+              },
             },
             label: "Organisation",
-            category: "organisation_select"
+            category: "organisation_select",
           } %>
         <% end %>
+
         <%= f.govuk_submit "Apply filters", class: "govuk-!-margin-bottom-0" %>
       <% end %>
     </div>

--- a/app/views/logs/_log_filters.erb
+++ b/app/views/logs/_log_filters.erb
@@ -11,12 +11,40 @@
         <% bulk_upload_options = (@session_filters["bulk_upload_id"] || []).reject(&:blank?).index_with { |_bulk_upload_id| "With logs from bulk upload" } %>
 
         <% if bulk_upload_options.present? %>
-          <%= render partial: "filters/checkbox_filter", locals: { f: f, options: bulk_upload_options, label: "Bulk upload", category: "bulk_upload_id" } %>
+          <%= render partial: "filters/checkbox_filter",
+                     locals: {
+                       f: f,
+                       options: bulk_upload_options,
+                       label: "Bulk upload",
+                       category: "bulk_upload_id",
+                     } %>
         <% end %>
 
-        <%= render partial: "filters/checkbox_filter", locals: { f: f, options: years, label: "Collection year", category: "years" } %>
-        <%= render partial: "filters/checkbox_filter", locals: { f: f, options: status_filters, label: "Status", category: "status" } %>
-        <%= render partial: "filters/radio_filter", locals: { f: f, options: all_or_yours, label: "Logs", category: "user" } %>
+        <% if bulk_upload_options.blank? %>
+          <%= render partial: "filters/checkbox_filter",
+                     locals: {
+                       f: f,
+                       options: years,
+                       label: "Collection year",
+                       category: "years",
+                     } %>
+
+          <%= render partial: "filters/checkbox_filter",
+                     locals: {
+                       f: f,
+                       options: status_filters,
+                       label: "Status",
+                       category: "status",
+                     } %>
+        <% end %>
+
+        <%= render partial: "filters/radio_filter",
+                   locals: {
+                     f: f,
+                     options: all_or_yours,
+                     label: "Logs",
+                     category: "user",
+                   } %>
 
         <% if (@current_user.support? || @current_user.organisation.has_managing_agents?) && request.path == "/lettings-logs" %>
           <%= render partial: "filters/radio_filter", locals: {

--- a/app/views/logs/_log_filters.erb
+++ b/app/views/logs/_log_filters.erb
@@ -8,19 +8,18 @@
       <%= form_with html: { method: :get } do |f| %>
         <% years = { "2021": "2021/22", "2022": "2022/23" } %>
         <% all_or_yours = { "all": { label: "All" }, "yours": { label: "Yours" } } %>
-        <% bulk_upload_options = (@session_filters["bulk_upload_id"] || []).reject(&:blank?).index_with { |_bulk_upload_id| "With logs from bulk upload" } %>
 
-        <% if bulk_upload_options.present? %>
+        <% if bulk_upload_options(@bulk_upload).present? %>
           <%= render partial: "filters/checkbox_filter",
                      locals: {
                        f: f,
-                       options: bulk_upload_options,
+                       options: bulk_upload_options(@bulk_upload),
                        label: "Bulk upload",
                        category: "bulk_upload_id",
                      } %>
         <% end %>
 
-        <% if bulk_upload_options.blank? %>
+        <% if bulk_upload_options(@bulk_upload).blank? %>
           <%= render partial: "filters/checkbox_filter",
                      locals: {
                        f: f,

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -11,17 +11,22 @@
       title_id: "impacted-logs-banner",
     ) do |notification_banner| %>
         <% notification_banner.heading(text: "A scheme has changed and it has affected #{@unresolved_count} #{'log'.pluralize(@unresolved_count)}") %>
-        <div class="govuk-notification-banner__heading">
-          <%= govuk_link_to "Update logs", update_logs_lettings_logs_path, class: "govuk-notification-banner__link" %>
-        </div>
-      <% end %>
+      <div class="govuk-notification-banner__heading">
+        <%= govuk_link_to "Update logs", update_logs_lettings_logs_path, class: "govuk-notification-banner__link" %>
+      </div>
     <% end %>
-  <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Lettings logs", sub: nil } : { main: "Lettings logs", sub: current_user.organisation.name } %>
-<% elsif current_page?(controller: 'sales_logs', action: 'index') %>
-  <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Sales logs", sub: nil } : { main: "Sales logs", sub: current_user.organisation.name } %>
+  <% end %>
 <% end %>
 
-<% if @bulk_upload %>
+<% unless @bulk_upload %>
+  <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "#{log_type_for_controller(controller).capitalize} logs", sub: nil } : { main: "#{log_type_for_controller(controller).capitalize} logs", sub: current_user.organisation.name } %>
+<% else %>
+  <%= render partial: "organisations/headings",
+             locals: {
+               main: "You need to fix XYZ logs from your bulk upload",
+               sub: "#{log_type_for_controller(controller).capitalize} logs (#{@bulk_upload.year_combo})",
+             } %>
+
   <div class="app-card govuk-!-margin-bottom-9">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -21,6 +21,24 @@
   <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Sales logs", sub: nil } : { main: "Sales logs", sub: current_user.organisation.name } %>
 <% end %>
 
+<% if @bulk_upload %>
+  <div class="app-card govuk-!-margin-bottom-9">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body-l">
+          The following logs are from your recent bulk upload. They have some incorrect or incomplete data. You’ll need to answer a few more questions for each one to mark them as complete.
+        </p>
+
+        <p class="govuk-body">
+          <strong>Bulk Upload details:</strong><br>
+          <%= @bulk_upload.filename %><br>
+          Uploaded on <%= @bulk_upload.created_at.to_fs(:govuk_date_and_time) %><br>
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="app-filter-layout" data-controller="filter-layout">
   <% unless @bulk_upload %>
     <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -22,21 +22,24 @@
 <% end %>
 
 <div class="app-filter-layout" data-controller="filter-layout">
-  <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
-    <% if current_page?(controller: 'lettings_logs', action: 'index') %>
-      <%= govuk_button_to "Create a new lettings log", lettings_logs_path, class: "govuk-!-margin-right-6" %>
-    <% end %>
+  <% unless @bulk_upload %>
+    <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
+      <% if current_page?(controller: 'lettings_logs', action: 'index') %>
+        <%= govuk_button_to "Create a new lettings log", lettings_logs_path, class: "govuk-!-margin-right-6" %>
+      <% end %>
 
-    <% if FeatureToggle.sales_log_enabled? && current_page?(controller: 'sales_logs', action: 'index') %>
-      <%= govuk_button_to "Create a new sales log", sales_logs_path, class: "govuk-!-margin-right-6" %>
-    <% end %>
+      <% if FeatureToggle.sales_log_enabled? && current_page?(controller: 'sales_logs', action: 'index') %>
+        <%= govuk_button_to "Create a new sales log", sales_logs_path, class: "govuk-!-margin-right-6" %>
+      <% end %>
 
-    <% if FeatureToggle.bulk_upload_logs? %>
-      <%= govuk_button_link_to "Upload #{log_type_for_controller(controller)} logs in bulk", bulk_upload_path_for_controller(controller, id: "start"), secondary: true %>
-    <% end %>
-  </div>
+      <% if FeatureToggle.bulk_upload_logs? %>
+        <%= govuk_button_link_to "Upload #{log_type_for_controller(controller)} logs in bulk", bulk_upload_path_for_controller(controller, id: "start"), secondary: true %>
+      <% end %>
+    </div>
+  <% end %>
 
   <%= render partial: "log_filters" %>
+
   <div class="app-filter-layout__content">
     <%= render SearchComponent.new(current_user:, search_label: "Search by log ID, tenant code, property reference or postcode", value: @searched) %>
     <%= govuk_section_break(visible: true, size: "m") %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -18,12 +18,12 @@
   <% end %>
 <% end %>
 
-<% unless @bulk_upload %>
+<% if @bulk_upload.blank? %>
   <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "#{log_type_for_controller(controller).capitalize} logs", sub: nil } : { main: "#{log_type_for_controller(controller).capitalize} logs", sub: current_user.organisation.name } %>
 <% else %>
   <%= render partial: "organisations/headings",
              locals: {
-               main: "You need to fix XYZ logs from your bulk upload",
+               main: "You need to fix #{pluralize(@pagy.count, 'log')} from your bulk upload",
                sub: "#{log_type_for_controller(controller).capitalize} logs (#{@bulk_upload.year_combo})",
              } %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,7 +134,11 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :bulk_upload_lettings_results, path: "bulk-upload-results", only: [:show]
+      resources :bulk_upload_lettings_results, path: "bulk-upload-results", only: [:show] do
+        member do
+          get :resume
+        end
+      end
 
       get "update-logs", to: "lettings_logs#update_logs"
     end

--- a/spec/controllers/bulk_upload_lettings_results_controller_spec.rb
+++ b/spec/controllers/bulk_upload_lettings_results_controller_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe BulkUploadLettingsResultsController do
       render_views
 
       it "displays copy to user" do
-
         get :resume, params: { id: bulk_upload.id }
 
         expect(response.body).to include("There are no more logs that need updating")

--- a/spec/controllers/bulk_upload_lettings_results_controller_spec.rb
+++ b/spec/controllers/bulk_upload_lettings_results_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe BulkUploadLettingsResultsController do
+  before do
+    sign_in user
+  end
+
+  describe "GET #resume /lettings-logs/bulk-upload-results/:ID/resume" do
+    let(:user) { create(:user) }
+    let(:bulk_upload) { create(:bulk_upload, :lettings, user:) }
+
+    it "clears the year filter" do
+      hash = {
+        years: ["", "2022"],
+      }
+
+      session["logs_filters"] = hash.to_json
+
+      get :resume, params: { id: bulk_upload.id }
+
+      expect(JSON.parse(session["logs_filters"])["years"]).to eql([""])
+    end
+
+    it "sets the status filter to in progress" do
+      session["logs_filters"] ||= {}.to_json
+
+      get :resume, params: { id: bulk_upload.id }
+
+      expect(JSON.parse(session["logs_filters"])["status"]).to eql(["", "in_progress"])
+    end
+
+    it "sets the user filter to all" do
+      session["logs_filters"] ||= {}.to_json
+
+      get :resume, params: { id: bulk_upload.id }
+
+      expect(JSON.parse(session["logs_filters"])["user"]).to eql("all")
+    end
+
+    it "redirects to logs with bulk upload filter applied" do
+      get :resume, params: { id: bulk_upload.id }
+
+      expect(response).to redirect_to("/lettings-logs?bulk_upload_id%5B%5D=#{bulk_upload.id}")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe User, type: :model do
         end
 
         it "can filter lettings logs by user, year and status" do
-          expect(user.logs_filters).to eq(%w[status years user])
+          expect(user.logs_filters).to eq(%w[status years user bulk_upload_id])
         end
       end
 
@@ -133,7 +133,7 @@ RSpec.describe User, type: :model do
         end
 
         it "can filter lettings logs by user, year, status and organisation" do
-          expect(user.logs_filters).to eq(%w[status years user organisation])
+          expect(user.logs_filters).to eq(%w[status years user organisation bulk_upload_id])
         end
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe User, type: :model do
       end
 
       it "can filter lettings logs by user, year, status and organisation" do
-        expect(user.logs_filters).to eq(%w[status years user organisation])
+        expect(user.logs_filters).to eq(%w[status years user organisation bulk_upload_id])
       end
     end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -427,6 +427,17 @@ RSpec.describe LettingsLogsController, type: :request do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).not_to have_content("Create a new lettings log")
               end
+
+              it "displays card with help info" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).to have_content("The following logs are from your recent bulk upload")
+              end
+
+              it "displays meta info about the bulk upload" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).to have_content(bulk_upload.filename)
+                expect(page).to have_content(bulk_upload.created_at.to_fs(:govuk_date_and_time))
+              end
             end
 
             context "with bulk upload that belongs to another user" do
@@ -457,6 +468,11 @@ RSpec.describe LettingsLogsController, type: :request do
             it "displays button to create a new log" do
               get "/lettings-logs"
               expect(page).to have_content("Create a new lettings log")
+            end
+
+            it "does not display card with help info" do
+              get "/lettings-logs"
+              expect(page).not_to have_content("The following logs are from your recent bulk upload")
             end
           end
         end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -418,6 +418,11 @@ RSpec.describe LettingsLogsController, type: :request do
                 expect(page).not_to have_content(excluded_log.id)
               end
 
+              it "dislays how many logs remaining to fix" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).to have_content("You need to fix 1 log")
+              end
+
               it "displays filter" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).to have_content("With logs from bulk upload")

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -408,8 +408,8 @@ RSpec.describe LettingsLogsController, type: :request do
               let(:user) { create(:user, organisation:) }
               let(:bulk_upload) { create(:bulk_upload, user:) }
 
-              let!(:included_log) { create(:lettings_log, bulk_upload:, owning_organisation: organisation) }
-              let!(:excluded_log) { create(:lettings_log, owning_organisation: organisation) }
+              let!(:included_log) { create(:lettings_log, :in_progress, bulk_upload:, owning_organisation: organisation) }
+              let!(:excluded_log) { create(:lettings_log, :in_progress, owning_organisation: organisation) }
 
               it "returns logs only associated with the bulk upload" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
@@ -470,6 +470,19 @@ RSpec.describe LettingsLogsController, type: :request do
 
                 expect(page).not_to have_content(excluded_log.id)
                 expect(page).not_to have_content(also_excluded_log.id)
+              end
+            end
+
+            context "when bulk upload has been resolved" do
+              let(:organisation) { create(:organisation) }
+
+              let(:user) { create(:user, organisation:) }
+              let(:bulk_upload) { create(:bulk_upload, user:) }
+
+              it "redirects to resume the bulk upload" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+
+                expect(response).to redirect_to(resume_bulk_upload_lettings_result_path(bulk_upload))
               end
             end
           end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -422,6 +422,11 @@ RSpec.describe LettingsLogsController, type: :request do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).to have_content("With logs from bulk upload")
               end
+
+              it "hides button to create a new log" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).not_to have_content("Create a new lettings log")
+              end
             end
 
             context "with bulk upload that belongs to another user" do
@@ -447,6 +452,11 @@ RSpec.describe LettingsLogsController, type: :request do
             it "does not display filter" do
               get "/lettings-logs"
               expect(page).not_to have_content("With logs from bulk upload")
+            end
+
+            it "displays button to create a new log" do
+              get "/lettings-logs"
+              expect(page).to have_content("Create a new lettings log")
             end
           end
         end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -423,6 +423,16 @@ RSpec.describe LettingsLogsController, type: :request do
                 expect(page).to have_content("With logs from bulk upload")
               end
 
+              it "hides collection year filter" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).not_to have_content("Collection year")
+              end
+
+              it "hides status filter" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).not_to have_content("Status")
+              end
+
               it "hides button to create a new log" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).not_to have_content("Create a new lettings log")

--- a/spec/support/bulk_upload/log_to_csv.rb
+++ b/spec/support/bulk_upload/log_to_csv.rb
@@ -159,12 +159,7 @@ class BulkUpload::LogToCsv
   end
 
   def renewal
-    case log.renewal
-    when 1
-      1
-    when 0
-      2
-    end
+    checkbox_value(log.renewal)
   end
 
   def london_affordable_rent
@@ -210,12 +205,7 @@ class BulkUpload::LogToCsv
   end
 
   def previous_postcode_known
-    case log.ppcodenk
-    when 1
-      1
-    when 0
-      2
-    end
+    checkbox_value(log.ppcodenk)
   end
 
   def homeless
@@ -228,25 +218,19 @@ class BulkUpload::LogToCsv
   end
 
   def cbl
-    case log.cbl
-    when 0
-      2
-    when 1
-      1
-    end
+    checkbox_value(log.cbl)
   end
 
   def chr
-    case log.chr
-    when 0
-      2
-    when 1
-      1
-    end
+    checkbox_value(log.chr)
   end
 
   def cap
-    case log.cap
+    checkbox_value(log.cap)
+  end
+
+  def checkbox_value(field)
+    case field
     when 0
       2
     when 1


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1764
- After a bulk upload assuming it proceeded to create the logs but a handful were invalid. We need to be able to playback these handful of logs to the user so they can be corrected

# Changes

- When passing the correct url eg `lettings-logs/bulk-upload-results/84/resume` it will redirect and load the lettings index screen showing only logs related to the specified bulk upload
- The LHS filter bar adds an additional area to signify a bulk upload filter is applied
- It also gives the user the ability to remove this applied filter
- The filter bar also has year and status filter removed as uploads relate to a single year and status is fixed to in progress
- When this filter is applied the buttons to create a new log or further do bulk uploads is hidden
- The existing mechanism of persisting filters to session remains, therefore after fixing a log and returning the bulk upload filter will continue to be applied
- The headings on the page have been updated to reflect the state of the bulk upload
- An additional banner displays context help text and offering meta info about the upload
- When all logs are resolved the interstitial page is displayed prompting that bulk upload process is complete
- Should the user revisit the link from the email they will be shown the same interstitial to say the process is complete

# Screenshots

![Screenshot 2023-01-25 at 13 00 57](https://user-images.githubusercontent.com/92580/214570051-f1281c6f-884b-46d7-acef-09042635fbdc.png)

## Interstitial

![Screenshot 2023-01-25 at 13 02 04](https://user-images.githubusercontent.com/92580/214570420-588f91b8-4361-4458-a6b9-5ecb969720f1.png)