### PR TITLE
CLDC-1767 Bulk upload fail email

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -63,16 +63,22 @@ class BulkUploadMailer < NotifyMailer
     )
   end
 
-  def send_bulk_upload_failed_service_error_mail(user, bulk_upload)
+  def send_bulk_upload_failed_service_error_mail(bulk_upload:)
+    bulk_upload_link = if bulk_upload.lettings?
+                         start_bulk_upload_lettings_logs_url
+                       else
+                         start_bulk_upload_sales_logs_url
+                       end
+
     send_email(
-      user.email,
+      bulk_upload.user.email,
       BULK_UPLOAD_FAILED_SERVICE_ERROR_TEMPLATE_ID,
       {
-        filename: "[#{bulk_upload} filename]",
-        upload_timestamp: "[#{bulk_upload} upload_timestamp]",
-        lettings_or_sales: "[#{bulk_upload} lettings_or_sales]",
-        year_combo: "[#{bulk_upload} year_combo]",
-        bulk_upload_link: "[#{bulk_upload} bulk_upload_link]",
+        filename: bulk_upload.filename,
+        upload_timestamp: bulk_upload.created_at,
+        lettings_or_sales: bulk_upload.log_type,
+        year_combo: bulk_upload.year_combo,
+        bulk_upload_link:,
       },
     )
   end

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -7,6 +7,9 @@ class BulkUpload::Processor
 
   def call
     download
+
+    return send_failure_mail if validator.invalid?
+
     validator.call
     create_logs if validator.create_logs?
     send_success_mail
@@ -20,6 +23,10 @@ private
     if validator.create_logs? && bulk_upload.logs.group(:status).count.keys == %w[completed]
       BulkUploadMailer.send_bulk_upload_complete_mail(user:, bulk_upload:).deliver_later
     end
+  end
+
+  def send_failure_mail
+    BulkUploadMailer.send_bulk_upload_failed_service_error_mail(bulk_upload:).deliver_later
   end
 
   def user

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -13,6 +13,9 @@ class BulkUpload::Processor
     validator.call
     create_logs if validator.create_logs?
     send_success_mail
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    send_failure_mail
   ensure
     downloader.delete_local_file!
   end

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BulkUploadMailer do
 
   let(:notify_client) { instance_double(Notifications::Client) }
   let(:user) { create(:user, email: "user@example.com") }
-  let(:bulk_upload) { build(:bulk_upload, :lettings) }
+  let(:bulk_upload) { build(:bulk_upload, :lettings, user:) }
 
   before do
     allow(Notifications::Client).to receive(:new).and_return(notify_client)
@@ -27,6 +27,24 @@ RSpec.describe BulkUploadMailer do
       )
 
       mailer.send_bulk_upload_complete_mail(user:, bulk_upload:)
+    end
+  end
+
+  describe "#send_bulk_upload_failed_service_error_mail" do
+    it "sends correctly formed email" do
+      expect(notify_client).to receive(:send_email).with(
+        email_address: user.email,
+        template_id: described_class::BULK_UPLOAD_FAILED_SERVICE_ERROR_TEMPLATE_ID,
+        personalisation: {
+          filename: bulk_upload.filename,
+          upload_timestamp: bulk_upload.created_at,
+          lettings_or_sales: bulk_upload.log_type,
+          year_combo: bulk_upload.year_combo,
+          bulk_upload_link: start_bulk_upload_lettings_logs_url,
+        },
+      )
+
+      mailer.send_bulk_upload_failed_service_error_mail(bulk_upload:)
     end
   end
 end

--- a/spec/services/bulk_upload/processor_spec.rb
+++ b/spec/services/bulk_upload/processor_spec.rb
@@ -47,7 +47,49 @@ RSpec.describe BulkUpload::Processor do
       end
     end
 
-    context "when the bulk upload processing throws an error"
+    context "when the bulk upload processing throws an error" do
+      let(:mock_downloader) do
+        instance_double(
+          BulkUpload::Downloader,
+          call: nil,
+          path: file_fixture("2022_23_lettings_bulk_upload.csv"),
+          delete_local_file!: nil,
+        )
+      end
+
+      let(:mock_validator) do
+        instance_double(
+          BulkUpload::Lettings::Validator,
+          invalid?: false,
+        )
+      end
+
+      before do
+        allow(BulkUpload::Downloader).to receive(:new).with(bulk_upload:).and_return(mock_downloader)
+        allow(BulkUpload::Lettings::Validator).to receive(:new).and_return(mock_validator)
+
+        allow(mock_validator).to receive(:call).and_raise(StandardError)
+      end
+
+      it "sends failure email" do
+        mail_double = instance_double("ActionMailer::MessageDelivery", deliver_later: nil)
+
+        allow(BulkUploadMailer).to receive(:send_bulk_upload_failed_service_error_mail).and_return(mail_double)
+
+        processor.call
+
+        expect(BulkUploadMailer).to have_received(:send_bulk_upload_failed_service_error_mail)
+        expect(mail_double).to have_received(:deliver_later)
+      end
+
+      it "we log the failure" do
+        allow(Sentry).to receive(:capture_exception)
+
+        processor.call
+
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
 
     context "when processing a bulk upload with errors" do
       let(:mock_downloader) do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1767
- When we fail to parse an bulk upload we need to email the user to inform them about the issue

# Changes

- When there is a validation error we on the file we exit early and email the user that there was a problem
- If an error was raised during the process we also send the user an email. We also capture the error in Sentry for logging and analysis later so if there was a problem our end we can work to resolve

# Notes for review

- These validation rules are rather limited at the moment. However at least this mechanism is in place so if there a scenarios we want to capture they can easily be added