### PR TITLE
CLDC-1938 Import relevant logs in sales and lettings log import

### DIFF
--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -120,7 +120,7 @@ jobs:
           cf set-env $APP_NAME API_KEY $API_KEY
           cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
-          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE dluhc-core-review-import-bucket
+          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE $IMPORT_PAAS_INSTANCE
           cf set-env $APP_NAME EXPORT_PAAS_INSTANCE "dluhc-core-review-export-bucket"
           cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
           cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE "dluhc-core-review-csv-bucket"

--- a/.github/workflows/review_pipeline.yml
+++ b/.github/workflows/review_pipeline.yml
@@ -120,7 +120,7 @@ jobs:
           cf set-env $APP_NAME API_KEY $API_KEY
           cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
-          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE $IMPORT_PAAS_INSTANCE
+          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE dluhc-core-review-import-bucket
           cf set-env $APP_NAME EXPORT_PAAS_INSTANCE "dluhc-core-review-export-bucket"
           cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
           cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE "dluhc-core-review-csv-bucket"

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -55,6 +55,8 @@ module Imports
     }.freeze
 
     def create_log(xml_doc)
+      return if meta_field_value(xml_doc, "form-name").include?("Sales")
+
       attributes = {}
 
       previous_status = meta_field_value(xml_doc, "status")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -122,9 +122,6 @@ module Imports
       attributes["socprevten"] = unsafe_string_as_integer(xml_doc, "PrevRentType")
       attributes["mortgagelender"] = mortgage_lender(xml_doc, attributes)
       attributes["mortgagelenderother"] = mortgage_lender_other(xml_doc, attributes)
-      attributes["totadult"] = safe_string_as_integer(xml_doc, "TOTADULT") # would get overridden
-      attributes["totchild"] = safe_string_as_integer(xml_doc, "TOTCHILD") # would get overridden
-      attributes["hhtype"] = unsafe_string_as_integer(xml_doc, "HHTYPE")
       attributes["pcode1"] = string_or_nil(xml_doc, "PCODE1")
       attributes["pcode2"] = string_or_nil(xml_doc, "PCODE2")
       attributes["postcode_full"] = compose_postcode(xml_doc, "PCODE1", "PCODE2")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -16,6 +16,8 @@ module Imports
   private
 
     def create_log(xml_doc)
+      return unless meta_field_value(xml_doc, "form-name").include?("Sales")
+
       attributes = {}
 
       previous_status = meta_field_value(xml_doc, "status")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -419,7 +419,10 @@ module Imports
       attributes["prevown"] ||= 3
       attributes["savingsnk"] ||= attributes["savings"].present? ? 0 : 1
       attributes["jointmore"] ||= 3 if attributes["jointpur"] == 1
-      # attributes["noint"] = 1 # not interviewed
+      attributes["inc1mort"] ||= 3
+      if [attributes["pregyrha"], attributes["pregla"], attributes["pregghb"], attributes["pregother"]].all?(&:blank?)
+        attributes["pregblank"] = 1
+      end
 
       # buyer 1 characteristics
       attributes["age1_known"] ||= 1
@@ -438,6 +441,7 @@ module Imports
         attributes["ecstat2"] ||= 10
         attributes["income2nk"] ||= attributes["income2"].present? ? 0 : 1
         attributes["relat2"] ||= "R"
+        attributes["inc2mort"] ||= 3
       end
 
       # other household members characteristics

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -32,7 +32,7 @@ module Imports
       attributes["created_at"] = Time.zone.parse(meta_field_value(xml_doc, "created-date"))
       attributes["updated_at"] = Time.zone.parse(meta_field_value(xml_doc, "modified-date"))
       attributes["purchid"] = string_or_nil(xml_doc, "PurchaserCode")
-      attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership")
+      attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership") || 1 if attributes["type"] == 2 # someties Ownership is missing, but type is set to 2
       attributes["othtype"] = string_or_nil(xml_doc, "Q38OtherSale")
       attributes["jointpur"] = unsafe_string_as_integer(xml_doc, "joint")
       attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["joint"] == 1
@@ -401,7 +401,7 @@ module Imports
     def mortgage_used(xml_doc, attributes)
       mortgage_used = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
       if mortgage_used == 3
-        [attributes["mortgage"], attributes["mortlen"], attributes["extrabor"]].any? { |x| x.present? } ? 1 : 2
+        [attributes["mortgage"], attributes["mortlen"], attributes["extrabor"]].any?(&:present?) ? 1 : 2
       else
         mortgage_used
       end
@@ -415,6 +415,7 @@ module Imports
       attributes["hb"] ||= 4
       attributes["prevown"] ||= 3
       attributes["savingsnk"] ||= attributes["savings"].present? ? 0 : 1
+      attributes["jointmore"] ||= 3 if attributes["jointpur"] == 1
       # attributes["noint"] = 1 # not interviewed
 
       # buyer 1 characteristics

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -33,10 +33,10 @@ module Imports
       attributes["updated_at"] = Time.zone.parse(meta_field_value(xml_doc, "modified-date"))
       attributes["purchid"] = string_or_nil(xml_doc, "PurchaserCode")
       attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership")
-      attributes["ownershipsch"] = ownership_from_type(attributes) if attributes["ownershipsch"].blank? # someties Ownership is missing, but type is set
+      attributes["ownershipsch"] = ownership_from_type(attributes) if attributes["ownershipsch"].blank? # sometimes Ownership is missing, but type is set
       attributes["othtype"] = string_or_nil(xml_doc, "Q38OtherSale")
       attributes["jointpur"] = unsafe_string_as_integer(xml_doc, "joint")
-      attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["joint"] == 1
+      attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["jointpur"] == 1
       attributes["beds"] = safe_string_as_integer(xml_doc, "Q11Bedrooms")
       attributes["companybuy"] = unsafe_string_as_integer(xml_doc, "company") if attributes["ownershipsch"] == 3
       attributes["hhmemb"] = safe_string_as_integer(xml_doc, "HHMEMB")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -435,6 +435,7 @@ module Imports
         attributes["sex2"] ||= "R"
         attributes["ecstat2"] ||= 10
         attributes["income2nk"] ||= attributes["income2"].present? ? 0 : 1
+        attributes["relat2"] ||= "R"
       end
 
       # other household members characteristics
@@ -451,11 +452,12 @@ module Imports
       applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id)
     end
 
-    # just for testing, logic might need to change
+    # just for testing, logic will need to change to match the number of people details known
     def default_household_count(attributes)
       return 0 if attributes["hhmemb"].zero? || attributes["hhmemb"].blank?
 
-      attributes["jointpur"] == 1 ? attributes["hhmemb"] - 2 : attributes["hhmemb"] - 1
+      household_count = attributes["jointpur"] == 1 ? attributes["hhmemb"] - 2 : attributes["hhmemb"] - 1
+      household_count.positive? ? household_count : 0    
     end
   end
 end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -111,7 +111,7 @@ module Imports
       attributes["prevten"] = unsafe_string_as_integer(xml_doc, "Q6PrevTenure")
       attributes["mortlen"] = mortgage_length(xml_doc, attributes)
       attributes["extrabor"] = borrowing(xml_doc, attributes)
-      attributes["mortgageused"] = mortgage_used(xml_doc, attributes)
+      attributes["mortgageused"] = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
       attributes["wchair"] = unsafe_string_as_integer(xml_doc, "Q15Wheelchair")
       attributes["armedforcesspouse"] = unsafe_string_as_integer(xml_doc, "ARMEDFORCESSPOUSE")
       attributes["hodate"] = compose_date(xml_doc, "HODAY", "HOMONTH", "HOYEAR")
@@ -396,15 +396,6 @@ module Imports
         safe_string_as_decimal(xml_doc, "Q29MonthlyCharges")
       when 2
         safe_string_as_decimal(xml_doc, "Q37MonthlyCharges")
