### PR TITLE
Allow empty `chcharge` values whilst `is_carehome` is set to true

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -111,9 +111,11 @@ module Validations::FinancialValidations
   def validate_care_home_charges(record)
     if record.is_carehome?
       period = record.form.get_question("period", record).label_from_value(record.period).downcase
+      # NOTE: This is a temporary change to allow `ccharge` values despite `is_carehome` being true. This value
+      # is going to be moved to a soft validation in CLDC-2074, so we can safely do this.
       if record.chcharge.blank?
-        record.errors.add :is_carehome, I18n.t("validations.financial.carehome.not_provided", period:)
-        record.errors.add :chcharge, I18n.t("validations.financial.carehome.not_provided", period:)
+        # record.errors.add :is_carehome, I18n.t("validations.financial.carehome.not_provided", period:)
+        # record.errors.add :chcharge, I18n.t("validations.financial.carehome.not_provided", period:)
       elsif !weekly_value_in_range(record, "chcharge", 10, 1000)
         max_chcharge = record.weekly_to_value_per_period(1000)
         min_chcharge = record.weekly_to_value_per_period(10)

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -990,7 +990,7 @@ RSpec.describe Validations::FinancialValidations do
       end
 
       context "and charges are not provided" do
-        it "throws and error" do
+        xit "throws and error" do
           record.period = 3
           record.chcharge = nil
           financial_validator.validate_care_home_charges(record)


### PR DESCRIPTION
- This validation is new to this service. The old CORE did not do it.
- A decision was decided to move this to a soft validation in CLDC-2074
- Before this change has been completed we have to do migrations that are incompatible with this validation, so we're temporarily relaxing the constraint so we can move forward with the migration.

This PR allows empty `chcharge` values despite `is_carehome` being true. Previously, they were linked and dependent.