### PR TITLE
CLDC-2026 Add minimum staircasing validation for shared ownership sales

### DIFF
--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -52,6 +52,16 @@ module Validations::Sales::FinancialValidations
     end
   end
 
+  def validate_percentage_bought_at_least_threshold(record)
+    return unless record.stairbought && record.type
+
+    if ([2, 18, 16, 24].include? record.type) && record.stairbought < 10
+      record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", percentage: 10)
+    elsif record.type == 30 && record.stairbought < 1
+      record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", percentage: 1)
+    end
+  end
+
   def validate_child_income(record)
     return unless record.income2 && record.ecstat2
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -55,11 +55,11 @@ module Validations::Sales::FinancialValidations
   def validate_percentage_bought_at_least_threshold(record)
     return unless record.stairbought && record.type
 
-    if [2, 16, 18, 24].include? record.type
-      threshold = 10
-    else
-      threshold = 1
-    end
+    threshold = if [2, 16, 18, 24].include? record.type
+                  10
+                else
+                  1
+                end
 
     if threshold && record.stairbought < threshold
       record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", threshold:)

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -63,6 +63,7 @@ module Validations::Sales::FinancialValidations
 
     if threshold && record.stairbought < threshold
       record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", threshold:)
+      record.errors.add :type, I18n.t("validations.setup.type.percentage_bought_must_be_at_least_threshold", threshold:)
     end
   end
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -55,10 +55,14 @@ module Validations::Sales::FinancialValidations
   def validate_percentage_bought_at_least_threshold(record)
     return unless record.stairbought && record.type
 
-    if ([2, 18, 16, 24].include? record.type) && record.stairbought < 10
-      record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", percentage: 10)
-    elsif record.type == 30 && record.stairbought < 1
-      record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", percentage: 1)
+    if [2, 18, 16, 24].include? record.type
+      threshold = 10
+    elsif record.type == 30
+      threshold = 1
+    end
+
+    if threshold && record.stairbought < threshold
+      record.errors.add :stairbought, I18n.t("validations.financial.staircasing.percentage_bought_must_be_at_least_threshold", threshold:)
     end
   end
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -57,7 +57,7 @@ module Validations::Sales::FinancialValidations
 
     if [2, 16, 18, 24].include? record.type
       threshold = 10
-    elsif record.type == 30
+    else
       threshold = 1
     end
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -55,7 +55,7 @@ module Validations::Sales::FinancialValidations
   def validate_percentage_bought_at_least_threshold(record)
     return unless record.stairbought && record.type
 
-    if [2, 18, 16, 24].include? record.type
+    if [2, 16, 18, 24].include? record.type
       threshold = 10
     elsif record.type == 30
       threshold = 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,7 @@ en:
       staircasing:
         percentage_bought_must_be_greater_than_percentage_owned: "Total percentage buyer now owns must be more than percentage bought in this transaction"
         older_person_percentage_owned_maximum_75: "Percentage cannot be above 75% under Older Person's Shared Ownership"
-        percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{percentage}%"
+        percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{threshold}%"
 
     household:
       reasonpref:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,8 @@ en:
           Enter a date within the %{current_start_year_short}/%{current_end_year_short} financial year, which is between %{current_start_year_long} and %{current_end_year_long}
         previous_and_current_financial_year:
           "Enter a date within the %{previous_start_year_short}/%{previous_end_year_short} or %{previous_end_year_short}/%{current_end_year_short} financial years, which is between %{previous_start_year_long} and %{current_end_year_long}"
+      type:
+        percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{threshold}% for this shared ownership type"
 
       startdate:
         later_than_14_days_after: "The tenancy start date must not be later than 14 days from today’s date"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
       staircasing:
         percentage_bought_must_be_greater_than_percentage_owned: "Total percentage buyer now owns must be more than percentage bought in this transaction"
         older_person_percentage_owned_maximum_75: "Percentage cannot be above 75% under Older Person's Shared Ownership"
+        percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{percentage}%"
 
     household:
       reasonpref:

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -165,102 +165,40 @@ RSpec.describe Validations::Sales::FinancialValidations do
 
     it "adds an error to stairbought and type if the percentage bought is less than the threshold (which is 1% by default, but higher for some shared ownership types)" do
       record.stairbought = 9
-
-      record.type = 2
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 16
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 18
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 24
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
-      record.errors.clear
+      [2, 16, 18, 24].each do |type|
+        record.type = type
+        financial_validator.validate_percentage_bought_at_least_threshold(record)
+        expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+        expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
+        record.errors.clear
+      end
 
       record.stairbought = 0
-
-      record.type = 28
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 30
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 31
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
-      record.errors.clear
-
-      record.type = 32
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
-      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
-      record.errors.clear
+      [28, 30, 31, 32].each do |type|
+        record.type = type
+        financial_validator.validate_percentage_bought_at_least_threshold(record)
+        expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+        expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
+        record.errors.clear
+      end
     end
 
     it "doesn't add an error to stairbought and type if the percentage bought is less than the threshold (which is 1% by default, but higher for some shared ownership types)" do
       record.stairbought = 10
-
-      record.type = 2
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 16
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 18
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 24
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
+      [2, 16, 18, 24].each do |type|
+        record.type = type
+        financial_validator.validate_percentage_bought_at_least_threshold(record)
+        expect(record.errors).to be_empty
+        record.errors.clear
+      end
 
       record.stairbought = 1
