### PR TITLE
CLDC-1911 Initialise missing forms using the new format

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -7,7 +7,7 @@ class Form
     if type == "sales" || (start_year && start_year.to_i > 2022)
       @setup_sections = type == "sales" ? [Form::Sales::Sections::Setup.new(nil, nil, self)] : [Form::Lettings::Sections::Setup.new(nil, nil, self)]
       @form_sections = sections_in_form.map { |sec| sec.new(nil, nil, self) }
-      @type = type == "sales" ? "sales" : "lettings"
+      @type = type
       @sections = setup_sections + form_sections
       @subsections = sections.flat_map(&:subsections)
       @pages = subsections.flat_map(&:pages)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,10 +4,10 @@ class Form
               :setup_sections, :form_sections, :unresolved_log_redirect_page_id
 
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
-    if type == "sales"
-      @setup_sections = [Form::Sales::Sections::Setup.new(nil, nil, self)]
+    if type == "sales" || (start_year && start_year.to_i > 2022)
+      @setup_sections = type == "sales" ? [Form::Sales::Sections::Setup.new(nil, nil, self)] : [Form::Lettings::Sections::Setup.new(nil, nil, self)]
       @form_sections = sections_in_form.map { |sec| sec.new(nil, nil, self) }
-      @type = "sales"
+      @type = type == "sales" ? "sales" : "lettings"
       @sections = setup_sections + form_sections
       @subsections = sections.flat_map(&:subsections)
       @pages = subsections.flat_map(&:pages)
@@ -20,6 +20,7 @@ class Form
         "end_date" => end_date,
         "sections" => sections,
       }
+      @unresolved_log_redirect_page_id = "tenancy_start_date"
     else
       raise "No form definition file exists for given year".freeze unless File.exist?(form_path)
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,7 +4,7 @@ class Form
               :setup_sections, :form_sections, :unresolved_log_redirect_page_id
 
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
-    if type == "sales" || (start_year && start_year.to_i > 2022)
+    if sales_or_start_year_after_2022?(type, start_year)
       @setup_sections = type == "sales" ? [Form::Sales::Sections::Setup.new(nil, nil, self)] : [Form::Lettings::Sections::Setup.new(nil, nil, self)]
       @form_sections = sections_in_form.map { |sec| sec.new(nil, nil, self) }
       @type = type
@@ -240,5 +240,9 @@ class Form
 
   def valid_start_date_for_form?(start_date)
     start_date >= self.start_date && start_date <= end_date
+  end
+
+  def sales_or_start_year_after_2022?(type, start_year)
+    type == "sales" || (start_year && start_year.to_i > 2022)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -20,7 +20,7 @@ class Form
         "end_date" => end_date,
         "sections" => sections,
       }
-      @unresolved_log_redirect_page_id = "tenancy_start_date"
+      @unresolved_log_redirect_page_id = "tenancy_start_date" if type == "lettings"
     else
       raise "No form definition file exists for given year".freeze unless File.exist?(form_path)
 

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -54,12 +54,8 @@ class FormHandler
     if forms["previous_lettings"].blank? && current_collection_start_year >= 2022
       forms["previous_lettings"] = Form.new(nil, current_collection_start_year - 1, lettings_sections, "lettings")
     end
-    if forms["current_lettings"].blank? && current_collection_start_year >= 2022
-      forms["current_lettings"] = Form.new(nil, current_collection_start_year, lettings_sections, "lettings")
-    end
-    if forms["next_lettings"].blank? && current_collection_start_year >= 2022
-      forms["next_lettings"] = Form.new(nil, current_collection_start_year + 1, lettings_sections, "lettings")
-    end
+    forms["current_lettings"] = Form.new(nil, current_collection_start_year, lettings_sections, "lettings") if forms["current_lettings"].blank?
+    forms["next_lettings"] = Form.new(nil, current_collection_start_year + 1, lettings_sections, "lettings") if forms["next_lettings"].blank?
 
     forms
   end

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -28,8 +28,10 @@ class FormHandler
     ]
     current_form = Form.new(nil, current_collection_start_year, sales_sections, "sales")
     previous_form = Form.new(nil, current_collection_start_year - 1, sales_sections, "sales")
-    { "current_sales" => current_form,
-      "previous_sales" => previous_form }
+    {
+      "current_sales" => current_form,
+      "previous_sales" => previous_form,
+    }
   end
 
   def lettings_forms
@@ -42,6 +44,23 @@ class FormHandler
         forms[form_to_set] = form if forms[form_to_set].blank?
       end
     end
+
+    lettings_sections = [
+      Form::Lettings::Sections::TenancyAndProperty,
+      Form::Lettings::Sections::Household,
+      Form::Lettings::Sections::RentAndCharges,
+    ]
+
+    if forms["previous_lettings"].blank? && current_collection_start_year >= 2022
+      forms["previous_lettings"] = Form.new(nil, current_collection_start_year - 1, lettings_sections, "lettings")
+    end
+    if forms["current_lettings"].blank? && current_collection_start_year >= 2022
+      forms["current_lettings"] = Form.new(nil, current_collection_start_year, lettings_sections, "lettings")
+    end
+    if forms["next_lettings"].blank? && current_collection_start_year >= 2022
+      forms["next_lettings"] = Form.new(nil, current_collection_start_year + 1, lettings_sections, "lettings")
+    end
+
     forms
   end
 

--- a/app/models/forms/bulk_upload_lettings/year.rb
+++ b/app/models/forms/bulk_upload_lettings/year.rb
@@ -34,7 +34,7 @@ module Forms
     private
 
       def possible_years
