### PR TITLE
CLDC-2142 Show "Most recent let type" question for both needs types

### DIFF
--- a/app/models/form/lettings/pages/property_let_type.rb
+++ b/app/models/form/lettings/pages/property_let_type.rb
@@ -2,7 +2,7 @@ class Form::Lettings::Pages::PropertyLetType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "property_let_type"
-    @depends_on = [{ "first_time_property_let_as_social_housing" => 0, "renewal" => 0, "needstype" => 1 }]
+    @depends_on = [{ "first_time_property_let_as_social_housing" => 0, "renewal" => 0 }]
   end
 
   def questions


### PR DESCRIPTION
## Context
- https://digital.dclg.gov.uk/jira/browse/CLDC-2142
- Ticket is very simple - making sure that the "Most recent let type" question shows up for both needs types (not just general needs).

## Notes
- I didn't write tests for this as I was following the "if a page doesn't already have a matching test file, don't add one" approach (see this thread for a discussion on this topic https://softwire.slack.com/archives/C03QXAE3Y3W/p1678191132116249)

## Screenshots
<img width="830" alt="image" src="https://user-images.githubusercontent.com/63662292/225398602-1194429f-10b9-401e-a34e-8f4dda0fe5ca.png">