### PR TITLE
CLDC-1766 Bulk upload sends success email

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -1,20 +1,34 @@
 class BulkUploadMailer < NotifyMailer
+  include ActionView::Helpers::TextHelper
+
   BULK_UPLOAD_COMPLETE_TEMPLATE_ID = "83279578-c890-4168-838b-33c9cf0dc9f0".freeze
   BULK_UPLOAD_FAILED_CSV_ERRORS_TEMPLATE_ID = "e27abcd4-5295-48c2-b127-e9ee4b781b75".freeze
   BULK_UPLOAD_FAILED_FILE_SETUP_ERROR_TEMPLATE_ID = "24c9f4c7-96ad-470a-ba31-eb51b7cbafd9".freeze
   BULK_UPLOAD_FAILED_SERVICE_ERROR_TEMPLATE_ID = "c3f6288c-7a74-4e77-99ee-6c4a0f6e125a".freeze
   BULK_UPLOAD_WITH_ERRORS_TEMPLATE_ID = "eb539005-6234-404e-812d-167728cf4274".freeze
 
-  def send_bulk_upload_complete_mail(user, bulk_upload)
+  def send_bulk_upload_complete_mail(user:, bulk_upload:)
+    url = if bulk_upload.lettings?
+            lettings_logs_url
+          else
+            sales_logs_url
+          end
+
+    n_logs = pluralize(bulk_upload.logs.count, "log")
+
+    title = "You’ve successfully uploaded #{n_logs}"
+
+    success_description = "The #{bulk_upload.log_type} #{bulk_upload.year_combo} data you uploaded has been checked. The #{n_logs} you uploaded are now complete."
+
     send_email(
       user.email,
       BULK_UPLOAD_COMPLETE_TEMPLATE_ID,
       {
-        title: "[#{bulk_upload} title]",
-        filename: "[#{bulk_upload} filename]",
-        upload_timestamp: "[#{bulk_upload} upload_timestamp]",
-        success_description: "[#{bulk_upload} success_description]",
-        logs_link: "[#{bulk_upload} logs_link]",
+        title:,
+        filename: bulk_upload.filename,
+        upload_timestamp: bulk_upload.created_at,
+        success_description:,
+        logs_link: url,
       },
     )
   end

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -14,6 +14,14 @@ class BulkUpload < ApplicationRecord
     "#{year}/#{year - 2000 + 1}"
   end
 
+  def logs
+    if lettings?
+      lettings_logs
+    else
+      sales_logs
+    end
+  end
+
 private
 
   def generate_identifier

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -9,11 +9,22 @@ class BulkUpload::Processor
     download
     validator.call
     create_logs if validator.create_logs?
+    send_success_mail
   ensure
     downloader.delete_local_file!
   end
 
 private
+
+  def send_success_mail
+    if validator.create_logs? && bulk_upload.logs.group(:status).count.keys == %w[completed]
+      BulkUploadMailer.send_bulk_upload_complete_mail(user:, bulk_upload:).deliver_later
+    end
+  end
+
+  def user
+    bulk_upload.user
+  end
 
   def create_logs
     log_creator_class.new(

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe BulkUploadMailer do
+  subject(:mailer) { described_class.new }
+
+  let(:notify_client) { instance_double(Notifications::Client) }
+  let(:user) { create(:user, email: "user@example.com") }
+  let(:bulk_upload) { build(:bulk_upload, :lettings) }
+
+  before do
+    allow(Notifications::Client).to receive(:new).and_return(notify_client)
+    allow(notify_client).to receive(:send_email).and_return(true)
+  end
+
+  describe "#send_bulk_upload_complete_mail" do
+    it "sends correctly formed email" do
+      expect(notify_client).to receive(:send_email).with(
+        email_address: user.email,
+        template_id: described_class::BULK_UPLOAD_COMPLETE_TEMPLATE_ID,
+        personalisation: {
+          title: "You’ve successfully uploaded 0 logs",
+          filename: bulk_upload.filename,
+          upload_timestamp: bulk_upload.created_at,
+          success_description: "The lettings 2022/23 data you uploaded has been checked. The 0 logs you uploaded are now complete.",
+          logs_link: lettings_logs_url,
+        },
+      )
+
+      mailer.send_bulk_upload_complete_mail(user:, bulk_upload:)
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1766
- When a user bulk uploads a CSV with perfect data where all logs are created as completed we want to send them email to notify them of the success 

# Changes

- Send user en email after a bulk uploading a perfect CSV