-      end
-    end
-
-    def mortgage_used(xml_doc, attributes)
-      mortgage_used = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
-      if mortgage_used == 3
-        [attributes["mortgage"], attributes["mortlen"], attributes["extrabor"]].any?(&:present?) ? 1 : 2
-      else
-        mortgage_used
       end
     end
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -459,7 +459,7 @@ module Imports
     end
 
     def missing_answers(sales_log)
-      applicable_questions = sales_log.form.subsections.map { |s| s.applicable_questions(sales_log) }.flatten
+      applicable_questions = sales_log.form.subsections.map { |s| s.applicable_questions(sales_log).select { |q| q.enabled?(sales_log) } }.flatten
       applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id)
     end
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -105,7 +105,7 @@ module Imports
       attributes["previous_la_known"] = nil
       attributes["hhregres"] = unsafe_string_as_integer(xml_doc, "ArmedF")
       attributes["hhregresstill"] = still_serving(xml_doc)
-      attributes["proplen"] = safe_string_as_integer(xml_doc, "Q16aProplen2")
+      attributes["proplen"] = safe_string_as_integer(xml_doc, "Q16aProplen2") || safe_string_as_integer(xml_doc, "Q16aProplensec2")
       attributes["mscharge"] = monthly_charges(xml_doc, attributes)
       attributes["mscharge_known"] = 1 if attributes["mscharge"].present?
       attributes["prevten"] = unsafe_string_as_integer(xml_doc, "Q6PrevTenure")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -33,7 +33,7 @@ module Imports
       attributes["updated_at"] = Time.zone.parse(meta_field_value(xml_doc, "modified-date"))
       attributes["purchid"] = string_or_nil(xml_doc, "PurchaserCode")
       attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership")
-      attributes["ownershipsch"] = 1 if attributes["type"] == 2 && attributes["ownershipsch"].blank? # someties Ownership is missing, but type is set to 2
+      attributes["ownershipsch"] = ownership_from_type(attributes) if attributes["ownershipsch"].blank? # someties Ownership is missing, but type is set
       attributes["othtype"] = string_or_nil(xml_doc, "Q38OtherSale")
       attributes["jointpur"] = unsafe_string_as_integer(xml_doc, "joint")
       attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["joint"] == 1
@@ -408,6 +408,17 @@ module Imports
       end
     end
 
+    def ownership_from_type(attributes)
+      case attributes["type"]
+      when 2, 24, 18, 16, 28, 31, 30
+        1 # shared ownership
+      when 8, 14, 27, 9, 29, 21, 22
+        2 # discounted ownership
+      when 10, 12
+        3 # outright sale
+      end
+    end
+
     def set_default_values(attributes)
       attributes["armedforcesspouse"] ||= 7
       attributes["hhregres"] ||= 8
@@ -457,7 +468,7 @@ module Imports
       return 0 if attributes["hhmemb"].zero? || attributes["hhmemb"].blank?
 
       household_count = attributes["jointpur"] == 1 ? attributes["hhmemb"] - 2 : attributes["hhmemb"] - 1
-      household_count.positive? ? household_count : 0    
+      household_count.positive? ? household_count : 0
     end
   end
 end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -34,8 +34,8 @@ module Imports
       attributes["purchid"] = string_or_nil(xml_doc, "PurchaserCode")
       attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership")
       attributes["othtype"] = string_or_nil(xml_doc, "Q38OtherSale")
-      attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore")
       attributes["jointpur"] = unsafe_string_as_integer(xml_doc, "joint")
+      attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["joint"] == 1
       attributes["beds"] = safe_string_as_integer(xml_doc, "Q11Bedrooms")
       attributes["companybuy"] = unsafe_string_as_integer(xml_doc, "company") if attributes["ownershipsch"] == 3
       attributes["hhmemb"] = safe_string_as_integer(xml_doc, "HHMEMB")
@@ -108,7 +108,9 @@ module Imports
       attributes["mscharge"] = monthly_charges(xml_doc, attributes)
       attributes["mscharge_known"] = 1 if attributes["mscharge"].present?
       attributes["prevten"] = unsafe_string_as_integer(xml_doc, "Q6PrevTenure")
-      attributes["mortgageused"] = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
+      attributes["mortlen"] = mortgage_length(xml_doc, attributes)
+      attributes["extrabor"] = borrowing(xml_doc, attributes)
+      attributes["mortgageused"] = mortgage_used(xml_doc, attributes)
       attributes["wchair"] = unsafe_string_as_integer(xml_doc, "Q15Wheelchair")
       attributes["armedforcesspouse"] = unsafe_string_as_integer(xml_doc, "ARMEDFORCESSPOUSE")
       attributes["hodate"] = compose_date(xml_doc, "HODAY", "HOMONTH", "HOYEAR")
@@ -119,8 +121,6 @@ module Imports
       attributes["socprevten"] = unsafe_string_as_integer(xml_doc, "PrevRentType")
       attributes["mortgagelender"] = mortgage_lender(xml_doc, attributes)
       attributes["mortgagelenderother"] = mortgage_lender_other(xml_doc, attributes)
-      attributes["mortlen"] = mortgage_length(xml_doc, attributes)
-      attributes["extrabor"] = borrowing(xml_doc, attributes)
       attributes["totadult"] = safe_string_as_integer(xml_doc, "TOTADULT") # would get overridden
       attributes["totchild"] = safe_string_as_integer(xml_doc, "TOTCHILD") # would get overridden
       attributes["hhtype"] = unsafe_string_as_integer(xml_doc, "HHTYPE")
@@ -395,6 +395,15 @@ module Imports
         safe_string_as_decimal(xml_doc, "Q29MonthlyCharges")
       when 2
         safe_string_as_decimal(xml_doc, "Q37MonthlyCharges")
+      end
+    end
+
+    def mortgage_used(xml_doc, attributes)
+      mortgage_used = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
+      if mortgage_used == 3
+        [attributes["mortgage"], attributes["mortlen"], attributes["extrabor"]].any? { |x| x.present? } ? 1 : 2
+      else
+        mortgage_used
       end
     end
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -32,7 +32,8 @@ module Imports
       attributes["created_at"] = Time.zone.parse(meta_field_value(xml_doc, "created-date"))
       attributes["updated_at"] = Time.zone.parse(meta_field_value(xml_doc, "modified-date"))
       attributes["purchid"] = string_or_nil(xml_doc, "PurchaserCode")
-      attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership") || 1 if attributes["type"] == 2 # someties Ownership is missing, but type is set to 2
+      attributes["ownershipsch"] = unsafe_string_as_integer(xml_doc, "Ownership")
+      attributes["ownershipsch"] = 1 if attributes["type"] == 2 && attributes["ownershipsch"].blank? # someties Ownership is missing, but type is set to 2
       attributes["othtype"] = string_or_nil(xml_doc, "Q38OtherSale")
       attributes["jointpur"] = unsafe_string_as_integer(xml_doc, "joint")
       attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["joint"] == 1

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -18,6 +18,7 @@ namespace :core do
       Import.new(Imports::DataProtectionConfirmationImportService, :create_data_protection_confirmations, "dataprotect"),
       Import.new(Imports::OrganisationRentPeriodImportService, :create_organisation_rent_periods, "rent-period"),
       Import.new(Imports::LettingsLogsImportService, :create_logs, "logs"),
+      Import.new(Imports::SalesLogsImportService, :create_logs, "logs"),
     ]
 
     import_list.each do |step|

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -18,7 +18,7 @@ namespace :core do
       Import.new(Imports::DataProtectionConfirmationImportService, :create_data_protection_confirmations, "dataprotect"),
       Import.new(Imports::OrganisationRentPeriodImportService, :create_organisation_rent_periods, "rent-period"),
       Import.new(Imports::LettingsLogsImportService, :create_logs, "logs"),
