### PR TITLE
CLDC-1888 Check for existing duplicate logs when bulk uploading

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -51,17 +51,26 @@ class BulkUploadMailer < NotifyMailer
     bulk_upload:
   )
 
-    any_setup_sections_incomplete_error_description = "Placeholder text for setup sections incomplete case. "
-    over_column_error_threshold_error_description = "We noticed that you have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}. "
-    any_logs_already_exist_error_description = "We noticed that one of the logs you are trying has been created previously. "
-    any_logs_invalid_error_description = "Placeholder text for invalid logs case. "
+    any_setup_sections_incomplete_error_description = "Placeholder text for setup sections incomplete case."
+    over_column_error_threshold_error_description = "You have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}."
+    any_logs_already_exist_error_description = "One of the logs you are trying to upload has been created previously."
+    any_logs_invalid_error_description = "Placeholder text for invalid logs case."
 
-    error_description = ""
-    error_description << any_setup_sections_incomplete_error_description if any_setup_sections_incomplete
-    error_description << over_column_error_threshold_error_description if over_column_error_threshold
-    error_description << any_logs_already_exist_error_description if any_logs_already_exist
-    error_description << any_logs_invalid_error_description if any_logs_invalid
-    error_description << "Please correct your data export and upload again."
+    errors = []
+    errors << any_setup_sections_incomplete_error_description if any_setup_sections_incomplete
+    errors << over_column_error_threshold_error_description if over_column_error_threshold
+    errors << any_logs_already_exist_error_description if any_logs_already_exist
+    errors << any_logs_invalid_error_description if any_logs_invalid
+
+    correct_and_reupload_description = "Please correct your data export and upload again."
+
+    if errors.size == 0
+      error_description = correct_and_reupload_description
+    else
+      error_description = "We noticed the following issues with your upload:\n\n" #{"s" if errors.size > 1}
+      errors.each { |error| error_description << "- #{error}\n" }
+      error_description << "\n"
+    end
 
     send_email(
       bulk_upload.user.email,

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -43,8 +43,25 @@ class BulkUploadMailer < NotifyMailer
     end
   end
 
-  def send_correct_and_upload_again_mail(bulk_upload:)
-    error_description = "We noticed that you have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}. Please correct your data export and upload again."
+  def send_correct_and_upload_again_mail(
+    any_setup_sections_incomplete,
+    over_column_error_threshold,
+    any_logs_already_exist,
+    any_logs_invalid,
+    bulk_upload:
+  )
+
+    any_setup_sections_incomplete_error_description = "Placeholder text for setup sections incomplete case. "
+    over_column_error_threshold_error_description = "We noticed that you have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}. "
+    any_logs_already_exist_error_description = "We noticed that one of the logs you are trying has been created previously. "
+    any_logs_invalid_error_description = "Placeholder text for invalid logs case. "
+
+    error_description = ""
+    error_description << any_setup_sections_incomplete_error_description if any_setup_sections_incomplete
+    error_description << over_column_error_threshold_error_description if over_column_error_threshold
+    error_description << any_logs_already_exist_error_description if any_logs_already_exist
+    error_description << any_logs_invalid_error_description if any_logs_invalid
+    error_description << "Please correct your data export and upload again."
 
     send_email(
       bulk_upload.user.email,

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -64,10 +64,10 @@ class BulkUploadMailer < NotifyMailer
 
     correct_and_reupload_description = "Please correct your data export and upload again."
 
-    if errors.size == 0
+    if errors.size.zero?
       error_description = correct_and_reupload_description
     else
-      error_description = "We noticed the following issues with your upload:\n\n" #{"s" if errors.size > 1}
+      error_description = "We noticed the following issues with your upload:\n\n" # {"s" if errors.size > 1}
       errors.each { |error| error_description << "- #{error}\n" }
       error_description << "\n"
     end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -182,7 +182,7 @@ class BulkUpload::Lettings::RowParser
   end
 
   def log_already_exists?
-    fields_for_duplicity_check = %w(
+    fields_for_duplicity_check = %w[
       startdate
       postcode_full
       brent
@@ -194,9 +194,9 @@ class BulkUpload::Lettings::RowParser
       sex1
       ecstat1
       ethnic
-    )
+    ]
 
-    LettingsLog.exists?(Hash[fields_for_duplicity_check.collect { |field| [field, log[field]] }])
+    LettingsLog.exists?(fields_for_duplicity_check.index_with { |field| log[field] })
   end
 
 private

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -329,7 +329,7 @@ private
       "ethnic" => field_43,
     }
 
-    LettingsLog.where(field_mappings).present?
+    LettingsLog.exists?(field_mappings)
   end
 
   def field_mapping_for_errors

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -315,21 +315,21 @@ private
   end
 
   def log_already_exists?
-    field_mappings = {
-      "startdate" => startdate,
-      "postcode_full" => postcode_full,
-      "brent" => brent,
-      "scharge" => scharge,
-      "pscharge" => pscharge,
-      "supcharg" => supcharg,
-      "tenancycode" => field_7,
-      "age1" => field_12,
-      "sex1" => field_20,
-      "ecstat1" => field_35,
-      "ethnic" => field_43,
-    }
+    fields_for_duplicity_check = %w(
+      startdate
+      postcode_full
+      brent
+      scharge
+      pscharge
+      supcharg
+      tenancycode
+      age1
+      sex1
+      ecstat1
+      ethnic
+    )
 
-    LettingsLog.exists?(field_mappings)
+    LettingsLog.exists?(Hash[fields_for_duplicity_check.collect { |field| [field, log[field]] }])
   end
 
   def field_mapping_for_errors
@@ -919,30 +919,6 @@ private
       4
     when 17
       17
-    end
-  end
-
-  def brent
-    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
-      self.field_80 ||= 0
-    end
-  end
-
-  def scharge
-    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
-      self.field_81 ||= 0
-    end
-  end
-
-  def pscharge
-    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
-      self.field_82 ||= 0
-    end
-  end
-
-  def supcharg
-    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
-      self.field_83 ||= 0
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -150,6 +150,7 @@ class BulkUpload::Lettings::RowParser
   validate :validate_cannot_be_la_referral_if_general_needs
   validate :validate_leaving_reason_for_renewal
   validate :validate_lettings_type_matches_bulk_upload
+  validate :validate_if_log_already_exists
   validate :validate_only_one_housing_needs_type
   validate :validate_no_disabled_needs_conjunction
   validate :validate_dont_know_disabled_needs_conjunction
@@ -289,6 +290,18 @@ private
       next if question.completed?(log)
 
       fields.each { |field| errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase)) }
