### PR TITLE
CLDC-2132 breadcrumbs logs link

### DIFF
--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, "#{subsection.id.humanize} - Check your answers" %>
-<% class_name = @log.class.name.underscore %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-  "Logs" => send("#{class_name.pluralize}_path"),
-  "Log #{@log.id}" => send("#{class_name}_path", @log),
+  "Logs" => url_for(@log.class),
+  "Log #{@log.id}" => url_for(@log),
   subsection.label => "",
 }) %>
 

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, "#{subsection.id.humanize} - Check your answers" %>
+<% class_name = @log.class.name.underscore %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-  "Logs" => "/logs",
-  "Log #{@log.id}" => send("#{@log.class.name.underscore}_path", @log),
+  "Logs" => send("#{class_name.pluralize}_path"),
+  "Log #{@log.id}" => send("#{class_name}_path", @log),
   subsection.label => "",
-  }) %>
+}) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -1,9 +1,9 @@
-<% class_name = @log.class.name.underscore %>
-<% content_for :title, "Review #{class_name.humanize(capitalize: false)}" %>
+<% class_name = @log.class.name.underscore.humanize(capitalize: false) %>
+<% content_for :title, "Review #{class_name}" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-  "Logs" => send("#{class_name.pluralize}_path"),
-  "Log #{@log.id}" => send("#{class_name}_path", @log.id),
-  "Review #{class_name.humanize(capitalize: false)}" => "",
+  "Logs" => url_for(@log.class),
+  "Log #{@log.id}" => url_for(@log),
+  "Review #{class_name}" => "",
 }) %>
 
 <div class="govuk-grid-row">

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -1,18 +1,10 @@
-<% if @log.sales? %>
-  <% content_for :title, "Review sales log" %>
-  <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-    "Logs" => "/logs",
-    "Log #{@log.id}" => "/sales-logs/#{@log.id}",
-    "Review sales log" => "",
-  }) %>
-<% else %>
-  <% content_for :title, "Review lettings log" %>
-  <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
-    "Logs" => "/logs",
-    "Log #{@log.id}" => "/lettings-logs/#{@log.id}",
-    "Review lettings log" => "",
-  }) %>
-<% end %>
+<% class_name = @log.class.name.underscore %>
+<% content_for :title, "Review #{class_name.humanize(capitalize: false)}" %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
+  "Logs" => send("#{class_name.pluralize}_path"),
+  "Log #{@log.id}" => send("#{class_name}_path", @log.id),
+  "Review #{class_name.humanize(capitalize: false)}" => "",
+}) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -1,4 +1,4 @@
-<% class_name = @log.class.name.underscore.humanize(capitalize: false) %>
+<% class_name = @log.class.model_name.human.downcase %>
 <% content_for :title, "Review #{class_name}" %>
 <% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: {
   "Logs" => url_for(@log.class),

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -98,12 +98,12 @@ RSpec.describe "Lettings Log Features" do
       let(:lettings_log) { FactoryBot.create(:lettings_log, :about_completed) }
 
       it "has the correct breadcrumbs with the correct links" do
-        visit lettings_log_setup_check_answers_path(lettings_log.id)
+        visit lettings_log_setup_check_answers_path(lettings_log)
         breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
         expect(breadcrumbs.first.text).to eq "Logs"
         expect(breadcrumbs.first[:href]).to eq lettings_logs_path
         expect(breadcrumbs[1].text).to eq "Log #{lettings_log.id}"
-        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log.id)
+        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log)
       end
     end
 
@@ -111,12 +111,12 @@ RSpec.describe "Lettings Log Features" do
       let(:lettings_log) { FactoryBot.create(:lettings_log, :completed) }
 
       it "has the correct breadcrumbs with the correct links" do
-        visit review_lettings_log_path(lettings_log.id)
+        visit review_lettings_log_path(lettings_log)
         breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
         expect(breadcrumbs.first.text).to eq "Logs"
         expect(breadcrumbs.first[:href]).to eq lettings_logs_path
         expect(breadcrumbs[1].text).to eq "Log #{lettings_log.id}"
-        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log.id)
+        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log)
       end
     end
 

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -94,6 +94,32 @@ RSpec.describe "Lettings Log Features" do
       end
     end
 
