### PR TITLE
Update collection year end dates for 2022 onwards

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,7 +6,11 @@ class Form
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
     if sales_or_start_year_after_2022?(type, start_year)
       @start_date = Time.zone.local(start_year, 4, 1)
-      @end_date = Time.zone.local(start_year + 1, 7, 1)
+      @end_date = if start_year && start_year.to_i > 2022
+                    Time.zone.local(start_year + 1, 7, 9)
+                  else
+                    Time.zone.local(start_year + 1, 7, 7)
+                  end
       @setup_sections = type == "sales" ? [Form::Sales::Sections::Setup.new(nil, nil, self)] : [Form::Lettings::Sections::Setup.new(nil, nil, self)]
       @form_sections = sections_in_form.map { |sec| sec.new(nil, nil, self) }
       @type = type

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1,7 +1,7 @@
 {
   "form_type": "lettings",
   "start_date": "2022-04-01T00:00:00.000+01:00",
-  "end_date": "2023-07-01T00:00:00.000+01:00",
+  "end_date": "2023-07-09T00:00:00.000+01:00",
   "unresolved_log_redirect_page_id": "tenancy_start_date",
   "sections": {
     "tenancy_and_property": {

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe TasklistHelper do
 
           it "returns relevant text" do
             expect(review_log_text(lettings_log)).to eq(
-              "You can #{govuk_link_to 'review and make changes to this log', review_lettings_log_path(lettings_log)} until 1 July 2024.".html_safe,
+              "You can #{govuk_link_to 'review and make changes to this log', review_lettings_log_path(lettings_log)} until 9 July 2024.".html_safe,
             )
           end
         end
@@ -136,7 +136,7 @@ RSpec.describe TasklistHelper do
 
         it "returns relevant text" do
           expect(review_log_text(sales_log)).to eq(
-            "You can #{govuk_link_to 'review and make changes to this log', review_sales_log_path(id: sales_log, sales_log: true)} until 1 July 2023.".html_safe,
+            "You can #{govuk_link_to 'review and make changes to this log', review_sales_log_path(id: sales_log, sales_log: true)} until 7 July 2023.".html_safe,
           )
         end
       end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Form, type: :model do
       expect(form.questions.count).to eq(16)
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
-      expect(form.end_date).to eq(Time.zone.parse("2023-07-01"))
+      expect(form.end_date).to eq(Time.zone.parse("2023-07-07"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)
     end
 


### PR DESCRIPTION
The source of truth for this update is: https://digital.dclg.gov.uk/confluence/pages/viewpage.action?spaceKey=MC&title=CORE+And+Collection+Years

2022-2023: 9th June 2023
2023-2024: 7th June 2024