### PR TITLE
CLDC-2015 Validate children to be 12 or more years younger than buyer 1

### DIFF
--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -89,7 +89,7 @@ private
     if person_age > buyer_1_age - 12 && person_is_child?(relationship)
       record.errors.add "age1", I18n.t("validations.household.age.child_12_years_younger")
       record.errors.add "age#{person_num}", I18n.t("validations.household.age.child_12_years_younger")
-      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.child_12_years_younger")
+      record.errors.add "relat#{person_num}", I18n.t("validations.household.age.child_12_years_younger")
     end
   end
 

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -6,6 +6,7 @@ module Validations::Sales::HouseholdValidations
       validate_person_age_matches_relationship(record, n)
       validate_person_age_and_relationship_matches_economic_status(record, n)
       validate_person_age_matches_economic_status(record, n)
+      validate_child_12_years_younger(record, n)
     end
     shared_validate_partner_count(record, 6)
   end
@@ -76,6 +77,19 @@ private
     if tenant_is_economic_child?(economic_status) && age > 16
       record.errors.add "ecstat#{person_num}", I18n.t("validations.household.ecstat.child_over_16", person_num:)
       record.errors.add "age#{person_num}", I18n.t("validations.household.age.child_over_16", person_num:)
+    end
+  end
+
+  def validate_child_12_years_younger(record, person_num)
+    buyer_1_age = record.public_send("age1")
+    person_age = record.public_send("age#{person_num}")
+    relationship = record.public_send("relat#{person_num}")
+    return unless buyer_1_age && person_age && relationship
+
+    if person_age > buyer_1_age - 12 && person_is_child?(relationship)
+      record.errors.add "age1", I18n.t("validations.household.age.child_12_years_younger")
+      record.errors.add "age#{person_num}", I18n.t("validations.household.age.child_12_years_younger")
+      record.errors.add "relat#{person_num}", I18n.t("validations.household.relat.child_12_years_younger")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
         child_under_16: "Answer cannot be under 16 as person’s %{person_num} working situation is not ‘child under 16’"
         child_over_16: "Answer cannot be over 16 as person’s %{person_num} working situation is ‘child under 16‘"
         child_over_20: "Answer cannot be 20 or over as the relationship is ‘child’"
+        child_12_years_younger: "A child must be at least 12 years younger than their parent"
         not_student_16_19: "Answer cannot be between 16 and 19 as person %{person_num} is a child of the lead tenant but is not a full-time student"
         student_16_19:
           cannot_be_16_19:

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe Validations::Sales::HouseholdValidations do
         expect(record.errors["age2"])
           .to include(match I18n.t("validations.household.age.child_over_16", person_num: 2))
       end
+
+      it "validates the child is at least 12 years younger than buyer 1" do
+        record.age1 = 30
+        record.age2 = 19
+        record.relat2 = "C"
+        household_validator.validate_household_number_of_other_members(record)
+        expect(record.errors["age1"])
+          .to include(match I18n.t("validations.household.age.child_12_years_younger", person_num: 2))
+        expect(record.errors["age2"])
+          .to include(match I18n.t("validations.household.age.child_12_years_younger", person_num: 2))
+        expect(record.errors["relat2"])
+          .to include(match I18n.t("validations.household.age.child_12_years_younger", person_num: 2))
+      end
+
+      it "expects the child is at least 12 years younger than buyer 1" do
+        record.age1 = 30
+        record.age2 = 18
+        record.relat2 = "C"
+        household_validator.validate_household_number_of_other_members(record)
+        expect(record.errors["age1"]).to be_empty
+        expect(record.errors["age2"]).to be_empty
+        expect(record.errors["relate2"]).to be_empty
+      end
     end
 
     it "validates that a person over 20 must not be a child of the buyer" do

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Validations::Sales::HouseholdValidations do
 
       it "validates the child is at least 12 years younger than buyer 1" do
         record.age1 = 30
-        record.age2 = 19
+        record.age2 = record.age1 - 13
         record.relat2 = "C"
         household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["age1"])
@@ -88,7 +88,7 @@ RSpec.describe Validations::Sales::HouseholdValidations do
 
       it "expects the child is at least 12 years younger than buyer 1" do
         record.age1 = 30
-        record.age2 = 18
+        record.age2 = record.age1 - 12
         record.relat2 = "C"
         household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["age1"]).to be_empty

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Validations::Sales::HouseholdValidations do
 
       it "validates the child is at least 12 years younger than buyer 1" do
         record.age1 = 30
-        record.age2 = record.age1 - 13
+        record.age2 = record.age1 - 11
         record.relat2 = "C"
         household_validator.validate_household_number_of_other_members(record)
         expect(record.errors["age1"])


### PR DESCRIPTION
Simple validation PR, adds a hard validation that children of buyer 1 (buyer 2, or any person) are 12 or more years younger than buyer 1.

![image](https://user-images.githubusercontent.com/94526761/226338439-033a6870-be21-4057-bc89-e84a5cba3e3e.png)

ticket:
https://digital.dclg.gov.uk/jira/browse/CLDC-2015