### PR TITLE
CLDC-2065 Bulk upload error summary minimum limit

### DIFF
--- a/app/components/bulk_upload_error_summary_table_component.rb
+++ b/app/components/bulk_upload_error_summary_table_component.rb
@@ -1,4 +1,6 @@
 class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
+  DISPLAY_THRESHOLD = 16
+
   attr_reader :bulk_upload
 
   def initialize(bulk_upload:)
@@ -11,7 +13,14 @@ class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
     @sorted_errors ||= bulk_upload
       .bulk_upload_errors
       .group(:col, :field, :error)
+      .having("count(*) > ?", display_threshold)
       .count
       .sort_by { |el| el[0][0].rjust(3, "0") }
+  end
+
+private
+
+  def display_threshold
+    DISPLAY_THRESHOLD
   end
 end

--- a/app/components/bulk_upload_error_summary_table_component.rb
+++ b/app/components/bulk_upload_error_summary_table_component.rb
@@ -18,6 +18,10 @@ class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
       .sort_by { |el| el[0][0].rjust(3, "0") }
   end
 
+  def errors?
+    sorted_errors.present?
+  end
+
 private
 
   def display_threshold

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -46,6 +46,12 @@ class BulkUploadMailer < NotifyMailer
   def send_correct_and_upload_again_mail(bulk_upload:)
     error_description = "We noticed that you have a lot of similar errors in column #{columns_with_errors(bulk_upload:)}. Please correct your data export and upload again."
 
+    summary_report_link = if BulkUploadErrorSummaryTableComponent.new(bulk_upload:).errors?
+                            summary_bulk_upload_lettings_result_url(bulk_upload)
+                          else
+                            bulk_upload_lettings_result_url(bulk_upload)
+                          end
+
     send_email(
       bulk_upload.user.email,
       BULK_UPLOAD_FAILED_CSV_ERRORS_TEMPLATE_ID,
@@ -55,7 +61,7 @@ class BulkUploadMailer < NotifyMailer
         year_combo: bulk_upload.year_combo,
         lettings_or_sales: bulk_upload.log_type,
         error_description:,
-        summary_report_link: summary_bulk_upload_lettings_result_url(bulk_upload),
+        summary_report_link:,
       },
     )
   end

--- a/app/views/bulk_upload_lettings_results/show.html.erb
+++ b/app/views/bulk_upload_lettings_results/show.html.erb
@@ -1,5 +1,7 @@
-<% content_for :before_content do %>
-  <%= govuk_back_link(text: "Back", href: summary_bulk_upload_lettings_result_path(@bulk_upload)) %>
+<% if BulkUploadErrorSummaryTableComponent.new(bulk_upload: @bulk_upload).errors? %>
+  <% content_for :before_content do %>
+    <%= govuk_back_link(text: "Back", href: summary_bulk_upload_lettings_result_path(@bulk_upload)) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/bulk_upload_lettings_results/show.html.erb
+++ b/app/views/bulk_upload_lettings_results/show.html.erb
@@ -24,3 +24,5 @@
     <% end %>
   </div>
 </div>
+
+<%= govuk_button_link_to "Upload your file again", start_bulk_upload_lettings_logs_path %>

--- a/spec/components/bulk_upload_error_summary_table_component_spec.rb
+++ b/spec/components/bulk_upload_error_summary_table_component_spec.rb
@@ -95,4 +95,22 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
       ])
     end
   end
+
+  describe "#errors?" do
+    context "when there are no errors" do
+      it "returns false" do
+        expect(component).not_to be_errors
+      end
+    end
+
+    context "when there are errors" do
+      before do
+        create(:bulk_upload_error, bulk_upload:, col: "A", row: 2, field: "field_1")
+      end
+
+      it "returns true" do
+        expect(component).to be_errors
+      end
+    end
+  end
 end

--- a/spec/components/bulk_upload_error_summary_table_component_spec.rb
+++ b/spec/components/bulk_upload_error_summary_table_component_spec.rb
@@ -5,10 +5,27 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
 
   let(:bulk_upload) { create(:bulk_upload) }
 
+  before do
+    stub_const("BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD", 0)
+  end
+
   context "when no errors" do
     it "does not renders any rows" do
       result = render_inline(component)
       expect(result).not_to have_selector("tbody tr")
+    end
+  end
+
+  context "when below threshold" do
+    before do
+      stub_const("BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD", 16)
+
+      create(:bulk_upload_error, bulk_upload:, col: "A", row: 1)
+    end
+
+    it "does not render rows" do
+      result = render_inline(component)
+      expect(result).to have_selector("tbody tr", count: 0)
     end
   end
 

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe BulkUploadMailer do
             year_combo: bulk_upload.year_combo,
             lettings_or_sales: bulk_upload.log_type,
             error_description: "We noticed that you have a lot of similar errors in column A, B. Please correct your data export and upload again.",
-            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary",
+            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}",
           },
         )
 
@@ -103,6 +103,8 @@ RSpec.describe BulkUploadMailer do
 
     context "when 4 columns with errors" do
       before do
+        stub_const("BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD", 0)
+
         create(:bulk_upload_error, bulk_upload:, col: "A")
         create(:bulk_upload_error, bulk_upload:, col: "B")
         create(:bulk_upload_error, bulk_upload:, col: "C")


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2065
- Bulk upload when viewing the errors summary table, when there are fewer than 16 errors we do not display these in the table
- This table is to summarise errors that are vast amount of issues. For errors that affect fewer than 16 rows in a column the user can go to the detailed report to view these error

# Changes

- Errors summary table only show errors that affect 16 or more rows
- If there are not enough errors to populate the summary table we email to link to full report instead of summary
- As a consequence of the above we remove the back link for this case so they cannot go back to the summary report