### PR TITLE
CLDC-1861 Update options order for lead tenant's working situation

### DIFF
--- a/app/models/form/lettings/questions/working_situation1.rb
+++ b/app/models/form/lettings/questions/working_situation1.rb
@@ -11,8 +11,8 @@ class Form::Lettings::Questions::WorkingSituation1 < ::Form::Question
   end
 
   ANSWER_OPTIONS = {
-    "2" => { "value" => "Part-time – Less than 30 hours" },
     "1" => { "value" => "Full-time – 30 hours or more" },
+    "2" => { "value" => "Part-time – Less than 30 hours" },
     "7" => { "value" => "Full-time student" },
     "3" => { "value" => "In government training into work, such as New Deal" },
     "4" => { "value" => "Jobseeker" },

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -1,14 +1,14 @@
 class FeatureToggle
   def self.startdate_two_week_validation_enabled?
-    Rails.env.production? || Rails.env.test?
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
   def self.startdate_collection_window_validation_enabled?
-    Rails.env.production? || Rails.env.test?
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
   def self.saledate_collection_window_validation_enabled?
-    Rails.env.production? || Rails.env.test?
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
   def self.sales_log_enabled?


### PR DESCRIPTION
Change Full time and Part time places for 23/24 lettings forms:
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/54268893/218145966-79ab64db-dd37-477b-b975-25fbd5869691.png">

Enable the sale/start date validations on staging so that it reflects validations on production, we can still create logs for future collection windows in review and development environments for testing.