-      Import.new(Imports::SalesLogsImportService, :create_logs, "logs"),
+      # Import.new(Imports::SalesLogsImportService, :create_logs, "logs"),
     ]
 
     import_list.each do |step|

--- a/spec/fixtures/imports/logs/shared_ownership_sales_log.xml
+++ b/spec/fixtures/imports/logs/shared_ownership_sales_log.xml
@@ -1,0 +1,333 @@
+<Group xmlns="http://data.gov.uk/core/logs/2022-CORE-Sales" xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:meta="http://data.gov.uk/core/metadata" xmlns:svc="http://www.w3.org/2007/app" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xfimpl="http://www.w3.org/2002/xforms/implementation" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xxf="http://orbeon.org/oxf/xml/xforms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <meta:metadata xmlns:es="http://www.ecmascript.org/" xmlns:xqx="http://www.w3.org/2005/XQueryX" xmlns:XSLT="http://www.w3.org/1999/XSL/Transform/compile">
+    <meta:form-name>2022-CORE-Sales</meta:form-name>
+    <meta:document-id>shared_ownership_sales_log</meta:document-id>
+    <meta:owner-user-id>c3061a2e6ea0b702e6f6210d5c52d2a92612d2aa</meta:owner-user-id>
+    <meta:owner-institution-id>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</meta:owner-institution-id>
+    <meta:managing-institution-id>7c5bd5fb549c09a2c55d7cb90d7ba84927e64618</meta:managing-institution-id>
+    <meta:created-date>2023-02-21T11:48:28.255968Z</meta:created-date>
+    <meta:modified-date>2023-02-22T11:00:06.575832Z</meta:modified-date>
+    <meta:status>submitted-valid</meta:status>
+    <meta:reporting-year>2022</meta:reporting-year>
+    <meta:upload-method>Manual Entry</meta:upload-method>
+    <meta:schema assert-valid="true"/>
+    <meta:rules assert-valid="true"/>
+  </meta:metadata>
+  <Group>
+    <Qdp>Yes</Qdp>
+    <CompletionDate>2023-01-17</CompletionDate>
+    <PurchaserCode>Shared ownership example</PurchaserCode>
+    <Ownership>1 Yes - a shared ownership scheme</Ownership>
+    <Q16SaleType>2 Shared Ownership</Q16SaleType>
+    <Q30SaleType/>
+    <Q38SaleType/>
+    <Q38OtherSale/>
+    <company>2 No</company>
+    <LiveInBuyer>1 Yes</LiveInBuyer>
+    <joint>2 No</joint>
+    <JointMore/>
+    <PartAPurchaser>2 Yes</PartAPurchaser>
+  </Group>
+  <Group>
+    <Q11Bedrooms override-field="">2</Q11Bedrooms>
+    <Q12PropertyType>1 Flat or maisonette</Q12PropertyType>
+    <Q13BuildingType>1 Purpose built</Q13BuildingType>
+    <Q14Postcode override-field="">SW1A 1AA</Q14Postcode>
+    <Q14PropertyLocation>Westminster</Q14PropertyLocation>
+    <Q14ONSLACode>E09000033</Q14ONSLACode>
+    <Q15Wheelchair>3 Don&#x2019;t know</Q15Wheelchair>
+  </Group>
+  <Group>
+    <P1Age>30</P1Age>
+    <P1Sex override-field="">Male</P1Sex>
+    <P1Eco>1 Full Time - 30 hours or more a week</P1Eco>
+    <P1Eth>2 White: Irish</P1Eth>
+    <P1Nat>18 United Kingdom</P1Nat>
+    <P2Age/>
+    <P2Sex override-field=""/>
+    <P2Rel/>
+    <P2Eco/>
+    <P3Age/>
+    <P3Sex override-field=""/>
+    <P3Rel/>
+    <P3Eco/>
+    <P4Age/>
+    <P4Sex override-field=""/>
+    <P4Rel/>
+    <P4Eco/>
+    <P5Age/>
+    <P5Sex override-field=""/>
+    <P5Rel/>
+    <P5Eco/>
+    <P6Age/>
+    <P6Sex override-field=""/>
+    <P6Rel/>
+    <P6Eco/>
+    <P7Age/>
+    <P7Sex override-field=""/>
+    <P7Rel/>
+    <P7Eco/>
+    <P8Age/>
+    <P8Sex override-field=""/>
+    <P8Rel/>
+    <P8Eco/>
+    <LiveInBuyer1>1 Yes</LiveInBuyer1>
+    <LiveInBuyer2/>
+    <LiveInOther/>
+  </Group>
+  <Group>
+    <P2Partner>0</P2Partner>
+    <P3Partner>0</P3Partner>
+    <P4Partner>0</P4Partner>
+    <P5Partner>0</P5Partner>
+    <P6Partner>0</P6Partner>
+    <P7Partner>0</P7Partner>
+    <P8Partner>0</P8Partner>
+    <Partner>0</Partner>
+    <P2AgeT>0</P2AgeT>
+    <P3AgeT>0</P3AgeT>
+    <P4AgeT>0</P4AgeT>
+    <P5AgeT>0</P5AgeT>
+    <P6AgeT>0</P6AgeT>
+    <P7AgeT>0</P7AgeT>
+    <P8AgeT>0</P8AgeT>
+    <P2SexT>0</P2SexT>
+    <P3SexT>0</P3SexT>
+    <P4SexT>0</P4SexT>
+    <P5SexT>0</P5SexT>
+    <P6SexT>0</P6SexT>
+    <P7SexT>0</P7SexT>
+    <P8SexT>0</P8SexT>
+    <P2RelT>0</P2RelT>
+    <P3RelT>0</P3RelT>
+    <P4RelT>0</P4RelT>
+    <P5RelT>0</P5RelT>
+    <P6RelT>0</P6RelT>
+    <P7RelT>0</P7RelT>
+    <P8RelT>0</P8RelT>
+    <P2EcoT>0</P2EcoT>
+    <P3EcoT>0</P3EcoT>
+    <P4EcoT>0</P4EcoT>
+    <P5EcoT>0</P5EcoT>
+    <P6EcoT>0</P6EcoT>
+    <P7EcoT>0</P7EcoT>
+    <P8EcoT>0</P8EcoT>
+    <P2HHoldT>0</P2HHoldT>
+    <P3HHoldT>0</P3HHoldT>
+    <P4HHoldT>0</P4HHoldT>
+    <P5HHoldT>0</P5HHoldT>
+    <P6HHoldT>0</P6HHoldT>
+    <P7HHoldT>0</P7HHoldT>
+    <P8HHoldT>0</P8HHoldT>
+    <P2PAge>0</P2PAge>
+    <P3PAge>0</P3PAge>
+    <P4PAge>0</P4PAge>
+    <P5PAge>0</P5PAge>
+    <P6PAge>0</P6PAge>
+    <P7PAge>0</P7PAge>
+    <P8PAge>0</P8PAge>
+    <PAGE/>
+    <Q30Answer/>
+    <P2Other>0</P2Other>
+    <P3Other>0</P3Other>
+    <P4Other>0</P4Other>
+    <P5Other>0</P5Other>
+    <P6Other>0</P6Other>
+    <P7Other>0</P7Other>
+    <P8Other>0</P8Other>
+    <Other>0</Other>
+    <P2RRefused>0</P2RRefused>
+    <P3RRefused>0</P3RRefused>
+    <P4RRefused>0</P4RRefused>
+    <P5RRefused>0</P5RRefused>
+    <P6RRefused>0</P6RRefused>
+    <P7RRefused>0</P7RRefused>
+    <P8RRefused>0</P8RRefused>
+    <TotRRefused>0</TotRRefused>
+    <CALCMORT>76000</CALCMORT>
+    <MORTGAGEUSED>1</MORTGAGEUSED>
+    <IM1>47000</IM1>
+    <IM2>0</IM2>
+    <IMT>235000</IMT>
+    <MortMultiple>0</MortMultiple>
+    <Form>300204</Form>
+  </Group>
+  <Group>
+    <minmaxP11/>
+    <minmaxP12/>
+    <minmaxP13/>
+    <minmaxP14/>
+    <minmaxP15/>
+    <minmaxP16/>
+    <minmaxP17/>
+    <minmaxP18/>
+    <minmaxP1T/>
+    <minmaxP19/>
+    <minmaxP10/>
+    <minmaxP21/>
+    <minmaxP22/>
+    <minmaxP23/>
+    <minmaxP24/>
+    <minmaxP25/>
+    <minmaxP26/>
+    <minmaxP27/>
+    <minmaxP28/>
+    <minmaxP2T/>
+    <minmaxP29/>
+    <minmaxP20/>
+    <Q16CHK>1</Q16CHK>
+    <Q30CHK>0</Q30CHK>
+    <Q38CHK>0</Q38CHK>
+    <SalesCHKT>1</SalesCHKT>
+    <Q23CHK>1</Q23CHK>
+    <Q16typeCHK>2</Q16typeCHK>
+    <Q16Q23>3</Q16Q23>
+    <DAY>17</DAY>
+    <MONTH>1</MONTH>
+    <YEAR>2023</YEAR>
+    <HODAY>6</HODAY>
+    <HOMONTH>9</HOMONTH>
+    <HOYEAR>2022</HOYEAR>
+    <EXDAY>8</EXDAY>
+    <EXMONTH>1</EXMONTH>
+    <EXYEAR>2023</EXYEAR>
+    <PPOSTC1>SW14</PPOSTC1>
+    <PPOSTC2>7QP</PPOSTC2>
+    <PCODE1>SW1A</PCODE1>
+    <PCODE2>1AA</PCODE2>
+    <NOINT/>
+  </Group>
+  <Group>
+    <Q6PrevTenure>2 Private registered provider (PRP) or housing association tenant</Q6PrevTenure>
+    <Q7Postcode override-field="">SW14 7QP</Q7Postcode>
+    <Q7UnknownPostcode/>
+    <Q7PrevLocation>Richmond-upon-Thames</Q7PrevLocation>
+    <Q7ONSLACode>E09000027</Q7ONSLACode>
+    <PREGYRHA>Yes</PREGYRHA>
+    <PREGORHA/>
+    <PREGLA/>
+    <PREGHBA/>
+    <PREGOTHER/>
+  </Group>
+  <Group>
+    <ArmedF>8 Don&#x2019;t know</ArmedF>
+    <LeftArmedF/>
+    <ARMEDFORCESSPOUSE/>
+    <Disability>2 No</Disability>
+    <Q10Wheelchair override-field="">2 No</Q10Wheelchair>
+  </Group>
+  <Group>
+    <P1IncKnown>1 Yes</P1IncKnown>
+    <Q2Person1Income>47000</Q2Person1Income>
+    <Q2Person1Mortgage>1 Yes</Q2Person1Mortgage>
+    <P2IncKnown/>
+    <Q2Person2Income/>
+    <Q2Person2MortApplication/>
+    <Q2a>4 Don&#x2019;t know</Q2a>
+    <savingsKnown>1 Yes</savingsKnown>
+    <Q3Savings override-field="true">89000</Q3Savings>
+    <Q4PrevOwnedProperty>1 Yes</Q4PrevOwnedProperty>
+  </Group>
+  <Group>
+    <!-- replace with commented options to test in the future -->
+    <!-- <Q16aProplen2/> -->
+    <Q16aProplen2>1</Q16aProplen2>
+    <Q17aStaircase>2 No</Q17aStaircase>
+    <PercentBought override-field=""/>
+    <PercentOwns>30</PercentOwns>
+    <Q17Resale>2 No</Q17Resale>
+    <Q18ContractExchange override-field="">2023-01-08</Q18ContractExchange>
+    <Q18PracticalCompletion override-field="">2022-09-06</Q18PracticalCompletion>
+    <Q19Rehoused>2 No</Q19Rehoused>
+    <Q20Bedrooms/>
+    <Q21PropertyType/>
+    <PrevRentType/>
+    <Q22PurchasePrice override-field="true">550000</Q22PurchasePrice>
+    <Q23Equity override-field="">30</Q23Equity>
+    <MortgageUsedSO>1 Yes</MortgageUsedSO>
+    <Q24Mortgage override-field="">76000</Q24Mortgage>
+    <Q24aMortgageLender>Nationwide</Q24aMortgageLender>
+    <Q24b>33</Q24b>
+    <Q25Borrowing>2 No</Q25Borrowing>
+    <Q26CashDeposit override-field="">89000</Q26CashDeposit>
+    <Q27SocialHomeBuy/>
+    <Q28MonthlyRent>912.00</Q28MonthlyRent>
+    <Q29MonthlyCharges>134.24</Q29MonthlyCharges>
+  </Group>
+  <Group>
+    <Q16aProplensec2/>
+    <Q31PurchasePrice override-field=""/>
+    <Q32Reductions override-field=""/>
+    <Q33Discount override-field=""/>
+    <MortgageUsedDO/>
+    <Q34Mortgage override-field=""/>
+    <Q34a/>
+    <Q34b/>
+    <Q35Borrowing/>
+    <Q36CashDeposit/>
+    <Q37MonthlyCharges/>
+  </Group>
+  <Group>
+    <Q40PurchasePrice override-field=""/>
+    <MortgageUsedOS/>
+    <Q41Mortgage override-field=""/>
+    <Q41aMortgageLender/>
+    <Q41b/>
+    <Q42Borrowing/>
+    <Q43CashDeposit override-field=""/>
+  </Group>
+  <Group>
+    <HHMEMB>1</HHMEMB>
+    <TOTADULT>1</TOTADULT>
+    <TOTCHILD>0</TOTCHILD>
+  </Group>
+  <Group>
+    <HHTYPE>3 = 1 adult</HHTYPE>
+  </Group>
+  <Group>
+    <DerSaleType>2 Shared Ownership</DerSaleType>
+  </Group>
+  <Group>
+    <HHTYPEP1A>1</HHTYPEP1A>
+    <HHTYPEP2A>0</HHTYPEP2A>
+    <HHTYPEP3A>0</HHTYPEP3A>
+    <HHTYPEP4A>0</HHTYPEP4A>
+    <HHTYPEP5A>0</HHTYPEP5A>
+    <HHTYPEP6A>0</HHTYPEP6A>
+    <HHTYPEP7A>0</HHTYPEP7A>
+    <HHTYPEP8A>0</HHTYPEP8A>
+    <TADULT>1</TADULT>
+    <HHTYPEP1E>0</HHTYPEP1E>
+    <HHTYPEP2E>0</HHTYPEP2E>
+    <HHTYPEP3E>0</HHTYPEP3E>
+    <HHTYPEP4E>0</HHTYPEP4E>
+    <HHTYPEP5E>0</HHTYPEP5E>
+    <HHTYPEP6E>0</HHTYPEP6E>
+    <HHTYPEP7E>0</HHTYPEP7E>
+    <HHTYPEP8E>0</HHTYPEP8E>
+    <TELDER>0</TELDER>
+    <HHTYPEP1C>0</HHTYPEP1C>
+    <HHTYPEP2C>0</HHTYPEP2C>
+    <HHTYPEP3C>0</HHTYPEP3C>
+    <HHTYPEP4C>0</HHTYPEP4C>
+    <HHTYPEP5C>0</HHTYPEP5C>
+    <HHTYPEP6C>0</HHTYPEP6C>
+    <HHTYPEP7C>0</HHTYPEP7C>
+    <HHTYPEP8C>0</HHTYPEP8C>
+    <TCHILD>0</TCHILD>
+    <Q8av>1</Q8av>
+    <Q8bv>0</Q8bv>
+    <Q8cv>0</Q8cv>
+    <Q8dv>0</Q8dv>
+    <Q8ev>0</Q8ev>
+    <Q8Validate>1</Q8Validate>
+  </Group>
+  <Group>
+    <PLOACODE/>
+    <OACODE/>
+    <GOVREG>E12000007</GOVREG>
+    <OWNINGORGID>1</OWNINGORGID>
+    <OWNINGORGNAME>1 Test</OWNINGORGNAME>
+    <HCNUM>655</HCNUM>
+  </Group>
+</Group>

