### PR TITLE
CLDC-1780 Bulk upload summary

### DIFF
--- a/app/components/bulk_upload_error_summary_table_component.html.erb
+++ b/app/components/bulk_upload_error_summary_table_component.html.erb
@@ -1,0 +1,25 @@
+<%= govuk_table do |table| %>
+  <% table.caption(size: "m", text: bulk_upload.filename) %>
+
+  <% table.head do |head| %>
+    <% head.row do |row| %>
+      <% row.cell(text: "Column", header: true) %>
+      <% row.cell(text: "Number of rows", header: true) %>
+      <% row.cell(text: "Question", header: true) %>
+      <% row.cell(text: "Error", header: true) %>
+      <% row.cell(text: "Specification", header: true) %>
+    <% end %>
+  <% end %>
+
+  <% table.body do |body| %>
+    <% sorted_errors.each do |error| %>
+      <% body.row do |row| %>
+        <% row.cell(text: error[0][0]) %>
+        <% row.cell(text: error[1]) %>
+        <% row.cell(text: BulkUpload::Lettings::Validator.question_for_field(error[0][1].to_sym)) %>
+        <% row.cell(text: error[0][2]) %>
+        <% row.cell(text: error[0][1]) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/bulk_upload_error_summary_table_component.rb
+++ b/app/components/bulk_upload_error_summary_table_component.rb
@@ -1,0 +1,17 @@
+class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
+  attr_reader :bulk_upload
+
+  def initialize(bulk_upload:)
+    @bulk_upload = bulk_upload
+
+    super
+  end
+
+  def sorted_errors
+    @sorted_errors ||= bulk_upload
+      .bulk_upload_errors
+      .group(:col, :field, :error)
+      .count
+      .sort_by { |el| el[0][0].rjust(3, "0") }
+  end
+end

--- a/app/controllers/bulk_upload_lettings_results_controller.rb
+++ b/app/controllers/bulk_upload_lettings_results_controller.rb
@@ -19,6 +19,10 @@ class BulkUploadLettingsResultsController < ApplicationController
     end
   end
 
+  def summary
+    @bulk_upload = current_user.bulk_uploads.lettings.find(params[:id])
+  end
+
 private
 
   def reset_logs_filters

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -3,7 +3,8 @@ class BulkUpload < ApplicationRecord
 
   belongs_to :user
 
-  has_many :bulk_upload_errors
+  has_many :bulk_upload_errors, dependent: :destroy
+
   has_many :lettings_logs
   has_many :sales_logs
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -164,6 +164,7 @@ class BulkUpload::Lettings::Validator
           property_ref: row_parser.field_100,
           row:,
           cell: "#{cols[field_number_for_attribute(error.attribute) - col_offset + 1]}#{row}",
+          col: cols[field_number_for_attribute(error.attribute) - col_offset + 1],
         )
       end
     end

