### PR TITLE
CLDC-1781 Bulk upload thresholds

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -171,6 +171,8 @@ class BulkUpload::Lettings::Validator
   end
 
   def create_logs?
+    return false if row_parsers.any? { |row_parser| row_parser.log.form.setup_sections[0].subsections[0].is_incomplete?(row_parser.log) }
+
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -171,7 +171,7 @@ class BulkUpload::Lettings::Validator
   end
 
   def create_logs?
-    row_parsers.all?(&:valid?)
+    row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
 
   def self.question_for_field(field)

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -174,8 +174,8 @@ class BulkUpload::Lettings::Validator
   end
 
   def create_logs?
-    return false if row_parsers.any? { |row_parser| row_parser.log.form.setup_sections[0].subsections[0].is_incomplete?(row_parser.log) }
-    return false if over_percent_column_error_threshold?
+    return false if any_setup_sections_incomplete?
+    return false if over_column_error_threshold?
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
@@ -186,7 +186,11 @@ class BulkUpload::Lettings::Validator
 
 private
 
-  def over_percent_column_error_threshold?
+  def any_setup_sections_incomplete?
+    row_parsers.any? { |row_parser| row_parser.log.form.setup_sections[0].subsections[0].is_incomplete?(row_parser.log) }
+  end
+
+  def over_column_error_threshold?
     fields = ("field_1".."field_134").to_a
     percentage_threshold = (row_parsers.size * COLUMN_PERCENTAGE_ERROR_THRESHOLD).ceil
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -2,6 +2,7 @@ require "csv"
 
 class BulkUpload::Lettings::Validator
   COLUMN_PERCENTAGE_ERROR_THRESHOLD = 0.6
+  COLUMN_ABSOLUTE_ERROR_THRESHOLD = 16
 
   include ActiveModel::Validations
 
@@ -190,7 +191,11 @@ private
     percentage_threshold = (row_parsers.size * COLUMN_PERCENTAGE_ERROR_THRESHOLD).ceil
 
     fields.any? do |field|
-      row_parsers.count { |row_parser| row_parser.errors[field].present? } > percentage_threshold
+      count = row_parsers.count { |row_parser| row_parser.errors[field].present? }
+
+      next if count < COLUMN_ABSOLUTE_ERROR_THRESHOLD
+
+      count > percentage_threshold
     end
   end
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -172,8 +172,18 @@ class BulkUpload::Lettings::Validator
 
   def create_logs?
     return false if row_parsers.any? { |row_parser| row_parser.log.form.setup_sections[0].subsections[0].is_incomplete?(row_parser.log) }
+    return false if over_60_percent_column_error_rate
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
+  end
+
+  def over_60_percent_column_error_rate
+    fields = ("field_1".."field_134").to_a
+    threshold = (row_parsers.size * 0.6).ceil
+
+    fields.any? do |field|
+      row_parsers.count { |row_parser| row_parser.errors[field].present? } > threshold
+    end
   end
 
   def self.question_for_field(field)

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe BulkUpload::Lettings::Validator do
     end
 
     context "when all logs valid?" do
-      let(:log_1) { build(:lettings_log, :completed, created_by: user) }
-      let(:log_2) { build(:lettings_log, :completed, created_by: user) }
+      let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+      let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
 
       before do
         file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
@@ -141,6 +141,19 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
       it "returns true" do
         expect(validator).to be_create_logs
+      end
+    end
+
+    context "when a log has incomplete setup secion" do
+      let(:log) { build(:lettings_log, :in_progress, created_by: user, startdate: Time.zone.local(2022, 5, 1)) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log:, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.close
+      end
+
+      it "returns false" do
+        expect(validator).not_to be_create_logs
       end
     end
   end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
 
       it "returns false" do
+        validator.call
         expect(validator).not_to be_create_logs
       end
     end
@@ -140,6 +141,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
 
       it "returns true" do
+        validator.call
         expect(validator).to be_create_logs
       end
     end
@@ -153,7 +155,52 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
 
       it "returns false" do
+        validator.call
         expect(validator).not_to be_create_logs
+      end
+    end
+
+    context "when a column is over 60% error threshold" do
+      let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+      let(:log_2) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+      let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+      let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+      let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.close
+      end
+
+      it "returns false" do
+        validator.call
+        expect(validator).not_to be_create_logs
+      end
+    end
+
+    context "when a column is under 60% error threshold" do
+      let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+      let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+      let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+      let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+      let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.close
+      end
+
+      it "returns true" do
+        validator.call
+        expect(validator).to be_create_logs
       end
     end
   end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -160,47 +160,99 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
     end
 
-    context "when a column is over 60% error threshold" do
-      let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-      let(:log_2) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-      let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-      let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-      let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+    context "when a column has error rate below absolute threshold" do
+      context "when a column is over 60% error threshold" do
+        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_2) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
 
