### PR TITLE
CLDC-1885 Bulk upload type must match given needs type

### DIFF
--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -34,6 +34,10 @@ class BulkUpload < ApplicationRecord
     needstype == 1
   end
 
+  def supported_housing?
+    needstype == 2
+  end
+
 private
 
   def generate_identifier

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -148,7 +148,8 @@ class BulkUpload::Lettings::RowParser
   validate :validate_relevant_collection_window
   validate :validate_la_with_local_housing_referral
   validate :validate_cannot_be_la_referral_if_general_needs
-  validate :leaving_reason_for_renewal
+  validate :validate_leaving_reason_for_renewal
+  validate :validate_lettings_type_matches_bulk_upload
 
   def valid?
     errors.clear
@@ -171,6 +172,16 @@ class BulkUpload::Lettings::RowParser
 
 private
 
+  def validate_lettings_type_matches_bulk_upload
+    if [1, 3, 5, 7, 9, 11].include?(field_1) && bulk_upload.supported_housing?
+      errors.add(:field_1, I18n.t("validations.setup.lettype.supported_housing_mismatch"))
+    end
+
+    if [2, 4, 6, 8, 10, 12].include?(field_1) && bulk_upload.general_needs?
+      errors.add(:field_1, I18n.t("validations.setup.lettype.general_needs_mismatch"))
+    end
+  end
+
   def validate_cannot_be_la_referral_if_general_needs
     if field_78 == 4 && bulk_upload.general_needs?
       errors.add :field_78, I18n.t("validations.household.referral.la_general_needs.prp_referred_by_la")
@@ -183,7 +194,7 @@ private
     end
   end
 
-  def leaving_reason_for_renewal
+  def validate_leaving_reason_for_renewal
     if field_134 == 1 && ![40, 42].include?(field_52)
       errors.add(:field_52, I18n.t("validations.household.reason.renewal_reason_needed"))
     end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -173,11 +173,11 @@ class BulkUpload::Lettings::RowParser
 private
 
   def validate_lettings_type_matches_bulk_upload
-    if [1, 3, 5, 7, 9, 11].include?(field_1) && bulk_upload.supported_housing?
+    if [1, 3, 5, 7, 9, 11].include?(field_1) && !bulk_upload.general_needs?
       errors.add(:field_1, I18n.t("validations.setup.lettype.supported_housing_mismatch"))
     end
 
-    if [2, 4, 6, 8, 10, 12].include?(field_1) && bulk_upload.general_needs?
+    if [2, 4, 6, 8, 10, 12].include?(field_1) && !bulk_upload.supported_housing?
       errors.add(:field_1, I18n.t("validations.setup.lettype.general_needs_mismatch"))
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,9 @@ en:
         invalid: "Please select owning organisation or managing organisation that you belong to"
       created_by:
         invalid: "Please select owning organisation or managing organisation that you belong to"
+      lettype:
+        general_needs_mismatch: Lettings type must be a general needs type
+        supported_housing_mismatch: Lettings type must be a supported housing type
 
     property:
       mrcdate:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,8 +171,8 @@ en:
       created_by:
         invalid: "Please select owning organisation or managing organisation that you belong to"
       lettype:
-        general_needs_mismatch: Lettings type must be a general needs type
-        supported_housing_mismatch: Lettings type must be a supported housing type
+        general_needs_mismatch: Lettings type must be a general needs type because you selected general needs when uploading the file
+        supported_housing_mismatch: Lettings type must be a supported housing type because you selected supported housing when uploading the file
 
     property:
       mrcdate:

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           let(:attributes) { { bulk_upload:, field_1: "2" } }
 
           it "is not permitted" do
-            expect(parser.errors[:field_1]).to include("Lettings type must be a general needs type")
+            expect(parser.errors[:field_1]).to include("Lettings type must be a general needs type because you selected general needs when uploading the file")
           end
         end
       end
@@ -230,7 +230,7 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           let(:attributes) { { bulk_upload:, field_1: "1" } }
 
           it "is not permitted" do
-            expect(parser.errors[:field_1]).to include("Lettings type must be a supported housing type")
+            expect(parser.errors[:field_1]).to include("Lettings type must be a supported housing type because you selected supported housing when uploading the file")
           end
         end
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -202,6 +202,46 @@ RSpec.describe BulkUpload::Lettings::RowParser do
           expect(parser.errors[:field_1]).to be_blank
         end
       end
+
+      context "when bulk upload is for general needs" do
+        let(:bulk_upload) { create(:bulk_upload, :lettings, user:, needstype: "1") }
+
+        context "when general needs option selected" do
+          let(:attributes) { { bulk_upload:, field_1: "1" } }
+
+          it "is permitted" do
+            expect(parser.errors[:field_1]).to be_blank
+          end
+        end
+
+        context "when supported housing option selected" do
+          let(:attributes) { { bulk_upload:, field_1: "2" } }
+
+          it "is not permitted" do
+            expect(parser.errors[:field_1]).to include("Lettings type must be a general needs type")
+          end
+        end
+      end
+
+      context "when bulk upload is for supported housing" do
+        let(:bulk_upload) { create(:bulk_upload, :lettings, user:, needstype: "2") }
+
+        context "when general needs option selected" do
+          let(:attributes) { { bulk_upload:, field_1: "1" } }
+
+          it "is not permitted" do
+            expect(parser.errors[:field_1]).to include("Lettings type must be a supported housing type")
+          end
+        end
+
+        context "when supported housing option selected" do
+          let(:attributes) { { bulk_upload:, field_1: "2" } }
+
+          it "is permitted" do
+            expect(parser.errors[:field_1]).to be_blank
+          end
+        end
+      end
     end
 
     describe "#field_4" do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1885
- For the bulk upload journey users can select whether they are uploading for `general needs` or `supported housing`

# Changes

- When a user bulk uploads we ensure the data they upload matches that selected in the journey, otherwise return a validation error that there is a mismatch

# Screenshots

![Screenshot 2023-02-10 at 16 08 36](https://user-images.githubusercontent.com/92580/218143333-26f7d248-a1b5-4d67-aab4-6f01d705a114.png)