### PR TITLE
CLDC-1965 Bulk upload correct again email

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -33,17 +33,29 @@ class BulkUploadMailer < NotifyMailer
     )
   end
 
-  def send_bulk_upload_failed_csv_errors_mail(user, bulk_upload)
+  def columns_with_errors(bulk_upload:)
+    array = bulk_upload.columns_with_errors
+
+    if array.size > 3
+      "#{array.take(3).join(', ')} and more"
+    else
+      array.join(", ")
+    end
+  end
+
+  def send_correct_and_upload_again_mail(bulk_upload:)
+    error_description = "We noticed that you have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}. Please correct your data export and upload again."
+
     send_email(
-      user.email,
+      bulk_upload.user.email,
       BULK_UPLOAD_FAILED_CSV_ERRORS_TEMPLATE_ID,
       {
-        filename: "[#{bulk_upload} filename]",
-        upload_timestamp: "[#{bulk_upload} upload_timestamp]",
-        year_combo: "[#{bulk_upload} year_combo]",
-        lettings_or_sales: "[#{bulk_upload} lettings_or_sales]",
-        error_description: "[#{bulk_upload} error_description]",
-        summary_report_link: "[#{bulk_upload} summary_report_link]",
+        filename: bulk_upload.filename,
+        upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
+        year_combo: bulk_upload.year_combo,
+        lettings_or_sales: bulk_upload.log_type,
+        error_description:,
+        summary_report_link: summary_bulk_upload_lettings_result_url(bulk_upload),
       },
     )
   end

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -30,6 +30,14 @@ class BulkUpload < ApplicationRecord
               end
   end
 
+  def columns_with_errors
+    bulk_upload_errors
+      .select(:col)
+      .distinct(:col)
+      .pluck(:col)
+      .sort_by { |col| col.rjust(2, "0") }
+  end
+
   def general_needs?
     needstype == 1
   end

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -13,6 +13,7 @@ class BulkUpload::Processor
     validator.call
 
     create_logs if validator.create_logs?
+    send_correct_and_upload_again_mail unless validator.create_logs?
 
     send_fix_errors_mail if created_logs_but_incompleted?
     send_success_mail if created_logs_and_all_completed?
@@ -24,6 +25,10 @@ class BulkUpload::Processor
   end
 
 private
+
+  def send_correct_and_upload_again_mail
+    BulkUploadMailer.send_correct_and_upload_again_mail(bulk_upload:).deliver_later
+  end
 
   def send_fix_errors_mail
     BulkUploadMailer.send_bulk_upload_with_errors_mail(bulk_upload:).deliver_later

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BulkUploadMailer do
 
   let(:notify_client) { instance_double(Notifications::Client) }
   let(:user) { create(:user, email: "user@example.com") }
-  let(:bulk_upload) { build(:bulk_upload, :lettings, user:) }
+  let(:bulk_upload) { create(:bulk_upload, :lettings, user:) }
 
   before do
     allow(Notifications::Client).to receive(:new).and_return(notify_client)
@@ -72,6 +72,58 @@ RSpec.describe BulkUploadMailer do
         )
 
         mailer.send_bulk_upload_with_errors_mail(bulk_upload:)
+      end
+    end
+  end
+
+  describe "#send_correct_and_upload_again_mail" do
+    context "when 2 columns with errors" do
+      before do
+        create(:bulk_upload_error, bulk_upload:, col: "A")
+        create(:bulk_upload_error, bulk_upload:, col: "B")
+      end
+
+      it "sends correctly formed email with A, B" do
+        expect(notify_client).to receive(:send_email).with(
+          email_address: user.email,
+          template_id: described_class::BULK_UPLOAD_FAILED_CSV_ERRORS_TEMPLATE_ID,
+          personalisation: {
+            filename: bulk_upload.filename,
+            upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
+            year_combo: bulk_upload.year_combo,
+            lettings_or_sales: bulk_upload.log_type,
+            error_description: "We noticed that you have a lot of similar errors in column A, B. Please correct your data export and upload again.",
+            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary",
+          },
+        )
+
+        mailer.send_correct_and_upload_again_mail(bulk_upload:)
+      end
+    end
+
+    context "when 4 columns with errors" do
+      before do
+        create(:bulk_upload_error, bulk_upload:, col: "A")
+        create(:bulk_upload_error, bulk_upload:, col: "B")
+        create(:bulk_upload_error, bulk_upload:, col: "C")
+        create(:bulk_upload_error, bulk_upload:, col: "D")
+      end
+
+      it "sends correctly formed email with A, B, C and more" do
+        expect(notify_client).to receive(:send_email).with(
+          email_address: user.email,
+          template_id: described_class::BULK_UPLOAD_FAILED_CSV_ERRORS_TEMPLATE_ID,
+          personalisation: {
+            filename: bulk_upload.filename,
+            upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
+            year_combo: bulk_upload.year_combo,
+            lettings_or_sales: bulk_upload.log_type,
+            error_description: "We noticed that you have a lot of similar errors in column A, B, C and more. Please correct your data export and upload again.",
+            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary",
+          },
+        )
+
+        mailer.send_correct_and_upload_again_mail(bulk_upload:)
       end
     end
   end

--- a/spec/services/bulk_upload/processor_spec.rb
+++ b/spec/services/bulk_upload/processor_spec.rb
@@ -171,6 +171,17 @@ RSpec.describe BulkUpload::Processor do
         expect(mock_downloader).to have_received(:delete_local_file!)
       end
 
+      it "sends correct and upload again mail" do
+        mail_double = instance_double("ActionMailer::MessageDelivery", deliver_later: nil)
+
+        allow(BulkUploadMailer).to receive(:send_correct_and_upload_again_mail).and_return(mail_double)
+
+        processor.call
+
+        expect(BulkUploadMailer).to have_received(:send_correct_and_upload_again_mail)
+        expect(mail_double).to have_received(:deliver_later)
+      end
+
       it "does not send fix errors email" do
         allow(BulkUploadMailer).to receive(:send_bulk_upload_with_errors_mail).and_call_original
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1965

# Changes

- When a user bulk uploads and logs could not be created we send them an email detailing this