### PR TITLE
CLDC-2143 Address import validations

### DIFF
--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -9,7 +9,7 @@ module Validations::Sales::FinancialValidations
     if record.london_property? && record.income1 > 90_000
       relevant_fields.each { |field| record.errors.add field, I18n.t("validations.financial.income.over_hard_max_for_london") }
     elsif record.property_not_in_london? && record.income1 > 80_000
-      relevant_fields.each { |field| record.errors.add field, I18n.t("validations.financial.income.over_hard_max_for_outside_london") }
+      relevant_fields.each { |field| record.errors.add field, :over_hard_max_for_outside_london, message: I18n.t("validations.financial.income.over_hard_max_for_outside_london") }
     end
   end
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -70,7 +70,7 @@ module Validations::Sales::FinancialValidations
   def validate_child_income(record)
     return unless record.income2 && record.ecstat2
 
-    if record.income2.positive? && is_economic_status_child?(record.ecstat2)
+    if record.income2.positive? && is_economic_status_child?(record.ecstat2) && record.form.start_date.year >= 2023
       record.errors.add :ecstat2, I18n.t("validations.financial.income.child_has_income")
       record.errors.add :income2, I18n.t("validations.financial.income.child_has_income")
     end

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -30,7 +30,7 @@ module Validations::Sales::SaleInformationValidations
     end
 
     if record.saledate - record.exdate >= 1.year
-      record.errors.add :exdate, I18n.t("validations.sale_information.exdate.must_be_less_than_1_year_from_saledate")
+      record.errors.add :exdate, :over_a_year_from_saledate, message: I18n.t("validations.sale_information.exdate.must_be_less_than_1_year_from_saledate")
       record.errors.add :saledate, I18n.t("validations.sale_information.saledate.must_be_less_than_1_year_from_exdate")
     end
   end

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -46,7 +46,7 @@ module Validations::Sales::SaleInformationValidations
 
   def validate_discounted_ownership_value(record)
     return unless record.value && record.deposit && record.ownershipsch
-    return unless record.mortgage || record.mortgageused == 2 || record.mortgageused == 3
+    return unless record.mortgage || record.mortgageused == 2
     return unless record.discount || record.grant || record.type == 29
 
     discount_amount = record.discount ? record.value * record.discount / 100 : 0

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -191,11 +191,12 @@ module Imports
           attributes.delete(error.attribute.to_s)
         end
         @logs_overridden << sales_log.old_id
-        if sales_log.errors.of_kind?(:postcode_full, :postcodes_not_matching)
-          @logger.warn("Log #{sales_log.old_id}: Removing postcode known and previous postcode known as the postcodes are invalid")
-          attributes.delete("pcodenk")
-          attributes.delete("ppcodenk")
-        end
+        save_sales_log(attributes, previous_status)
+      elsif sales_log.errors.of_kind?(:postcode_full, :postcodes_not_matching)
+        @logger.warn("Log #{sales_log.old_id}: Removing previous postcode known and previous postcode as the postcode is invalid")
+        @logs_overridden << sales_log.old_id
+        attributes.delete("ppcodenk")
+        attributes.delete("ppostcode_full")
         save_sales_log(attributes, previous_status)
       else
         @logger.error("Log #{sales_log.old_id}: Failed to import")

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -198,6 +198,11 @@ module Imports
         attributes.delete("ppcodenk")
         attributes.delete("ppostcode_full")
         save_sales_log(attributes, previous_status)
+      elsif sales_log.errors.of_kind?(:exdate, :over_a_year_from_saledate)
+        @logger.warn("Log #{sales_log.old_id}: Removing exchange date as the exchange date is invalid")
+        @logs_overridden << sales_log.old_id
+        attributes.delete("exdate")
+        save_sales_log(attributes, previous_status)
       else
         @logger.error("Log #{sales_log.old_id}: Failed to import")
         sales_log.errors.each do |error|

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -203,6 +203,11 @@ module Imports
         @logs_overridden << sales_log.old_id
         attributes.delete("exdate")
         save_sales_log(attributes, previous_status)
+      elsif sales_log.errors.of_kind?(:income1, :over_hard_max_for_outside_london)
+        @logger.warn("Log #{sales_log.old_id}: Removing income1 as the income1 is invalid")
+        @logs_overridden << sales_log.old_id
+        attributes.delete("income1")
+        save_sales_log(attributes, previous_status)
       else
         @logger.error("Log #{sales_log.old_id}: Failed to import")
         sales_log.errors.each do |error|

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -251,6 +251,7 @@ RSpec.describe Validations::Sales::FinancialValidations do
 
     context "when buyer 2 is a child" do
       it "does not add an error if buyer 2 has no income" do
+        record.saledate = Time.zone.local(2023, 4, 3)
         record.ecstat2 = 9
         record.income2 = 0
         financial_validator.validate_child_income(record)
