### PR TITLE
CLDC-2021 ensure that status is up to date when records are called from the DB

### DIFF
--- a/app/models/form/subsection.rb
+++ b/app/models/form/subsection.rb
@@ -34,6 +34,10 @@ class Form::Subsection
     :in_progress
   end
 
+  def complete?(log)
+    status(log) == :completed
+  end
+
   def is_incomplete?(log)
     %i[not_started in_progress].include?(status(log))
   end
@@ -50,5 +54,9 @@ class Form::Subsection
 
   def displayed_in_tasklist?(_log)
     true
+  end
+
+  def not_displayed_in_tasklist?(log)
+    !displayed_in_tasklist?(log)
   end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -111,14 +111,12 @@ private
   end
 
   def all_fields_completed?
-    subsection_statuses = form.subsections.map { |subsection| subsection.status(self) if subsection.displayed_in_tasklist?(self) }.uniq.compact
-    subsection_statuses == [:completed]
+    form.subsections.all? { |subsection| subsection.complete?(self) || subsection.not_displayed_in_tasklist?(self) }
   end
 
   def all_fields_nil?
     not_started_statuses = %i[not_started cannot_start_yet]
-    subsection_statuses = form.subsections.map { |subsection| subsection.status(self) }.uniq
-    subsection_statuses.all? { |status| not_started_statuses.include?(status) }
+    form.subsections.all? { |subsection| not_started_statuses.include? subsection.status(self) }
   end
 
   def reset_invalidated_dependent_fields!


### PR DESCRIPTION
After discussion with Kat we think the most likely reason for inconsistent data on staging is that there were logs that were completed at the time and subsequently questions were added to the form.

that has been dealt with in a console, here are just some small changes that I find more readable/efficient looking