### PR TITLE
Bulk upload validation tweaks

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -139,7 +139,8 @@ class BulkUpload::Lettings::RowParser
   attribute :field_133, :integer
   attribute :field_134, :integer
 
-  validates :field_1, presence: true, inclusion: { in: (1..12).to_a }
+  validates :field_1, presence: { message: I18n.t("validations.not_answered", question: "letting type") },
+                      inclusion: { in: (1..12).to_a, message: I18n.t("validations.invalid_option", question: "letting type") }
   validates :field_4, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_1) } }
 
   def valid?
@@ -172,7 +173,7 @@ private
 
   def validate_data_types
     unless attribute_set["field_1"].value_before_type_cast&.match?(/\A\d+\z/)
-      errors.add(:field_1, :invalid)
+      errors.add(:field_1, I18n.t("validations.invalid_number", question: "letting type"))
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -142,10 +142,6 @@ class BulkUpload::Lettings::RowParser
   validates :field_1, presence: true, inclusion: { in: (1..12).to_a }
   validates :field_4, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_1) } }
 
-  validates :field_96, presence: true
-  validates :field_97, presence: true
-  validates :field_98, presence: true
-
   def valid?
     errors.clear
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -162,7 +162,7 @@ class BulkUpload::Lettings::Validator
       row_parser.errors.each do |error|
         bulk_upload.bulk_upload_errors.create!(
           field: error.attribute,
-          error: error.type,
+          error: error.message,
           tenant_code: row_parser.field_7,
           property_ref: row_parser.field_100,
           row:,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
         already_added: "You have already added this managing agent"
     not_answered: "You must answer %{question}"
     invalid_option: "Enter a valid value for %{question}"
+    invalid_number: "Enter a number for %{question}"
 
     other_field_missing: "If %{main_field_label} is other then %{other_field_label} must be provided"
     other_field_not_required: "%{other_field_label} must not be provided if %{main_field_label} was not other"

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -42,15 +42,15 @@ RSpec.describe BulkUpload::Lettings::Validator do
       it "create validation error with correct values" do
         validator.call
 
-        error = BulkUploadError.first
+        error = BulkUploadError.order(:row, :field).first
 
-        expect(error.field).to eql("field_96")
-        expect(error.error).to eql("blank")
+        expect(error.field).to eql("field_11")
+        expect(error.error).to eql("You must only answer the length of the tenancy if it's fixed-term")
         expect(error.tenant_code).to eql("123")
         expect(error.property_ref).to be_nil
         expect(error.row).to eql("7")
-        expect(error.cell).to eql("CS7")
-        expect(error.col).to eql("CS")
+        expect(error.cell).to eql("L7")
+        expect(error.col).to eql("L")
       end
     end
 


### PR DESCRIPTION
# Context

- We should be persisting full validation error messages for bulk uploads
- We simply play these back to the user

# Changes

- In some places we were not persisting the full error message and instead just the error type
- These have now been changes to persist the full error message meaning correct error messages are now played back to the user rather than just messages that read `blank` or `invalid`

# Screenshots

## Before change with duplicates and incorrect message 

![Screenshot 2023-02-06 at 10 49 39](https://user-images.githubusercontent.com/92580/216953202-920eed89-51a8-4a29-840d-65a41f5f7b21.png)

## After change with dupes removed and full error messages

![Screenshot 2023-02-06 at 10 51 23](https://user-images.githubusercontent.com/92580/216953317-9d23acd6-2858-40e6-a6b6-6c2526bd868e.png)