--- a/spec/fixtures/imports/sales_logs/lettings_log.xml
+++ b/spec/fixtures/imports/sales_logs/lettings_log.xml
@@ -1,0 +1,524 @@
+<Group xmlns="http://data.gov.uk/core/logs/2021-CORE-SR-SH" xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:meta="http://data.gov.uk/core/metadata" xmlns:svc="http://www.w3.org/2007/app" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xfimpl="http://www.w3.org/2002/xforms/implementation" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xxf="http://orbeon.org/oxf/xml/xforms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <meta:metadata xmlns:es="http://www.ecmascript.org/" xmlns:xqx="http://www.w3.org/2005/XQueryX" xmlns:XSLT="http://www.w3.org/1999/XSL/Transform/compile">
+    <meta:form-name>2021-CORE-SR-SH</meta:form-name>
+    <meta:document-id>lettings_log</meta:document-id>
+    <meta:owner-user-id>c3061a2e6ea0b702e6f6210d5c52d2a92612d2aa</meta:owner-user-id>
+    <meta:owner-institution-id>7c5bd5fb549c09z2c55d9cb90d7ba84927e64618</meta:owner-institution-id>
+    <meta:managing-institution-id>7c5bd5fb549c09z2c55d9cb90d7ba84927e64618</meta:managing-institution-id>
+    <meta:created-date>2022-01-05T12:50:20.39153Z</meta:created-date>
+    <meta:modified-date>2022-01-05T12:50:20.39153Z</meta:modified-date>
+    <meta:status>submitted-valid</meta:status>
+    <meta:reporting-year>2021</meta:reporting-year>
+    <meta:upload-method>Manual Entry</meta:upload-method>
+    <meta:schema assert-valid="true"/>
+    <meta:rules assert-valid="true"/>
+  </meta:metadata>
+  <Group>
+    <Qdp>Yes</Qdp>
+    <KeyDate>2021-11-05</KeyDate>
+    <FORM>123456</FORM>
+    <Landlord source-value="2">2 Local Authority</Landlord>
+    <Group>
+      <_1cmangroupcode>0123</_1cmangroupcode>
+      <_1cschemecode>10</_1cschemecode>
+      <schPC/>
+      <Q1e>3 No</Q1e>
+    </Group>
+  </Group>
+  <Group>
+    <_2a>2 No</_2a>
+    <Q2b>1 Secure (inc flexible)</Q2b>
+    <Q2ba/>
+    <_2bTenCode>14044912001</_2bTenCode>
+    <_2cYears>2</_2cYears>
+  </Group>
+  <Group>
+    <P1Age override-field="">72</P1Age>
+    <P1AR/>
+    <P1Sex override-field="">Female</P1Sex>
+    <P1Eco>5) Retired</P1Eco>
+    <P1Eth>1 White: English/Scottish/Welsh/Northern Irish/British</P1Eth>
+    <P1Nat>1 UK national resident in UK</P1Nat>
+    <P2Age override-field="">74</P2Age>
+    <P2AR/>
+    <P2Sex override-field="">Male</P2Sex>
+    <P2Rel>Partner</P2Rel>
+    <P2Eco>5) Retired</P2Eco>
+    <P3Age override-field=""/>
+    <P3AR/>
+    <P3Sex override-field=""/>
+    <P3Rel/>
+    <P3Eco/>
+    <P4Age override-field=""/>
+    <P4AR/>
+    <P4Sex override-field=""/>
+    <P4Rel/>
+    <P4Eco/>
+    <P5Age override-field=""/>
+    <P5AR/>
+    <P5Sex override-field=""/>
+    <P5Rel/>
+    <P5Eco/>
+    <P6Age override-field=""/>
+    <P6AR/>
+    <P6Sex override-field=""/>
+    <P6Rel/>
+    <P6Eco/>
+    <P7Age override-field=""/>
+    <P7AR/>
+    <P7Sex override-field=""/>
+    <P7Rel/>
+    <P7Eco/>
+    <P8Age override-field=""/>
+    <P8AR/>
+    <P8Sex override-field=""/>
+    <P8Rel/>
+    <P8Eco/>
+    <Group>
+      <ArmedF>2 No</ArmedF>
+      <LeftAF/>
+      <Inj/>
+      <Preg override-field="">2 No</Preg>
+    </Group>
+    <Group>
+      <Q6Ben>9 Not in receipt of either UC or HB</Q6Ben>
+    </Group>
+    <Group>
+      <Q7Ben>2 Some</Q7Ben>
+      <Q8Refused>Refused</Q8Refused>
+      <Q8Money override-field=""/>
+      <Q8a/>
+    </Group>
+    <Group>
+      <Q9a>13 Property unsuitable because of ill health / disability</Q9a>
+      <Q9aa/>
+    </Group>
+    <Group>
+      <_9b override-field="">2 No</_9b>
+      <Q10-a/>
+      <Q10-b/>
+      <Q10-c/>
+      <Q10-f/>
+      <Q10-g>Yes</Q10-g>
+      <Q10-h/>
+      <Q10ia>1 Yes</Q10ia>
+      <Q10ib-1/>
+      <Q10ib-2/>
+      <Q10ib-3>Yes</Q10ib-3>
+      <Q10ib-4/>
+      <Q10ib-5/>
+      <Q10ib-6/>
+      <Q10ib-7/>
+      <Q10ib-8/>
+      <Q10ib-9/>
+      <Q10ib-10/>
+      <Q11 override-field="">26 Owner occupation (private)</Q11>
+      <Q12a>DLUHC</Q12a>
+      <Q12aONS>E08000035</Q12aONS>
+      <Q12b override-field="">S80 4DJ</Q12b>
+      <Q12bnot/>
+      <Q12c>5 5 years or more</Q12c>
+      <Q12d>9 3 years but under 4 years</Q12d>
+    </Group>
+    <Group>
+      <Q13>1 Not homeless</Q13>
+      <Q14a>2 No</Q14a>
+      <Q14b1/>
+      <Q14b2/>
+      <Q14b3/>
+      <Q14b4/>
+      <Q14b5/>
+    </Group>
+    <Group>
+      <Q15CBL>1 Yes</Q15CBL>
+      <Q15CHR>1 Yes</Q15CHR>
+      <Q15CAP>1 Yes</Q15CAP>
+    </Group>
+    <Group>
+      <Q16>2 Tenant applied direct (no referral or nomination)</Q16>
+    </Group>
+  </Group>
+  <Group>
+    <Q17>7 Weekly for 48 weeks</Q17>
+    <Q18ai override-field="true">125.00</Q18ai>
+    <Q18aii override-field=""/>
+    <Q18aiii override-field=""/>
+    <Q18aiv override-field="">7.00</Q18aiv>
+    <Q18av override-field="">132.00</Q18av>
+    <Q18b override-field=""/>
+    <Q18c/>
+    <Q18d/>
+    <Q18dyes override-field=""/>
+    <Q19void>2021-08-24</Q19void>
+    <Q19repair/>
+    <Q19supsch/>
+    <Q20 override-field="">0</Q20>
+    <Q21a>14044912</Q21a>
+  </Group>
+  <Group>
+    <Q25>1 Yes</Q25>
+    <Q27>15 First let of newbuild property</Q27>
+  </Group>
+  <Group>
+    <F1Age>0</F1Age>
+    <F2Age>0</F2Age>
+    <F3Age>0</F3Age>
+    <F4Age>0</F4Age>
+    <F5Age>0</F5Age>
+    <F6Age>0</F6Age>
+    <F7Age>0</F7Age>
+    <F8Age>0</F8Age>
+    <FAge>0</FAge>
+    <F1>1</F1>
+    <F2>0</F2>
+    <F3>0</F3>
+    <F4>0</F4>
+    <F5>0</F5>
+    <F6>0</F6>
+    <F7>0</F7>
+    <F8>0</F8>
+    <F>1</F>
+    <P1100>0</P1100>
+    <P2100>0</P2100>
+    <P3100>0</P3100>
+    <P4100>0</P4100>
+    <P5100>0</P5100>
+    <P6100>0</P6100>
+    <P7100>0</P7100>
+    <P8100>0</P8100>
+    <_100>0</_100>
+    <P170>1</P170>
+    <P270>1</P270>
+    <P370>0</P370>
+    <P470>0</P470>
+    <P570>0</P570>
+    <P670>0</P670>
+    <P770>0</P770>
+    <P870>0</P870>
+    <_70>1</_70>
+    <P1PT>0</P1PT>
+    <P2PT>0</P2PT>
+    <P3PT>0</P3PT>
+    <P4PT>0</P4PT>
+    <P5PT>0</P5PT>
+    <P6PT>0</P6PT>
+    <P7PT>0</P7PT>
+    <P8PT>0</P8PT>
+    <PT>0</PT>
+    <P1FT>0</P1FT>
+    <P2FT>0</P2FT>
+    <P3FT>0</P3FT>
+    <P4FT>0</P4FT>
+    <P5FT>0</P5FT>
+    <P6FT>0</P6FT>
+    <P7FT>0</P7FT>
+    <P8FT>0</P8FT>
+    <FT>0</FT>
+    <P1Stud>0</P1Stud>
+    <P2Stud>0</P2Stud>
+    <P3Stud>0</P3Stud>
+    <P4Stud>0</P4Stud>
+    <P5Stud>0</P5Stud>
+    <P6Stud>0</P6Stud>
+    <P7Stud>0</P7Stud>
+    <P8Stud>0</P8Stud>
+    <Stud>0</Stud>
+    <P2Child>0</P2Child>
+    <P3Child>0</P3Child>
+    <P4Child>0</P4Child>
+    <P5Child>0</P5Child>
+    <P6Child>0</P6Child>
+    <P7Child>0</P7Child>
+    <P8Child>0</P8Child>
+    <Child>0</Child>
+    <P2Partner>1</P2Partner>
+    <P3Partner>0</P3Partner>
+    <P4Partner>0</P4Partner>
+    <P5Partner>0</P5Partner>
+    <P6Partner>0</P6Partner>
+    <P7Partner>0</P7Partner>
+    <P8Partner>0</P8Partner>
+    <Partner>1</Partner>
+    <Q1cV1>1</Q1cV1>
+    <Q1cV2>1</Q1cV2>
+    <Q1cVT>2</Q1cVT>
+    <P1Adult>1</P1Adult>
+    <P2Adult>1</P2Adult>
+    <P3Adult>0</P3Adult>
+    <P4Adult>0</P4Adult>
+    <P5Adult>0</P5Adult>
+    <P6Adult>0</P6Adult>
+    <P7Adult>0</P7Adult>
+    <P8Adult>0</P8Adult>
+    <PAdultT>2</PAdultT>
+    <P2PAge>74</P2PAge>
+    <P3PAge>0</P3PAge>
+    <P4PAge>0</P4PAge>
+    <P5PAge>0</P5PAge>
+    <P6PAge>0</P6PAge>
+    <P7PAge>0</P7PAge>
+    <P8PAge>0</P8PAge>
+    <PAGE>74</PAGE>
+    <P2ChildAge>0</P2ChildAge>
+    <P3ChildAge>0</P3ChildAge>
+    <P4ChildAge>0</P4ChildAge>
+    <P5ChildAge>0</P5ChildAge>
+    <P6ChildAge>0</P6ChildAge>
+    <P7ChildAge>0</P7ChildAge>
+    <P8ChildAge>0</P8ChildAge>
+    <ChildAgeMin>0</ChildAgeMin>
+    <AgeDiff1>72</AgeDiff1>
+    <AgeDiff2>0</AgeDiff2>
+    <AgeDiff3>74</AgeDiff3>
+    <TODAY>2022-01-05Z</TODAY>
+    <FutureLimit>2022-01-20Z</FutureLimit>
+    <minmax1/>
+    <minmax2/>
+    <minmax3/>
+    <minmax4/>
+    <minmax5/>
+    <minmax6/>
+    <minmax7/>
+    <minmax8/>
+    <minmax9/>
+    <minmax0/>
+    <minmax10/>
+    <minmaxT/>
+    <Q10av>0</Q10av>
+    <Q10bv>0</Q10bv>
+    <Q10cv>0</Q10cv>
+    <Q10fv>0</Q10fv>
+    <Q10gv>20</Q10gv>
+    <Q10hv>0</Q10hv>
+    <Q10Validate>20</Q10Validate>
+    <Q2bv>A</Q2bv>
+    <P2Agev>1</P2Agev>
+    <P2Sexv>1</P2Sexv>
+    <P2Relv>1</P2Relv>
+    <P2Ecov>1</P2Ecov>
+    <P2valid>4</P2valid>
+    <P3Agev>0</P3Agev>
+    <P3Sexv>0</P3Sexv>
+    <P3Relv>0</P3Relv>
+    <P3Ecov>0</P3Ecov>
+    <P3valid>0</P3valid>
+    <P4Agev>0</P4Agev>
+    <P4Sexv>0</P4Sexv>
+    <P4Relv>0</P4Relv>
+    <P4Ecov>0</P4Ecov>
+    <P4valid>0</P4valid>
+    <P5Agev>0</P5Agev>
+    <P5Sexv>0</P5Sexv>
+    <P5Relv>0</P5Relv>
+    <P5Ecov>0</P5Ecov>
+    <P5valid>0</P5valid>
+    <P6Agev>0</P6Agev>
+    <P6Sexv>0</P6Sexv>
+    <P6Relv>0</P6Relv>
+    <P6Ecov>0</P6Ecov>
+    <P6valid>0</P6valid>
+    <P7Agev>0</P7Agev>
+    <P7Sexv>0</P7Sexv>
+    <P7Relv>0</P7Relv>
+    <P7Ecov>0</P7Ecov>
+    <P7valid>0</P7valid>
+    <P8Agev>0</P8Agev>
+    <P8Sexv>0</P8Sexv>
+    <P8Relv>0</P8Relv>
+    <P8Ecov>0</P8Ecov>
+    <P8valid>0</P8valid>
+    <Q14b1v>0</Q14b1v>
+    <Q14b2v>0</Q14b2v>
+    <Q14b3v>0</Q14b3v>
+    <Q14b4v>0</Q14b4v>
+    <Q14b5v>0</Q14b5v>
+    <Q14bv>0</Q14bv>
+    <P2Other>0</P2Other>
+    <P3Other>0</P3Other>
+    <P4Other>0</P4Other>
+    <P5Other>0</P5Other>
+    <P6Other>0</P6Other>
+    <P7Other>0</P7Other>
+    <P8Other>0</P8Other>
+    <Other>0</Other>
+    <P2ARefused>0</P2ARefused>
+    <P3ARefused>0</P3ARefused>
+    <P4ARefused>0</P4ARefused>
+    <P5ARefused>0</P5ARefused>
+    <P6ARefused>0</P6ARefused>
+    <P7ARefused>0</P7ARefused>
+    <P8ARefused>0</P8ARefused>
+    <TAREUSED>0</TAREUSED>
+    <P2RRefused>0</P2RRefused>
+    <P3RRefused>0</P3RRefused>
+    <P4RRefused>0</P4RRefused>
+    <P5RRefused>0</P5RRefused>
+    <P6RRefused>0</P6RRefused>
+    <P7RRefused>0</P7RRefused>
+    <P8RRefused>0</P8RRefused>
+    <TotRRefused>0</TotRRefused>
+    <TOTREFUSED>0</TOTREFUSED>
+  </Group>
+  <Group>
+    <ChildBen>0.00</ChildBen>
+    <TOTADULT>2</TOTADULT>
+    <NEW_OLD>1 New Tenant</NEW_OLD>
+    <WCHCHRG/>
+    <VACDAYS>73</VACDAYS>
+    <HHMEMB>2</HHMEMB>
+    <HHTYPEP1A>0</HHTYPEP1A>
+    <HHTYPEP2A>0</HHTYPEP2A>
+    <HHTYPEP3A>0</HHTYPEP3A>
+    <HHTYPEP4A>0</HHTYPEP4A>
+    <HHTYPEP5A>0</HHTYPEP5A>
+    <HHTYPEP6A>0</HHTYPEP6A>
+    <HHTYPEP7A>0</HHTYPEP7A>
+    <HHTYPEP8A>0</HHTYPEP8A>
+    <TADULT>0</TADULT>
+    <HHTYPEP1E>1</HHTYPEP1E>
+    <HHTYPEP2E>1</HHTYPEP2E>
+    <HHTYPEP3E>0</HHTYPEP3E>
+    <HHTYPEP4E>0</HHTYPEP4E>
+    <HHTYPEP5E>0</HHTYPEP5E>
+    <HHTYPEP6E>0</HHTYPEP6E>
+    <HHTYPEP7E>0</HHTYPEP7E>
+    <HHTYPEP8E>0</HHTYPEP8E>
+    <TELDER>2</TELDER>
+    <HHTYPEP1C>0</HHTYPEP1C>
+    <HHTYPEP2C>0</HHTYPEP2C>
+    <HHTYPEP3C>0</HHTYPEP3C>
+    <HHTYPEP4C>0</HHTYPEP4C>
+    <HHTYPEP5C>0</HHTYPEP5C>
+    <HHTYPEP6C>0</HHTYPEP6C>
+    <HHTYPEP7C>0</HHTYPEP7C>
+    <HHTYPEP8C>0</HHTYPEP8C>
+    <TCHILD>0</TCHILD>
+    <Q18aValid>1</Q18aValid>
+    <Q18bValid>0</Q18bValid>
+    <Q18cValid>0</Q18cValid>
+    <Q18Valid>1</Q18Valid>
+    <HHTYPE>2 = 2 Adults at least one is an Elder</HHTYPE>
+    <WEEKLYINC/>
+    <INCOME/>
+    <TYPEHB>15.00</TYPEHB>
+    <AFFRATE/>
+    <Weekinc/>
+    <LETTYPE>2 Local Authority</LETTYPE>
+    <PLOACODE/>
+    <OACODE/>
+    <GOVREG>E12000004</GOVREG>
+    <OWNINGORGID>1</OWNINGORGID>
+    <OWNINGORGNAME>DLUHC</OWNINGORGNAME>
+    <MANINGORGNAME>DLUHC</MANINGORGNAME>
+    <HCNUM>N/A</HCNUM>
+    <MANHCNUM>N/A</MANHCNUM>
+    <LAHA/>
+    <MANINGORGID>2</MANINGORGID>
+    <Q28same1>false</Q28same1>
+    <HBTYPE1/>
+    <HBTYPE2/>
+    <HBTYPE3/>
+    <HBTYPE4/>
+    <HBTYPE5/>
+    <HBTYPE6/>
+    <HBTYPE7/>
+    <HBTYPE8/>
+    <HBTYPE9/>
+    <HBTYPE10/>
+    <HBTYPE11/>
+    <HBTYPE12/>
+    <HBTYPE13/>
+    <HBTYPE14/>
+    <HBTYPE15>15</HBTYPE15>
+    <HBTYPE>15</HBTYPE>
+    <SCHEME>000001005048</SCHEME>
+    <MANTYPE>D</MANTYPE>
+    <UNITS>15</UNITS>
+    <UNITTYPE>6</UNITTYPE>
+    <SCHTYPE>7</SCHTYPE>
+    <REGHOME>1</REGHOME>
+    <SUPPORT>2</SUPPORT>
+    <MOBSTAND>A</MOBSTAND>
+    <INTSTAY>P</INTSTAY>
+    <CLIGRP1>M</CLIGRP1>
+    <CLIGRP2/>
+    <Q28Auth>DLUHC</Q28Auth>
+    <Q28ONS>E08000035</Q28ONS>
+    <Q28pc override-field="">S80 4QE</Q28pc>
+    <Q28same/>
+    <P1R>0</P1R>
+    <P2R>0</P2R>
+    <P3R>0</P3R>
+    <P4R>0</P4R>
+    <P5R>0</P5R>
+    <P6R>0</P6R>
+    <P7R>0</P7R>
+    <P8R>0</P8R>
+    <REFUSEDTOT>0</REFUSEDTOT>
+    <REFUSED/>
+    <WTSHORTFALL/>
+    <WTSHORTFALLHB/>
+    <WTSHORTFALLHE/>
+    <WRENT>115.38</WRENT>
+    <WTCHARGE>121.85</WTCHARGE>
+    <WSCHARGE/>
+    <WPSCHRGE/>
+    <WSUPCHRG>6.46</WSUPCHRG>
+    <WTSHORTFALL1/>
+    <WRENT1>115.38</WRENT1>
+    <WTCHARGE1>121.85</WTCHARGE1>
+    <WSCHARGE1/>
+    <WPSCHRGE1/>
+    <WSUPCHRG1>6.46</WSUPCHRG1>
+  </Group>
+  <Group>
+    <BSa>1</BSa>
+    <BSb>0</BSb>
+    <BSc>0</BSc>
+    <BScm>0</BScm>
+    <BScf>0</BScf>
+    <BSd>0</BSd>
+    <BSdm>0</BSdm>
+    <BSdf>0</BSdf>
+    <BSe>0</BSe>
+    <BSem>0</BSem>
+    <BSef>0</BSef>
+    <BSf>0</BSf>
+    <BSfm>0</BSfm>
+    <BSff>0</BSff>
+    <BSfmx>0</BSfmx>
+    <BSffx>0</BSffx>
+    <BEDROOMSTAND>1</BEDROOMSTAND>
+    <BEDMINUSBEDS/>
+    <WRENTreduced>115.38</WRENTreduced>
+    <NonDepDeduct>0</NonDepDeduct>
+    <RENTHB/>
+    <ChildAllowan>0</ChildAllowan>
+    <PrsnlAllowan>117.4</PrsnlAllowan>
+    <HousBenDisAl>10</HousBenDisAl>
+    <PAIDHB/>
+    <HCNETAF/>
+    <ChldAlloCat1>0</ChldAlloCat1>
+    <ChldAlloCat2>0</ChldAlloCat2>
+    <P2NnDepDedct>0</P2NnDepDedct>
+    <P3NnDepDedct>0</P3NnDepDedct>
+    <P4NnDepDedct>0</P4NnDepDedct>
+    <P5NnDepDedct>0</P5NnDepDedct>
+    <P6NnDepDedct>0</P6NnDepDedct>
+    <P7NnDepDedct>0</P7NnDepDedct>
+    <P8NnDepDedct>0</P8NnDepDedct>
+    <DAY>5</DAY>
+    <MONTH>11</MONTH>
+    <YEAR>2021</YEAR>
+    <VDAY>24</VDAY>
+    <VMONTH>8</VMONTH>
+    <VYEAR>2021</VYEAR>
+    <MRCDAY/>
+    <MRCMONTH/>
+    <MRCYEAR/>
+    <PPOSTC1>LS16</PPOSTC1>
+    <PPOSTC2>6FT</PPOSTC2>
+    <POSTCODE>LS16</POSTCODE>
+    <POSTCOD2>6FT</POSTCOD2>
+  </Group>
+</Group>

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -22,6 +22,7 @@ describe "rake core:full_import", type: :task do
 
   context "when starting a full import" do
     let(:lettings_logs_service) { instance_double(Imports::LettingsLogsImportService) }
