### PR TITLE
CLDC-1938 Import LA and mortgage used fixes

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -110,7 +110,7 @@ module Imports
       attributes["prevten"] = unsafe_string_as_integer(xml_doc, "Q6PrevTenure")
       attributes["mortlen"] = mortgage_length(xml_doc, attributes)
       attributes["extrabor"] = borrowing(xml_doc, attributes)
-      attributes["mortgageused"] = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
+      attributes["mortgageused"] = mortgage_used(xml_doc, attributes)
       attributes["wchair"] = unsafe_string_as_integer(xml_doc, "Q15Wheelchair")
       attributes["armedforcesspouse"] = unsafe_string_as_integer(xml_doc, "ARMEDFORCESSPOUSE")
       attributes["hodate"] = compose_date(xml_doc, "HODAY", "HOMONTH", "HOYEAR")
@@ -442,6 +442,17 @@ module Imports
       return if postcode.blank?
 
       UKPostcode.parse(postcode).to_s
+    end
+
+    def mortgage_used(xml_doc, attributes)
+      mortgageused = unsafe_string_as_integer(xml_doc, "MORTGAGEUSED")
+      return mortgageused unless mortgageused == 3
+
+      if attributes["mortgage"].present? || attributes["mortlen"].present? || attributes["extrabor"].present?
+        1 # yes
+      else
+        3 # don't know
+      end
     end
 
     def set_default_values(attributes)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -76,7 +76,7 @@ module Imports
       attributes["inc2mort"] = unsafe_string_as_integer(xml_doc, "Q2Person2MortApplication")
       attributes["hb"] = unsafe_string_as_integer(xml_doc, "Q2a")
       attributes["frombeds"] = safe_string_as_integer(xml_doc, "Q20Bedrooms")
-      attributes["staircase"] = unsafe_string_as_integer(xml_doc, "Q17aStaircase")
+      attributes["staircase"] = unsafe_string_as_integer(xml_doc, "Q17aStaircase") if attributes["ownershipsch"] == 1
       attributes["stairbought"] = safe_string_as_integer(xml_doc, "PercentBought")
       attributes["stairowned"] = safe_string_as_integer(xml_doc, "PercentOwns") if attributes["staircase"] == 1
       attributes["mrent"] = safe_string_as_decimal(xml_doc, "Q28MonthlyRent")
@@ -102,7 +102,6 @@ module Imports
       attributes["ppcodenk"] = previous_postcode_known(xml_doc, attributes["ppostcode_full"], attributes["prevloc"]) # Q7UNKNOWNPOSTCODE check mapping
       attributes["ppostc1"] = string_or_nil(xml_doc, "PPOSTC1")
       attributes["ppostc2"] = string_or_nil(xml_doc, "PPOSTC2")
-      attributes["previous_la_known"] = nil
       attributes["hhregres"] = unsafe_string_as_integer(xml_doc, "ArmedF")
       attributes["hhregresstill"] = still_serving(xml_doc)
       attributes["proplen"] = safe_string_as_integer(xml_doc, "Q16aProplen2") || safe_string_as_integer(xml_doc, "Q16aProplensec2")
@@ -130,9 +129,8 @@ module Imports
       attributes["prevshared"] = nil # 23/24 variable
       attributes["staircasesale"] = nil # 23/24 variable
 
-      # Required for our form invalidated questions (not present in import)
-      attributes["previous_la_known"] = 1 if attributes["prevloc"].present? && attributes["ppostcode_full"].blank?
-      if attributes["la"].present? && attributes["postcode_full"].blank?
+      attributes["previous_la_known"] = 1 if attributes["prevloc"].present?
+      if attributes["la"].present?
         attributes["la_known"] = 1
         attributes["is_la_inferred"] = false
       end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -18,7 +18,7 @@ module Imports
     def create_log(xml_doc)
       # only import sales logs from 22/23 collection period onwards
       return unless meta_field_value(xml_doc, "form-name").include?("Sales")
-      return unless compose_date(xml_doc, "DAY", "MONTH", "YEAR") > Time.zone.local(2022, 4, 1)
+      return unless compose_date(xml_doc, "DAY", "MONTH", "YEAR") >= Time.zone.local(2022, 4, 1)
 
       attributes = {}
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -16,7 +16,9 @@ module Imports
   private
 
     def create_log(xml_doc)
+      # only import sales logs from 22/23 collection period onwards
       return unless meta_field_value(xml_doc, "form-name").include?("Sales")
