### PR TITLE
CLDC-1937 Bulk upload start date

### DIFF
--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -22,6 +22,14 @@ class BulkUpload < ApplicationRecord
     end
   end
 
+  def form
+    @form ||= if lettings?
+                FormHandler.instance.lettings_form_for_start_year(year)
+              else
+                FormHandler.instance.sales_form_for_start_year(year)
+              end
+  end
+
 private
 
   def generate_identifier

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -236,4 +236,8 @@ class Form
   def inspect
     "#<#{self.class} @type=#{type} @name=#{name}>"
   end
+
+  def valid_start_date_for_form?(start_date)
+    start_date >= self.start_date && start_date <= end_date
+  end
 end

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -45,6 +45,14 @@ class FormHandler
     forms
   end
 
+  def lettings_form_for_start_year(year)
+    lettings_forms.values.find { |form| form.start_date.year == year }
+  end
+
+  def sales_form_for_start_year(year)
+    sales_forms.values.find { |form| form.start_date.year == year }
+  end
+
   def form_name_from_start_year(year, type)
     form_mappings = { 0 => "current_#{type}", 1 => "previous_#{type}", -1 => "next_#{type}" }
     form_mappings[current_collection_start_year - year]

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -150,6 +150,7 @@ class BulkUpload::Lettings::RowParser
 
     validate_data_types
     validate_nulls
+    validate_relevant_collection_window
 
     log.valid?
 
@@ -166,6 +167,23 @@ class BulkUpload::Lettings::RowParser
   end
 
 private
+
+  def validate_relevant_collection_window
+    return unless start_date
+    return unless bulk_upload.form
+
+    unless bulk_upload.form.valid_start_date_for_form?(start_date)
+      errors.add(:field_96, I18n.t("validations.date.outside_collection_window"))
+      errors.add(:field_97, I18n.t("validations.date.outside_collection_window"))
+      errors.add(:field_98, I18n.t("validations.date.outside_collection_window"))
+    end
+  end
+
+  def start_date
+    Date.parse("20#{field_98}-#{field_97}-#{field_96}")
+  rescue StandardError
+    nil
+  end
 
   def attribute_set
     @attribute_set ||= instance_variable_get(:@attributes)

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -179,7 +179,7 @@ private
   end
 
   def start_date
-    Date.parse("20#{field_98}-#{field_97}-#{field_96}")
+    Date.parse("20#{field_98.to_s.rjust(2, '0')}-#{field_97}-#{field_96}")
   rescue StandardError
     nil
   end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -169,8 +169,7 @@ class BulkUpload::Lettings::RowParser
 private
 
   def validate_relevant_collection_window
-    return unless start_date
-    return unless bulk_upload.form
+    return unless start_date && bulk_upload.form
 
     unless bulk_upload.form.valid_start_date_for_form?(start_date)
       errors.add(:field_96, I18n.t("validations.date.outside_collection_window"))

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -143,14 +143,14 @@ class BulkUpload::Lettings::RowParser
                       inclusion: { in: (1..12).to_a, message: I18n.t("validations.invalid_option", question: "letting type") }
   validates :field_4, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_1) } }
 
+  validate :validate_data_types
+  validate :validate_nulls
+  validate :validate_relevant_collection_window
+
   def valid?
     errors.clear
 
     super
-
-    validate_data_types
-    validate_nulls
-    validate_relevant_collection_window
 
     log.valid?
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -774,4 +774,14 @@ RSpec.describe BulkUpload::Lettings::RowParser do
       end
     end
   end
+
+  describe "#start_date" do
+    context "when year of 9 is passed to represent 2009" do
+      let(:attributes) { { bulk_upload:, field_96: "1", field_97: "1", field_98: "9" } }
+
+      it "uses the year 2009" do
+        expect(parser.send(:start_date)).to eql(Date.new(2009, 1, 1))
+      end
+    end
+  end
 end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -255,6 +255,42 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         let(:attributes) { { bulk_upload:, field_96: nil, field_97: nil, field_98: nil } }
 
         it "returns an error" do
+          parser.valid?
+
+          expect(parser.errors[:field_96]).to be_present
+          expect(parser.errors[:field_97]).to be_present
+          expect(parser.errors[:field_98]).to be_present
+        end
+      end
+
+      context "when inside of collection year" do
+        let(:attributes) { { bulk_upload:, field_96: "1", field_97: "10", field_98: "22" } }
+
+        let(:bulk_upload) { create(:bulk_upload, :lettings, user:, year: 2022) }
+
+        it "does not return errors" do
+          parser.valid?
+
+          expect(parser.errors[:field_96]).not_to be_present
+          expect(parser.errors[:field_97]).not_to be_present
+          expect(parser.errors[:field_98]).not_to be_present
+        end
+      end
+
+      context "when outside of collection year" do
+        around do |example|
+          Timecop.freeze(Date.new(2022, 4, 2)) do
+            example.run
+          end
+        end
+
+        let(:attributes) { { bulk_upload:, field_96: "1", field_97: "1", field_98: "22" } }
+
+        let(:bulk_upload) { create(:bulk_upload, :lettings, user:, year: 2022) }
+
+        it "returns errors" do
+          parser.valid?
+
           expect(parser.errors[:field_96]).to be_present
           expect(parser.errors[:field_97]).to be_present
           expect(parser.errors[:field_98]).to be_present


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1937
- When uploading logs, users are free to specify any start dates

# Changes

- With validation we constrain what start dates are permitted by using the collection window based on the bulk upload journey
- During bulk upload journey they specify a year if they are in the crossover period, otherwise the year is selected for them
- We check to see if the logs match this year otherwise fails validation