### PR TITLE
Change numeric validation to display prefixes in error message

### DIFF
--- a/app/models/form/sales/questions/deposit_amount.rb
+++ b/app/models/form/sales/questions/deposit_amount.rb
@@ -7,7 +7,7 @@ class Form::Sales::Questions::DepositAmount < ::Form::Question
     @type = "numeric"
     @min = 0
     @width = 5
-    @max = 9_999_999
+    @max = 999_999
     @prefix = "£"
     @hint_text = "Enter the total cash sum paid by the buyer towards the property that was not funded by the mortgage"
     @derived = true

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -1,12 +1,4 @@
 module Validations::Sales::SaleInformationValidations
-  def validate_deposit_range(record)
-    return if record.deposit.blank?
-
-    unless record.deposit >= 0 && record.deposit <= 999_999
-      record.errors.add :deposit, "Cash deposit must be £0 - £999,999"
-    end
-  end
-
   def validate_pratical_completion_date_before_saledate(record)
     return if record.saledate.blank? || record.hodate.blank?
 

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -19,17 +19,19 @@ module Validations::SharedValidations
       next unless record[question.id]
 
       field = question.check_answer_label || question.id
+      min = [question.prefix, question.min].join("")
+      max = [question.prefix, question.max].join("")
 
       begin
         answer = Float(record.public_send("#{question.id}_before_type_cast"))
       rescue ArgumentError
-        record.errors.add question.id.to_sym, I18n.t("validations.numeric.valid", field:, min: question.min, max: question.max)
+        record.errors.add question.id.to_sym, I18n.t("validations.numeric.valid", field:, min:, max:)
       end
 
       next unless answer
 
       if (question.min && question.min > answer) || (question.max && question.max < answer)
-        record.errors.add question.id.to_sym, I18n.t("validations.numeric.valid", field:, min: question.min, max: question.max)
+        record.errors.add question.id.to_sym, I18n.t("validations.numeric.valid", field:, min:, max:)
       end
     end
   end

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -1,4 +1,6 @@
 module Validations::SharedValidations
+  include ActionView::Helpers::NumberHelper
+
   def validate_other_field(record, value_other = nil, main_field = nil, other_field = nil, main_label = nil, other_label = nil)
     return unless main_field || other_field
 
@@ -19,8 +21,8 @@ module Validations::SharedValidations
       next unless record[question.id]
 
       field = question.check_answer_label || question.id
-      min = [question.prefix, question.min].join("")
-      max = [question.prefix, question.max].join("")
+      min = [question.prefix, number_with_delimiter(question.min, delimiter: ","), question.suffix].join("")
+      max = [question.prefix, number_with_delimiter(question.max, delimiter: ","), question.suffix].join("")
 
       begin
         answer = Float(record.public_send("#{question.id}_before_type_cast"))

--- a/spec/models/form/sales/questions/deposit_amount_spec.rb
+++ b/spec/models/form/sales/questions/deposit_amount_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe Form::Sales::Questions::DepositAmount, type: :model do
   end
 
   it "has correct max" do
-    expect(question.max).to eq(9_999_999)
+    expect(question.max).to eq(999_999)
   end
 end

--- a/spec/models/validations/sales/sale_information_validations_spec.rb
+++ b/spec/models/validations/sales/sale_information_validations_spec.rb
@@ -5,48 +5,6 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
 
   let(:validator_class) { Class.new { include Validations::Sales::SaleInformationValidations } }
 
-  describe "#validate_deposit_range" do
-    context "when within permitted bounds" do
-      let(:record) { build(:sales_log, deposit: 0) }
-
-      it "does not add an error" do
-        sale_information_validator.validate_deposit_range(record)
-
-        expect(record.errors[:deposit]).not_to be_present
-      end
-    end
-
-    context "when blank" do
-      let(:record) { build(:sales_log, deposit: nil) }
-
-      it "does not add an error" do
-        sale_information_validator.validate_deposit_range(record)
-
-        expect(record.errors[:deposit]).not_to be_present
-      end
-    end
-
-    context "when below lower bound" do
-      let(:record) { build(:sales_log, deposit: -1) }
-
-      it "adds an error" do
-        sale_information_validator.validate_deposit_range(record)
-
-        expect(record.errors[:deposit]).to be_present
-      end
-    end
-
-    context "when higher than upper bound" do
-      let(:record) { build(:sales_log, deposit: 1_000_000) }
-
-      it "adds an error" do
-        sale_information_validator.validate_deposit_range(record)
-
-        expect(record.errors[:deposit]).to be_present
-      end
-    end
-  end
-
   describe "#validate_pratical_completion_date_before_saledate" do
     context "when hodate blank" do
       let(:record) { build(:sales_log, hodate: nil) }

--- a/spec/models/validations/shared_validations_spec.rb
+++ b/spec/models/validations/shared_validations_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Validations::SharedValidations do
 
   let(:validator_class) { Class.new { include Validations::SharedValidations } }
   let(:record) { FactoryBot.create(:lettings_log) }
+  let(:sales_record) { FactoryBot.create(:sales_log) }
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   describe "numeric min max validations" do
@@ -65,6 +66,24 @@ RSpec.describe Validations::SharedValidations do
         record.age6 = 45
         shared_validator.validate_numeric_min_max(record)
         expect(record.errors["age6"]).to be_empty
+      end
+    end
+
+    context "when validating percent" do
+      it "validates that % suffix is added in the error message" do
+        sales_record.stairbought = "random"
+        shared_validator.validate_numeric_min_max(sales_record)
+        expect(sales_record.errors["stairbought"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Percentage bought in this staircasing transaction", min: "0 percent", max: "100 percent"))
+      end
+    end
+
+    context "when validating price" do
+      it "validates that £ prefix  and , is added in the error message" do
+        sales_record.income1 = "random"
+        shared_validator.validate_numeric_min_max(sales_record)
+        expect(sales_record.errors["income1"])
+          .to include(match I18n.t("validations.numeric.valid", field: "Buyer 1’s gross annual income", min: "£0", max: "£999,999"))
       end
     end
   end


### PR DESCRIPTION
Update the numeric validation method to display prefixes, suffixes and appropriate delimiters for large values
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54268893/214588600-df0baac9-e20a-40ef-a078-d4f8a1b5e43c.png">
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/54268893/214588688-2454fb5f-9531-447e-8f8e-4aa36b30c37f.png">
