### PR TITLE
CLDC-1938 Partial postcode and previous tenure import fixes

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -460,6 +460,7 @@ module Imports
         attributes["pregblank"] = 1
       end
       attributes["pcodenk"] ||= 1
+      attributes["prevten"] ||= 0
 
       # buyer 1 characteristics
       attributes["age1_known"] ||= 1

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -493,7 +493,7 @@ module Imports
 
     def missing_answers(sales_log)
       applicable_questions = sales_log.form.subsections.map { |s| s.applicable_questions(sales_log).select { |q| q.enabled?(sales_log) } }.flatten
-      applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id)
+      applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id) - sales_log.optional_fields
     end
   end
 end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -122,8 +122,6 @@ module Imports
       attributes["socprevten"] = unsafe_string_as_integer(xml_doc, "PrevRentType")
       attributes["mortgagelender"] = mortgage_lender(xml_doc, attributes)
       attributes["mortgagelenderother"] = mortgage_lender_other(xml_doc, attributes)
-      attributes["pcode1"] = string_or_nil(xml_doc, "PCODE1")
-      attributes["pcode2"] = string_or_nil(xml_doc, "PCODE2")
       attributes["postcode_full"] = parse_postcode(string_or_nil(xml_doc, "Q14Postcode"))
       attributes["pcodenk"] = 0 if attributes["postcode_full"].present? # known if given
       attributes["soctenant"] = soctenant(attributes)

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -800,6 +800,30 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.status).to eq("completed")
         end
       end
+
+      context "when setting default buyer 1 previous tenancy" do
+        let(:sales_log_id) { "outright_sale_sales_log" }
+
+        before do
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "sets prevten to don't know if not answered" do
+          sales_log_xml.at_xpath("//xmlns:Q6PrevTenure").content = ""
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.prevten).to eq(0) # don't know
+        end
+
+        it "sets prevten to correctly if answered" do
+          sales_log_xml.at_xpath("//xmlns:Q6PrevTenure").content = "2 Private registered provider (PRP) or housing association tenant"
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.prevten).to eq(2)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Do not import partial postcode, because we infer that
Set default previous tenure to "Don't know" if the log is completed