-        FormHandler.instance.lettings_forms.values.map { |form| form.start_date.year }.sort.reverse
+        [FormHandler.instance.lettings_forms["current_lettings"].start_date.year, FormHandler.instance.lettings_forms["previous_lettings"].start_date.year]
       end
     end
   end

--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -39,7 +39,7 @@ module Validations::DateValidations
       record.errors.add :startdate, I18n.t("validations.date.outside_collection_window")
     end
 
-    if record.startdate < first_collection_start_date || record.startdate > second_collection_end_date
+    if (record.startdate < first_collection_start_date || record.startdate > second_collection_end_date) && FeatureToggle.startdate_collection_window_validation_enabled?
       record.errors.add :startdate, I18n.t("validations.date.outside_collection_window")
     end
 

--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -69,19 +69,19 @@ module Validations::DateValidations
 private
 
   def first_collection_start_date
-    @first_collection_start_date ||= FormHandler.instance.forms.map { |_name, form| form.start_date }.compact.min
+    @first_collection_start_date ||= FormHandler.instance.lettings_forms["previous_lettings"].start_date
   end
 
   def first_collection_end_date
-    @first_collection_end_date ||= FormHandler.instance.forms.map { |_name, form| form.end_date }.compact.min
+    @first_collection_end_date ||= FormHandler.instance.lettings_forms["previous_lettings"].end_date
   end
 
   def second_collection_start_date
-    @second_collection_start_date ||= FormHandler.instance.forms.map { |_name, form| form.start_date }.compact.max
+    @second_collection_start_date ||= FormHandler.instance.lettings_forms["current_lettings"].start_date
   end
 
   def second_collection_end_date
-    @second_collection_end_date ||= FormHandler.instance.forms.map { |_name, form| form.end_date }.compact.max
+    @second_collection_end_date ||= FormHandler.instance.lettings_forms["current_lettings"].end_date
   end
 
   def is_rsnvac_first_let?(record)

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -1,6 +1,6 @@
 class FeatureToggle
   def self.startdate_two_week_validation_enabled?
-    Rails.env.production?
+    Rails.env.production? || Rails.env.test?
   end
 
   def self.sales_log_enabled?

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -3,6 +3,10 @@ class FeatureToggle
     Rails.env.production? || Rails.env.test?
   end
 
+  def self.startdate_collection_window_validation_enabled?
+    Rails.env.production? || Rails.env.test?
+  end
+
   def self.sales_log_enabled?
     !Rails.env.production?
   end

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -1,6 +1,6 @@
 class FeatureToggle
   def self.startdate_two_week_validation_enabled?
-    true
+    Rails.env.production?
   end
 
   def self.sales_log_enabled?

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -171,6 +171,8 @@ RSpec.describe FormHandler do
 
   describe "lettings_forms" do
     context "when current and previous forms are defined in JSON (current collection start year before 2023)" do
+      let(:now) { Time.utc(2022, 9, 20) }
+
       it "creates a next_lettings form from ruby form objects" do
         expect(form_handler.lettings_forms["previous_lettings"]).to be_present
         expect(form_handler.lettings_forms["previous_lettings"].start_date.year).to eq(2021)

--- a/spec/models/form_handler_spec.rb
+++ b/spec/models/form_handler_spec.rb
@@ -168,5 +168,44 @@ RSpec.describe FormHandler do
       end
     end
   end
+
+  describe "lettings_forms" do
+    context "when current and previous forms are defined in JSON (current collection start year before 2023)" do
+      it "creates a next_lettings form from ruby form objects" do
+        expect(form_handler.lettings_forms["previous_lettings"]).to be_present
+        expect(form_handler.lettings_forms["previous_lettings"].start_date.year).to eq(2021)
+        expect(form_handler.lettings_forms["current_lettings"]).to be_present
+        expect(form_handler.lettings_forms["current_lettings"].start_date.year).to eq(2022)
+        expect(form_handler.lettings_forms["next_lettings"]).to be_present
+        expect(form_handler.lettings_forms["next_lettings"].start_date.year).to eq(2023)
+      end
+    end
+
+    context "when only previous form is defined in JSON (current collection start year 2023)" do
+      let(:now) { Time.utc(2023, 9, 20) }
+
+      it "creates current_lettings and next_lettings forms from ruby form objects" do
+        expect(form_handler.lettings_forms["previous_lettings"]).to be_present
+        expect(form_handler.lettings_forms["previous_lettings"].start_date.year).to eq(2022)
+        expect(form_handler.lettings_forms["current_lettings"]).to be_present
+        expect(form_handler.lettings_forms["current_lettings"].start_date.year).to eq(2023)
+        expect(form_handler.lettings_forms["next_lettings"]).to be_present
+        expect(form_handler.lettings_forms["next_lettings"].start_date.year).to eq(2024)
+      end
+    end
+
+    context "when no form is defined in JSON (current collection start year 2024 onwards)" do
+      let(:now) { Time.utc(2024, 9, 20) }
+
+      it "creates previous_lettings, current_lettings and next_lettings forms from ruby form objects" do
+        expect(form_handler.lettings_forms["previous_lettings"]).to be_present
+        expect(form_handler.lettings_forms["previous_lettings"].start_date.year).to eq(2023)
+        expect(form_handler.lettings_forms["current_lettings"]).to be_present
+        expect(form_handler.lettings_forms["current_lettings"].start_date.year).to eq(2024)
+        expect(form_handler.lettings_forms["next_lettings"]).to be_present
+        expect(form_handler.lettings_forms["next_lettings"].start_date.year).to eq(2025)
+      end
+    end
+  end
   # rubocop:enable RSpec/PredicateMatcher
 end


### PR DESCRIPTION
Initialise missing forms using the new format (non JSON)
Disable 14 days validation on non production
Do not use the next lettings form in validations and as a bulk upload option