### PR TITLE
Bulk upload handles social housing first time let

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -776,6 +776,8 @@ private
     case rsnvac
     when 15, 16, 17
       1
+    else
+      0
     end
   end
 

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -186,6 +186,12 @@ RSpec.describe BulkUpload::Lettings::RowParser do
             field_80: "1234.56",
             field_87: "1",
             field_88: "234.56",
+
+            field_106: "15",
+            field_99: "0",
+            field_89: now.day.to_s,
+            field_90: now.month.to_s,
+            field_91: now.strftime("%g"),
           }
         end
 
@@ -1152,6 +1158,14 @@ RSpec.describe BulkUpload::Lettings::RowParser do
 
         it "sets to 1" do
           expect(parser.log.first_time_property_let_as_social_housing).to eq(1)
+        end
+      end
+
+      context "when field_106 is not 15, 16, or 17" do
+        let(:attributes) { { bulk_upload:, field_106: "1" } }
+
+        it "sets to 0" do
+          expect(parser.log.first_time_property_let_as_social_housing).to eq(0)
         end
       end
     end


### PR DESCRIPTION
# Context

- Social housing first time let is a  question is present in the web form
- however is not surfaced for bulk upload therefore the answer must be inferred

# Changes

- explicitly infer from first time let as social housing from vacancy reason