### PR TITLE
CLDC-2017-monthly-charges-validation

### DIFF
--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -1,6 +1,7 @@
 module DerivedVariables::SalesLogVariables
   def set_derived_fields!
     self.ethnic = 17 if ethnic_refused?
+    self.mscharge = nil if monthly_leasehold_charges_unknown?
     if exdate.present?
       self.exday = exdate.day
       self.exmonth = exdate.month
@@ -12,9 +13,6 @@ module DerivedVariables::SalesLogVariables
       self.hoyear = hodate.year
     end
     self.deposit = value if outright_sale? && mortgage_not_used?
-    if mscharge_known.present? && mscharge_known.zero?
-      self.mscharge = 0
-    end
     if mortgage_not_used?
       self.mortgage = 0
     end

--- a/app/models/form/sales/questions/leasehold_charges.rb
+++ b/app/models/form/sales/questions/leasehold_charges.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::LeaseholdCharges < ::Form::Question
     @check_answer_label = "Monthly leasehold charges"
     @header = "Enter the total monthly charge"
     @type = "numeric"
-    @min = 0
+    @min = 1
     @width = 5
     @prefix = "£"
     @ownershipsch = ownershipsch

--- a/app/models/form/sales/questions/leasehold_charges_known.rb
+++ b/app/models/form/sales/questions/leasehold_charges_known.rb
@@ -3,7 +3,7 @@ class Form::Sales::Questions::LeaseholdChargesKnown < ::Form::Question
     super(id, hsh, subsection)
     @id = "mscharge_known"
     @check_answer_label = "Monthly leasehold charges known?"
-    @header = "Does the property have any monthly leasehold charges?"
+    @header = "Do you know the monthly leasehold charges for the property?"
     @hint_text = "For example, service and management charges"
     @type = "radio"
     @answer_options = ANSWER_OPTIONS

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -299,6 +299,10 @@ class SalesLog < Log
     companybuy == 1
   end
 
+  def monthly_leasehold_charges_unknown?
+    mscharge_known&.zero?
+  end
+
   def buyers_age_for_old_persons_shared_ownership_invalid?
     return unless old_persons_shared_ownership?
 

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -41,7 +41,7 @@ module Validations::Sales::FinancialValidations
   end
 
   def validate_monthly_leasehold_charges(record)
-    record.errors.add :mscharge, I18n.t("validations.financial.monthly_leasehold_charges.not_zero") if record.mscharge == 0
+    record.errors.add :mscharge, I18n.t("validations.financial.monthly_leasehold_charges.not_zero") if record.mscharge&.zero?
   end
 
   def validate_percentage_bought_not_greater_than_percentage_owned(record)

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -40,12 +40,8 @@ module Validations::Sales::FinancialValidations
     record.errors.add :mortgage, :cannot_be_0, message: I18n.t("validations.financial.mortgage") if record.mortgage_used? && record.mortgage&.zero?
   end
 
-  def validate_cash_discount(record)
-    return unless record.cashdis
-
-    unless record.cashdis.between?(0, 999_999)
-      record.errors.add :cashdis, I18n.t("validations.financial.cash_discount_invalid")
-    end
+  def validate_monthly_leasehold_charges(record)
+    record.errors.add :mscharge, I18n.t("validations.financial.monthly_leasehold_charges.not_zero") if record.mscharge == 0
   end
 
   def validate_percentage_bought_not_greater_than_percentage_owned(record)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,8 @@ en:
         percentage_bought_must_be_greater_than_percentage_owned: "Total percentage buyer now owns must be more than percentage bought in this transaction"
         older_person_percentage_owned_maximum_75: "Percentage cannot be above 75% under Older Person's Shared Ownership"
         percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{threshold}%"
+      monthly_leasehold_charges:
+        not_zero: "Monthly leasehold charges cannot be £0 if the property has monthly charges"
       equity:
         under_min: "The minimum initial equity stake for this type of shared ownership sale is %{min_equity}%"
         over_max: "The maximum initial equity stake is %{max_equity}%"

--- a/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/discounted_ownership_sales_log.xml
@@ -280,7 +280,7 @@
     <Q34b>33</Q34b>
     <Q35Borrowing>2 No</Q35Borrowing>
     <Q36CashDeposit>0</Q36CashDeposit>
-    <Q37MonthlyCharges>0.00</Q37MonthlyCharges>
+    <Q37MonthlyCharges>10.00</Q37MonthlyCharges>
   </Group>
   <Group>
     <Q40PurchasePrice override-field=""/>

