### PR TITLE
Only load session fiters when getting or exporting the logs

### DIFF
--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -1,7 +1,7 @@
 class LettingsLogsController < LogsController
   before_action :find_resource, except: %i[create index edit]
-  before_action :session_filters, if: :current_user
-  before_action :set_session_filters, if: :current_user
+  before_action :session_filters, if: :current_user, only: %i[index email_csv download_csv]
+  before_action :set_session_filters, if: :current_user, only: %i[index email_csv download_csv]
 
   before_action :extract_bulk_upload_from_session_filters, only: [:index]
   before_action :redirect_if_bulk_upload_resolved, only: [:index]

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -6,8 +6,8 @@ class OrganisationsController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource, except: %i[index new create]
   before_action :authenticate_scope!, except: [:index]
-  before_action -> { session_filters(specific_org: true) }, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }
-  before_action :set_session_filters, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }
+  before_action -> { session_filters(specific_org: true) }, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }, only: %i[lettings_logs sales_logs email_csv download_csv]
+  before_action :set_session_filters, if: -> { current_user.support? || current_user.organisation.has_managing_agents? }, only: %i[lettings_logs sales_logs email_csv download_csv]
 
   def index
     redirect_to organisation_path(current_user.organisation) unless current_user.support?

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -1,6 +1,6 @@
 class SalesLogsController < LogsController
-  before_action :session_filters, if: :current_user
-  before_action :set_session_filters, if: :current_user
+  before_action :session_filters, if: :current_user, only: %i[index email_csv download_csv]
+  before_action :set_session_filters, if: :current_user, only: %i[index email_csv download_csv]
 
   def create
     super { SalesLog.new(log_params) }


### PR DESCRIPTION
When creating a new organisation we would pass through params including "organisation". 
That's the same param we use to set organisation session filters.

Previously we would set session filters on every organisation or log load.
When creating a new organisation it would set the organisation filter to the new org params.
When loading lettings logs page we would get an error because we would try to filter by using an unexpected format. Now we set session filters only when we need to