+      return unless compose_date(xml_doc, "DAY", "MONTH", "YEAR") > Time.zone.local(2022, 4, 1)
 
       attributes = {}
 

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -822,7 +822,6 @@ RSpec.describe Imports::SalesLogsImportService do
 
           sales_log = SalesLog.find_by(old_id: sales_log_id)
           expect(sales_log&.pcodenk).to eq(0) # postcode known
-          # expect(sales_log&.is_la_inferred).to eq(nil)
           expect(sales_log&.la_known).to eq(1) # la known
           expect(sales_log&.la).to eq("E07000142")
           expect(sales_log&.status).to eq("completed")

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and the log startdate is before 22/23 collection period" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:DAY").content = 10
+        sales_log_xml.at_xpath("//xmlns:MONTH").content = 10
+        sales_log_xml.at_xpath("//xmlns:YEAR").content = 2021
+        sales_log_xml.at_xpath("//xmlns:HODAY").content = 9
+        sales_log_xml.at_xpath("//xmlns:HOMONTH").content = 10
+        sales_log_xml.at_xpath("//xmlns:HOYEAR").content = 2021
+        sales_log_xml.at_xpath("//xmlns:EXDAY").content = 9
+        sales_log_xml.at_xpath("//xmlns:EXMONTH").content = 10
+        sales_log_xml.at_xpath("//xmlns:EXYEAR").content = 2021
+      end
+
+      it "does not create the log" do
+        expect(logger).not_to receive(:error)
+        expect(logger).not_to receive(:warn)
+        expect { sales_log_service.send(:create_log, sales_log_xml) }
+        .to change(SalesLog, :count).by(0)
+      end
+    end
+
     context "when the mortgage lender is set to an existing option" do
       let(:sales_log_id) { "discounted_ownership_sales_log" }
 

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -829,6 +829,59 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.prevten).to eq(2)
         end
       end
+
+      context "when mortgage used is don't know" do
+        let(:sales_log_id) { "discounted_ownership_sales_log" }
+
+        before do
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "sets mortgageused to don't know if mortlen, mortgage and extrabor are blank" do
+          sales_log_xml.at_xpath("//xmlns:MORTGAGEUSED").content = "3 Don't know"
+          sales_log_xml.at_xpath("//xmlns:Q35Borrowing").content = ""
+          sales_log_xml.at_xpath("//xmlns:Q34b").content = ""
+          sales_log_xml.at_xpath("//xmlns:CALCMORT").content = ""
+          sales_log_xml.at_xpath("//xmlns:Q36CashDeposit").content = "134750"
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.mortgageused).to eq(3)
+        end
+
+        it "sets mortgageused to yes if mortgage is given" do
+          sales_log_xml.at_xpath("//xmlns:MORTGAGEUSED").content = "3 Don't know"
+          sales_log_xml.at_xpath("//xmlns:Q35Borrowing").content = ""
+          sales_log_xml.at_xpath("//xmlns:Q34b").content = ""
+          sales_log_xml.at_xpath("//xmlns:CALCMORT").content = "134750"
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.mortgageused).to eq(1)
+        end
+
+        it "sets mortgageused to yes if mortlen is given" do
+          sales_log_xml.at_xpath("//xmlns:MORTGAGEUSED").content = "3 Don't know"
+          sales_log_xml.at_xpath("//xmlns:Q35Borrowing").content = ""
+          sales_log_xml.at_xpath("//xmlns:Q34b").content = "10"
+          sales_log_xml.at_xpath("//xmlns:CALCMORT").content = ""
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.mortgageused).to eq(1)
+        end
+
+        it "sets mortgageused to yes if extrabor is given" do
+          sales_log_xml.at_xpath("//xmlns:MORTGAGEUSED").content = "3 Don't know"
+          sales_log_xml.at_xpath("//xmlns:Q35Borrowing").content = "3000"
+          sales_log_xml.at_xpath("//xmlns:Q34b").content = ""
+          sales_log_xml.at_xpath("//xmlns:CALCMORT").content = ""
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.mortgageused).to eq(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Import `staircase` if it's shared ownership only, because it is only asked for shared ownership
- Import LA manually if it cannot be inferred, this will likely result in differences when importing if it can be inferred, but no data loss
- Infer mortgage used as yes if any of the mortgage information is given, as we don't want to lose that data
- Only import 22/23 sales collection onwards, because we don't have 21/22 form on our service and it is not necessary to import those logs from the data perspective