+    end
+  end
+
+  def validate_if_log_already_exists
+    fields = {
+      "beds" => field_101,
+      "joint" => field_133,
+    }
+    duplicate_log_exists = LettingsLog.where(fields).present?
+
+    if duplicate_log_exists
+      errors.add('test', "test")
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -294,23 +294,9 @@ private
   end
 
   def validate_if_log_already_exists
-    field_mappings = {
-      "startdate" => startdate,
-      "postcode_full" => postcode_full,
-      "brent" => brent,
-      "scharge" => scharge,
-      "pscharge" => pscharge,
-      "supcharg" => supcharg,
-      "tenancycode" => field_7,
-      "age1" => field_12,
-      "sex1" => field_20,
-      "ecstat1" => field_35,
-      "ethnic" => field_43,
-    }
-    duplicate_log_exists = LettingsLog.where(field_mappings).present?
-
-    if duplicate_log_exists
+    if log_already_exists?
       error_message = "This is a duplicate log"
+
       errors.add(:field_96, error_message) # startdate
       errors.add(:field_97, error_message) # startdate
       errors.add(:field_98, error_message) # startdate
@@ -326,6 +312,24 @@ private
       errors.add(:field_35, error_message) # ecstat1
       errors.add(:field_43, error_message) # ethnic
     end
+  end
+
+  def log_already_exists?
+    field_mappings = {
+      "startdate" => startdate,
+      "postcode_full" => postcode_full,
+      "brent" => brent,
+      "scharge" => scharge,
+      "pscharge" => pscharge,
+      "supcharg" => supcharg,
+      "tenancycode" => field_7,
+      "age1" => field_12,
+      "sex1" => field_20,
+      "ecstat1" => field_35,
+      "ethnic" => field_43,
+    }
+
+    LettingsLog.where(field_mappings).present?
   end
 
   def field_mapping_for_errors

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -294,14 +294,36 @@ private
   end
 
   def validate_if_log_already_exists
