### PR TITLE
Fix: get real validation messages for rent range soft validations

### DIFF
--- a/app/models/form/lettings/pages/max_rent_value_check.rb
+++ b/app/models/form/lettings/pages/max_rent_value_check.rb
@@ -4,11 +4,11 @@ class Form::Lettings::Pages::MaxRentValueCheck < ::Form::Page
     @id = "max_rent_value_check"
     @depends_on = [{ "rent_in_soft_max_range?" => true }]
     @title_text = {
-      "translation" => "soft_validations.rent.max.title_text",
+      "translation" => "soft_validations.rent.outside_range_title",
       "arguments" => [{ "key" => "brent", "label" => true, "i18n_template" => "brent" }],
     }
     @informative_text = {
-      "translation" => "soft_validations.rent.max.hint_text",
+      "translation" => "soft_validations.rent.max_hint_text",
       "arguments" => [
         {
           "key" => "soft_max_for_period",

--- a/app/models/form/lettings/pages/min_rent_value_check.rb
+++ b/app/models/form/lettings/pages/min_rent_value_check.rb
@@ -4,11 +4,11 @@ class Form::Lettings::Pages::MinRentValueCheck < ::Form::Page
     @id = "min_rent_value_check"
     @depends_on = [{ "rent_in_soft_min_range?" => true }]
     @title_text = {
-      "translation" => "soft_validations.rent.min.title_text",
+      "translation" => "soft_validations.rent.outside_range_title",
       "arguments" => [{ "key" => "brent", "label" => true, "i18n_template" => "brent" }],
     }
     @informative_text = {
-      "translation" => "soft_validations.rent.min.hint_text",
+      "translation" => "soft_validations.rent.min_hint_text",
       "arguments" => [
         {
           "key" => "soft_min_for_period",


### PR DESCRIPTION
The soft validation banners shown when the rent ranges for a lettings log are unusually high or low were not displaying correctly. The validation logic was looking up things in `en.yml` which didn't exist. This PR fixes that.