+    let(:sales_logs_service) { instance_double(Imports::SalesLogsImportService) }
     let(:rent_period_service) { instance_double(Imports::OrganisationRentPeriodImportService) }
     let(:data_protection_service) { instance_double(Imports::DataProtectionConfirmationImportService) }
     let(:user_service) { instance_double(Imports::UserImportService) }
@@ -37,6 +38,7 @@ describe "rake core:full_import", type: :task do
       allow(Imports::DataProtectionConfirmationImportService).to receive(:new).and_return(data_protection_service)
       allow(Imports::OrganisationRentPeriodImportService).to receive(:new).and_return(rent_period_service)
       allow(Imports::LettingsLogsImportService).to receive(:new).and_return(lettings_logs_service)
+      allow(Imports::SalesLogsImportService).to receive(:new).and_return(sales_logs_service)
     end
 
     it "raises an exception if no parameters are provided" do
@@ -54,6 +56,7 @@ describe "rake core:full_import", type: :task do
         expect(data_protection_service).to receive(:create_data_protection_confirmations).with("dataprotect")
         expect(rent_period_service).to receive(:create_organisation_rent_periods).with("rent-period")
         expect(lettings_logs_service).to receive(:create_logs).with("logs")
+        expect(sales_logs_service).to receive(:create_logs).with("logs")
 
         task.invoke(fixture_path)
       end