--- a/app/views/bulk_upload_lettings_results/show.html.erb
+++ b/app/views/bulk_upload_lettings_results/show.html.erb
@@ -1,6 +1,10 @@
+<% content_for :before_content do %>
+  <%= govuk_back_link(text: "Back", href: summary_bulk_upload_lettings_result_path(@bulk_upload)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Bulk Upload for lettings (<%= @bulk_upload.year_combo %>)</span>
+    <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>
     <h1 class="govuk-heading-l">We found <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in your file</h1>
 
     <div class="govuk-body">

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -1,0 +1,44 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>
+    <h1 class="govuk-heading-l">Correct data export and reupload</h1>
+
+    <p class="govuk-body-l">
+      We noticed that you have a lot of similar errors for some questions. You can download the specification which we reference below to understand how to correct the data. Once you have fixed these errors you can upload again.
+    </p>
+  </div>
+</div>
+
+<%= govuk_table do |table| %>
+  <% table.caption(size: "m", text: @bulk_upload.filename) %>
+
+  <% table.head do |head| %>
+    <% head.row do |row| %>
+      <% row.cell(text: "Column", header: true) %>
+      <% row.cell(text: "Number of rows", header: true) %>
+      <% row.cell(text: "Question", header: true) %>
+      <% row.cell(text: "Error", header: true) %>
+      <% row.cell(text: "Specification", header: true) %>
+    <% end %>
+  <% end %>
+
+  <% table.body do |body| %>
+    <% body.row do |row| %>
+      <% row.cell(text: "Bulbasaur") %>
+      <% row.cell(text: "Bulbasaur") %>
+      <% row.cell(text: "Bulbasaur") %>
+      <% row.cell(text: "Bulbasaur") %>
+      <% row.cell(text: "Bulbasaur") %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      You also have other errors in your file which you can either fix them in the CSV file or you can reupload and fix on CORE. <%= govuk_link_to "View the full report", bulk_upload_lettings_result_path(@bulk_upload) %>
+    </p>
+  </div>
+</div>
+
+<%= govuk_button_link_to "Upload your file again", start_bulk_upload_lettings_logs_path %>

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -9,29 +9,7 @@
   </div>
 </div>
 
-<%= govuk_table do |table| %>
-  <% table.caption(size: "m", text: @bulk_upload.filename) %>
-
-  <% table.head do |head| %>
-    <% head.row do |row| %>
-      <% row.cell(text: "Column", header: true) %>
-      <% row.cell(text: "Number of rows", header: true) %>
-      <% row.cell(text: "Question", header: true) %>
-      <% row.cell(text: "Error", header: true) %>
-      <% row.cell(text: "Specification", header: true) %>
-    <% end %>
-  <% end %>
-
-  <% table.body do |body| %>
-    <% body.row do |row| %>
-      <% row.cell(text: "Bulbasaur") %>
-      <% row.cell(text: "Bulbasaur") %>
-      <% row.cell(text: "Bulbasaur") %>
-      <% row.cell(text: "Bulbasaur") %>
-      <% row.cell(text: "Bulbasaur") %>
-    <% end %>
-  <% end %>
-<% end %>
+<%= render BulkUploadErrorSummaryTableComponent.new(bulk_upload: @bulk_upload) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
       resources :bulk_upload_lettings_results, path: "bulk-upload-results", only: [:show] do
         member do
           get :resume
+          get :summary
         end
       end
 

--- a/db/migrate/20230126145529_add_column_to_bulk_upload_errors.rb
+++ b/db/migrate/20230126145529_add_column_to_bulk_upload_errors.rb
@@ -1,0 +1,5 @@
+class AddColumnToBulkUploadErrors < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_upload_errors, :col, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_160741) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_145529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_160741) do
     t.text "error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "col"
     t.index ["bulk_upload_id"], name: "index_bulk_upload_errors_on_bulk_upload_id"
   end
 

--- a/spec/components/bulk_upload_error_summary_table_component_spec.rb
+++ b/spec/components/bulk_upload_error_summary_table_component_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
+  subject(:component) { described_class.new(bulk_upload:) }
+
+  let(:bulk_upload) { create(:bulk_upload) }
+
+  context "when no errors" do
+    it "does not renders any rows" do
+      result = render_inline(component)
+      expect(result).not_to have_selector("tbody tr")
+    end
+  end
+
+  context "when there are 2 independent errors" do
+    let!(:error_2) { create(:bulk_upload_error, bulk_upload:, col: "B", row: 2) }
+    let!(:error_1) { create(:bulk_upload_error, bulk_upload:, col: "A", row: 1) }
+
+    it "renders rows for each error" do
+      result = render_inline(component)
+      expect(result).to have_selector("tbody tr", count: 2)
+    end
+
+    it "renders rows by col order" do
+      result = render_inline(component)
+      order = result.css("tbody tr td:nth-of-type(1)").map(&:content)
+      expect(order).to eql(%w[A B])
+    end
+
+    it "render correct data" do
+      result = render_inline(component)
+
+      row_1 = result.css("tbody tr:nth-of-type(1) td").map(&:content)
+
+      expect(row_1).to eql([
+        "A",
+        "1",
+        BulkUpload::Lettings::Validator.question_for_field(error_1.field.to_sym),
+        error_1.error,
+        error_1.field,
+      ])
+
+      row_2 = result.css("tbody tr:nth-of-type(2) td").map(&:content)
+
+      expect(row_2).to eql([
+        "B",
+        "1",
+        BulkUpload::Lettings::Validator.question_for_field(error_2.field.to_sym),
+        error_2.error,
+        error_2.field,
+      ])
+    end
+  end
+
+  context "when there are 2 grouped errors" do
+    let!(:error_1) { create(:bulk_upload_error, bulk_upload:, col: "A", row: 1, field: "field_1") }
+
+    before do
+      create(:bulk_upload_error, bulk_upload:, col: "A", row: 2, field: "field_1")
+    end
+
+    it "renders 1 row combining the errors" do
+      result = render_inline(component)
+      expect(result).to have_selector("tbody tr", count: 1)
+    end
+
+    it "render correct data" do
+      result = render_inline(component)
+
+      row_1 = result.css("tbody tr:nth-of-type(1) td").map(&:content)
+
+      expect(row_1).to eql([
+        "A",
+        "2",
+        BulkUpload::Lettings::Validator.question_for_field(error_1.field.to_sym),
+        error_1.error,
+        error_1.field,
+      ])
+    end
+  end
+end

