### PR TITLE
CLDC-1904 Infer unitletas for renewal logs

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -18,6 +18,15 @@ module DerivedVariables::LettingsLogVariables
     5 => 4, # "Other intermediate rent product"  => "Intermediate Rent basis"
   }.freeze
 
+  UNITLETAS_MAPPING_23_24 = {
+    0 => 1, # "Social Rent"  =>  "Social Rent basis"
+    1 => 2, # "Affordable Rent" => "Affordable Rent basis"
+    2 => 5, # "London Affordable Rent"  =>  "London Affordable Rent basis"
+    3 => 6, # "Rent to Buy"  => "Rent to Buy basis"
+    4 => 7, # "London Living Rent"  => "London Living Rent basis"
+    5 => 8, # "Other intermediate rent product"  => "Another Intermediate Rent basis"
+  }.freeze
+
   def scheme_has_multiple_locations?
     return false unless scheme
 
@@ -66,7 +75,7 @@ module DerivedVariables::LettingsLogVariables
       self.voiddate = startdate
       self.first_time_property_let_as_social_housing = 0
       self.rsnvac = 14
-      self.unitletas = UNITLETAS_MAPPING[rent_type]
+      self.unitletas = form.start_date.year >= 2023 ? UNITLETAS_MAPPING_23_24[rent_type] : UNITLETAS_MAPPING[rent_type]
       if is_general_needs?
         # fixed term
         self.prevten = 32 if managing_organisation&.provider_type == "PRP"

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -1,5 +1,22 @@
 module DerivedVariables::LettingsLogVariables
-  RENT_TYPE_MAPPING = { 0 => 1, 1 => 2, 2 => 2, 3 => 3, 4 => 3, 5 => 3 }.freeze
+  # renttype and unitletas values are different for intermediate rent (3 for renttype and 4 for unitletas)
+  RENT_TYPE_MAPPING = {
+    0 => 1, # "Social Rent"  =>  "Social Rent"
+    1 => 2, # "Affordable Rent" => "Affordable Rent"
+    2 => 2, # "London Affordable Rent"  =>  "Affordable Rent"
+    3 => 3, # "Rent to Buy"  => "Intermediate Rent"
+    4 => 3, # "London Living Rent"  => "Intermediate Rent"
+    5 => 3, # "Other intermediate rent product"  => "Intermediate Rent"
+  }.freeze
+
+  UNITLETAS_MAPPING = {
+    0 => 1, # "Social Rent"  =>  "Social Rent basis"
+    1 => 2, # "Affordable Rent" => "Affordable Rent basis"
+    2 => 2, # "London Affordable Rent"  =>  "Affordable Rent basis"
+    3 => 4, # "Rent to Buy"  => "Intermediate Rent basis"
+    4 => 4, # "London Living Rent"  => "Intermediate Rent basis"
+    5 => 4, # "Other intermediate rent product"  => "Intermediate Rent basis"
+  }.freeze
 
   def scheme_has_multiple_locations?
     return false unless scheme
@@ -49,6 +66,7 @@ module DerivedVariables::LettingsLogVariables
       self.voiddate = startdate
       self.first_time_property_let_as_social_housing = 0
       self.rsnvac = 14
+      self.unitletas = UNITLETAS_MAPPING[rent_type]
       if is_general_needs?
         # fixed term
         self.prevten = 32 if managing_organisation&.provider_type == "PRP"

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1477,6 +1477,7 @@ RSpec.describe LettingsLog do
 
       context "when deriving renttype and unitletas" do
         before do
+          allow(FeatureToggle).to receive(:startdate_two_week_validation_enabled?).and_return(false)
           lettings_log.update!(rent_type:, irproduct_other: "other")
         end
 
@@ -1494,6 +1495,15 @@ RSpec.describe LettingsLog do
             expect(lettings_log.unitletas).to eq(1)
             expect(record_from_db["unitletas"]).to eq(1)
           end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as Social rent(1)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(1)
+              expect(record_from_db["unitletas"]).to eq(1)
+            end
+          end
         end
 
         context "when the rent_type is Affordable Rent(1)" do
@@ -1509,6 +1519,15 @@ RSpec.describe LettingsLog do
             record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
             expect(lettings_log.unitletas).to eq(2)
             expect(record_from_db["unitletas"]).to eq(2)
+          end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as Affordable Rent basis(2)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(2)
+              expect(record_from_db["unitletas"]).to eq(2)
+            end
           end
         end
 
@@ -1526,6 +1545,15 @@ RSpec.describe LettingsLog do
             expect(lettings_log.unitletas).to eq(2)
             expect(record_from_db["unitletas"]).to eq(2)
           end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as London Affordable Rent basis(5)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(5)
+              expect(record_from_db["unitletas"]).to eq(5)
+            end
+          end
         end
 
         context "when the rent_type is Rent to Buy(3)" do
@@ -1541,6 +1569,15 @@ RSpec.describe LettingsLog do
             record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
             expect(lettings_log.unitletas).to eq(4)
             expect(record_from_db["unitletas"]).to eq(4)
