### PR TITLE
Make privacy notice question mandatory

### DIFF
--- a/app/models/form/sales/pages/privacy_notice.rb
+++ b/app/models/form/sales/pages/privacy_notice.rb
@@ -3,9 +3,6 @@ class Form::Sales::Pages::PrivacyNotice < ::Form::Page
     super
     @id = "privacy_notice"
     @header = "Department for Levelling Up, Housing and Communities privacy notice"
-    @depends_on = [{
-      "noint" => 2,
-    }]
   end
 
   def questions

--- a/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
@@ -14,8 +14,7 @@
     <meta:rules assert-valid="true"/>
   </meta:metadata>
   <Group>
-    <!-- replace with commented options to test in the future -->
-    <!-- <Qdp>Yes</Qdp> -->
+    <Qdp>Yes</Qdp>
     <Qdp/>
     <CompletionDate>2023-02-01</CompletionDate>
     <PurchaserCode>Discount ownership example</PurchaserCode>

--- a/spec/models/form/sales/pages/privacy_notice_spec.rb
+++ b/spec/models/form/sales/pages/privacy_notice_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe Form::Sales::Pages::PrivacyNotice, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{ "noint" => 2 }])
+    expect(page.depends_on).to be_nil
   end
 end


### PR DESCRIPTION
Privacy notice was mandatory in old CORE to submit the logs and we probably don't want to relax the validation around it