### PR TITLE
Return correct type if no LAs found for location

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -84,7 +84,7 @@ class LettingsLog < Log
 
   def la
     if location
-      location.linked_local_authorities.active(form.start_date).first&.code
+      location.linked_local_authorities.active(form.start_date).first&.code || location.location_code
     else
       super
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -14,7 +14,7 @@ class Location < ApplicationRecord
 
   has_paper_trail
 
-  before_save :lookup_postcode!, if: :postcode_changed?
+  before_validation :lookup_postcode!, if: :postcode_changed?
 
   auto_strip_attributes :name
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -132,7 +132,7 @@ class Location < ApplicationRecord
 
   def linked_local_authorities
     la = LocalAuthority.find_by(code: location_code)
-    return [] unless la
+    return LocalAuthority.none unless la
 
     LocalAuthority.where(id: [la.id] + la.linked_local_authority_ids)
   end

--- a/spec/features/schemes_helpers.rb
+++ b/spec/features/schemes_helpers.rb
@@ -64,7 +64,8 @@ module SchemesHelpers
     click_button "Add a location"
     fill_in with: "AA11AA"
     click_button "Save and continue"
-    fill_in with: "Adur"
+    select "Adur"
+    click_button "Save and continue"
     fill_in with: "Some name"
     click_button "Save and continue"
     fill_in with: 5
@@ -84,7 +85,8 @@ module SchemesHelpers
     click_button "Add a location"
     fill_in with: "AA12AA"
     click_button "Save and continue"
-    fill_in with: "Adur"
+    select "Adur"
+    click_button "Save and continue"
     fill_in with: "Other name"
     click_button "Save and continue"
     fill_in with: 2

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -284,7 +284,8 @@ RSpec.describe "Schemes scheme Features" do
                 before do
                   fill_in with: "AA12AA"
                   click_button "Save and continue"
-                  fill_in with: "Adur"
+                  select "Adur"
+                  click_button "Save and continue"
                   fill_in with: location_name
                   click_button "Save and continue"
                   fill_in with: 1
@@ -904,7 +905,8 @@ RSpec.describe "Schemes scheme Features" do
                 before do
                   fill_in with: "AA12AA"
                   click_button "Save and continue"
-                  fill_in with: "Adur"
+                  select "Adur"
+                  click_button "Save and continue"
                   fill_in with: location_name
                   click_button "Save and continue"
                   fill_in with: 1

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2033,6 +2033,19 @@ RSpec.describe LettingsLog do
             end
           end
         end
+
+        context "and the location no local authorities associated with the location_code" do
+          before do
+            location.update!(location_code: "E01231231")
+            lettings_log.update!(location:)
+          end
+
+          it "returns the correct la" do
+            expect(location.location_code).to eq("E01231231")
+            expect(lettings_log["location_id"]).to eq(location.id)
+            expect(lettings_log.la).to eq("E01231231")
+          end
+        end
       end
 
       context "and not renewal" do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Location, type: :model do
       expect(location.linked_local_authorities.active(Time.zone.local(2022, 4, 1)).first.code).to eq("E07000030")
       expect(location.linked_local_authorities.active(Time.zone.local(2023, 4, 1)).first.code).to eq("E06000063")
     end
+
+    context "when location_code is no in LocalAuthorities table" do
+      before do
+        stub_request(:get, /api.postcodes.io\/postcodes\/CA101AA/)
+          .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Eden","codes":{"admin_district":"E01231231"}}}', headers: {})
+      end
+
+      it "defaults for location code for la" do
+        location.update!(postcode: "CA10 1AA")
+        expect(location.linked_local_authorities.count).to eq(0)
+        expect(location.location_code).to eq("E01231231")
+      end
+    end
   end
 
   describe "#postcode" do

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "redirects correctly when postcodes.io does return a local authority" do
           follow_redirect!
-          expect(page).to have_content("What is the name of this location?")
+          expect(page).to have_content("What is the local authority")
         end
       end
 
@@ -478,7 +478,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "redirects correctly when postcodes.io does return a local authority" do
           follow_redirect!
-          expect(page).to have_content("What is the name of this location?")
+          expect(page).to have_content("What is the local authority")
         end
       end
 


### PR DESCRIPTION
- Default to location code if LocalAuthority is not found by location code
- Set local authority before validation, because we run `validate_confirmed` on validation and it get's sent to false unless the la is inferred before then 
Had to fix some tests as part of these that looks like they were false positives 
