### PR TITLE
CLDC-1883 bulk upload validate LA and local housing referral

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -30,6 +30,8 @@ class Organisation < ApplicationRecord
 
   enum provider_type: PROVIDER_TYPE
 
+  alias_method :la?, :LA?
+
   validates :name, presence: { message: I18n.t("validations.organisation.name_missing") }
   validates :provider_type, presence: { message: I18n.t("validations.organisation.provider_type_missing") }
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -171,7 +171,7 @@ private
 
   def validate_la_with_local_housing_referral
     if field_78 == 3 && owning_organisation && owning_organisation.la?
-      errors.add(:field_78, "The source of the referral cannot be Nominated by local housing authority as your organisation is a local authority")
+      errors.add(:field_78, I18n.t("validations.household.referral.nominated_by_local_ha_but_la"))
     end
   end
 

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -146,6 +146,7 @@ class BulkUpload::Lettings::RowParser
   validate :validate_data_types
   validate :validate_nulls
   validate :validate_relevant_collection_window
+  validate :validate_la_with_local_housing_referral
 
   def valid?
     errors.clear
@@ -167,6 +168,12 @@ class BulkUpload::Lettings::RowParser
   end
 
 private
+
+  def validate_la_with_local_housing_referral
+    if field_78 == 3 && owning_organisation && owning_organisation.la?
+      errors.add(:field_78, "The source of the referral cannot be Nominated by local housing authority as your organisation is a local authority")
+    end
+  end
 
   def validate_relevant_collection_window
     return unless start_date && bulk_upload.form
@@ -413,8 +420,12 @@ private
     end
   end
 
+  def owning_organisation
+    Organisation.find_by(old_visible_id: field_111)
+  end
+
   def owning_organisation_id
-    Organisation.find_by(old_visible_id: field_111)&.id
+    owning_organisation&.id
   end
 
   def managing_organisation_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,6 +356,7 @@ en:
         other_homeless: "Answer cannot be internal transfer as the tenant was considered homeless by their landlord"
         prevten_invalid: "Answer cannot be internal transfer as the household situation immediately before this letting was %{prevten}"
         reason_permanently_decanted: "Answer must be internal transfer as the tenant was permanently decanted from another property owned by this landlord"
+        nominated_by_local_ha_but_la: The source of the referral cannot be Nominated by local housing authority as your organisation is a local authority
         la_general_needs:
           internal_transfer: "Answer cannot be internal transfer as it’s the same landlord on the tenancy agreement and the household had either a fixed-term or lifetime local authority general needs tenancy immediately before this letting"
         prp:

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   let(:attributes) { { bulk_upload: } }
   let(:bulk_upload) { create(:bulk_upload, :lettings, user:) }
   let(:user) { create(:user, organisation: owning_org) }
-  let(:owning_org) { create(:organisation) }
-  let(:managing_org) { create(:organisation) }
+  let(:owning_org) { create(:organisation, :with_old_visible_id) }
+  let(:managing_org) { create(:organisation, :with_old_visible_id) }
   let(:setup_section_params) do
     {
       bulk_upload:,
@@ -246,6 +246,16 @@ RSpec.describe BulkUpload::Lettings::RowParser do
 
         xit "returns an error" do
           expect(parser.errors[:field_10]).to be_present
+        end
+      end
+    end
+
+    describe "#field_78" do
+      context "when 3 ie PRP nominated by LA and owning org is LA" do
+        let(:attributes) { { bulk_upload:, field_78: "3", field_111: owning_org.old_visible_id } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_78]).to be_present
         end
       end
     end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1883

# Changes

- Validate for bulk upload when owning organisation is an LA, the referral cannot be a PRP nominated by LA

# Notes for review

- There does already seem to be such an validation directly on the log. However I could never get this to fire for bulk upload. I believe this to be because the question is not routed to and therefore blanked
- We do still want this validation to appear though so therefore it has been attached as a validation thats exists on the bulk upload process

# Screenshots

![Screenshot 2023-02-09 at 12 36 36](https://user-images.githubusercontent.com/92580/217815090-bf446de5-885a-47a1-ac60-12656d24859a.png)