### PR TITLE
CLDC-2143 Set default and optional missing import fields

### DIFF
--- a/app/models/form/sales/pages/previous_bedrooms.rb
+++ b/app/models/form/sales/pages/previous_bedrooms.rb
@@ -3,9 +3,14 @@ class Form::Sales::Pages::PreviousBedrooms < ::Form::Page
     super
     @id = "previous_bedrooms"
     @header = "About the buyers’ previous property"
-    @depends_on = [{
-      "soctenant" => 1,
-    }]
+    @depends_on = [
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/pages/previous_property_type.rb
+++ b/app/models/form/sales/pages/previous_property_type.rb
@@ -5,9 +5,14 @@ class Form::Sales::Pages::PreviousPropertyType < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
-    @depends_on = [{
-      "soctenant" => 1,
-    }]
+    @depends_on = [
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/pages/previous_tenure.rb
+++ b/app/models/form/sales/pages/previous_tenure.rb
@@ -5,9 +5,14 @@ class Form::Sales::Pages::PreviousTenure < ::Form::Page
     @header = ""
     @description = ""
     @subsection = subsection
-    @depends_on = [{
-      "soctenant" => 1,
-    }]
+    @depends_on = [
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ]
   end
 
   def questions

--- a/app/models/form/sales/questions/buyer_previous.rb
+++ b/app/models/form/sales/questions/buyer_previous.rb
@@ -12,5 +12,13 @@ class Form::Sales::Questions::BuyerPrevious < ::Form::Question
   ANSWER_OPTIONS = {
     "1" => { "value" => "Yes" },
     "2" => { "value" => "No" },
+    "0" => { "value" => "Don’t know" },
   }.freeze
+
+  def displayed_answer_options(_log, _user = nil)
+    {
+      "1" => { "value" => "Yes" },
+      "2" => { "value" => "No" },
+    }
+  end
 end

--- a/app/models/form/sales/questions/fromprop.rb
+++ b/app/models/form/sales/questions/fromprop.rb
@@ -17,5 +17,16 @@ class Form::Sales::Questions::Fromprop < ::Form::Question
     "3" => { "value" => "House" },
     "4" => { "value" => "Bungalow" },
     "9" => { "value" => "Other" },
+    "0" => { "value" => "Don’t know" },
   }.freeze
+
+  def displayed_answer_options(_log, _user = nil)
+    {
+      "1" => { "value" => "Flat or maisonette" },
+      "2" => { "value" => "Bedsit" },
+      "3" => { "value" => "House" },
+      "4" => { "value" => "Bungalow" },
+      "9" => { "value" => "Other" },
+    }
+  end
 end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -78,6 +78,7 @@ class SalesLog < Log
   def dynamically_not_required
     not_required = []
     not_required << "proplen" if proplen_optional?
+    not_required << "mortlen" if mortlen_optional?
 
     not_required |= %w[address_line2 county postcode_full] if saledate && saledate.year >= 2023
 
@@ -85,6 +86,12 @@ class SalesLog < Log
   end
 
   def proplen_optional?
+    return false unless collection_start_year
+
+    collection_start_year < 2023
+  end
+
+  def mortlen_optional?
     return false unless collection_start_year
 
     collection_start_year < 2023

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -42,7 +42,7 @@ class SalesLog < Log
   }
   scope :filter_by_organisation, ->(org, _user = nil) { where(owning_organisation: org) }
 
-  OPTIONAL_FIELDS = %w[saledate_check purchid monthly_charges_value_check old_persons_shared_ownership_value_check].freeze
+  OPTIONAL_FIELDS = %w[saledate_check purchid monthly_charges_value_check old_persons_shared_ownership_value_check mortgagelender othtype].freeze
   RETIREMENT_AGES = { "M" => 65, "F" => 60, "X" => 65 }.freeze
 
   def lettings?

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -79,6 +79,7 @@ class SalesLog < Log
     not_required = []
     not_required << "proplen" if proplen_optional?
     not_required << "mortlen" if mortlen_optional?
+    not_required << "frombeds" if frombeds_optional?
 
     not_required |= %w[address_line2 county postcode_full] if saledate && saledate.year >= 2023
 
@@ -92,6 +93,12 @@ class SalesLog < Log
   end
 
   def mortlen_optional?
+    return false unless collection_start_year
+
+    collection_start_year < 2023
+  end
+
+  def frombeds_optional?
     return false unless collection_start_year
 
     collection_start_year < 2023

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -510,6 +510,7 @@ module Imports
       end
       attributes["pcodenk"] ||= 1
       attributes["prevten"] ||= 0
+      attributes["extrabor"] ||= 3 if attributes["mortgageused"] == 1
 
       # buyer 1 characteristics
       attributes["age1_known"] ||= 1

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -124,7 +124,7 @@ module Imports
       attributes["mortgagelenderother"] = mortgage_lender_other(xml_doc, attributes)
       attributes["postcode_full"] = parse_postcode(string_or_nil(xml_doc, "Q14Postcode"))
       attributes["pcodenk"] = 0 if attributes["postcode_full"].present? # known if given
-      attributes["soctenant"] = soctenant(attributes)
+      attributes["soctenant"] = 0 if attributes["ownershipsch"] == 1
       attributes["ethnic_group2"] = nil # 23/24 variable
       attributes["ethnicbuy2"] = nil # 23/24 variable
       attributes["prevshared"] = nil # 23/24 variable
@@ -364,17 +364,6 @@ module Imports
       end
     end
 
-    def soctenant(attributes)
-      return nil unless attributes["ownershipsch"] == 1
-
-      if attributes["frombeds"].blank? && attributes["fromprop"].blank? && attributes["socprevten"].blank?
-        2
-      else
-        1
-      end
-      # NO (2) if FROMBEDS, FROMPROP and socprevten are blank, and YES(1) if they are completed
-    end
-
     def still_serving(xml_doc)
       case unsafe_string_as_integer(xml_doc, "LeftArmedF")
       when 4