-    fields = {
-      "beds" => field_101,
-      "joint" => field_133,
+    field_mappings = {
+      "startdate" => startdate,
+      "postcode_full" => postcode_full,
+      "brent" => brent,
+      "scharge" => scharge,
+      "pscharge" => pscharge,
+      "supcharg" => supcharg,
+      "tenancycode" => field_7,
+      "age1" => field_12,
+      "sex1" => field_20,
+      "ecstat1" => field_35,
+      "ethnic" => field_43,
     }
-    duplicate_log_exists = LettingsLog.where(fields).present?
+    duplicate_log_exists = LettingsLog.where(field_mappings).present?
 
     if duplicate_log_exists
-      errors.add(:field_101, "test")
+      errors.add(:field_96, "test") # startdate
+      errors.add(:field_97, "test") # startdate
+      errors.add(:field_98, "test") # startdate
+      errors.add(:field_108, "test") # postcode_full
+      errors.add(:field_109, "test") # postcode_full
+      errors.add(:field_80, "test") # brent
+      errors.add(:field_81, "test") # scharge
+      errors.add(:field_82, "test") # pscharge
+      errors.add(:field_83, "test") # supcharg
+      errors.add(:field_7, "test") # tenancycode
+      errors.add(:field_12, "test") # age1
+      errors.add(:field_20, "test") # sex1
+      errors.add(:field_35, "test") # ecstat1
+      errors.add(:field_43, "test") # ethnic
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -895,6 +895,30 @@ private
     end
   end
 
+  def brent
+    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
+      self.field_80 ||= 0
+    end
+  end
+
+  def scharge
+    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
+      self.field_81 ||= 0
+    end
+  end
+
+  def pscharge
+    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
+      self.field_82 ||= 0
+    end
+  end
+
+  def supcharg
+    if %i[field_80 field_81 field_82 field_83].any? { |f| public_send(f).present? }
+      self.field_83 ||= 0
+    end
+  end
+
   def scheme
     @scheme ||= Scheme.find_by(old_visible_id: field_4)
   end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -310,20 +310,21 @@ private
     duplicate_log_exists = LettingsLog.where(field_mappings).present?
 
     if duplicate_log_exists
-      errors.add(:field_96, "test") # startdate
-      errors.add(:field_97, "test") # startdate
-      errors.add(:field_98, "test") # startdate
-      errors.add(:field_108, "test") # postcode_full
-      errors.add(:field_109, "test") # postcode_full
-      errors.add(:field_80, "test") # brent
-      errors.add(:field_81, "test") # scharge
-      errors.add(:field_82, "test") # pscharge
-      errors.add(:field_83, "test") # supcharg
-      errors.add(:field_7, "test") # tenancycode
-      errors.add(:field_12, "test") # age1
-      errors.add(:field_20, "test") # sex1
-      errors.add(:field_35, "test") # ecstat1
-      errors.add(:field_43, "test") # ethnic
+      error_message = "This is a duplicate log"
+      errors.add(:field_96, error_message) # startdate
+      errors.add(:field_97, error_message) # startdate
+      errors.add(:field_98, error_message) # startdate
+      errors.add(:field_108, error_message) # postcode_full
+      errors.add(:field_109, error_message) # postcode_full
+      errors.add(:field_80, error_message) # brent
+      errors.add(:field_81, error_message) # scharge
+      errors.add(:field_82, error_message) # pscharge
+      errors.add(:field_83, error_message) # supcharg
+      errors.add(:field_7, error_message) # tenancycode
+      errors.add(:field_12, error_message) # age1
+      errors.add(:field_20, error_message) # sex1
+      errors.add(:field_35, error_message) # ecstat1
+      errors.add(:field_43, error_message) # ethnic
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -301,7 +301,7 @@ private
     duplicate_log_exists = LettingsLog.where(fields).present?
 
     if duplicate_log_exists
-      errors.add('test', "test")
+      errors.add(:field_101, "test")
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -181,6 +181,24 @@ class BulkUpload::Lettings::RowParser
     @log ||= LettingsLog.new(attributes_for_log)
   end
 
+  def log_already_exists?
+    fields_for_duplicity_check = %w(
+      startdate
+      postcode_full
+      brent
+      scharge
+      pscharge
+      supcharg
+      tenancycode
+      age1
+      sex1
+      ecstat1
+      ethnic
+    )
+
+    LettingsLog.exists?(Hash[fields_for_duplicity_check.collect { |field| [field, log[field]] }])
+  end
+
 private
 
   def validate_no_and_dont_know_disabled_needs_conjunction
@@ -312,24 +330,6 @@ private
       errors.add(:field_35, error_message) # ecstat1
       errors.add(:field_43, error_message) # ethnic
     end
-  end
-
-  def log_already_exists?
-    fields_for_duplicity_check = %w(
-      startdate
-      postcode_full
-      brent
-      scharge
-      pscharge
-      supcharg
-      tenancycode
-      age1
-      sex1
-      ecstat1
-      ethnic
-    )
-
-    LettingsLog.exists?(Hash[fields_for_duplicity_check.collect { |field| [field, log[field]] }])
   end
 
   def field_mapping_for_errors

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -174,9 +174,8 @@ class BulkUpload::Lettings::Validator
   end
 
   def create_logs?
-    # return false if any_setup_sections_incomplete?
+    return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
-    return false if duplicate_log_already_exists?
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
@@ -201,16 +200,6 @@ private
       next if count < COLUMN_ABSOLUTE_ERROR_THRESHOLD
 
       count > percentage_threshold
-    end
-  end
-
-  def duplicate_log_already_exists?
-    fields = ["lettype", "beds"]
-
-    fields.all? do |field|
-      count = row_parsers.count { |row_parser| LettingsLog.where("#{field}": row_parser.attributes[field]).present? }
-
-      count > 0
     end
   end
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -176,6 +176,7 @@ class BulkUpload::Lettings::Validator
   def create_logs?
     return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
+    return false if any_logs_already_exist?
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
@@ -201,6 +202,10 @@ private
 
       count > percentage_threshold
     end
+  end
+
+  def any_logs_already_exist?
+    row_parsers.any? { |row_parser| row_parser.log_already_exists? }
   end
 
   def csv_parser

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -174,7 +174,7 @@ class BulkUpload::Lettings::Validator
   end
 
   def create_logs?
-    return false if any_setup_sections_incomplete?
+    # return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
     return false if duplicate_log_already_exists?
 
@@ -205,11 +205,10 @@ private
   end
 
   def duplicate_log_already_exists?
-    fields = ["lettype"]
+    fields = ["lettype", "beds"]
 
-    fields.any? do |field|
-      # binding.pry
-      count = row_parsers.count { |row_parser| LettingsLog.where("lettype": 7).present? }
+    fields.all? do |field|
+      count = row_parsers.count { |row_parser| LettingsLog.where("#{field}": row_parser.attributes[field]).present? }
 
       count > 0
     end

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -177,15 +177,14 @@ class BulkUpload::Lettings::Validator
     return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
     return false if any_logs_already_exist?
+    return false if any_logs_invalid?
 
-    row_parsers.all? { |row_parser| row_parser.log.valid? }
+    true
   end
 
   def self.question_for_field(field)
     QUESTIONS[field]
   end
-
-private
 
   def any_setup_sections_incomplete?
     row_parsers.any? { |row_parser| row_parser.log.form.setup_sections[0].subsections[0].is_incomplete?(row_parser.log) }
@@ -207,6 +206,12 @@ private
   def any_logs_already_exist?
     row_parsers.any? { |row_parser| row_parser.log_already_exists? }
   end
+
+  def any_logs_invalid?
+    row_parsers.any? { |row_parser| row_parser.log.invalid? }
+  end
+
+  private
 
   def csv_parser
     @csv_parser ||= BulkUpload::Lettings::CsvParser.new(path:)

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -176,6 +176,7 @@ class BulkUpload::Lettings::Validator
   def create_logs?
     return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
+    return false if duplicate_log_already_exists?
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end
@@ -200,6 +201,17 @@ private
       next if count < COLUMN_ABSOLUTE_ERROR_THRESHOLD
 
       count > percentage_threshold
+    end
+  end
+
+  def duplicate_log_already_exists?
+    fields = ["lettype"]
+
+    fields.any? do |field|
+      # binding.pry
+      count = row_parsers.count { |row_parser| LettingsLog.where("lettype": 7).present? }
+
+      count > 0
     end
   end
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -204,14 +204,14 @@ class BulkUpload::Lettings::Validator
   end
 
   def any_logs_already_exist?
-    row_parsers.any? { |row_parser| row_parser.log_already_exists? }
+    row_parsers.any?(&:log_already_exists?)
   end
 
   def any_logs_invalid?
     row_parsers.any? { |row_parser| row_parser.log.invalid? }
   end
 
-  private
+private
 
   def csv_parser
     @csv_parser ||= BulkUpload::Lettings::CsvParser.new(path:)

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -8,7 +8,6 @@ class BulkUpload::Processor
   def call
     download
 
-    # binding.pry
     return send_failure_mail if validator.invalid?
 
     validator.call

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -21,10 +21,9 @@ class BulkUpload::Processor
         validator.any_setup_sections_incomplete?,
         validator.over_column_error_threshold?,
         validator.any_logs_already_exist?,
-        validator.any_logs_invalid?
+        validator.any_logs_invalid?,
       )
     end
