### PR TITLE
CLDC-1889 Bulk upload schemes + locations

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -366,6 +366,12 @@ class Location < ApplicationRecord
 
   enum type_of_unit: TYPE_OF_UNIT
 
+  def self.find_by_id_on_mulitple_fields(id)
+    return if id.nil?
+
+    where(id:).or(where(old_visible_id: id)).first
+  end
+
   def postcode=(postcode)
     if postcode
       super UKPostcode.parse(postcode).to_s

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -110,6 +110,16 @@ class Scheme < ApplicationRecord
 
   enum arrangement_type: ARRANGEMENT_TYPE, _suffix: true
 
+  def self.find_by_id_on_mulitple_fields(id)
+    return if id.nil?
+
+    if id.start_with?("S")
+      where(id: id[1..]).first
+    else
+      where(old_visible_id: id).first
+    end
+  end
+
   def id_to_display
     "S#{id}"
   end

--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -8,7 +8,7 @@ class BulkUpload::Lettings::RowParser
   attribute :field_1, :integer
   attribute :field_2
   attribute :field_3
-  attribute :field_4, :integer
+  attribute :field_4, :string
   attribute :field_5, :integer
   attribute :field_6
   attribute :field_7, :string
@@ -964,6 +964,6 @@ private
   end
 
   def scheme
-    @scheme ||= Scheme.find_by(old_visible_id: field_4)
+    @scheme ||= Scheme.find_by_id_on_mulitple_fields(field_4)
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     startdate { Time.zone.local(2022, 4, 1) }
     confirmed { true }
     scheme
+
     trait :export do
       postcode { "SW1A 2AA" }
       name { "Downing Street" }
@@ -18,6 +19,10 @@ FactoryBot.define do
       mobility_type { "A" }
       scheme { FactoryBot.create(:scheme, :export) }
       old_visible_id { "111" }
+    end
+
+    trait :with_old_visible_id do
+      old_visible_id { rand(9_999_999).to_s }
     end
   end
 end

--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
       primary_client_group { "G" }
       secondary_client_group { "M" }
     end
+
+    trait :with_old_visible_id do
+      old_visible_id { rand(9_999_999) }
+    end
   end
 end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   let(:owning_org) { create(:organisation, :with_old_visible_id) }
   let(:managing_org) { create(:organisation, :with_old_visible_id) }
   let(:scheme) { create(:scheme, :with_old_visible_id, owning_organisation: owning_org) }
+  let(:location) { create(:location, :with_old_visible_id, scheme:) }
 
   let(:setup_section_params) do
     {
@@ -330,6 +331,59 @@ RSpec.describe BulkUpload::Lettings::RowParser do
       end
     end
 
+    describe "#field_5" do
+      context "when location does not exist" do
+        let(:scheme) { create(:scheme, :with_old_visible_id, owning_organisation: owning_org) }
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_1: "1",
+            field_4: scheme.old_visible_id,
+            field_5: "dontexist",
+            field_111: owning_org.old_visible_id,
+          }
+        end
+
+        it "returns an error" do
+          expect(parser.errors[:field_5]).to be_present
+        end
+      end
+
+      context "when location exists" do
+        let(:scheme) { create(:scheme, :with_old_visible_id, owning_organisation: owning_org) }
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_1: "1",
+            field_4: scheme.old_visible_id,
+            field_5: location.old_visible_id,
+            field_111: owning_org.old_visible_id,
+          }
+        end
+
+        it "does not return an error" do
+          expect(parser.errors[:field_5]).to be_blank
+        end
+      end
+
+      context "when location exists but not related" do
+        let(:location) { create(:scheme, :with_old_visible_id) }
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_1: "1",
+            field_4: scheme.old_visible_id,
+            field_5: location.old_visible_id,
+            field_111: owning_org.old_visible_id,
+          }
+        end
+
+        it "returns an error" do
+          expect(parser.errors[:field_5]).to be_present
+        end
+      end
+    end
+
     describe "#field_7" do
       context "when null" do
         let(:attributes) { { bulk_upload:, field_7: nil } }
@@ -620,6 +674,16 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   end
 
   describe "#log" do
+    describe "#location" do
+      context "when lookup is via new core id" do
+        let(:attributes) { { bulk_upload:, field_4: scheme.old_visible_id, field_5: location.id, field_111: owning_org } }
+
+        it "assigns the correct location" do
+          expect(parser.log.location).to eql(location)
+        end
+      end
+    end
+
     describe "#scheme" do
       context "when lookup is via id prefixed with S" do
         let(:attributes) { { bulk_upload:, field_4: "S#{scheme.id}", field_111: owning_org } }

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -620,6 +620,16 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   end
 
   describe "#log" do
+    describe "#scheme" do
+      context "when lookup is via id prefixed with S" do
+        let(:attributes) { { bulk_upload:, field_4: "S#{scheme.id}", field_111: owning_org } }
+
+        it "assigns the correct scheme" do
+          expect(parser.log.scheme).to eql(scheme)
+        end
+      end
+    end
+
     describe "#owning_organisation" do
       context "when lookup is via id prefixed with ORG" do
         let(:attributes) { { bulk_upload:, field_111: "ORG#{owning_org.id}" } }


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1889
- Bulk upload needs to handle schemes and locations

# Changes

- Add extra lookups so schemes and locations can be identified via `old_visible_id` or simply `id` aka new core id
- For schemes new core identifier lookups will be prefixed with an `s`
- For locations there are no prefixes but we scope the scheme so risk of returning the wrong location seems low
- Extra validation added so these scheme and locations need to belong either to the owning org or managing org