### PR TITLE
CLDC-1938 Set soft validations to confirmed

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -142,6 +142,17 @@ module Imports
       attributes["shared_ownership_deposit_value_check"] = 0
       attributes["value_value_check"] = 0
       attributes["savings_value_check"] = 0
+      attributes["income1_value_check"] = 0
+      attributes["deposit_value_check"] = 0
+      attributes["wheel_value_check"] = 0
+      attributes["retirement_value_check"] = 0
+      attributes["extrabor_value_check"] = 0
+      attributes["grant_value_check"] = 0
+      attributes["staircase_bought_value_check"] = 0
+      attributes["deposit_and_mortgage_value_check"] = 0
+      attributes["old_persons_shared_ownership_value_check"] = 0
+      attributes["income2_value_check"] = 0
+      attributes["monthly_charges_value_check"] = 0
 
       # Sets the log creator
       owner_id = meta_field_value(xml_doc, "owner-user-id").strip
@@ -203,6 +214,7 @@ module Imports
     def fields_not_present_in_softwire_data
       %w[created_by
          income1_value_check
+         income2_value_check
          mortgage_value_check
          savings_value_check
          deposit_value_check
@@ -402,7 +414,6 @@ module Imports
     end
 
     def monthly_charges(xml_doc, attributes)
-      safe_string_as_decimal(xml_doc, "Q29MonthlyCharges")
       case attributes["ownershipsch"]
       when 1
         safe_string_as_decimal(xml_doc, "Q29MonthlyCharges")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -137,6 +137,12 @@ module Imports
         attributes["is_la_inferred"] = false
       end
 
+      # Soft validations can become required answers, set them to yes by default
+      attributes["mortgage_value_check"] = 0
+      attributes["shared_ownership_deposit_value_check"] = 0
+      attributes["value_value_check"] = 0
+      attributes["savings_value_check"] = 0
+
       # Sets the log creator
       owner_id = meta_field_value(xml_doc, "owner-user-id").strip
       if owner_id.present?

--- a/spec/fixtures/imports/sales_logs/shared_ownership_sales_log3.xml
+++ b/spec/fixtures/imports/sales_logs/shared_ownership_sales_log3.xml
@@ -144,7 +144,7 @@
     <P7RRefused>0</P7RRefused>
     <P8RRefused>0</P8RRefused>
     <TotRRefused>0</TotRRefused>
-    <CALCMORT>76000</CALCMORT>
+    <CALCMORT></CALCMORT>
     <MORTGAGEUSED>1</MORTGAGEUSED>
     <IM1>47000</IM1>
     <IM2>0</IM2>

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -203,6 +203,65 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and the mortgage soft validation is triggered (mortgage_value_check)" do
+      let(:sales_log_id) { "discounted_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q2Person1Income").content = "10"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the shared ownership deposit soft validation is triggered (shared_ownership_deposit_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:DerSaleType").content = "2"
+        sales_log_xml.at_xpath("//xmlns:CALCMORT").content = "275000"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the purchase price soft validation is triggered (value_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        LaSaleRange.create!(la: "E09000033", bedrooms: 2, soft_min: 177_000, soft_max: 384_000, start_year: 2022)
+        sales_log_xml.at_xpath("//xmlns:Q22PurchasePrice").content = "2750"
+        sales_log_xml.at_xpath("//xmlns:CALCMORT").content = "2750"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the savings soft validation is triggered (savings_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q3Savings").content = "200750"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
     context "when inferring default answers for completed sales logs" do
       context "when the armedforcesspouse is not answered" do
         let(:sales_log_id) { "discounted_ownership_sales_log" }

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -363,6 +363,37 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and it has an invalid record with invalid child, student and 16-19 age combination" do
+      let(:sales_log_id) { "discounted_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//meta:status").content = "submitted-invalid"
+        sales_log_xml.at_xpath("//xmlns:P2Age").content = 16
+        sales_log_xml.at_xpath("//xmlns:P2Eco").content = 7
+        sales_log_xml.at_xpath("//xmlns:P2Rel").content = "X"
+      end
+
+      it "intercepts the relevant validation error" do
+        expect(logger).to receive(:warn).with(/Removing field age2 from log triggering validation: Person cannot be aged 16-19 if they are a student but don't have relationship ‘child’/)
+        expect(logger).to receive(:warn).with(/Removing field relat2 from log triggering validation: Answer must be ‘child’ if the person is aged 16-19 and a student/)
+        expect(logger).to receive(:warn).with(/Removing field ecstat2 from log triggering validation: Person cannot be a student if they are aged 16-19 but don‘t have relationship ‘child’/)
+        expect { sales_log_service.send(:create_log, sales_log_xml) }
+          .not_to raise_error
+      end
+
+      it "clears out the invalid answers" do
+        allow(logger).to receive(:warn)
+
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+
+        expect(sales_log).not_to be_nil
+        expect(sales_log.age2).to be_nil
+        expect(sales_log.relat2).to be_nil
+        expect(sales_log.ecstat2).to be_nil
+      end
+    end
+
     context "when inferring default answers for completed sales logs" do
       context "when the armedforcesspouse is not answered" do
         let(:sales_log_id) { "discounted_ownership_sales_log" }

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -248,11 +248,112 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and the purchase price soft validation is triggered (income1_value_check, income2_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q2Person1Income").content = "20"
+        sales_log_xml.at_xpath("//xmlns:Q2Person2Income").content = "10"
+        sales_log_xml.at_xpath("//xmlns:P2Eco").content = "1"
+        sales_log_xml.at_xpath("//xmlns:joint").content = "1 Yes"
+        sales_log_xml.at_xpath("//xmlns:JointMore").content = "2 No"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
     context "and the savings soft validation is triggered (savings_value_check)" do
       let(:sales_log_id) { "shared_ownership_sales_log" }
 
       before do
         sales_log_xml.at_xpath("//xmlns:Q3Savings").content = "200750"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the deposit soft validation is triggered (deposit_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q3Savings").content = "10"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the wheelchair soft validation is triggered (wheel_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q10Wheelchair").content = "1"
+        sales_log_xml.at_xpath("//xmlns:Disability").content = "2"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the retirement soft validation is triggered (retirement_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:P1Eco").content = "5"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the grant soft validation is triggered (grant_value_check)" do
+      let(:sales_log_id) { "discounted_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q32Reductions").content = "5000"
+        sales_log_xml.at_xpath("//xmlns:CALCMORT").content = "270000"
+        sales_log_xml.at_xpath("//xmlns:Q33Discount").content = ""
+        sales_log_xml.at_xpath("//xmlns:DerSaleType").content = "22"
+      end
+
+      it "completes the log" do
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log.status).to eq("completed")
+      end
+    end
+
+    context "and the stairbought soft validation is triggered (staircase_bought_value_check)" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:PercentBought").content = "51"
+        sales_log_xml.at_xpath("//xmlns:PercentOwns").content = "81"
+        sales_log_xml.at_xpath("//xmlns:Q17aStaircase").content = "1"
+        sales_log_xml.at_xpath("//xmlns:Q17Resale").content = ""
+        sales_log_xml.at_xpath("//xmlns:EXDAY").content = ""
+        sales_log_xml.at_xpath("//xmlns:EXMONTH").content = ""
+        sales_log_xml.at_xpath("//xmlns:EXYEAR").content = ""
+        sales_log_xml.at_xpath("//xmlns:HODAY").content = ""
+        sales_log_xml.at_xpath("//xmlns:HOMONTH").content = ""
+        sales_log_xml.at_xpath("//xmlns:HOYEAR").content = ""
       end
 
       it "completes the log" do


### PR DESCRIPTION
- Soft validations can become required answers, set them to yes by default, following the pattern in lettings logs
- Remove invalidated field for in progress logs when importing
