### PR TITLE
CLDC-1838 update copy for both offered questions

### DIFF
--- a/app/models/form/lettings/questions/offered.rb
+++ b/app/models/form/lettings/questions/offered.rb
@@ -2,14 +2,14 @@ class Form::Lettings::Questions::Offered < ::Form::Question
   def initialize(id, hsh, page)
     super
     @id = "offered"
-    @check_answer_label = "Times previously offered since becoming available"
-    @header = "Since becoming available for re-let, how many times has the property been previously offered?"
+    @check_answer_label = I18n.t("check_answer_labels.offered")
+    @header = I18n.t("questions.offered")
     @type = "numeric"
     @width = 2
     @check_answers_card_number = 0
     @max = 150
     @min = 0
-    @hint_text = "This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
+    @hint_text = I18n.t("hints.offered")
     @step = 1
   end
 end

--- a/app/models/form/lettings/questions/offered_social_let.rb
+++ b/app/models/form/lettings/questions/offered_social_let.rb
@@ -2,14 +2,14 @@ class Form::Lettings::Questions::OfferedSocialLet < ::Form::Question
   def initialize(id, hsh, page)
     super
     @id = "offered"
-    @check_answer_label = "Times previously offered since becoming available"
-    @header = "How many times was the property offered between becoming vacant and this letting?"
+    @check_answer_label = I18n.t("check_answer_labels.offered")
+    @header = I18n.t("questions.offered")
     @type = "numeric"
     @width = 2
     @check_answers_card_number = 0
     @max = 150
     @min = 0
-    @hint_text = "Do not include the offer that led to this letting.This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
+    @hint_text = I18n.t("hints.offered")
     @step = 1
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -560,7 +560,7 @@ en:
       toggle_active: "If the date is before %{date}, select ‘From the start of the current collection period’ because the previous period has now closed."
     bulk_upload:
       needstype: "General needs housing includes both self-contained and shared housing without support or specific adaptations. Supported housing can include direct access hostels, group homes, residential care and nursing homes."
-    offered: "Do not include the offer that led to this letting.This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
+    offered: "Do not include the offer that led to this letting. This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
 
   check_answer_labels:
     soctenant:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,6 +547,7 @@ en:
     stairowned:
       one: "What percentage of the property does the buyer now own in total?"
       other: "What percentage of the property do the buyers now own in total?"
+    offered: "How many times was the property offered between becoming vacant and this letting?"
 
   hints:
     location:
@@ -559,6 +560,7 @@ en:
       toggle_active: "If the date is before %{date}, select ‘From the start of the current collection period’ because the previous period has now closed."
     bulk_upload:
       needstype: "General needs housing includes both self-contained and shared housing without support or specific adaptations. Supported housing can include direct access hostels, group homes, residential care and nursing homes."
+    offered: "Do not include the offer that led to this letting.This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
 
   check_answer_labels:
     soctenant:
@@ -570,6 +572,7 @@ en:
     stairowned:
       one: "Percentage the buyer now owns in total"
       other: "Percentage the buyers now own in total"
+    offered: "Times previously offered since becoming available"
 
   warnings:
     location:

--- a/spec/models/form/lettings/questions/offered_social_let_spec.rb
+++ b/spec/models/form/lettings/questions/offered_social_let_spec.rb
@@ -39,6 +39,6 @@ RSpec.describe Form::Lettings::Questions::OfferedSocialLet, type: :model do
   end
 
   it "has the correct hint_text" do
-    expect(question.hint_text).to eq "Do not include the offer that led to this letting.This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
+    expect(question.hint_text).to eq "Do not include the offer that led to this letting. This is after the last tenancy ended. If the property is being offered for let for the first time, enter 0."
   end
 end


### PR DESCRIPTION
ensure copy is changed for both questions relating to how many times a property has been offered

extract to en.yml so that both questions keep identical copy in the future

https://digital.dclg.gov.uk/jira/browse/CLDC-1838