### PR TITLE
Generate old_visible_id for organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -35,6 +35,8 @@ class Organisation < ApplicationRecord
   validates :name, presence: { message: I18n.t("validations.organisation.name_missing") }
   validates :provider_type, presence: { message: I18n.t("validations.organisation.provider_type_missing") }
 
+  after_create :persist_missing_old_visible_id
+
   def lettings_logs
     LettingsLog.filter_by_organisation(self)
   end
@@ -95,5 +97,14 @@ class Organisation < ApplicationRecord
 
   def has_managing_agents?
     managing_agents.count.positive?
+  end
+
+private
+
+  def persist_missing_old_visible_id
+    if old_visible_id.blank?
+      self.old_visible_id ||= "ORG#{id}"
+      update_column(:old_visible_id, old_visible_id)
+    end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -239,4 +239,26 @@ RSpec.describe Organisation, type: :model do
       end
     end
   end
+
+  describe "callbacks" do
+    describe "after create" do
+      context "when old_visible_id present" do
+        subject(:model) { described_class.new(name: "foo", provider_type: "LA", old_visible_id: "123") }
+
+        it "keeps old_visible_id" do
+          model.save!
+          expect(model.old_visible_id).to eql("123")
+        end
+      end
+
+      context "when old_visible_id not present" do
+        subject(:model) { described_class.new(name: "foo", provider_type: "LA") }
+
+        it "generates an old_visible_id" do
+          model.save!
+          expect(model.old_visible_id).to eql("ORG#{model.id}")
+        end
+      end
+    end
+  end
 end

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Exports::LettingsLogExportService do
 
   def replace_entity_ids(lettings_log, export_template)
     export_template.sub!(/\{id\}/, (lettings_log["id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
-    export_template.sub!(/\{owning_org_id\}/, (lettings_log["owning_organisation_id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
-    export_template.sub!(/\{managing_org_id\}/, (lettings_log["managing_organisation_id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
+    export_template.sub!(/\{owning_org_id\}/, "ORG#{lettings_log['owning_organisation_id']}")
+    export_template.sub!(/\{managing_org_id\}/, "ORG#{lettings_log['managing_organisation_id']}")
   end
 
   def replace_record_number(export_template, record_number)


### PR DESCRIPTION
# Context

- We need a mechanism to be able to find organisations based on an identifier
- We will be importing orgs from old core which will already have an identifier which is available at `Organisation#old_visible_id`
- These are used by external third parties to identify records
- New organisations created in new core will not have such an ID
- Therefore we generate this value so we can continue to identify records
- These need to be prefixed with something so they do not clash with an existing identifiers
- We have not fully imported from old core there we do not know all the existing identifier ahead of time
- A prefix will get around this by having a totally different key space

# Changes

- As an active record `after_create` callback on an org, generate `old_visible_id` if it does not already have one
- This value is prefixed to prevent any clashes