+          end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as Rent to Buy basis(6)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(6)
+              expect(record_from_db["unitletas"]).to eq(6)
+            end
           end
         end
 
@@ -1558,6 +1595,15 @@ RSpec.describe LettingsLog do
             expect(lettings_log.unitletas).to eq(4)
             expect(record_from_db["unitletas"]).to eq(4)
           end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as London Living Rent basis(7)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(7)
+              expect(record_from_db["unitletas"]).to eq(7)
+            end
+          end
         end
 
         context "when the rent_type is Other intermediate rent product(5)" do
@@ -1573,6 +1619,15 @@ RSpec.describe LettingsLog do
             record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
             expect(lettings_log.unitletas).to eq(4)
             expect(record_from_db["unitletas"]).to eq(4)
+          end
+
+          context "and it is a 23/24 form" do
+            it "derives and saves unitletas as Other intermediate rent basis(8)" do
+              lettings_log.update!(startdate: Time.zone.local(2023, 5, 1))
+              record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+              expect(lettings_log.unitletas).to eq(8)
+              expect(record_from_db["unitletas"]).to eq(8)
+            end
           end
         end
       end

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1474,6 +1474,108 @@ RSpec.describe LettingsLog do
         expect(record_from_db["rsnvac"]).to eq(14)
         expect(lettings_log["rsnvac"]).to eq(14)
       end
+
+      context "when deriving renttype and unitletas" do
+        before do
+          lettings_log.update!(rent_type:, irproduct_other: "other")
+        end
+
+        context "when the rent_type is Social Rent (0)" do
+          let(:rent_type) { 0 }
+
+          it "derives and saves renttype and unitletas as Social rent(1)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(1)
+            expect(record_from_db["renttype"]).to eq(1)
+          end
+
+          it "derives and saves unitletas as Social rent(1)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(1)
+            expect(record_from_db["unitletas"]).to eq(1)
+          end
+        end
+
+        context "when the rent_type is Affordable Rent(1)" do
+          let(:rent_type) { 1 }
+
+          it "derives and saves renttype as Affordable Rent(2)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(2)
+            expect(record_from_db["renttype"]).to eq(2)
+          end
+
+          it "derives and saves unitletas as Affordable Rent(2)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(2)
+            expect(record_from_db["unitletas"]).to eq(2)
+          end
+        end
+
+        context "when the rent_type is London Affordable Rent(2)" do
+          let(:rent_type) { 2 }
+
+          it "derives and saves renttype as London Affordable Rent(2)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(2)
+            expect(record_from_db["renttype"]).to eq(2)
+          end
+
+          it "derives and saves unitletas as London Affordable Rent(2)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(2)
+            expect(record_from_db["unitletas"]).to eq(2)
+          end
+        end
+
+        context "when the rent_type is Rent to Buy(3)" do
+          let(:rent_type) { 3 }
+
+          it "derives and saves renttype as Intermediate Rent(3)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(3)
+            expect(record_from_db["renttype"]).to eq(3)
+          end
+
+          it "derives and saves unitletas as Intermediate Rent(4)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(4)
+            expect(record_from_db["unitletas"]).to eq(4)
+          end
+        end
+
+        context "when the rent_type is London Living Rent(4)" do
+          let(:rent_type) { 4 }
+
+          it "derives and saves renttype as Intermediate Rent(3)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(3)
+            expect(record_from_db["renttype"]).to eq(3)
+          end
+
+          it "derives and saves unitletas as Intermediate Rent(4)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(4)
+            expect(record_from_db["unitletas"]).to eq(4)
+          end
+        end
+
+        context "when the rent_type is Other intermediate rent product(5)" do
+          let(:rent_type) { 5 }
+
+          it "derives and saves renttype as Intermediate Rent(3)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select renttype from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.renttype).to eq(3)
+            expect(record_from_db["renttype"]).to eq(3)
+          end
+
+          it "derives and saves unitletas as Intermediate Rent(4)" do
+            record_from_db = ActiveRecord::Base.connection.execute("select unitletas from lettings_logs where id=#{lettings_log.id}").to_a[0]
+            expect(lettings_log.unitletas).to eq(4)
+            expect(record_from_db["unitletas"]).to eq(4)
+          end
+        end
+      end
     end
 
     context "when answering the household characteristics questions" do
@@ -1966,7 +2068,7 @@ RSpec.describe LettingsLog do
     end
 
     context "when a non select question associated with several pages is routed to" do
-      let(:lettings_log) { FactoryBot.create(:lettings_log, :in_progress, period: 2, needstype: 1) }
+      let(:lettings_log) { FactoryBot.create(:lettings_log, :in_progress, period: 2, needstype: 1, renewal: 0) }
 
       it "does not clear the answer value" do
         lettings_log.update!({ unitletas: 1 })


### PR DESCRIPTION
Map unitletas based on rent type and collection year if it's a renewal
There are currently 330 lettings logs that will need to be updated (LettingsLog.where(renewal: 1, unitletas: nil))