@@ -73,6 +76,7 @@ describe "rake core:full_import", type: :task do
         expect(data_protection_service).to receive(:create_data_protection_confirmations)
         expect(rent_period_service).to receive(:create_organisation_rent_periods)
         expect(lettings_logs_service).to receive(:create_logs)
+        expect(sales_logs_service).to receive(:create_logs)
 
         expect(scheme_service).not_to receive(:create_schemes)
         expect(location_service).not_to receive(:create_scheme_locations)

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -56,7 +56,7 @@ describe "rake core:full_import", type: :task do
         expect(data_protection_service).to receive(:create_data_protection_confirmations).with("dataprotect")
         expect(rent_period_service).to receive(:create_organisation_rent_periods).with("rent-period")
         expect(lettings_logs_service).to receive(:create_logs).with("logs")
-        expect(sales_logs_service).to receive(:create_logs).with("logs")
+        # expect(sales_logs_service).to receive(:create_logs).with("logs")
 
         task.invoke(fixture_path)
       end
@@ -76,7 +76,7 @@ describe "rake core:full_import", type: :task do
         expect(data_protection_service).to receive(:create_data_protection_confirmations)
         expect(rent_period_service).to receive(:create_organisation_rent_periods)
         expect(lettings_logs_service).to receive(:create_logs)