@@ -511,6 +500,8 @@ module Imports
       attributes["pcodenk"] ||= 1
       attributes["prevten"] ||= 0
       attributes["extrabor"] ||= 3 if attributes["mortgageused"] == 1
+      attributes["socprevten"] ||= 10 if attributes["ownershipsch"] == 1
+      attributes["fromprop"] ||= 0 if attributes["ownershipsch"] == 1
 
       # buyer 1 characteristics
       attributes["age1_known"] ||= 1

--- a/spec/models/form/sales/pages/previous_bedrooms_spec.rb
+++ b/spec/models/form/sales/pages/previous_bedrooms_spec.rb
@@ -28,8 +28,13 @@ RSpec.describe Form::Sales::Pages::PreviousBedrooms, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "soctenant" => 1,
-    }])
+    expect(page.depends_on).to eq([
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ])
   end
 end

--- a/spec/models/form/sales/pages/previous_property_type_spec.rb
+++ b/spec/models/form/sales/pages/previous_property_type_spec.rb
@@ -28,8 +28,13 @@ RSpec.describe Form::Sales::Pages::PreviousPropertyType, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "soctenant" => 1,
-    }])
+    expect(page.depends_on).to eq([
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ])
   end
 end

--- a/spec/models/form/sales/pages/previous_tenure_spec.rb
+++ b/spec/models/form/sales/pages/previous_tenure_spec.rb
@@ -28,8 +28,13 @@ RSpec.describe Form::Sales::Pages::PreviousTenure, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "soctenant" => 1,
-    }])
+    expect(page.depends_on).to eq([
+      {
+        "soctenant" => 1,
+      },
+      {
+        "soctenant" => 0,
+      },
+    ])
   end
 end

--- a/spec/models/form/sales/questions/buyer_previous_spec.rb
+++ b/spec/models/form/sales/questions/buyer_previous_spec.rb
@@ -46,10 +46,18 @@ RSpec.describe Form::Sales::Questions::BuyerPrevious, type: :model do
     expect(question.derived?).to be false
   end
 
+  it "has the correct displayed_answer_options" do
+    expect(question.displayed_answer_options(nil)).to eq({
+      "1" => { "value" => "Yes" },
+      "2" => { "value" => "No" },
+    })
+  end
+
   it "has the correct answer_options" do
     expect(question.answer_options).to eq({
       "1" => { "value" => "Yes" },
       "2" => { "value" => "No" },
+      "0" => { "value" => "Don’t know" },
     })
   end
 

--- a/spec/models/form/sales/questions/fromprop_spec.rb
+++ b/spec/models/form/sales/questions/fromprop_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Form::Sales::Questions::Fromprop, type: :model do
     expect(question.hint_text).to eq("")
   end
 
+  it "has the correct displayed_answer_options" do
+    expect(question.displayed_answer_options(nil)).to eq({
+      "1" => { "value" => "Flat or maisonette" },
+      "2" => { "value" => "Bedsit" },
+      "3" => { "value" => "House" },
+      "4" => { "value" => "Bungalow" },
+      "9" => { "value" => "Other" },
+    })
+  end
+
   it "has the correct answer_options" do
     expect(question.answer_options).to eq({
       "1" => { "value" => "Flat or maisonette" },
@@ -42,6 +52,7 @@ RSpec.describe Form::Sales::Questions::Fromprop, type: :model do
       "3" => { "value" => "House" },
       "4" => { "value" => "Bungalow" },
       "9" => { "value" => "Other" },
+      "0" => { "value" => "Don’t know" },
     })
   end
 end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe SalesLog, type: :model do
           monthly_charges_value_check
           old_persons_shared_ownership_value_check
           proplen
+          mortlen
         ])
       end
     end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe SalesLog, type: :model do
           othtype
           proplen
           mortlen
+          frombeds
         ])
       end
     end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe SalesLog, type: :model do
           purchid
           monthly_charges_value_check
           old_persons_shared_ownership_value_check
+          mortgagelender
+          othtype
           proplen
           mortlen
         ])
@@ -74,6 +76,8 @@ RSpec.describe SalesLog, type: :model do
           purchid
           monthly_charges_value_check
           old_persons_shared_ownership_value_check
+          mortgagelender
+          othtype
           address_line2
           county
           postcode_full

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -1142,6 +1142,38 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.extrabor).to be(3)
         end
       end
+
+      context "when the fromprop is not answered" do
+        let(:sales_log_id) { "shared_ownership_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:Q21PropertyType").content = ""
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "sets fromprop to don't know" do
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.fromprop).to be(0)
+        end
+      end
+
+      context "when the socprevten is not answered" do
+        let(:sales_log_id) { "shared_ownership_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:PrevRentType").content = ""
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "sets socprevten to don't know" do
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.socprevten).to be(10)
+        end
+      end
     end
   end
 end

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -1126,6 +1126,22 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.mortgageused).to eq(1)
         end
       end
+
+      context "when the extrabor is not answered" do
+        let(:sales_log_id) { "discounted_ownership_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:Q35Borrowing").content = ""
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "sets extrabor to don't know" do
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.extrabor).to be(3)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Some fields were missing during the import, to fix that:
- [x] Make `mortlen` optional for 22/23
- [x] Set `extrabor` to don't know it is not answered
- [x] Make `mortgagelender` and `othtype` optional
- [x] Add `Don't know` options to `soctenant` and `fromprop`
- [x] Make `frombeds` optional
- [x] Infer `soctenant` as Don't know
- [x] Infer `socprevten` and `fromprop` as `Don't know` if not given