### PR TITLE
Allow issues/pull-request write permissions for GitHub token

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -72,6 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     needs: [postgres, redis]
+    permissions:
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
We believe that the default GITHUB_TOKEN permissions on this org has changed from permissive to restrictive, so we need to be explicit here about the permissions we need to post a comment on the PR.

https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token