### PR TITLE
Run CSV export before XML export to CDS

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -1,5 +1,5 @@
 data_export_csv:
-  cron: "every day at 5am"
+  cron: "every day at 4am"
   class: "DataExportCsvJob"
   queue: default
 data_export_xml:


### PR DESCRIPTION
- The XML export mutates the `LogsExport` table which determines the period in which logs are exported.
- The CSV export does not change this table, so if the CSV gets ran at the same time as the XML log it could skip records.
- In reality, the CSV export is a nice-to-have and is being depreciated.

This PR changes the CSV CDS export to run at 4am.