### PR TITLE
Run tests in parallel

### DIFF
--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: password
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      PARALLEL_TEST_PROCESSORS: 4
 
     steps:
       - name: Get latest release with tag

--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create database
         run: |
-          bundle exec rake db:prepare
+          bundle exec rake parallel:setup
 
       - name: Compile Assets
         run: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec --exclude-pattern "features/*" --fail-fast
+          bundle exec rake parallel:spec['spec\/(?!features)']
 
   feature_test:
     name: Feature Tests

--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -45,6 +45,7 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: password
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      PARALLEL_TEST_PROCESSORS: 4
 
     steps:
       - name: Checkout
@@ -63,7 +64,7 @@ jobs:
 
       - name: Create database
         run: |
-          bundle exec rake db:prepare
+          bundle exec rake parallel:setup
 
       - name: Compile assets
         run: |
@@ -71,7 +72,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec --exclude-pattern "features/*" --fail-fast
+          bundle exec rake parallel:spec['spec\/(?!features)']
 
   feature_test:
     name: Feature Tests

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -421,6 +421,10 @@ RSpec.describe Imports::LettingsLogsImportService do
         expect(lettings_log.location_id).not_to be_nil
         expect(lettings_log.status).to eq("completed")
       end
+
+      it "is a failing test" do
+        expect(true).to eq(false)
+      end
     end
 
     context "and this is a supported housing log with a single location under a scheme" do

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -421,10 +421,6 @@ RSpec.describe Imports::LettingsLogsImportService do
         expect(lettings_log.location_id).not_to be_nil
         expect(lettings_log.status).to eq("completed")
       end
-
-      it "is a failing test" do
-        expect(true).to eq(false)
-      end
     end
 
     context "and this is a supported housing log with a single location under a scheme" do


### PR DESCRIPTION
Run unit tests in parallel using parallel_test gem
Brings down the running time in CI from ~10min to ~6min
Remove --fail-fast from the unit tests, which means the tests will have to run fully before gihtub actions marks it as failed, but looking at some examples, our tests would still often take longer than 6 minutes to fail even with --fail-fast