### PR TITLE
Better validation on bulk upload start year

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -143,6 +143,7 @@ class BulkUpload::Lettings::RowParser
   validates :field_1, presence: { message: I18n.t("validations.not_answered", question: "letting type") },
                       inclusion: { in: (1..12).to_a, message: I18n.t("validations.invalid_option", question: "letting type") }
   validates :field_4, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_1) } }
+  validates :field_98, format: { with: /\A\d{2}\z/, message: I18n.t("validations.setup.startdate.year_not_two_digits") }
 
   validate :validate_data_types
   validate :validate_nulls
@@ -500,6 +501,8 @@ private
 
   def startdate
     Date.new(field_98 + 2000, field_97, field_96) if field_98.present? && field_97.present? && field_96.present?
+  rescue Date::Error
+    Date.new
   end
 
   def renttype

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
         before_scheme_end_date: "The tenancy start date must be before the end date for this supported housing scheme"
         after_void_date: "Enter a tenancy start date that is after the void date"
         after_major_repair_date: "Enter a tenancy start date that is after the major repair date"
+        year_not_two_digits: Tenancy start year must be 2 digits
         location:
           deactivated: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered."
           reactivating_soon: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -443,6 +443,24 @@ RSpec.describe BulkUpload::Lettings::RowParser do
         end
       end
 
+      context "when field 98 is 4 digits instead of 2" do
+        let(:attributes) { { bulk_upload:, field_98: "2022" } }
+
+        it "returns an error" do
+          parser.valid?
+
+          expect(parser.errors[:field_98]).to include("Tenancy start year must be 2 digits")
+        end
+      end
+
+      context "when invalid date given" do
+        let(:attributes) { { bulk_upload:, field_1: "1", field_96: "a", field_97: "12", field_98: "2022" } }
+
+        it "does not raise an error" do
+          expect { parser.valid? }.not_to raise_error
+        end
+      end
+
       context "when inside of collection year" do
         let(:attributes) { { bulk_upload:, field_96: "1", field_97: "10", field_98: "22" } }
 


### PR DESCRIPTION
# Context

- The reason for this change was due to an exception raised whilst testing upload

# Changes

- If for whatever reason we can't parse the start date, we blank it so it least doesn't error and validation messages can be collected
- Added additional validation for tenancy start year which has caught out myself and other people. This needs to be 2 digits and not 4 and the validation checks this and offers more informative feedback

# Screenshots

![Screenshot 2023-02-17 at 11 32 44](https://user-images.githubusercontent.com/92580/219641262-e8c3da2f-c08b-45bb-8b24-0f8267960ea0.png)