### PR TITLE
CLDC-1938 Fix household members import 

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -432,9 +432,11 @@ module Imports
     end
 
     def household_members(_xml_doc, attributes)
-      return attributes["hholdcount"] + 2 if attributes["jointpur"] == 1
-
-      attributes["hholdcount"] + 1 if attributes["jointpur"] == 2
+      if attributes["jointpur"] == 2
+        attributes["hholdcount"] + 1
+      else
+        attributes["hholdcount"] + 2
+      end
     end
 
     def set_default_values(attributes)

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -604,6 +604,13 @@ RSpec.describe Imports::SalesLogsImportService do
           sales_log = SalesLog.find_by(old_id: sales_log_id)
           expect(sales_log&.hholdcount).to eq(0)
         end
+
+        it "doesn't hang if jointpur is not given" do
+          sales_log_xml.at_xpath("//xmlns:joint").content = ""
+          sales_log_xml.at_xpath("//xmlns:HHMEMB").content = "0"
+
+          sales_log_service.send(:create_log, sales_log_xml)
+        end
       end
 
       context "when inferring income used" do


### PR DESCRIPTION
Logs for 21/22 don't have joint purchase field, so they fail when setting hhmemb during the import. 
We're not going to import those logs, but we don't want the import to fail when testing