-
-      record.type = 28
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 30
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 31
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
-
-      record.type = 32
-      financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors).to be_empty
-      record.errors.clear
+      [28, 30, 31, 32].each do |type|
+        record.type = type
+        financial_validator.validate_percentage_bought_at_least_threshold(record)
+        expect(record.errors).to be_empty
+        record.errors.clear
+      end
     end
   end
 

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -163,27 +163,31 @@ RSpec.describe Validations::Sales::FinancialValidations do
   describe "#validate_percentage_bought_at_least_threshold" do
     let(:record) { FactoryBot.create(:sales_log) }
 
-    it "adds an error to stairbought if the percentage bought is less than the threshold (which depends on the shared ownership type)" do
+    it "adds an error to stairbought and type if the percentage bought is less than the threshold (which is 1% by default, but higher for some shared ownership types)" do
       record.stairbought = 9
 
       record.type = 2
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
       record.errors.clear
 
       record.type = 16
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
       record.errors.clear
 
       record.type = 18
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
       record.errors.clear
 
       record.type = 24
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 10% for this shared ownership type"])
       record.errors.clear
 
       record.stairbought = 0
@@ -191,45 +195,53 @@ RSpec.describe Validations::Sales::FinancialValidations do
       record.type = 28
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
       record.errors.clear
 
       record.type = 30
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
       record.errors.clear
 
       record.type = 31
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
       record.errors.clear
 
       record.type = 32
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      expect(record.errors["type"]).to eq(["The minimum increase in equity while staircasing is 1% for this shared ownership type"])
       record.errors.clear
     end
 
-    it "doesn't add an error to stairbought if the percentage bought is greater than or equal to the threshold (which depends on the shared ownership type)" do
+    it "doesn't add an error to stairbought and type if the percentage bought is less than the threshold (which is 1% by default, but higher for some shared ownership types)" do
       record.stairbought = 10
 
       record.type = 2
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 16
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 18
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 24
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.stairbought = 1
@@ -237,21 +249,25 @@ RSpec.describe Validations::Sales::FinancialValidations do
       record.type = 28
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 30
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 31
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
 
       record.type = 32
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
+      expect(record.errors["type"]).to be_empty
       record.errors.clear
     end
   end

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -160,6 +160,93 @@ RSpec.describe Validations::Sales::FinancialValidations do
     end
   end
 
+  describe "#validate_percentage_bought_at_least_threshold" do
+    let(:record) { FactoryBot.create(:sales_log) }
+
+    it "adds an error to stairbought if the percentage bought is less than the threshold (which depends on the shared ownership type)" do
+      record.stairbought = 9
+
+      record.type = 2
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      record.errors.clear
+
+      record.type = 16
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      record.errors.clear
+
+      record.type = 18
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      record.errors.clear
+
+      record.type = 24
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
+      record.errors.clear
+
+
+      record.stairbought = 0
+
+      record.type = 30
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      record.errors.clear
+    end
+
+    it "doesn't add an error to stairbought if the percentage bought is greater than or equal to the threshold (which depends on the shared ownership type)" do
+      record.stairbought = 10
+
+      record.type = 2
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+      record.type = 16
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+      record.type = 18
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+      record.type = 24
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+
+      record.stairbought = 1
+
+      record.type = 30
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+    end
+
+    it "doesn't add an error to stairbought if the percentage bought is less than the smallest possible threshold and the shared ownership type is not one which should have a threshold associated with it" do
+      record.stairbought = 0
+
+      record.type = 28
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+      record.type = 31
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+
+      record.type = 32
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to be_empty
+      record.errors.clear
+    end
+  end
+
   describe "#validate_percentage_owned_not_too_much_if_older_person" do
     let(:record) { FactoryBot.create(:sales_log) }
 

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe Validations::Sales::FinancialValidations do
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 10%"])
       record.errors.clear
 
-
       record.stairbought = 0
 
       record.type = 30
@@ -217,7 +216,6 @@ RSpec.describe Validations::Sales::FinancialValidations do
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
       record.errors.clear
-
 
       record.stairbought = 1
 

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -188,7 +188,22 @@ RSpec.describe Validations::Sales::FinancialValidations do
 
       record.stairbought = 0
 
+      record.type = 28
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      record.errors.clear
+
       record.type = 30
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      record.errors.clear
+
+      record.type = 31
+      financial_validator.validate_percentage_bought_at_least_threshold(record)
+      expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
+      record.errors.clear
+
+      record.type = 32
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to eq(["The minimum increase in equity while staircasing is 1%"])
       record.errors.clear
@@ -219,16 +234,12 @@ RSpec.describe Validations::Sales::FinancialValidations do
 
       record.stairbought = 1
 
-      record.type = 30
+      record.type = 28
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
       record.errors.clear
-    end
 
-    it "doesn't add an error to stairbought if the percentage bought is less than the smallest possible threshold and the shared ownership type is not one which should have a threshold associated with it" do
-      record.stairbought = 0
-
-      record.type = 28
+      record.type = 30
       financial_validator.validate_percentage_bought_at_least_threshold(record)
       expect(record.errors["stairbought"]).to be_empty
       record.errors.clear

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -222,52 +222,44 @@ RSpec.describe Validations::Sales::FinancialValidations do
 
       record.type = 2
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 16
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 18
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 24
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.stairbought = 1
 
       record.type = 28
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 30
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 31
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
 
       record.type = 32
       financial_validator.validate_percentage_bought_at_least_threshold(record)
-      expect(record.errors["stairbought"]).to be_empty
-      expect(record.errors["type"]).to be_empty
+      expect(record.errors).to be_empty
       record.errors.clear
     end
   end


### PR DESCRIPTION
## Context
- https://digital.dclg.gov.uk/jira/browse/CLDC-2026

## The changes
- Added 10% threshold validation for shared ownership types 2, 16, 18, 24.
- Added 1% threshold validation for all other shared ownership types.
- Added tests for all shared ownership types - might have been overkill, but maybe fine.