### PR TITLE
CLDC-1997 Infer new LAs for post 2023 logs

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -135,9 +135,34 @@ private
     process_postcode(ppostcode_full, "ppcodenk", "is_previous_la_inferred", "prevloc")
   end
 
+  LA_CHANGES = {
+    "E07000027" => "E06000063", # Barrow-in-Furness => Cumberland
+    "E07000030" => "E06000063", # Eden => Cumberland
+    "E07000031" => "E06000063", # South Lakeland => Cumberland
+    "E07000026" => "E06000064", # Allerdale => Westmorland and Furness
+    "E07000028" => "E06000064", # Carlisle => Westmorland and Furness
+    "E07000029" => "E06000064", # Copeland => Westmorland and Furness
+    "E07000163" => "E06000065", # Craven => North Yorkshire
+    "E07000164" => "E06000065", # Hambleton => North Yorkshire
+    "E07000165" => "E06000065", # Harrogate => North Yorkshire
+    "E07000166" => "E06000065", # Richmondshire => North Yorkshire
+    "E07000167" => "E06000065", # Ryedale => North Yorkshire
+    "E07000168" => "E06000065", # Scarborough => North Yorkshire
+    "E07000169" => "E06000065", # Selby => North Yorkshire
+    "E07000187" => "E06000066", # Mendip => Somerset
+    "E07000188" => "E06000066", # Sedgemoor => Somerset
+    "E07000246" => "E06000066", # Somerset West and Taunton => Somerset
+    "E07000189" => "E06000066", # South Somerset => Somerset
+  }.freeze
+
   def get_inferred_la(postcode)
     result = PIO.lookup(postcode)
-    result[:location_code] if result
+    location_code = result[:location_code] if result
+    if LA_CHANGES.key?(location_code) && form.start_date.year >= 2023
+      LA_CHANGES[location_code]
+    else
+      location_code
+    end
   end
 
   def upcase_and_remove_whitespace(string)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -247,6 +247,7 @@ RSpec.describe SalesLog, type: :model do
 
       after do
         Timecop.unfreeze
+        Singleton.__init__(FormHandler)
       end
 
       it "correctly infers new la" do

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -226,6 +226,36 @@ RSpec.describe SalesLog, type: :model do
       expect(record_from_db["la"]).to eq("E08000003")
     end
 
+    context "with 23/24 logs" do
+      let(:address_sales_log_23_24) do
+        described_class.create({
+          owning_organisation:,
+          created_by: created_by_user,
+          ppcodenk: 1,
+          postcode_full: "CA10 1AA",
+          saledate: Time.zone.local(2023, 5, 2),
+        })
+      end
+
+      before do
+        WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/CA101AA/)
+        .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Eden","codes":{"admin_district":"E07000030"}}}', headers: {})
+
+        Timecop.freeze(2023, 4, 1)
+        Singleton.__init__(FormHandler)
+      end
+
+      after do
+        Timecop.unfreeze
+      end
+
+      it "correctly infers new la" do
+        record_from_db = ActiveRecord::Base.connection.execute("select la from sales_logs where id=#{address_sales_log_23_24.id}").to_a[0]
+        expect(address_sales_log_23_24.la).to eq("E06000063")
+        expect(record_from_db["la"]).to eq("E06000063")
+      end
+    end
+
     it "errors if the property postcode is emptied" do
       expect { address_sales_log.update!({ postcode_full: "" }) }
         .to raise_error(ActiveRecord::RecordInvalid, /#{I18n.t("validations.postcode")}/)


### PR DESCRIPTION
When inferring local authorities from postcodes for 23/24 we want to infer correct local authorities.
 
The postcodes api won’t get updated with the new local authorities until around May time, so before that happens we need to map to the new LAs manually.
 
For 23/24 logs that return an old inferred LA map it to the new LA.
