### PR TITLE
Blank out incompatible data when importing from CDS

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -24,11 +24,11 @@ module Validations::FinancialValidations
   def validate_net_income(record)
     if record.ecstat1 && record.weekly_net_income
       if record.weekly_net_income > record.applicable_income_range.hard_max
-        record.errors.add :earnings, I18n.t("validations.financial.earnings.over_hard_max", hard_max: record.applicable_income_range.hard_max)
+        record.errors.add :earnings, :over_hard_max, message: I18n.t("validations.financial.earnings.over_hard_max", hard_max: record.applicable_income_range.hard_max)
       end
 
       if record.weekly_net_income < record.applicable_income_range.hard_min
-        record.errors.add :earnings, I18n.t("validations.financial.earnings.under_hard_min", hard_min: record.applicable_income_range.hard_min)
+        record.errors.add :earnings, :under_hard_min, message: I18n.t("validations.financial.earnings.under_hard_min", hard_min: record.applicable_income_range.hard_min)
       end
     end
 

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -67,7 +67,7 @@ module Validations::HouseholdValidations
     end
 
     if record.age1.present? && record.age1 > 19 && record.previous_tenancy_was_foster_care?
-      record.errors.add :prevten, I18n.t("validations.household.prevten.over_20_foster_care")
+      record.errors.add :prevten, :over_20_foster_care, message: I18n.t("validations.household.prevten.over_20_foster_care")
       record.errors.add :age1, I18n.t("validations.household.age.lead.over_20")
     end
 

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -287,6 +287,27 @@ module Imports
         @logs_overridden << lettings_log.old_id
         attributes.delete("referral")
         save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:earnings, :under_hard_min)
+        @logger.warn("Log #{lettings_log.old_id}: Where the income is 0, set earnings and income to blank and set incref to refused")
+        @logs_overridden << lettings_log.old_id
+
+        attributes.delete("earnings")
+        attributes.delete("incfreq")
+        attributes["incref"] = 1
+        attributes["net_income_known"] = 2
+        save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.include?(:tenancylength) && lettings_log.errors.include?(:tenancy)
+        @logger.warn("Log #{lettings_log.old_id}: Removing tenancylength as invalid")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("tenancylength")
+        attributes.delete("tenancy")
+        save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:prevten, :over_20_foster_care)
+        @logger.warn("Log #{lettings_log.old_id}: Removing age1 and prevten as incompatible")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("prevten")
+        attributes.delete("age1")
+        save_lettings_log(attributes, previous_status)
       else
         @logger.error("Log #{lettings_log.old_id}: Failed to import")
         raise exception


### PR DESCRIPTION
While importing data from CDS we might encounter hard validations where the new service is more strict. We do have a pattern for blanking values where they are incompatible so that the user can enter them properly. This expands on that pattern for three new conditions described below.

This covers the following errors:

- Where the income is 0, set earnings and income to blank and set incref to refused
- Removing invalid tenancylength and tenancy values where tenancylength is invalid
- Removing prevten and age1 where incompatible