### PR TITLE
CLDC-1938 Reset invalid postcodes

### DIFF
--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -14,8 +14,8 @@ module Validations::Sales::HouseholdValidations
     return unless record.postcode_full && record.ppostcode_full && record.discounted_ownership_sale?
 
     unless record.postcode_full == record.ppostcode_full
-      record.errors.add :postcode_full, I18n.t("validations.household.postcode.discounted_ownership")
-      record.errors.add :ppostcode_full, I18n.t("validations.household.postcode.discounted_ownership")
+      record.errors.add :postcode_full, :postcodes_not_matching, message: I18n.t("validations.household.postcode.discounted_ownership")
+      record.errors.add :ppostcode_full, :postcodes_not_matching, message: I18n.t("validations.household.postcode.discounted_ownership")
     end
   end
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -210,7 +210,7 @@ module Imports
 
     def reset_postcode_known(attributes)
       attributes["pcodenk"] = attributes["postcode_full"].present? ? 0 : nil
-      attributes["ppcodenk"] =  attributes["postcode_full"].present? ? 0 : nil
+      attributes["ppcodenk"] = attributes["postcode_full"].present? ? 0 : nil
     end
 
     def compute_differences(sales_log, attributes)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -192,6 +192,7 @@ module Imports
           attributes.delete(error.attribute.to_s)
         end
         @logs_overridden << sales_log.old_id
+        reset_postcode_known(attributes)
         save_sales_log(attributes, previous_status)
       else
         @logger.error("Log #{sales_log.old_id}: Failed to import")
@@ -205,6 +206,11 @@ module Imports
         end
         raise exception
       end
+    end
+
+    def reset_postcode_known(attributes)
+      attributes["pcodenk"] = attributes["postcode_full"].present? ? 0 : nil
+      attributes["ppcodenk"] =  attributes["postcode_full"].present? ? 0 : nil
     end
 
     def compute_differences(sales_log, attributes)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -210,7 +210,7 @@ module Imports
 
     def reset_postcode_known(attributes)
       attributes["pcodenk"] = attributes["postcode_full"].present? ? 0 : nil
-      attributes["ppcodenk"] = attributes["postcode_full"].present? ? 0 : nil
+      attributes["ppcodenk"] = attributes["ppostcode_full"].present? ? 0 : nil
     end
 
     def compute_differences(sales_log, attributes)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -192,7 +192,11 @@ module Imports
           attributes.delete(error.attribute.to_s)
         end
         @logs_overridden << sales_log.old_id
-        reset_postcode_known(attributes)
+        if sales_log.errors.of_kind?(:postcode_full, :postcodes_not_matching)
+          @logger.warn("Log #{sales_log.old_id}: Removing postcode known and previous postcode known as the postcodes are invalid")
+          attributes.delete("pcodenk")
+          attributes.delete("ppcodenk")
+        end
         save_sales_log(attributes, previous_status)
       else
         @logger.error("Log #{sales_log.old_id}: Failed to import")
@@ -206,11 +210,6 @@ module Imports
         end
         raise exception
       end
-    end
-
-    def reset_postcode_known(attributes)
-      attributes["pcodenk"] = attributes["postcode_full"].present? ? 0 : nil
-      attributes["ppcodenk"] = attributes["ppostcode_full"].present? ? 0 : nil
     end
 
     def compute_differences(sales_log, attributes)

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -406,8 +406,9 @@ RSpec.describe Imports::SalesLogsImportService do
       it "intercepts the relevant validation error" do
         expect(logger).to receive(:warn).with(/Removing field postcode_full from log triggering validation: Buyer's last accommodation and discounted ownership postcodes must match/)
         expect(logger).to receive(:warn).with(/Removing field ppostcode_full from log triggering validation: Buyer's last accommodation and discounted ownership postcodes must match/)
-        expect(logger).to receive(:warn).with(/Removing field postcode_full from log triggering validation: Last settled accommodation and discounted ownership property postcodes must match/)
-        expect(logger).to receive(:warn).with(/Removing field ppostcode_full from log triggering validation: Last settled accommodation and discounted ownership property postcodes must match/)
+        expect(logger).to receive(:warn).with(/Removing field postcode_full from log triggering validation: postcodes_not_matching/)
+        expect(logger).to receive(:warn).with(/Removing field ppostcode_full from log triggering validation: postcodes_not_matching/)
+        expect(logger).to receive(:warn).with(/Removing postcode known and previous postcode known as the postcodes are invalid/)
         expect { sales_log_service.send(:create_log, sales_log_xml) }
           .not_to raise_error
       end


### PR DESCRIPTION
When clearing the postcodes due to a failing validation, we want to reset the postcode known field as well, because otherwise a wrong format validation keeps triggering for (now empty) postcode field