### PR TITLE
CLDC-1846 Derive hhmemb from hholdcount

### DIFF
--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -21,11 +21,18 @@ module DerivedVariables::SalesLogVariables
     self.pcode1, self.pcode2 = postcode_full.split(" ") if postcode_full.present?
     self.totchild = total_child
     self.totadult = total_adult + total_elder
-    self.hhmemb = totchild + totadult
+    self.hhmemb = number_of_household_members
     self.hhtype = household_type
   end
 
 private
+
+  def number_of_household_members
+    return unless hholdcount.present? && jointpur.present?
+
+    number_of_buyers = joint_purchase? ? 2 : 1
+    hholdcount + number_of_buyers
+  end
 
   def total_elder
     ages = [age1, age2, age3, age4, age5, age6]

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -422,7 +422,8 @@ module Imports
         age = string_or_nil(xml_doc, "P#{person_index}Age")
         gender = string_or_nil(xml_doc, "P#{person_index}Sex")
         relationship = string_or_nil(xml_doc, "P#{person_index}Rel")
-        if gender.present? || age.present? || relationship.present?
+        economic_status = string_or_nil(xml_doc, "P#{person_index}Eco")
+        if gender.present? || age.present? || relationship.present? || economic_status.present?
           highest_person_index_with_details = person_index
         end
       end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -39,7 +39,8 @@ module Imports
       attributes["jointmore"] = unsafe_string_as_integer(xml_doc, "JointMore") if attributes["jointpur"] == 1
       attributes["beds"] = safe_string_as_integer(xml_doc, "Q11Bedrooms")
       attributes["companybuy"] = unsafe_string_as_integer(xml_doc, "company") if attributes["ownershipsch"] == 3
-      attributes["hhmemb"] = safe_string_as_integer(xml_doc, "HHMEMB")
+      attributes["hholdcount"] = other_household_members(xml_doc, attributes)
+      attributes["hhmemb"] = household_members(xml_doc, attributes)
       (1..6).each do |index|
         attributes["age#{index}"] = safe_string_as_integer(xml_doc, "P#{index}Age")
         attributes["sex#{index}"] = sex(xml_doc, index)
@@ -62,7 +63,6 @@ module Imports
       attributes["noint"] = unsafe_string_as_integer(xml_doc, "PartAPurchaser")
       attributes["buy2livein"] = unsafe_string_as_integer(xml_doc, "LiveInBuyer2")
       attributes["wheel"] = unsafe_string_as_integer(xml_doc, "Q10Wheelchair")
-      attributes["hholdcount"] = safe_string_as_integer(xml_doc, "LiveInOther")
       attributes["la"] = string_or_nil(xml_doc, "Q14ONSLACode")
       attributes["income1"] = safe_string_as_integer(xml_doc, "Q2Person1Income")
       attributes["income1nk"] = income_known(unsafe_string_as_integer(xml_doc, "P1IncKnown"))
@@ -407,6 +407,35 @@ module Imports
       end
     end
 
+    def other_household_members(xml_doc, attributes)
+      hholdcount = safe_string_as_integer(xml_doc, "LiveInOther")
+      return hholdcount if hholdcount.present?
+
+      other_people_with_details(xml_doc, attributes)
+    end
+
+    def other_people_with_details(xml_doc, attributes)
+      number_of_buyers = attributes["jointpur"] == 1 ? 2 : 1
+      highest_person_index_with_details = number_of_buyers
+
+      (2..6).each do |person_index|
+        age = string_or_nil(xml_doc, "P#{person_index}Age")
+        gender = string_or_nil(xml_doc, "P#{person_index}Sex")
+        relationship = string_or_nil(xml_doc, "P#{person_index}Rel")
+        if gender.present? || age.present? || relationship.present?
+          highest_person_index_with_details = person_index
+        end
+      end
+
+      highest_person_index_with_details - number_of_buyers
+    end
+
+    def household_members(_xml_doc, attributes)
+      return attributes["hholdcount"] + 2 if attributes["jointpur"] == 1
+
+      attributes["hholdcount"] + 1 if attributes["jointpur"] == 2
+    end
+
     def set_default_values(attributes)
       attributes["armedforcesspouse"] ||= 7
       attributes["hhregres"] ||= 8
@@ -429,7 +458,6 @@ module Imports
       attributes["national"] ||= 13
       attributes["ecstat1"] ||= 10
       attributes["income1nk"] ||= attributes["income1"].present? ? 0 : 1
-      attributes["hholdcount"] ||= default_household_count(attributes) # just for testing, might need to change
 
       # buyer 2 characteristics
       if attributes["jointpur"] == 1
@@ -453,14 +481,6 @@ module Imports
     def missing_answers(sales_log)
       applicable_questions = sales_log.form.subsections.map { |s| s.applicable_questions(sales_log).select { |q| q.enabled?(sales_log) } }.flatten
       applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id)
