### PR TITLE
CLDC-1891 Bulk upload handles owning organisation

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -17,8 +17,21 @@ class Organisation < ApplicationRecord
   has_many :managing_agent_relationships, foreign_key: :parent_organisation_id, class_name: "OrganisationRelationship"
   has_many :managing_agents, through: :managing_agent_relationships, source: :child_organisation
 
+  def affiliated_stock_owners
+    ids = []
+
+    if holds_own_stock? && persisted?
+      ids << id
+    end
+
+    ids.concat(stock_owners.pluck(:id))
+
+    Organisation.where(id: ids)
+  end
+
   scope :search_by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }
   scope :search_by, ->(param) { search_by_name(param) }
+
   has_paper_trail
 
   auto_strip_attributes :name

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -48,6 +48,16 @@ class Organisation < ApplicationRecord
   validates :name, presence: { message: I18n.t("validations.organisation.name_missing") }
   validates :provider_type, presence: { message: I18n.t("validations.organisation.provider_type_missing") }
 
+  def self.find_by_id_on_mulitple_fields(id)
+    return if id.nil?
+
+    if id.start_with?("ORG")
+      where(id: id[3..]).first
+    else
+      where(old_visible_id: id).first
+    end
+  end
+
   def lettings_logs
     LettingsLog.filter_by_organisation(self)
   end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -115,7 +115,7 @@ class BulkUpload::Lettings::RowParser
   attribute :field_108, :string
   attribute :field_109, :string
   attribute :field_110
-  attribute :field_111, :integer
+  attribute :field_111, :string
   attribute :field_112, :string
   attribute :field_113, :integer
   attribute :field_114, :integer
@@ -518,7 +518,7 @@ private
   end
 
   def owning_organisation
-    Organisation.find_by(old_visible_id: field_111)
+    Organisation.find_by_id_on_mulitple_fields(field_111)
   end
 
   def owning_organisation_id

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -176,6 +176,7 @@ class BulkUpload::Lettings::Validator
   def create_logs?
     return false if any_setup_sections_incomplete?
     return false if over_column_error_threshold?
+    return false if row_parsers.any?(&:block_log_creation?)
 
     row_parsers.all? { |row_parser| row_parser.log.valid? }
   end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     trait :with_old_visible_id do
       old_visible_id { rand(9_999_999).to_s }
     end
+
+    trait :does_not_own_stock do
+      holds_own_stock { false }
+    end
   end
 
   factory :organisation_rent_period do

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -479,6 +479,10 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         it "is not permitted" do
           expect(parser.errors[:field_111]).to eql(["The owning organisation code provided is for an organisation that does not own stock"])
         end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
       end
 
       context "when not affiliated with owning org" do
@@ -488,6 +492,10 @@ RSpec.describe BulkUpload::Lettings::RowParser do
 
         it "is not permitted" do
           expect(parser.errors[:field_111]).to eql(["You do not have permission to add logs for this owning organisation"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -462,6 +462,36 @@ RSpec.describe BulkUpload::Lettings::RowParser do
       end
     end
 
+    describe "#field_111" do # owning org
+      context "when cannot find owning org" do
+        let(:attributes) { { bulk_upload:, field_111: "donotexist" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_111]).to eql(["The owning organisation code is incorrect"])
+        end
+      end
+
+      context "when org is not stock owning" do
+        let(:owning_org) { create(:organisation, :with_old_visible_id, :does_not_own_stock) }
+
+        let(:attributes) { { bulk_upload:, field_111: owning_org.old_visible_id } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_111]).to eql(["The owning organisation code provided is for an organisation that does not own stock"])
+        end
+      end
+
+      context "when not affiliated with owning org" do
+        let(:unaffiliated_org) { create(:organisation, :with_old_visible_id) }
+
+        let(:attributes) { { bulk_upload:, field_111: unaffiliated_org.old_visible_id } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_111]).to eql(["You do not have permission to add logs for this owning organisation"])
+        end
+      end
+    end
+
     describe "#field_134" do
       context "when an unpermitted value" do
         let(:attributes) { { bulk_upload:, field_134: 3 } }

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -534,6 +534,16 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   end
 
   describe "#log" do
+    describe "#owning_organisation" do
+      context "when lookup is via id prefixed with ORG" do
+        let(:attributes) { { bulk_upload:, field_111: "ORG#{owning_org.id}" } }
+
+        it "assigns the correct org" do
+          expect(parser.log.owning_organisation).to eql(owning_org)
+        end
+      end
+    end
+
     describe "#cbl" do
       context "when field_75 is yes ie 1" do
         let(:attributes) { { bulk_upload:, field_75: 1 } }


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1891
- This PR addresses several issues around handling owning organisation for bulk upload
- We need to validate data from CSV on the owning organisation
- We need users to be able to reference owning organisation either via their old core id stored as `old_visible_id` or via their new core `id` which will be prefixed with `ORG` eg. `ORG123`

# Changes

- When given the owning organisation id in bulk upload we look up on both the `old_visible_id` and `id` to attempt to find the correct organisation
- Present back relevant validations based on the data entered for the owning organisation
- If for whatever reason the user has managed to use an ID that references an existing organisation but not permitted to use them we block log creation so invalid data does not enter the system