### PR TITLE
Fix location units export field

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -214,7 +214,7 @@ module Exports
       attribute_hash["reghome"] = scheme.registered_under_care_act_before_type_cast
       attribute_hash["schtype"] = scheme.scheme_type_before_type_cast
       attribute_hash["support"] = scheme.support_type_before_type_cast
-      attribute_hash["units_scheme"] = scheme.locations.map(&:units).sum
+      attribute_hash["units_scheme"] = scheme.locations.map(&:units).compact.sum
     end
 
     def add_location_fields!(location, attribute_hash)

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -258,6 +258,10 @@ RSpec.describe Exports::LettingsLogExportService do
 
     let(:lettings_log) { FactoryBot.create(:lettings_log, :completed, :export, :sh, scheme:, location:, created_by: user, owning_organisation: organisation, startdate: Time.utc(2022, 2, 2, 10, 36, 49), underoccupation_benefitcap: 4, sheltered: 1) }
 
+    before do
+      FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2021, 4, 1), units: nil)
+    end
+
     it "generates an XML export file with the expected content" do
       expected_content = replace_entity_ids(lettings_log, export_file.read)
       expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args) do |_, content|


### PR DESCRIPTION
If a scheme has a location with no units it will throw an error when we try to sum them.
This PR removes nils before adding up location units. 

Currently there are no locations with units nil on production that are being used, but it is a possible scenario