-    end
-
-    # just for testing, logic will need to change to match the number of people details known
-    def default_household_count(attributes)
-      return 0 if attributes["hhmemb"].zero? || attributes["hhmemb"].blank?
-
-      household_count = attributes["jointpur"] == 1 ? attributes["hhmemb"] - 2 : attributes["hhmemb"] - 1
-      household_count.positive? ? household_count : 0
     end
   end
 end

--- a/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
@@ -292,7 +292,7 @@
     <Q43CashDeposit override-field=""/>
   </Group>
   <Group>
-    <HHMEMB>0</HHMEMB>
+    <HHMEMB>1</HHMEMB>
     <TOTADULT>0</TOTADULT>
     <TOTCHILD>0</TOTCHILD>
   </Group>

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -283,6 +283,12 @@ RSpec.describe SalesLog, type: :model do
       expect(record_from_db["hhmemb"]).to eq(6)
     end
 
+    it "correctly derives and saves hhmemb if it's a joint purchase" do
+      sales_log.update!(jointpur: 2, jointmore: 2)
+      record_from_db = ActiveRecord::Base.connection.execute("select hhmemb from sales_logs where id=#{sales_log.id}").to_a[0]
+      expect(record_from_db["hhmemb"]).to eq(5)
+    end
+
     it "correctly derives and saves totchild" do
       record_from_db = ActiveRecord::Base.connection.execute("select totchild from sales_logs where id=#{sales_log.id}").to_a[0]
       expect(record_from_db["totchild"]).to eq(2)

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -543,10 +543,26 @@ RSpec.describe Imports::SalesLogsImportService do
           allow(logger).to receive(:warn).and_return(nil)
         end
 
-        it "sets hholdcount to hhmemb - 1 if not answered and not joint purchase" do
-          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = "3"
+        it "sets hholdcount to last person the information is given for if HHMEMB is not set" do
           sales_log_xml.at_xpath("//xmlns:joint").content = "2 No"
-          sales_log_xml.at_xpath("//xmlns:LiveInOther").content = ""
+          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Age").content = "20"
+          sales_log_xml.at_xpath("//xmlns:P3Sex").content = "R"
+          sales_log_xml.at_xpath("//xmlns:P4Age").content = "23"
+
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.hholdcount).to eq(3)
+        end
+
+        it "sets hholdcount to last person the information is given for - buyers if HHMEMB is 0" do
+          sales_log_xml.at_xpath("//xmlns:joint").content = "1 Yes"
+          sales_log_xml.at_xpath("//xmlns:JointMore").content = "2 No"
+          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Age").content = "20"
+          sales_log_xml.at_xpath("//xmlns:P3Sex").content = "R"
+          sales_log_xml.at_xpath("//xmlns:P4Age").content = "23"
 
           sales_log_service.send(:create_log, sales_log_xml)
 
@@ -554,23 +570,34 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.hholdcount).to eq(2)
         end
 
-        it "sets hholdcount to hhmemb - 2 if not answered and joint purchase" do
+        it "sets hholdcount to 0 no information for people is given and HHMEMB is not set" do
           sales_log_xml.at_xpath("//xmlns:joint").content = "1 Yes"
           sales_log_xml.at_xpath("//xmlns:JointMore").content = "2 No"
-          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = "3"
+          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = ""
           sales_log_xml.at_xpath("//xmlns:LiveInOther").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Sex").content = ""
+          sales_log_xml.at_xpath("//xmlns:P3Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P3Sex").content = ""
+          sales_log_xml.at_xpath("//xmlns:P4Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P4Sex").content = ""
 
           sales_log_service.send(:create_log, sales_log_xml)
 
           sales_log = SalesLog.find_by(old_id: sales_log_id)
-          expect(sales_log&.hholdcount).to eq(1)
+          expect(sales_log&.hholdcount).to eq(0)
         end
 
-        it "sets hholdcount to 0 if HHMEMB is 0" do
-          sales_log_xml.at_xpath("//xmlns:joint").content = "1 Yes"
-          sales_log_xml.at_xpath("//xmlns:JointMore").content = "2 No"
+        it "sets hholdcount to the 0 if no information for people is given and HHMEMB is 0" do
+          sales_log_xml.at_xpath("//xmlns:joint").content = "2 No"
           sales_log_xml.at_xpath("//xmlns:HHMEMB").content = "0"
           sales_log_xml.at_xpath("//xmlns:LiveInOther").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P2Sex").content = ""
+          sales_log_xml.at_xpath("//xmlns:P3Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P3Sex").content = ""
+          sales_log_xml.at_xpath("//xmlns:P4Age").content = ""
+          sales_log_xml.at_xpath("//xmlns:P4Sex").content = ""
 
           sales_log_service.send(:create_log, sales_log_xml)
 


### PR DESCRIPTION
Instead of looking at totadult and totchild, derive the number of total household members from other household members + buyers, because totadult and totchild depend on ages and would be 0 is none of the ages are given.

Adjust the import to calculate household members and other household members