### PR TITLE
CLDC-1762 Bulk upload fix errors email

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -84,13 +84,13 @@ class BulkUploadMailer < NotifyMailer
   end
 
   def send_bulk_upload_with_errors_mail(bulk_upload:)
-    n = bulk_upload.logs.where.not(status: %w[completed]).count
+    count = bulk_upload.logs.where.not(status: %w[completed]).count
 
-    n_logs = pluralize(n, "log")
+    n_logs = pluralize(count, "log")
 
     title = "We found #{n_logs} with errors"
 
-    error_description = "We created logs from your #{bulk_upload.year_combo} #{bulk_upload.log_type} data. There was a problem with #{n} of the logs. Click the below link to fix these logs."
+    error_description = "We created logs from your #{bulk_upload.year_combo} #{bulk_upload.log_type} data. There was a problem with #{count} of the logs. Click the below link to fix these logs."
 
     send_email(
       bulk_upload.user.email,

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -83,16 +83,24 @@ class BulkUploadMailer < NotifyMailer
     )
   end
 
-  def send_bulk_upload_with_errors_mail(user, bulk_upload)
+  def send_bulk_upload_with_errors_mail(bulk_upload:)
+    n = bulk_upload.logs.where.not(status: %w[completed]).count
+
+    n_logs = pluralize(n, "log")
+
+    title = "We found #{n_logs} with errors"
+
+    error_description = "We created logs from your #{bulk_upload.year_combo} #{bulk_upload.log_type} data. There was a problem with #{n} of the logs. Click the below link to fix these logs."
+
     send_email(
-      user.email,
+      bulk_upload.user.email,
       BULK_UPLOAD_WITH_ERRORS_TEMPLATE_ID,
       {
-        title: "[#{bulk_upload} title]",
-        filename: "[#{bulk_upload} filename]",
-        upload_timestamp: "[#{bulk_upload} upload_timestamp]",
-        error_description: "[#{bulk_upload} error_description]",
-        summary_report_link: "[#{bulk_upload} summary_report_link]",
+        title:,
+        filename: bulk_upload.filename,
+        upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
+        error_description:,
+        summary_report_link: summary_bulk_upload_lettings_result_url(bulk_upload),
       },
     )
   end

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -100,7 +100,7 @@ class BulkUploadMailer < NotifyMailer
         filename: bulk_upload.filename,
         upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
         error_description:,
-        summary_report_link: summary_bulk_upload_lettings_result_url(bulk_upload),
+        summary_report_link: resume_bulk_upload_lettings_result_url(bulk_upload),
       },
     )
   end

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -11,8 +11,10 @@ class BulkUpload::Processor
     return send_failure_mail if validator.invalid?
 
     validator.call
+
     create_logs if validator.create_logs?
-    send_success_mail
+
+    send_success_mail if created_logs_and_all_completed?
   rescue StandardError => e
     Sentry.capture_exception(e)
     send_failure_mail
@@ -23,9 +25,11 @@ class BulkUpload::Processor
 private
 
   def send_success_mail
-    if validator.create_logs? && bulk_upload.logs.group(:status).count.keys == %w[completed]
-      BulkUploadMailer.send_bulk_upload_complete_mail(user:, bulk_upload:).deliver_later
-    end
+    BulkUploadMailer.send_bulk_upload_complete_mail(user:, bulk_upload:).deliver_later
+  end
+
+  def created_logs_and_all_completed?
+    validator.create_logs? && bulk_upload.logs.group(:status).count.keys == %w[completed]
   end
 
   def send_failure_mail

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe BulkUploadMailer do
             filename: bulk_upload.filename,
             upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
             error_description:,
-            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary",
+            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/resume",
           },
         )
 

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -47,4 +47,32 @@ RSpec.describe BulkUploadMailer do
       mailer.send_bulk_upload_failed_service_error_mail(bulk_upload:)
     end
   end
+
+  context "when bulk upload has log which is not completed" do
+    before do
+      create(:lettings_log, :in_progress, bulk_upload:)
+    end
+
+    describe "#send_bulk_upload_with_errors_mail" do
+      let(:error_description) do
+        "We created logs from your 2022/23 lettings data. There was a problem with 1 of the logs. Click the below link to fix these logs."
+      end
+
+      it "sends correctly formed email" do
+        expect(notify_client).to receive(:send_email).with(
+          email_address: bulk_upload.user.email,
+          template_id: described_class::BULK_UPLOAD_WITH_ERRORS_TEMPLATE_ID,
+          personalisation: {
+            title: "We found 1 log with errors",
+            filename: bulk_upload.filename,
+            upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
+            error_description:,
+            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary",
+          },
+        )
+
+        mailer.send_bulk_upload_with_errors_mail(bulk_upload:)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1762
- After performing a bulk upload if logs are created but some require fixing on the site we email the user to inform them and to link back to the site where they can fix the logs via the website 

# Changes

- Add tests to bulk upload mailer
- If we create logs but there are some that are not completed, send relevant email to user