-
   rescue StandardError => e
     Sentry.capture_exception(e)
     send_failure_mail
@@ -45,7 +44,7 @@ private
       over_column_error_threshold,
       any_logs_already_exist,
       any_logs_invalid,
-      bulk_upload:
+      bulk_upload:,
     ).deliver_later
   end
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -208,20 +208,20 @@ RSpec.describe BulkUpload::Lettings::RowParser do
 
             error_message = "This is a duplicate log"
             expected_errors = {
-              :field_96 => [error_message], # startdate
-              :field_97 => [error_message], # startdate
-              :field_98 => [error_message], # startdate
-              :field_108 => [error_message], # postcode_full
-              :field_109 => [error_message], # postcode_full
-              :field_80 => [error_message], # brent
-              :field_81 => [error_message], # scharge
-              :field_82 => [error_message], # pscharge
-              :field_83 => [error_message], # supcharg
-              :field_7 => [error_message], # tenancycode
-              :field_12 => [error_message], # age1
-              :field_20 => [error_message], # sex1
-              :field_35 => [error_message], # ecstat1
-              :field_43 => [error_message], # ethnic
+              field_96: [error_message], # startdate
+              field_97: [error_message], # startdate
+              field_98: [error_message], # startdate
+              field_108: [error_message], # postcode_full
+              field_109: [error_message], # postcode_full
+              field_80: [error_message], # brent
+              field_81: [error_message], # scharge
+              field_82: [error_message], # pscharge
+              field_83: [error_message], # supcharg
+              field_7: [error_message], # tenancycode
+              field_12: [error_message], # age1
+              field_20: [error_message], # sex1
+              field_35: [error_message], # ecstat1
+              field_43: [error_message], # ethnic
             }
             expect(parser.errors.as_json).to eq(expected_errors)
           end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -195,8 +195,11 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         end
 
         context "when the log already exists in the db" do
