### PR TITLE
CLDC-1883 Tweak bulk upload validation

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -147,7 +147,7 @@ class BulkUpload::Lettings::RowParser
   validate :validate_nulls
   validate :validate_relevant_collection_window
   validate :validate_la_with_local_housing_referral
-  validate :validate_cannot_be_la_referral_if_general_needs
+  validate :validate_cannot_be_la_referral_if_general_needs_and_la
   validate :validate_leaving_reason_for_renewal
   validate :validate_lettings_type_matches_bulk_upload
 
@@ -188,8 +188,8 @@ private
     end
   end
 
-  def validate_cannot_be_la_referral_if_general_needs
-    if field_78 == 4 && bulk_upload.general_needs?
+  def validate_cannot_be_la_referral_if_general_needs_and_la
+    if field_78 == 4 && bulk_upload.general_needs? && owning_organisation && owning_organisation.la?
       errors.add :field_78, I18n.t("validations.household.referral.la_general_needs.prp_referred_by_la")
     end
   end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     trait :with_old_visible_id do
       old_visible_id { rand(9_999_999).to_s }
     end
+
+    trait :prp do
+      provider_type { "PRP" }
+    end
   end
 
   factory :organisation_rent_period do

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -353,11 +353,21 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         end
       end
 
-      context "when 4 ie referred by LA and is general needs" do
-        let(:attributes) { { bulk_upload:, field_78: "4" } }
+      context "when 4 ie referred by LA and is general needs and owning org is LA" do
+        let(:attributes) { { bulk_upload:, field_78: "4", field_111: owning_org.old_visible_id.to_s } }
 
         it "is not permitted" do
           expect(parser.errors[:field_78]).to be_present
+        end
+      end
+
+      context "when 4 ie referred by LA and is general needs and owning org is PRP" do
+        let(:owning_org) { create(:organisation, :prp, :with_old_visible_id) }
+
+        let(:attributes) { { bulk_upload:, field_78: "4", field_111: owning_org.old_visible_id.to_s } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_78]).to be_blank
         end
       end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1883
- This is minor rework of the ticket due to small change in validation rule
- Added to the validation rule is that the owning must also be an LA on top of the existing rule where log is general needs and referral is by an LA

# Changes

- Validation rule change to meet the above criteria