### PR TITLE
CLDC-1860 Change location question header for 23/24

### DIFF
--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -2,7 +2,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
   def initialize(_id, hsh, page)
     super("location_id", hsh, page)
     @check_answer_label = "Location"
-    @header = "Which location is this log for?"
+    @header = header_text
     @type = "radio"
     @answer_options = answer_options
     @inferred_answers = {
@@ -46,5 +46,13 @@ private
 
   def selected_answer_option_is_derived?(_lettings_log)
     false
+  end
+
+  def header_text
+    if form.start_date && form.start_date.year >= 2023
+      "Which location is this letting for?"
+    else
+      "Which location is this log for?"
+    end
   end
 end

--- a/spec/models/form/lettings/pages/location_spec.rb
+++ b/spec/models/form/lettings/pages/location_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Form::Lettings::Pages::Location, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form) }
+
+  before do
+    allow(form).to receive(:start_date).and_return(Time.zone.local(2022, 4, 1))
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form) }
+
+  before do
+    allow(form).to receive(:start_date).and_return(Time.zone.local(2022, 4, 1))
+    allow(page).to receive(:subsection).and_return(subsection)
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -101,6 +109,16 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
           expect(question.displayed_answer_options(lettings_log).count).to eq(1)
         end
       end
+    end
+  end
+
+  context "with collection year on or after 2023" do
+    before do
+      allow(form).to receive(:start_date).and_return(Time.zone.local(2023, 4, 1))
+    end
+
+    it "has the correct header" do
+      expect(question.header).to eq("Which location is this letting for?")
     end
   end
 end


### PR DESCRIPTION
Change the wording of location question for 23/24 logs.
The location question comes before the date question in the form, so the default wording will be the one of the current_form, which currently is 22/23 but will switch to 23/24 in April.