--- a/spec/models/form/sales/questions/leasehold_charges_known_spec.rb
+++ b/spec/models/form/sales/questions/leasehold_charges_known_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Form::Sales::Questions::LeaseholdChargesKnown, type: :model do
   end
 
   it "has the correct header" do
-    expect(question.header).to eq("Does the property have any monthly leasehold charges?")
+    expect(question.header).to eq("Do you know the monthly leasehold charges for the property?")
   end
 
   it "has the correct check_answer_label" do

--- a/spec/models/form/sales/questions/leasehold_charges_spec.rb
+++ b/spec/models/form/sales/questions/leasehold_charges_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Form::Sales::Questions::LeaseholdCharges, type: :model do
   end
 
   it "has the correct width" do
-    expect(question.width).to eq(5)
+    expect(question.width).to be 5
   end
 
   it "has the correct min" do
-    expect(question.min).to eq(0)
+    expect(question.min).to be 1
   end
 
   it "has the correct prefix" do

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Validations::FinancialValidations do
     end
 
     context "when outstanding rent or charges is yes" do
-      let(:record) { FactoryBot.create(:lettings_log, :about_completed, startdate: Time.zone.now) }
+      let(:record) { FactoryBot.create(:lettings_log, :about_completed, startdate: Time.zone.local(2023, 1, 1)) }
 
       it "expects that a shortfall is provided" do
         record.hbrentshortfall = 1

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Validations::Sales::FinancialValidations do
     end
   end
 
-  describe "#validate_monthly_leasehold_charges", focus: true do
+  describe "#validate_monthly_leasehold_charges" do
     let(:record) { FactoryBot.create(:sales_log) }
 
     it "does not add an error if monthly leasehold charges are positive" do

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -131,28 +131,6 @@ RSpec.describe Validations::Sales::FinancialValidations do
     end
   end
 
-  describe "#validate_cash_discount" do
-    let(:record) { FactoryBot.create(:sales_log) }
-
-    it "adds an error if the cash discount is below zero" do
-      record.cashdis = -1
-      financial_validator.validate_cash_discount(record)
-      expect(record.errors["cashdis"]).to include(match I18n.t("validations.financial.cash_discount_invalid"))
-    end
-
-    it "adds an error if the cash discount is one million or more" do
-      record.cashdis = 1_000_000
-      financial_validator.validate_cash_discount(record)
-      expect(record.errors["cashdis"]).to include(match I18n.t("validations.financial.cash_discount_invalid"))
-    end
-
-    it "does not add an error if the cash discount is in the expected range" do
-      record.cashdis = 10_000
-      financial_validator.validate_cash_discount(record)
-      expect(record.errors).to be_empty
-    end
-  end
-
   describe "#validate_percentage_bought_not_greater_than_percentage_owned" do
     let(:record) { FactoryBot.create(:sales_log) }
 
@@ -175,6 +153,22 @@ RSpec.describe Validations::Sales::FinancialValidations do
       record.stairowned = 40
       financial_validator.validate_percentage_bought_not_greater_than_percentage_owned(record)
       expect(record.errors["stairowned"]).to include(match I18n.t("validations.financial.staircasing.percentage_bought_must_be_greater_than_percentage_owned"))
+    end
+  end
+
+  describe "#validate_monthly_leasehold_charges", focus: true do
+    let(:record) { FactoryBot.create(:sales_log) }
+
+    it "does not add an error if monthly leasehold charges are positive" do
+      record.mscharge = 2345
+      financial_validator.validate_monthly_leasehold_charges(record)
+      expect(record.errors).to be_empty
+    end
+
+    it "adds an error if monthly leasehold charges are zero" do
+      record.mscharge = 0
+      financial_validator.validate_monthly_leasehold_charges(record)
+      expect(record.errors[:mscharge]).to include I18n.t("validations.financial.monthly_leasehold_charges.not_zero")
     end
   end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -891,14 +891,14 @@ RSpec.describe LettingsLogsController, type: :request do
             end
           end
 
-          context "when a lettings log is for a renewal of supported housing, so property information does not need to show" do
+          context "when a lettings log is for a renewal of supported housing, property information does not need to show" do
             let(:lettings_log) do
               FactoryBot.create(
                 :lettings_log,
                 owning_organisation: user.organisation,
                 managing_organisation: user.organisation,
                 created_by: user,
-                startdate: Time.zone.now,
+                startdate: Time.zone.local(2023, 1, 1),
                 renewal: 1,
                 needstype: 2,
                 rent_type: 3,


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2017

after discussing with Jemma, it is not the case that this can be covered by the standard error messages for any field with values outside min max range given.
The error message specifically directs them to change their answer to another question in the case they feel the value should be 0.

The existing range validation error message still applies for non zero but non valid inputs