### PR TITLE
CLDC-2125 Bulk upload age can be null

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -282,13 +282,13 @@ class BulkUpload::Lettings::Year2022::RowParser
   validates :field_4, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_1) } }
 
   validates :field_12, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 1 must be a number or the letter R" }
-  validates :field_13, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 2 must be a number or the letter R" }
-  validates :field_14, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 3 must be a number or the letter R" }
-  validates :field_15, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 4 must be a number or the letter R" }
-  validates :field_16, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 5 must be a number or the letter R" }
-  validates :field_17, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 6 must be a number or the letter R" }
-  validates :field_18, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }
-  validates :field_19, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }
+  validates :field_13, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 2 must be a number or the letter R" }, allow_blank: true
+  validates :field_14, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 3 must be a number or the letter R" }, allow_blank: true
+  validates :field_15, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 4 must be a number or the letter R" }, allow_blank: true
+  validates :field_16, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 5 must be a number or the letter R" }, allow_blank: true
+  validates :field_17, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 6 must be a number or the letter R" }, allow_blank: true
+  validates :field_18, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }, allow_blank: true
+  validates :field_19, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }, allow_blank: true
 
   validates :field_96, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (day)") }
   validates :field_97, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (month)") }
@@ -848,28 +848,28 @@ private
     attributes["tenancylength"] = field_11
     attributes["declaration"] = field_132
 
-    attributes["age1_known"] = field_12 == "R" ? 1 : 0
+    attributes["age1_known"] = (field_12 == "R" || field_12.blank? ? 1 : 0)
     attributes["age1"] = field_12 if attributes["age1_known"].zero? && field_12&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age2_known"] = field_13 == "R" ? 1 : 0
+    attributes["age2_known"] = (field_13 == "R" || field_13.blank? ? 1 : 0)
     attributes["age2"] = field_13 if attributes["age2_known"].zero? && field_13&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age3_known"] = field_14 == "R" ? 1 : 0
+    attributes["age3_known"] = (field_14 == "R" || field_14.blank? ? 1 : 0)
     attributes["age3"] = field_14 if attributes["age3_known"].zero? && field_14&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age4_known"] = field_15 == "R" ? 1 : 0
+    attributes["age4_known"] = (field_15 == "R" || field_15.blank? ? 1 : 0)
     attributes["age4"] = field_15 if attributes["age4_known"].zero? && field_15&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age5_known"] = field_16 == "R" ? 1 : 0
+    attributes["age5_known"] = (field_16 == "R" || field_16.blank? ? 1 : 0)
     attributes["age5"] = field_16 if attributes["age5_known"].zero? && field_16&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age6_known"] = field_17 == "R" ? 1 : 0
+    attributes["age6_known"] = (field_17 == "R" || field_17.blank? ? 1 : 0)
     attributes["age6"] = field_17 if attributes["age6_known"].zero? && field_17&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age7_known"] = field_18 == "R" ? 1 : 0
+    attributes["age7_known"] = (field_18 == "R" || field_18.blank? ? 1 : 0)
     attributes["age7"] = field_18 if attributes["age7_known"].zero? && field_18&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age8_known"] = field_19 == "R" ? 1 : 0
+    attributes["age8_known"] = (field_19 == "R" || field_19.blank? ? 1 : 0)
     attributes["age8"] = field_19 if attributes["age8_known"].zero? && field_19&.match(/\A\d{1,3}\z|\AR\z/)
 
     attributes["sex1"] = field_20

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -284,13 +284,13 @@ class BulkUpload::Lettings::Year2023::RowParser
   validates :field_16, presence: { if: proc { [2, 4, 6, 8, 10, 12].include?(field_5) } }
 
   validates :field_46, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 1 must be a number or the letter R" }