-        expect(sales_logs_service).to receive(:create_logs)
+        # expect(sales_logs_service).to receive(:create_logs)
 
         expect(scheme_service).not_to receive(:create_schemes)
         expect(location_service).not_to receive(:create_scheme_locations)

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -47,11 +47,12 @@ RSpec.describe Imports::LettingsLogsImportService do
     let(:lettings_log_id2) { "166fc004-392e-47a8-acb8-1c018734882b" }
     let(:lettings_log_id3) { "00d2343e-d5fa-4c89-8400-ec3854b0f2b4" }
     let(:lettings_log_id4) { "0b4a68df-30cc-474a-93c0-a56ce8fdad3b" }
+    let(:sales_log) { "shared_ownership_sales_log" }
 
     before do
       # Stub the S3 file listing and download
       allow(storage_service).to receive(:list_files)
-                                  .and_return(%W[#{remote_folder}/#{lettings_log_id}.xml #{remote_folder}/#{lettings_log_id2}.xml #{remote_folder}/#{lettings_log_id3}.xml #{remote_folder}/#{lettings_log_id4}.xml])
+                                  .and_return(%W[#{remote_folder}/#{lettings_log_id}.xml #{remote_folder}/#{lettings_log_id2}.xml #{remote_folder}/#{lettings_log_id3}.xml #{remote_folder}/#{lettings_log_id4}.xml #{remote_folder}/#{sales_log}.xml])
       allow(storage_service).to receive(:get_file_io)
                                   .with("#{remote_folder}/#{lettings_log_id}.xml")
                                   .and_return(open_file(fixture_directory, lettings_log_id), open_file(fixture_directory, lettings_log_id))
@@ -64,6 +65,9 @@ RSpec.describe Imports::LettingsLogsImportService do
       allow(storage_service).to receive(:get_file_io)
                                   .with("#{remote_folder}/#{lettings_log_id4}.xml")
                                   .and_return(open_file(fixture_directory, lettings_log_id4), open_file(fixture_directory, lettings_log_id4))
+      allow(storage_service).to receive(:get_file_io)
+                                  .with("#{remote_folder}/#{sales_log}.xml")
+                                  .and_return(open_file(fixture_directory, sales_log), open_file(fixture_directory, sales_log))
     end
 
     it "successfully create all lettings logs" do

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Imports::SalesLogsImportService do
     before do
       # Stub the S3 file listing and download
       allow(storage_service).to receive(:list_files)
-                                  .and_return(%W[#{remote_folder}/shared_ownership_sales_log.xml #{remote_folder}/shared_ownership_sales_log2.xml #{remote_folder}/outright_sale_sales_log.xml #{remote_folder}/discounted_ownership_sales_log.xml])
+                                  .and_return(%W[#{remote_folder}/shared_ownership_sales_log.xml #{remote_folder}/shared_ownership_sales_log2.xml #{remote_folder}/outright_sale_sales_log.xml #{remote_folder}/discounted_ownership_sales_log.xml #{remote_folder}/lettings_log.xml])
       allow(storage_service).to receive(:get_file_io)
                                   .with("#{remote_folder}/shared_ownership_sales_log.xml")
                                   .and_return(open_file(fixture_directory, "shared_ownership_sales_log"), open_file(fixture_directory, "shared_ownership_sales_log"))
@@ -51,6 +51,9 @@ RSpec.describe Imports::SalesLogsImportService do
       allow(storage_service).to receive(:get_file_io)
                                   .with("#{remote_folder}/discounted_ownership_sales_log.xml")
                                   .and_return(open_file(fixture_directory, "discounted_ownership_sales_log"), open_file(fixture_directory, "discounted_ownership_sales_log"))
+      allow(storage_service).to receive(:get_file_io)
+                                  .with("#{remote_folder}/lettings_log.xml")
+                                  .and_return(open_file(fixture_directory, "lettings_log"), open_file(fixture_directory, "lettings_log"))
     end
 
     it "successfully creates all sales logs" do


### PR DESCRIPTION
- Check the header of XML files for the type of log before importing. 
The logs folder for the dry run contains all of the logs (sales and lettings), for the future uploads those shouldn't be too hard to get the separated logs, but adding the check here for the purpose of testing

- Backfill ownership type if only the type is given
 
- Only import jointmore if it's a joint purchase, because it only gets asked then
 
- Look at an extra column for proplen, because it might be coming through both columns
 
- If not answered, set default to "Don't know" for the following questions:
  - What organisations were the buyers registered with? 
  - Buyer 1’s income used for mortgage application?
  - Buyer 2’s income used for mortgage application?
  - Was a mortgage used for the purchase of this property?
 
- Remove mapping for totadult, totchild and hhtype, because we infer it