--- a/spec/factories/bulk_upload_error.rb
+++ b/spec/factories/bulk_upload_error.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
   factory :bulk_upload_error do
     bulk_upload
     row { rand(9_999) }
-    cell { "#{('A'..'Z').to_a.sample}#{row}" }
+    col { ("A".."Z").to_a.sample }
+    cell { "#{col}#{row}" }
     tenant_code { SecureRandom.hex(4) }
     property_ref { SecureRandom.hex(4) }
     purchaser_code { SecureRandom.hex(4) }

--- a/spec/requests/bulk_upload_lettings_results_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_results_controller_spec.rb
@@ -9,12 +9,27 @@ RSpec.describe BulkUploadLettingsResultsController, type: :request do
     sign_in user
   end
 
+  describe "GET /lettings-logs/bulk-upload-results/:ID/summary" do
+    it "renders year combo" do
+      get "/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary"
+
+      expect(response).to be_successful
+      expect(response.body).to include("Bulk upload for lettings (2022/23)")
+    end
+
+    it "renders the bulk upload filename" do
+      get "/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary"
+
+      expect(response.body).to include(bulk_upload.filename)
+    end
+  end
+
   describe "GET /lettings-logs/bulk-upload-results/:ID" do
     it "renders correct year" do
       get "/lettings-logs/bulk-upload-results/#{bulk_upload.id}"
 
       expect(response).to be_successful
-      expect(response.body).to include("Bulk Upload for lettings (2022/23)")
+      expect(response.body).to include("Bulk upload for lettings (2022/23)")
     end
 
     it "renders correct number of errors" do

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -43,7 +43,14 @@ RSpec.describe BulkUpload::Lettings::Validator do
         validator.call
 
         error = BulkUploadError.first
-        expect(error.row).to eq("7")
+
+        expect(error.field).to eql("field_96")
+        expect(error.error).to eql("blank")
+        expect(error.tenant_code).to eql("123")
+        expect(error.property_ref).to be_nil
+        expect(error.row).to eql("7")
+        expect(error.cell).to eql("CS7")
+        expect(error.col).to eql("CS")
       end
     end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1780
- In order to get a glimpse of what the errors are for a bulk upload we offer a summary page which groups and counts errors together based on all the errors

# Changes

- Add a page that summarises the bulk upload errors
- This will be the page linked to from the email that will act as the landing page
- Therefore the full report page has a back link added to return back to the summary page

# Notes for review

- This PR also contains https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1239 which can be reviewed and merged independently but is needed for this PR

# Screenshots

![Screenshot 2023-01-27 at 14 38 45](https://user-images.githubusercontent.com/92580/215112925-0ed7f8c7-8053-4b0c-a200-e5cb40835714.png)