-      before do
-        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.close
+        before do
+          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.close
+        end
+
+        it "returns true" do
+          validator.call
+          expect(validator).to be_create_logs
+        end
       end
 
-      it "returns false" do
-        validator.call
-        expect(validator).not_to be_create_logs
+      context "when a column is under 60% error threshold" do
+        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+
+        before do
+          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.close
+        end
+
+        it "returns true" do
+          validator.call
+          expect(validator).to be_create_logs
+        end
       end
     end
 
-    context "when a column is under 60% error threshold" do
-      let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-      let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-      let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-      let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-      let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-
+    context "when a column has error rate above absolute threshold" do
       before do
-        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.close
+        stub_const("BulkUpload::Lettings::Validator::COLUMN_ABSOLUTE_ERROR_THRESHOLD", 1)
       end
 
-      it "returns true" do
-        validator.call
-        expect(validator).to be_create_logs
+      context "when a column is over 60% error threshold" do
+        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_2) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+
+        before do
+          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.close
+        end
+
+        it "returns false" do
+          validator.call
+          expect(validator).not_to be_create_logs
+        end
+      end
+
+      context "when a column is under 60% error threshold" do
+        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
+        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
+
+        before do
+          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_csv_row)
+          file.close
+        end
+
+        it "returns true" do
+          validator.call
+          expect(validator).to be_create_logs
+        end
       end
     end
   end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
       before do
         file.write(BulkUpload::LogToCsv.new(log:, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.rewind
+        file.close
       end
 
       it "creates validation errors" do
@@ -109,6 +109,38 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
       it "returns falsey" do
         expect(validator).not_to be_create_logs
+      end
+    end
+  end
+
+  describe "#create_logs?" do
+    context "when a log is not valid?" do
+      let(:log_1) { build(:lettings_log, :completed, created_by: user) }
+      let(:log_2) { build(:lettings_log, :completed, created_by: user) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0, overrides: { illness: 100 }).to_csv_row)
+        file.close
+      end
+
+      it "returns false" do
+        expect(validator).not_to be_create_logs
+      end
+    end
+
+    context "when all logs valid?" do
+      let(:log_1) { build(:lettings_log, :completed, created_by: user) }
+      let(:log_2) { build(:lettings_log, :completed, created_by: user) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.close
+      end
+
+      it "returns true" do
+        expect(validator).to be_create_logs
       end
     end
   end

--- a/spec/support/bulk_upload/log_to_csv.rb
+++ b/spec/support/bulk_upload/log_to_csv.rb
@@ -1,10 +1,11 @@
 class BulkUpload::LogToCsv
-  attr_reader :log, :line_ending, :col_offset
+  attr_reader :log, :line_ending, :col_offset, :overrides
 
-  def initialize(log:, line_ending: "\n", col_offset: 1)
+  def initialize(log:, line_ending: "\n", col_offset: 1, overrides: {})
     @log = log
     @line_ending = line_ending
     @col_offset = col_offset
+    @overrides = overrides
   end
 
   def to_csv_row
@@ -135,7 +136,7 @@ class BulkUpload::LogToCsv
       nil,
       log.incfreq,
       log.sheltered,
-      log.illness,
+      overrides[:illness] || log.illness,
       log.illness_type_1,
 
       log.illness_type_2, # 120


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1781
- When bulk uploading logs we only want to create logs when a certain number pass validation

# Changes

- Prevent log creation if there are more than 16 errors in a column
- Only create logs if error rate is below a certain percentage threshold, this has been set to 60%
- There is also a final check to ensure `some_log.valid?` is true so no log from the bulk upload is lost