### PR TITLE
Bulk upload handles invalid byte sequences

### DIFF
--- a/app/services/bulk_upload/lettings/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/csv_parser.rb
@@ -52,6 +52,7 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
+    @normalised_string.scrub!("")
 
     @normalised_string
   end

--- a/spec/services/bulk_upload/lettings/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/csv_parser_spec.rb
@@ -52,4 +52,21 @@ RSpec.describe BulkUpload::Lettings::CsvParser do
       expect(service.row_parsers[0].field_12).to eql(log.age1)
     end
   end
+
+  context "when an invalid byte sequence" do
+    let(:file) { Tempfile.new }
+    let(:path) { file.path }
+    let(:log) { build(:lettings_log, :completed) }
+    let(:invalid_sequence) { "\x81" }
+
+    before do
+      file.write(invalid_sequence)
+      file.write(BulkUpload::LogToCsv.new(log:, col_offset: 0).to_csv_row)
+      file.close
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_12).to eql(log.age1)
+    end
+  end
 end


### PR DESCRIPTION
# Context

- Sometimes CSV is not exported as utf8 by spreadsheet software therefore invalid byte sequences are present

# Changes

- if invalid byte sequence is found, remove this before parsing as CSV

# Notes for review

- Not sure if I'm doing this right or if there's a better way?