### PR TITLE
Make proplen optional for 22/23 collection

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -65,11 +65,6 @@ class LettingsLog < Log
     FormHandler.instance.get_form(form_name) || FormHandler.instance.current_lettings_form
   end
 
-  def recalculate_start_year!
-    @start_year = nil
-    collection_start_year
-  end
-
   def lettings?
     true
   end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -39,6 +39,11 @@ class Log < ApplicationRecord
     @start_year = startdate < window_end_date ? startdate.year - 1 : startdate.year
   end
 
+  def recalculate_start_year!
+    @start_year = nil
+    collection_start_year
+  end
+
   def lettings?
     false
   end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -24,6 +24,7 @@ class SalesLog < Log
   has_paper_trail
 
   validates_with SalesLogValidator
+  before_validation :recalculate_start_year!, if: :saledate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
@@ -65,7 +66,20 @@ class SalesLog < Log
   end
 
   def optional_fields
-    OPTIONAL_FIELDS
+    OPTIONAL_FIELDS + dynamically_not_required
+  end
+
+  def dynamically_not_required
+    not_required = []
+    not_required << "proplen" if proplen_optional?
+
+    not_required
+  end
+
+  def proplen_optional?
+    return false unless collection_start_year
+
+    collection_start_year < 2023
   end
 
   def not_started?

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -90,6 +90,30 @@ RSpec.describe SalesLog, type: :model do
       expect(completed_sales_log.not_started?).to be(false)
       expect(completed_sales_log.completed?).to be(true)
     end
+
+    context "when proplen is not given" do
+      before do
+        Timecop.freeze(Time.zone.local(2023, 5, 1))
+      end
+
+      after do
+        Timecop.unfreeze
+      end
+
+      it "is set to completed for a log with a saledate before 23/24" do
+        completed_sales_log.update!(proplen: nil, saledate: Time.zone.local(2022, 5, 1))
+        expect(completed_sales_log.in_progress?).to be(false)
+        expect(completed_sales_log.not_started?).to be(false)
+        expect(completed_sales_log.completed?).to be(true)
+      end
+
+      it "is set to in_progress for a log with a saledate after 23/24" do
+        completed_sales_log.update!(proplen: nil, saledate: Time.zone.local(2023, 5, 1))
+        expect(completed_sales_log.in_progress?).to be(true)
+        expect(completed_sales_log.not_started?).to be(false)
+        expect(completed_sales_log.completed?).to be(false)
+      end
+    end
   end
 
   context "when filtering by organisation" do


### PR DESCRIPTION
This is to allow imported logs without proplen to stay completed 