### PR TITLE
Hide 'What are the monthly leasehold charges?' for 22/23

### DIFF
--- a/app/models/form/sales/subsections/outright_sale.rb
+++ b/app/models/form/sales/subsections/outright_sale.rb
@@ -20,12 +20,18 @@ class Form::Sales::Subsections::OutrightSale < ::Form::Subsection
       Form::Sales::Pages::ExtraBorrowing.new("extra_borrowing_outright_sale", nil, self),
       Form::Sales::Pages::AboutDepositWithoutDiscount.new("about_deposit_outright_sale", nil, self),
       Form::Sales::Pages::DepositValueCheck.new("outright_sale_deposit_value_check", nil, self),
-      Form::Sales::Pages::LeaseholdCharges.new("leasehold_charges_outright_sale", nil, self),
+      leasehold_charge_pages,
       Form::Sales::Pages::MonthlyChargesValueCheck.new("monthly_charges_outright_sale_value_check", nil, self),
-    ]
+    ].compact
   end
 
   def displayed_in_tasklist?(log)
     log.ownershipsch == 3
+  end
+
+  def leasehold_charge_pages
+    if form.start_date.year >= 2023
+      Form::Sales::Pages::LeaseholdCharges.new("leasehold_charges_outright_sale", nil, self)
+    end
   end
 end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -397,8 +397,6 @@ module Imports
     end
 
     def set_default_values(attributes)
-      attributes["mscharge_known"] ||= 0 if attributes["ownershipsch"] == 3
-      attributes["mscharge"] ||= 0 if attributes["ownershipsch"] == 3
       attributes["armedforcesspouse"] ||= 7
       attributes["hhregres"] ||= 8
       attributes["disabled"] ||= 3

--- a/spec/models/form/sales/subsections/outright_sale_spec.rb
+++ b/spec/models/form/sales/subsections/outright_sale_spec.rb
@@ -11,25 +11,57 @@ RSpec.describe Form::Sales::Subsections::OutrightSale, type: :model do
     expect(outright_sale.section).to eq(section)
   end
 
-  it "has correct pages" do
-    expect(outright_sale.pages.map(&:id)).to eq(
-      %w[
-        purchase_price_outright_sale
-        about_price_outright_sale_value_check
-        mortgage_used_outright_sale
-        outright_sale_mortgage_used_mortgage_value_check
-        mortgage_amount_outright_sale
-        outright_sale_mortgage_amount_mortgage_value_check
-        mortgage_lender_outright_sale
-        mortgage_lender_other_outright_sale
-        mortgage_length_outright_sale
-        extra_borrowing_outright_sale
-        about_deposit_outright_sale
-        outright_sale_deposit_value_check
-        leasehold_charges_outright_sale
-        monthly_charges_outright_sale_value_check
-      ],
-    )
+  describe "pages" do
+    let(:section) { instance_double(described_class, form: instance_double(Form, start_date:)) }
+
+    context "when 2022" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "has correct pages" do
+        expect(outright_sale.pages.compact.map(&:id)).to eq(
+          %w[
+            purchase_price_outright_sale
+            about_price_outright_sale_value_check
+            mortgage_used_outright_sale
+            outright_sale_mortgage_used_mortgage_value_check
+            mortgage_amount_outright_sale
+            outright_sale_mortgage_amount_mortgage_value_check
+            mortgage_lender_outright_sale
+            mortgage_lender_other_outright_sale
+            mortgage_length_outright_sale
+            extra_borrowing_outright_sale
+            about_deposit_outright_sale
+            outright_sale_deposit_value_check
+            monthly_charges_outright_sale_value_check
+          ],
+        )
+      end
+    end
+
+    context "when 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "has correct pages" do
+        expect(outright_sale.pages.map(&:id)).to eq(
+          %w[
+            purchase_price_outright_sale
+            about_price_outright_sale_value_check
+            mortgage_used_outright_sale
+            outright_sale_mortgage_used_mortgage_value_check
+            mortgage_amount_outright_sale
+            outright_sale_mortgage_amount_mortgage_value_check
+            mortgage_lender_outright_sale
+            mortgage_lender_other_outright_sale
+            mortgage_length_outright_sale
+            extra_borrowing_outright_sale
+            about_deposit_outright_sale
+            outright_sale_deposit_value_check
+            leasehold_charges_outright_sale
+            monthly_charges_outright_sale_value_check
+          ],
+        )
+      end
+    end
   end
 
   it "has the correct id" do

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -235,21 +235,6 @@ RSpec.describe Imports::SalesLogsImportService do
         end
       end
 
-      context "and it's an outright sale" do
-        let(:sales_log_id) { "outright_sale_sales_log" }
-
-        before do
-          allow(logger).to receive(:warn).and_return(nil)
-        end
-
-        it "infers mscharge_known as no" do
-          sales_log_service.send(:create_log, sales_log_xml)
-
-          sales_log = SalesLog.find_by(old_id: sales_log_id)
-          expect(sales_log.mscharge_known).to eq(0)
-        end
-      end
-
       context "when inferring age known" do
         let(:sales_log_id) { "discounted_ownership_sales_log" }
 


### PR DESCRIPTION
- We discovered earlier today (thanks @kosiakkatrina ) that we have accidentally missed out ‘what are the monthly leasehold charges?’ in the ‘outright sales’ section of the 22/23 sales form on old CORE – the very last question on the form.
- We've decided that we will not add the question back in for 22/23. However we will add it back in for the upcoming 23/24 forms.
- The monthly charges value check can stay in because it has a nil check against this field before running.