@@ -258,11 +259,20 @@ RSpec.describe Validations::Sales::FinancialValidations do
       end
 
       it "adds errors if buyer 2 has an income" do
+        record.saledate = Time.zone.local(2023, 4, 3)
         record.ecstat2 = 9
         record.income2 = 40_000
         financial_validator.validate_child_income(record)
         expect(record.errors["ecstat2"]).to include(match I18n.t("validations.financial.income.child_has_income"))
         expect(record.errors["income2"]).to include(match I18n.t("validations.financial.income.child_has_income"))
+      end
+
+      it "does not add an error if the saledate is before the 23/24 collection window" do
+        record.saledate = Time.zone.local(2022, 4, 3)
+        record.ecstat2 = 9
+        record.income2 = 40_000
+        financial_validator.validate_child_income(record)
+        expect(record.errors).to be_empty
       end
     end
   end

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -398,17 +398,12 @@ RSpec.describe Imports::SalesLogsImportService do
       let(:sales_log_id) { "discounted_ownership_sales_log" }
 
       before do
-        sales_log_xml.at_xpath("//meta:status").content = "submitted-invalid"
-        sales_log_xml.at_xpath("//xmlns:Q7Postcode").content = "A1 1AA"
-        sales_log_xml.at_xpath("//xmlns:Q14Postcode").content = "A1 2AA"
+        sales_log_xml.at_xpath("//xmlns:Q7Postcode").content = "A1 1AA" # previous postcode
+        sales_log_xml.at_xpath("//xmlns:Q14Postcode").content = "A1 2AA" # postcode
       end
 
       it "intercepts the relevant validation error" do
-        expect(logger).to receive(:warn).with(/Removing field postcode_full from log triggering validation: Buyer's last accommodation and discounted ownership postcodes must match/)
-        expect(logger).to receive(:warn).with(/Removing field ppostcode_full from log triggering validation: Buyer's last accommodation and discounted ownership postcodes must match/)
-        expect(logger).to receive(:warn).with(/Removing field postcode_full from log triggering validation: postcodes_not_matching/)
-        expect(logger).to receive(:warn).with(/Removing field ppostcode_full from log triggering validation: postcodes_not_matching/)
-        expect(logger).to receive(:warn).with(/Removing postcode known and previous postcode known as the postcodes are invalid/)
+        expect(logger).to receive(:warn).with(/Removing previous postcode known and previous postcode as the postcode is invalid/)
         expect { sales_log_service.send(:create_log, sales_log_xml) }
           .not_to raise_error
       end
@@ -420,7 +415,7 @@ RSpec.describe Imports::SalesLogsImportService do
         sales_log = SalesLog.find_by(old_id: sales_log_id)
 
         expect(sales_log).not_to be_nil
-        expect(sales_log.postcode_full).to be_nil
+        expect(sales_log.postcode_full).to eq("A1 2AA")
         expect(sales_log.ppostcode_full).to be_nil
       end
     end

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -420,6 +420,36 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and it has an invalid record with invalid contracts exchange date" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:DAY").content = "1"
+        sales_log_xml.at_xpath("//xmlns:MONTH").content = "10"
+        sales_log_xml.at_xpath("//xmlns:YEAR").content = "2022"
+        sales_log_xml.at_xpath("//xmlns:EXDAY").content = "1"
+        sales_log_xml.at_xpath("//xmlns:EXMONTH").content = "4"
+        sales_log_xml.at_xpath("//xmlns:EXYEAR").content = "2020"
+      end
+
+      it "intercepts the relevant validation error" do
+        expect(logger).to receive(:warn).with(/Removing exchange date as the exchange date is invalid/)
+        expect { sales_log_service.send(:create_log, sales_log_xml) }
+          .not_to raise_error
+      end
+
+      it "clears out the invalid answers" do
+        allow(logger).to receive(:warn)
+
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+
+        expect(sales_log).not_to be_nil
+        expect(sales_log.saledate).to eq(Time.zone.local(2022, 10, 1))
+        expect(sales_log.exdate).to be_nil
+      end
+    end
+
     context "when inferring default answers for completed sales logs" do
       context "when the armedforcesspouse is not answered" do
         let(:sales_log_id) { "discounted_ownership_sales_log" }


### PR DESCRIPTION
Address errors happening during the import:
- [x] Buyer's last accommodation and discounted ownership postcodes must match - Clear previous postcode
- [x] Child's income must be £0 - remove the validation for 22/23
- [x] Contract exchange date must be less than 1 year before completion date - Clear exchange date
- [x] Income must not exceed £80,000 for properties outside London local authorities - Clear income

Also do not run the discounted ownership validation when mortgageused is don't know (3) only impacts imports, because don't know is a hidden value in single log submission flow.

Errors to be addressed in a separate PRs:

- Mortgage, deposit, and grant total must equal x
- Person cannot be aged 16-19 if they are a student but don't have relationship child