### PR TITLE
Persist column for bulk upload errors

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -164,6 +164,7 @@ class BulkUpload::Lettings::Validator
           property_ref: row_parser.field_100,
           row:,
           cell: "#{cols[field_number_for_attribute(error.attribute) - col_offset + 1]}#{row}",
+          col: cols[field_number_for_attribute(error.attribute) - col_offset + 1],
         )
       end
     end

--- a/db/migrate/20230126145529_add_column_to_bulk_upload_errors.rb
+++ b/db/migrate/20230126145529_add_column_to_bulk_upload_errors.rb
@@ -1,0 +1,5 @@
+class AddColumnToBulkUploadErrors < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_upload_errors, :col, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_160741) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_145529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_160741) do
     t.text "error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "col"
     t.index ["bulk_upload_id"], name: "index_bulk_upload_errors_on_bulk_upload_id"
   end
 

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -43,7 +43,14 @@ RSpec.describe BulkUpload::Lettings::Validator do
         validator.call
 
         error = BulkUploadError.first
-        expect(error.row).to eq("7")
+
+        expect(error.field).to eql("field_96")
+        expect(error.error).to eql("blank")
+        expect(error.tenant_code).to eql("123")
+        expect(error.property_ref).to be_nil
+        expect(error.row).to eql("7")
+        expect(error.cell).to eql("CS7")
+        expect(error.col).to eql("CS")
       end
     end
 


### PR DESCRIPTION
# Context

- At the moment we do not persist the column for bulk upload errors
- For the summary for bulk upload errors we need to display the column
- Persisting the column makes the query for the summary trivial
- If not persisted we'd have to select a substring in query to extract the column then add it to the grouping which makes things a little more complicated and brittle in my opinion

# Changes

- Add a new column called `col` to `bulk_upload_errors` table
- When extracting errors persist the column to database