+          before do
+            parser.log.save!
+          end
+
           it "is not a valid row" do
-            parser.log.save
             expect(parser).not_to be_valid
           end
         end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -206,21 +206,22 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           it "adds an error to all (and only) the fields used to determine duplicity" do
             parser.valid?
 
+            error_message = "This is a duplicate log"
             expected_errors = {
-              :field_96 => ["test"], # startdate
-              :field_97 => ["test"], # startdate
-              :field_98 => ["test"], # startdate
-              :field_108 => ["test"], # postcode_full
-              :field_109 => ["test"], # postcode_full
-              :field_80 => ["test"], # brent
-              :field_81 => ["test"], # scharge
-              :field_82 => ["test"], # pscharge
-              :field_83 => ["test"], # supcharg
-              :field_7 => ["test"], # tenancycode
-              :field_12 => ["test"], # age1
-              :field_20 => ["test"], # sex1
-              :field_35 => ["test"], # ecstat1
-              :field_43 => ["test"], # ethnic
+              :field_96 => [error_message], # startdate
+              :field_97 => [error_message], # startdate
+              :field_98 => [error_message], # startdate
+              :field_108 => [error_message], # postcode_full
+              :field_109 => [error_message], # postcode_full
+              :field_80 => [error_message], # brent
+              :field_81 => [error_message], # scharge
+              :field_82 => [error_message], # pscharge
+              :field_83 => [error_message], # supcharg
+              :field_7 => [error_message], # tenancycode
+              :field_12 => [error_message], # age1
+              :field_20 => [error_message], # sex1
+              :field_35 => [error_message], # ecstat1
+              :field_43 => [error_message], # ethnic
             }
             expect(parser.errors.as_json).to eq(expected_errors)
           end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           expect(questions.map(&:id).size).to eq(0)
           expect(questions.map(&:id)).to eql([])
         end
+
+        context "when the log already exists in the db" do
+          it "is not a valid row" do
+            parser.log.save
+            expect(parser).not_to be_valid
+          end
+        end
       end
     end
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -203,9 +203,26 @@ RSpec.describe BulkUpload::Lettings::RowParser do
             expect(parser).not_to be_valid
           end
 