-  validates :field_52, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 2 must be a number or the letter R" }
-  validates :field_56, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 3 must be a number or the letter R" }
-  validates :field_60, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 4 must be a number or the letter R" }
-  validates :field_64, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 5 must be a number or the letter R" }
-  validates :field_68, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 6 must be a number or the letter R" }
-  validates :field_72, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }
-  validates :field_76, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }
+  validates :field_52, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 2 must be a number or the letter R" }, allow_blank: true
+  validates :field_56, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 3 must be a number or the letter R" }, allow_blank: true
+  validates :field_60, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 4 must be a number or the letter R" }, allow_blank: true
+  validates :field_64, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 5 must be a number or the letter R" }, allow_blank: true
+  validates :field_68, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 6 must be a number or the letter R" }, allow_blank: true
+  validates :field_72, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }, allow_blank: true
+  validates :field_76, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }, allow_blank: true
 
   validates :field_7, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (day)") }
   validates :field_8, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (month)") }
@@ -790,28 +790,28 @@ private
     attributes["tenancylength"] = field_43
     attributes["declaration"] = field_45
 
-    attributes["age1_known"] = field_46 == "R" ? 1 : 0
+    attributes["age1_known"] = (field_46 == "R" || field_46.blank? ? 1 : 0)
     attributes["age1"] = field_46 if attributes["age1_known"].zero? && field_46&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age2_known"] = field_52 == "R" ? 1 : 0
+    attributes["age2_known"] = (field_52 == "R" || field_52.blank? ? 1 : 0)
     attributes["age2"] = field_52 if attributes["age2_known"].zero? && field_52&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age3_known"] = field_56 == "R" ? 1 : 0
+    attributes["age3_known"] = (field_56 == "R" || field_56.blank? ? 1 : 0)
     attributes["age3"] = field_56 if attributes["age3_known"].zero? && field_56&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age4_known"] = field_60 == "R" ? 1 : 0
+    attributes["age4_known"] = (field_60 == "R" || field_60.blank? ? 1 : 0)
     attributes["age4"] = field_60 if attributes["age4_known"].zero? && field_60&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age5_known"] = field_64 == "R" ? 1 : 0
+    attributes["age5_known"] = (field_64 == "R" || field_64.blank? ? 1 : 0)
     attributes["age5"] = field_64 if attributes["age5_known"].zero? && field_64&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age6_known"] = field_68 == "R" ? 1 : 0
+    attributes["age6_known"] = (field_68 == "R" || field_68.blank? ? 1 : 0)
     attributes["age6"] = field_68 if attributes["age6_known"].zero? && field_68&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age7_known"] = field_72 == "R" ? 1 : 0
+    attributes["age7_known"] = (field_72 == "R" || field_72.blank? ? 1 : 0)
     attributes["age7"] = field_72 if attributes["age7_known"].zero? && field_72&.match(/\A\d{1,3}\z|\AR\z/)
 
-    attributes["age8_known"] = field_76 == "R" ? 1 : 0
+    attributes["age8_known"] = (field_76 == "R" || field_76.blank? ? 1 : 0)
     attributes["age8"] = field_76 if attributes["age8_known"].zero? && field_76&.match(/\A\d{1,3}\z|\AR\z/)
 
     attributes["sex1"] = field_47

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -742,6 +742,18 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       %w[age8_known age8 field_19],
     ].each do |known, age, field|
       describe "##{known} and ##{age}" do
+        context "when #{field} is blank" do
+          let(:attributes) { { bulk_upload:, field.to_s => nil } }
+
+          it "sets ##{known} 1" do
+            expect(parser.log.public_send(known)).to be(1)
+          end
+
+          it "sets ##{age} to nil" do
+            expect(parser.log.public_send(age)).to be_nil
+          end
+        end
+
         context "when #{field} is R" do
           let(:attributes) { { bulk_upload:, field.to_s => "R" } }
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -700,6 +700,18 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       %w[age8_known age8 field_76],
     ].each do |known, age, field|
       describe "##{known} and ##{age}" do
+        context "when #{field} is blank" do
+          let(:attributes) { { bulk_upload:, field.to_s => nil } }
+
+          it "sets ##{known} 1" do
+            expect(parser.log.public_send(known)).to be(1)
+          end
+
+          it "sets ##{age} to nil" do
+            expect(parser.log.public_send(age)).to be_nil
+          end
+        end
+
         context "when #{field} is R" do
           let(:attributes) { { bulk_upload:, field.to_s => "R" } }
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2125
- Bulk upload ages not correctly implemented

# Changes

- Before this change it was mandatory. With this change is can now be `R` or blank to denote age is not known