### PR TITLE
CLDC-1979 Fix postcode bug

### DIFF
--- a/app/models/form/sales/questions/previous_postcode_known.rb
+++ b/app/models/form/sales/questions/previous_postcode_known.rb
@@ -10,6 +10,16 @@ class Form::Sales::Questions::PreviousPostcodeKnown < ::Form::Question
       "ppostcode_full" => [0],
     }
     @hint_text = "This is also known as the household’s 'last settled home'"
+    @hidden_in_check_answers = {
+      "depends_on" => [
+        {
+          "ppcodenk" => 0,
+        },
+        {
+          "ppcodenk" => 1,
+        },
+      ],
+    }
   end
 
   ANSWER_OPTIONS = {

--- a/spec/models/form/sales/questions/previous_postcode_known_spec.rb
+++ b/spec/models/form/sales/questions/previous_postcode_known_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe Form::Sales::Questions::PreviousPostcodeKnown, type: :model do
   it "has the correct hint" do
     expect(question.hint_text).to eq("This is also known as the household’s 'last settled home'")
   end
+
+  it "has the correct hidden_in_check_answers" do
+    expect(question.hidden_in_check_answers).to eq({
+      "depends_on" => [
+        { "ppcodenk" => 0 },
+        { "ppcodenk" => 1 },
+      ],
+    })
+  end
 end


### PR DESCRIPTION
Previous accommodation postcode KNOWN question wasn't being hidden in CYA once the nested postcode question was answers. Now it is :D 
![image](https://user-images.githubusercontent.com/94526761/220095808-86025ecf-c12a-4ace-a2e3-8eb54aaee75b.png)

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-1979