+    context "when visiting a subsection check answers page" do
+      let(:lettings_log) { FactoryBot.create(:lettings_log, :about_completed) }
+
+      it "has the correct breadcrumbs with the correct links" do
+        visit lettings_log_setup_check_answers_path(lettings_log.id)
+        breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
+        expect(breadcrumbs.first.text).to eq "Logs"
+        expect(breadcrumbs.first[:href]).to eq lettings_logs_path
+        expect(breadcrumbs[1].text).to eq "Log #{lettings_log.id}"
+        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log.id)
+      end
+    end
+
+    context "when reviewing a complete log" do
+      let(:lettings_log) { FactoryBot.create(:lettings_log, :completed) }
+
+      it "has the correct breadcrumbs with the correct links" do
+        visit review_lettings_log_path(lettings_log.id)
+        breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
+        expect(breadcrumbs.first.text).to eq "Logs"
+        expect(breadcrumbs.first[:href]).to eq lettings_logs_path
+        expect(breadcrumbs[1].text).to eq "Log #{lettings_log.id}"
+        expect(breadcrumbs[1][:href]).to eq lettings_log_path(lettings_log.id)
+      end
+    end
+
     context "when the owning organisation question isn't answered" do
       it "doesn't show the managing agent question" do
         visit("/lettings-logs")

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Sales Log Features" do
           click_link("Logs")
         end
 
-        it "navigates you to the lettings logs page" do
+        it "navigates you to the sales logs page" do
           expect(page).to have_current_path("/sales-logs")
         end
       end
@@ -62,6 +62,52 @@ RSpec.describe "Sales Log Features" do
           visit("/sales-logs")
           expect(page).not_to have_content("Create a new sales log")
         end
+      end
+    end
+  end
+
+  context "when signed in as a support user" do
+    let(:devise_notify_mailer) { DeviseNotifyMailer.new }
+    let(:notify_client) { instance_double(Notifications::Client) }
+    let(:otp) { "999111" }
+    let(:organisation) { FactoryBot.create(:organisation, name: "Big ORG") }
+    let(:user) { FactoryBot.create(:user, :support, last_sign_in_at: Time.zone.now, organisation:) }
+    let(:sales_log) { FactoryBot.create(:sales_log, :completed) }
+
+    before do
+      allow(DeviseNotifyMailer).to receive(:new).and_return(devise_notify_mailer)
+      allow(devise_notify_mailer).to receive(:notify_client).and_return(notify_client)
+      allow(notify_client).to receive(:send_email).and_return(true)
+      allow(SecureRandom).to receive(:random_number).and_return(otp)
+      visit("/sales-logs")
+      fill_in("user[email]", with: user.email)
+      fill_in("user[password]", with: user.password)
+      click_button("Sign in")
+      fill_in("code", with: otp)
+      click_button("Submit")
+    end
+
+    context "when visiting a subsection check answers page as a support user" do
+
+      it "has the correct breadcrumbs with the correct links" do
+        visit sales_log_setup_check_answers_path(sales_log.id)
+        breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
+        expect(breadcrumbs.first.text).to eq "Logs"
+        expect(breadcrumbs.first[:href]).to eq sales_logs_path
+        expect(breadcrumbs[1].text).to eq "Log #{sales_log.id}"
+        expect(breadcrumbs[1][:href]).to eq sales_log_path(sales_log.id)
+      end
+    end
+
+    context "when reviewing a complete log" do
+
+      it "has the correct breadcrumbs with the correct links" do
+        visit review_sales_log_path(sales_log.id, sales_log: true)
+        breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
+        expect(breadcrumbs.first.text).to eq "Logs"
+        expect(breadcrumbs.first[:href]).to eq sales_logs_path
+        expect(breadcrumbs[1].text).to eq "Log #{sales_log.id}"
+        expect(breadcrumbs[1][:href]).to eq sales_log_path(sales_log.id)
       end
     end
   end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe "Sales Log Features" do
     end
 
     context "when visiting a subsection check answers page as a support user" do
-
       it "has the correct breadcrumbs with the correct links" do
         visit sales_log_setup_check_answers_path(sales_log.id)
         breadcrumbs = page.find_all(".govuk-breadcrumbs__link")
@@ -100,7 +99,6 @@ RSpec.describe "Sales Log Features" do
     end
 
     context "when reviewing a complete log" do
-
       it "has the correct breadcrumbs with the correct links" do
         visit review_sales_log_path(sales_log.id, sales_log: true)
         breadcrumbs = page.find_all(".govuk-breadcrumbs__link")


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2132

remove a chunk of hardcoded values to create paths from the class name of the relevant log that the page is for.