### PR TITLE
CLDC-1919: Ensure 2023 rent ranges CSV is *not* UTF-8

### DIFF
--- a/config/rent_range_data/2023.csv
+++ b/config/rent_range_data/2023.csv
@@ -1,4 +1,4 @@
-﻿ranges_rent_id,lettype,la,beds,soft_min,soft_max,hard_min,hard_max
+ranges_rent_id,lettype,la,beds,soft_min,soft_max,hard_min,hard_max
 1,1,E07000223,1,57.21,123.09,25.84,176.15
 327,1,E07000223,2,71.06,146.43,25.84,186.77
 653,1,E07000223,3,81.2,161.3,25.84,203.75


### PR DESCRIPTION
Small PR to fix something that was previously merged (

When trying to import the 2023 rent ranges CSV using `Imports::RentRangesService.new(path: "config/rent_range_data/2023.csv", start_year: 2023).call` I found that the first column (`ranges_rent_id`) was getting imported as nil. This is because when creating the CSV I saved it as CSV UTF-8 format in Excel. An explanation for why this was causing the nil value can be seen here: https://stackoverflow.com/questions/57418707/csv-foreach-not-reading-first-column-in-csv-file.

This PR simply resaves the CSV in basic CSV format.