### PR TITLE
CLDC-1995 bulk upload handles age is not known

### DIFF
--- a/app/services/bulk_upload/lettings/row_parser.rb
+++ b/app/services/bulk_upload/lettings/row_parser.rb
@@ -16,14 +16,14 @@ class BulkUpload::Lettings::RowParser
   attribute :field_9, :integer
   attribute :field_10, :string
   attribute :field_11, :integer
-  attribute :field_12, :integer
-  attribute :field_13, :integer
-  attribute :field_14, :integer
-  attribute :field_15, :integer
-  attribute :field_16, :integer
-  attribute :field_17, :integer
-  attribute :field_18, :integer
-  attribute :field_19, :integer
+  attribute :field_12, :string
+  attribute :field_13, :string
+  attribute :field_14, :string
+  attribute :field_15, :string
+  attribute :field_16, :string
+  attribute :field_17, :string
+  attribute :field_18, :string
+  attribute :field_19, :string
   attribute :field_20, :string
   attribute :field_21, :string
   attribute :field_22, :string
@@ -627,22 +627,29 @@ private
     attributes["tenancylength"] = field_11
     attributes["declaration"] = field_132
 
-    attributes["age1_known"] = field_12.present? ? 0 : 1
-    attributes["age1"] = field_12
-    attributes["age2_known"] = field_13.present? ? 0 : 1
-    attributes["age2"] = field_13
-    attributes["age3_known"] = field_14.present? ? 0 : 1
-    attributes["age3"] = field_14
-    attributes["age4_known"] = field_15.present? ? 0 : 1
-    attributes["age4"] = field_15
-    attributes["age5_known"] = field_16.present? ? 0 : 1
-    attributes["age5"] = field_16
-    attributes["age6_known"] = field_17.present? ? 0 : 1
-    attributes["age6"] = field_17
-    attributes["age7_known"] = field_18.present? ? 0 : 1
-    attributes["age7"] = field_18
-    attributes["age8_known"] = field_19.present? ? 0 : 1
-    attributes["age8"] = field_19
+    attributes["age1_known"] = field_12 == "R" ? 1 : 0
+    attributes["age1"] = field_12 if attributes["age1_known"].zero?
+
+    attributes["age2_known"] = field_13 == "R" ? 1 : 0
+    attributes["age2"] = field_13 if attributes["age2_known"].zero?
+
+    attributes["age3_known"] = field_14 == "R" ? 1 : 0
+    attributes["age3"] = field_14 if attributes["age3_known"].zero?
+
+    attributes["age4_known"] = field_15 == "R" ? 1 : 0
+    attributes["age4"] = field_15 if attributes["age4_known"].zero?
+
+    attributes["age5_known"] = field_16 == "R" ? 1 : 0
+    attributes["age5"] = field_16 if attributes["age5_known"].zero?
+
+    attributes["age6_known"] = field_17 == "R" ? 1 : 0
+    attributes["age6"] = field_17 if attributes["age6_known"].zero?
+
+    attributes["age7_known"] = field_18 == "R" ? 1 : 0
+    attributes["age7"] = field_18 if attributes["age7_known"].zero?
+
+    attributes["age8_known"] = field_19 == "R" ? 1 : 0
+    attributes["age8"] = field_19 if attributes["age8_known"].zero?
 
     attributes["sex1"] = field_20
     attributes["sex2"] = field_21

--- a/spec/services/bulk_upload/lettings/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/csv_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkUpload::Lettings::CsvParser do
     end
 
     it "parses csv correctly" do
-      expect(service.row_parsers[0].field_12).to eq(55)
+      expect(service.row_parsers[0].field_12.to_i).to eq(55)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe BulkUpload::Lettings::CsvParser do
     end
 
     it "parses csv correctly" do
-      expect(service.row_parsers[0].field_12).to eql(log.age1)
+      expect(service.row_parsers[0].field_12.to_i).to eql(log.age1)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe BulkUpload::Lettings::CsvParser do
     end
 
     it "parses csv correctly" do
-      expect(service.row_parsers[0].field_12).to eql(log.age1)
+      expect(service.row_parsers[0].field_12.to_i).to eql(log.age1)
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe BulkUpload::Lettings::CsvParser do
     end
 
     it "parses csv correctly" do
-      expect(service.row_parsers[0].field_12).to eql(log.age1)
+      expect(service.row_parsers[0].field_12.to_i).to eql(log.age1)
     end
   end
 end

--- a/spec/services/bulk_upload/lettings/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/row_parser_spec.rb
@@ -680,6 +680,43 @@ RSpec.describe BulkUpload::Lettings::RowParser do
   end
 
   describe "#log" do
+    [
+      %w[age1_known age1 field_12],
+      %w[age2_known age2 field_13],
+      %w[age3_known age3 field_14],
+      %w[age4_known age4 field_15],
+      %w[age5_known age5 field_16],
+      %w[age6_known age6 field_17],
+      %w[age7_known age7 field_18],
+      %w[age8_known age8 field_19],
+    ].each do |known, age, field|
+      describe "##{known} and ##{age}" do
+        context "when #{field} is R" do
+          let(:attributes) { { bulk_upload:, field.to_s => "R" } }
+
+          it "sets ##{known} 1" do
+            expect(parser.log.public_send(known)).to be(1)
+          end
+
+          it "sets ##{age} to nil" do
+            expect(parser.log.public_send(age)).to be_nil
+          end
+        end
+
+        context "when #{field} is a number" do
+          let(:attributes) { { bulk_upload:, field.to_s => "50" } }
+
+          it "sets ##{known} to 0" do
+            expect(parser.log.public_send(known)).to be(0)
+          end
+
+          it "sets ##{age} to given age" do
+            expect(parser.log.public_send(age)).to be(50)
+          end
+        end
+      end
+    end
+
     describe "#location" do
       context "when lookup is via new core id" do
         let(:attributes) { { bulk_upload:, field_4: scheme.old_visible_id, field_5: location.id, field_111: owning_org } }


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1995
- For bulk upload age can also be a string of `R` which represents that they don't know the answer

# Changes

- Handle `R` as an option for ages