### PR TITLE
Change CDS export archive names from quarter to financial year

### DIFF
--- a/app/helpers/collection_time_helper.rb
+++ b/app/helpers/collection_time_helper.rb
@@ -1,16 +1,26 @@
 module CollectionTimeHelper
+  def collection_start_year(date)
+    window_end_date = Time.zone.local(date.year, 4, 1)
+    date < window_end_date ? date.year - 1 : date.year
+  end
+
   def current_collection_start_year
-    today = Time.zone.now
-    window_end_date = Time.zone.local(today.year, 4, 1)
-    today < window_end_date ? today.year - 1 : today.year
+    collection_start_year(Time.zone.now)
   end
 
   def collection_start_date(date)
-    window_end_date = Time.zone.local(date.year, 4, 1)
-    date < window_end_date ? Time.zone.local(date.year - 1, 4, 1) : Time.zone.local(date.year, 4, 1)
+    Time.zone.local(collection_start_year(date), 4, 1)
   end
 
   def current_collection_start_date
     Time.zone.local(current_collection_start_year, 4, 1)
+  end
+
+  def collection_end_date(date)
+    Time.zone.local(collection_start_year(date) + 1, 3, 31)
+  end
+
+  def current_collection_end_date
+    Time.zone.local(current_collection_start_year + 1, 3, 31)
   end
 end

--- a/app/services/exports/lettings_log_export_constants.rb
+++ b/app/services/exports/lettings_log_export_constants.rb
@@ -7,13 +7,6 @@ module Exports::LettingsLogExportConstants
     csv: 2,
   }.freeze
 
-  QUARTERS = {
-    0 => "jan_mar",
-    1 => "apr_jun",
-    2 => "jul_sep",
-    3 => "oct_dec",
-  }.freeze
-
   EXPORT_FIELDS = Set[
     "armedforces",
     "beds",

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -1,6 +1,7 @@
 module Exports
   class LettingsLogExportService
     include Exports::LettingsLogExportConstants
+    include CollectionTimeHelper
 
     def initialize(storage_service, logger = Rails.logger)
       @storage_service = storage_service
@@ -66,11 +67,11 @@ module Exports
       return unless lettings_log.startdate
 
       collection_start = lettings_log.collection_start_year
-      month = lettings_log.startdate.month
-      quarter = QUARTERS[(month - 1) / 3]
+      start_month = collection_start_date(lettings_log.startdate).strftime("%b")
+      end_month = collection_end_date(lettings_log.startdate).strftime("%b")
       base_number_str = "f#{base_number.to_s.rjust(4, '0')}"
       increment_str = "inc#{increment.to_s.rjust(4, '0')}"
-      "core_#{collection_start}_#{collection_start + 1}_#{quarter}_#{base_number_str}_#{increment_str}"
+      "core_#{collection_start}_#{collection_start + 1}_#{start_month}_#{end_month}_#{base_number_str}_#{increment_str}".downcase
     end
 
     def write_export_archive(export, lettings_logs)

--- a/spec/helpers/collection_time_helper_spec.rb
+++ b/spec/helpers/collection_time_helper_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe CollectionTimeHelper do
       it "returns the correct current start date" do
         expect(current_collection_start_date).to eq(Time.zone.local(2022, 4, 1))
       end
+
+      it "returns the correct current end date" do
+        expect(current_collection_end_date).to eq(Time.zone.local(2023, 3, 31))
+      end
     end
 
     context "with the date before 1st of April" do
@@ -28,6 +32,48 @@ RSpec.describe CollectionTimeHelper do
 
       it "returns the previous year as the current start year" do
         expect(current_collection_start_year).to eq(2021)
+      end
+
+      it "returns the correct current start date" do
+        expect(current_collection_start_date).to eq(Time.zone.local(2021, 4, 1))
+      end
+
+      it "returns the correct current end date" do
+        expect(current_collection_end_date).to eq(Time.zone.local(2022, 3, 31))
+      end
+    end
+  end
+
+  describe "Any collection year" do
+    context "when the date is after 1st of April" do
+      let(:now) { Time.utc(2022, 8, 3) }
+
+      it "returns the same year as the current start year" do
+        expect(collection_start_year(now)).to eq(2022)
+      end
+
+      it "returns the correct current start date" do
+        expect(collection_start_date(now)).to eq(Time.zone.local(2022, 4, 1))
+      end
+
+      it "returns the correct current end date" do
+        expect(collection_end_date(now)).to eq(Time.zone.local(2023, 3, 31))
+      end
+    end
+
+    context "with the date before 1st of April" do
+      let(:now) { Time.utc(2022, 2, 3) }
+
+      it "returns the previous year as the current start year" do
+        expect(collection_start_year(now)).to eq(2021)
+      end
+
+      it "returns the correct current start date" do
+        expect(collection_start_date(now)).to eq(Time.zone.local(2021, 4, 1))
+      end
+
+      it "returns the correct current end date" do
+        expect(collection_end_date(now)).to eq(Time.zone.local(2022, 3, 31))
       end
     end
   end

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Exports::LettingsLogExportService do
 
   let(:expected_master_manifest_filename) { "Manifest_2022_05_01_0001.csv" }
   let(:expected_master_manifest_rerun) { "Manifest_2022_05_01_0002.csv" }
-  let(:expected_zip_filename) { "core_2021_2022_jan_mar_f0001_inc0001.zip" }
-  let(:expected_data_filename) { "core_2021_2022_jan_mar_f0001_inc0001_pt001.xml" }
+  let(:expected_zip_filename) { "core_2021_2022_apr_mar_f0001_inc0001.zip" }
+  let(:expected_data_filename) { "core_2021_2022_apr_mar_f0001_inc0001_pt001.xml" }
   let(:expected_manifest_filename) { "manifest.xml" }
   let(:start_time) { Time.zone.local(2022, 5, 1) }
 
@@ -108,7 +108,7 @@ RSpec.describe Exports::LettingsLogExportService do
     end
 
     context "and multiple lettings logs are available for export on different periods" do
-      let(:expected_zip_filename2) { "core_2022_2023_apr_jun_f0001_inc0001.zip" }
+      let(:expected_zip_filename2) { "core_2022_2023_apr_mar_f0001_inc0001.zip" }
 
       before do
         FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1))
@@ -206,7 +206,7 @@ RSpec.describe Exports::LettingsLogExportService do
         end
 
         it "generates a ZIP export file with the expected filename" do
-          expect(storage_service).to receive(:write_file).with("core_2021_2022_jan_mar_f0002_inc0001.zip", any_args)
+          expect(storage_service).to receive(:write_file).with("core_2021_2022_apr_mar_f0002_inc0001.zip", any_args)
           export_service.export_xml_lettings_logs(full_update: true)
         end
       end


### PR DESCRIPTION
Follows on from a set of changes to the CDS export (e.g., #1306)

# Context

- We previously pushed logs into archives categorised by the quarter that they were created for.
- CDS requested that instead we push everything into a larger bucket separated by FY.

This PR changes the format of archives to to be categorised by financial year. For example:

`core_2021_2022_jan_mar_f0002_inc0001.zip `becomes: `core_2021_2022_apr_mar_f0002_inc0001.zip`

I have also made a push to start standardising collection start and end date calculations in `CollectionTimeHelper`. This is just a stop-gap to prevent a growing list of hard-coded values for collection start and end dates. We should start _asking_ the form what these dates are. There's a Slack thread [about this here](https://communities-govuk.slack.com/archives/C03QXAE3Y3W/p1676476617031739).
 