### PR TITLE
CLDC-1883 Validate general needs cannot be referred by LA

### DIFF
--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -30,6 +30,10 @@ class BulkUpload < ApplicationRecord
               end
   end
 
+  def general_needs?
+    needstype == 1
+  end
+
 private
 
   def generate_identifier

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -147,6 +147,7 @@ class BulkUpload::Lettings::RowParser
   validate :validate_nulls
   validate :validate_relevant_collection_window
   validate :validate_la_with_local_housing_referral
+  validate :validate_cannot_be_la_referral_if_general_needs
 
   def valid?
     errors.clear
@@ -168,6 +169,12 @@ class BulkUpload::Lettings::RowParser
   end
 
 private
+
+  def validate_cannot_be_la_referral_if_general_needs
+    if field_78 == 4 && bulk_upload.general_needs?
+      errors.add :field_78, I18n.t("validations.household.referral.la_general_needs.prp_referred_by_la")
+    end
+  end
 
   def validate_la_with_local_housing_referral
     if field_78 == 3 && owning_organisation && owning_organisation.la?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,6 +359,7 @@ en:
         nominated_by_local_ha_but_la: The source of the referral cannot be Nominated by local housing authority as your organisation is a local authority
         la_general_needs:
           internal_transfer: "Answer cannot be internal transfer as it’s the same landlord on the tenancy agreement and the household had either a fixed-term or lifetime local authority general needs tenancy immediately before this letting"
+          prp_referred_by_la: "The source of the referral cannot be referred by local authority housing department for a general needs log"
         prp:
           local_housing_referral: "Answer cannot be ‘nominated by a local housing authority’ as a local authority is on the tenancy agreement"
       homeless:

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -250,12 +250,29 @@ RSpec.describe BulkUpload::Lettings::RowParser do
       end
     end
 
-    describe "#field_78" do
+    describe "#field_78" do # referral
       context "when 3 ie PRP nominated by LA and owning org is LA" do
         let(:attributes) { { bulk_upload:, field_78: "3", field_111: owning_org.old_visible_id } }
 
         it "is not permitted" do
           expect(parser.errors[:field_78]).to be_present
+        end
+      end
+
+      context "when 4 ie referred by LA and is general needs" do
+        let(:attributes) { { bulk_upload:, field_78: "4" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_78]).to be_present
+        end
+      end
+
+      context "when 4 ie referred by LA and is not general needs" do
+        let(:bulk_upload) { create(:bulk_upload, :lettings, user:, needstype: 2) }
+        let(:attributes) { { bulk_upload:, field_78: "4" } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_78]).to be_blank
         end
       end
     end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1883
- The source of a referral cannot be referred by local authority housing department for a general needs log

# Changes

- Add validation to meet above criteria