-          it "adds an error to all fields used to determine duplicity" do
+          it "adds an error to all (and only) the fields used to determine duplicity" do
             parser.valid?
-            expect(parser.errors.added?(:field_101, "test")).to be true
+
+            expected_errors = {
+              :field_96 => ["test"], # startdate
+              :field_97 => ["test"], # startdate
+              :field_98 => ["test"], # startdate
+              :field_108 => ["test"], # postcode_full
+              :field_109 => ["test"], # postcode_full
+              :field_80 => ["test"], # brent
+              :field_81 => ["test"], # scharge
+              :field_82 => ["test"], # pscharge
+              :field_83 => ["test"], # supcharg
+              :field_7 => ["test"], # tenancycode
+              :field_12 => ["test"], # age1
+              :field_20 => ["test"], # sex1
+              :field_35 => ["test"], # ecstat1
+              :field_43 => ["test"], # ethnic
+            }
+            expect(parser.errors.as_json).to eq(expected_errors)
           end
         end
       end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -202,6 +202,11 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           it "is not a valid row" do
             expect(parser).not_to be_valid
           end
+
+          it "adds an error to all fields used to determine duplicity" do
+            parser.valid?
+            expect(parser.errors.added?(:field_101, "test")).to be true
+          end
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -255,26 +255,5 @@ RSpec.describe BulkUpload::Lettings::Validator do
         end
       end
     end
-
-    context "when the file contains a log which already exists in the db" do
-      let(:log_1) { create(:lettings_log, :completed, lettype: 7, beds: 3, created_by: user) } # DB
-      let(:log_2) { build(:lettings_log, :completed, lettype: 7, beds: 3, created_by: user) } # Bulk upload
-
-      before do
-        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
-        file.close
-      end
-
-      it "prevents log creation if there is a duplicate log" do
-        validator.call
-        expect(validator).not_to be_create_logs
-      end
-
-      it "allows log creation if there are no duplicate logs" do
-        log_1.update!(beds: 2)
-        validator.call
-        expect(validator).to be_create_logs
-      end
-    end
   end
 end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -255,5 +255,19 @@ RSpec.describe BulkUpload::Lettings::Validator do
         end
       end
     end
+
+    context "when the file contains a log which already exists in the db" do
+      let(:log_1) { create(:lettings_log, :completed, lettype: 7, created_by: user) }
+
+      before do
+        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.close
+      end
+
+      it "returns true" do
+        validator.call
+        expect(validator).not_to be_create_logs
+      end
+    end
   end
 end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -257,16 +257,23 @@ RSpec.describe BulkUpload::Lettings::Validator do
     end
 
     context "when the file contains a log which already exists in the db" do
-      let(:log_1) { create(:lettings_log, :completed, lettype: 7, created_by: user) }
+      let(:log_1) { create(:lettings_log, :completed, lettype: 7, beds: 3, created_by: user) } # DB
+      let(:log_2) { build(:lettings_log, :completed, lettype: 7, beds: 3, created_by: user) } # Bulk upload
 
       before do
-        file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_csv_row)
+        file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_csv_row)
         file.close
       end
 
-      it "returns true" do
+      it "prevents log creation if there is a duplicate log" do
         validator.call
         expect(validator).not_to be_create_logs
+      end
+
+      it "allows log creation if there are no duplicate logs" do
+        log_1.update!(beds: 2)
+        validator.call
+        expect(validator).to be_create_logs
       end
     end
   end


### PR DESCRIPTION
## Context
- https://digital.dclg.gov.uk/jira/browse/CLDC-1888
- When doing a bulk upload, we want to check whether any logs already exist in the db which are duplicates of logs in the bulk upload file. We don't care about them being duplicated across _every_ field - just specific fields (these are given in the ticket linked above).

## The changes
- Added a validation in `app/services/bulk_upload/lettings/row_parser.rb` (will do for sales next) which:
  - Defines which fields in the log we care about checking.
  - Defines what fields in the bulk upload these map to (sometimes they map to a method which acts on 1 or more fields in the bulk upload).
  - Checks for any existing logs which match the current row being processed in the bulk upload (where matches are found based on the field mapping described above).
  - If any matches are found, an error is added to _all_ relevant fields in the bulk upload.

## Remaining work
- Confirm which email should get sent to users if a duplicate is detected, and plumb connection in so that the email actually gets sent.
- Potentially make the error message more descriptive.
- Repeat everything for sales (after confirming whether exactly the same fields should be used for matching).