### PR TITLE
Lettings log import validations

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -25,6 +25,7 @@ module Validations::FinancialValidations
     if record.ecstat1 && record.weekly_net_income
       if record.weekly_net_income > record.applicable_income_range.hard_max
         record.errors.add :earnings, :over_hard_max, message: I18n.t("validations.financial.earnings.over_hard_max", hard_max: record.applicable_income_range.hard_max)
+        record.errors.add :ecstat1, :over_hard_max, message: I18n.t("validations.financial.ecstat.over_hard_max", hard_max: record.applicable_income_range.hard_max)
       end
 
       if record.weekly_net_income < record.applicable_income_range.hard_min

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -63,7 +63,7 @@ module Validations::HouseholdValidations
 
   def validate_previous_housing_situation(record)
     if record.is_relet_to_temp_tenant? && !record.previous_tenancy_was_temporary?
-      record.errors.add :prevten, I18n.t("validations.household.prevten.non_temp_accommodation")
+      record.errors.add :prevten, :non_temp_accommodation, message: I18n.t("validations.household.prevten.non_temp_accommodation")
     end
 
     if record.age1.present? && record.age1 > 19 && record.previous_tenancy_was_foster_care?

--- a/app/models/validations/property_validations.rb
+++ b/app/models/validations/property_validations.rb
@@ -16,7 +16,7 @@ module Validations::PropertyValidations
     end
 
     if record.offered.negative? || record.offered > 20
-      record.errors.add :offered, I18n.t("validations.property.offered.relet_number")
+      record.errors.add :offered, :over_20, message: I18n.t("validations.property.offered.relet_number")
     end
   end
 

--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -43,7 +43,7 @@ module Validations::TenancyValidations
     return unless record.collection_start_year && record.joint
 
     if record.hhmemb == 1 && record.joint != 2 && record.collection_start_year >= 2022
-      record.errors.add :joint, I18n.t("validations.tenancy.not_joint")
+      record.errors.add :joint, :not_joint_tenancy, message: I18n.t("validations.tenancy.not_joint")
       record.errors.add :hhmemb, I18n.t("validations.tenancy.joint_more_than_one_member")
     end
   end

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -311,6 +311,12 @@ module Imports
         attributes.delete("prevten")
         attributes.delete("age1")
         save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:prevten, :non_temp_accommodation)
+        @logger.warn("Log #{lettings_log.old_id}: Removing vacancy reason and previous tenancy since this accommodation is not temporary")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("prevten")
+        attributes.delete("rsnvac")
+        save_lettings_log(attributes, previous_status)
       else
         @logger.error("Log #{lettings_log.old_id}: Failed to import")
         lettings_log.errors.each do |error|

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -317,6 +317,11 @@ module Imports
         attributes.delete("prevten")
         attributes.delete("rsnvac")
         save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:joint, :not_joint_tenancy)
+        @logger.warn("Log #{lettings_log.old_id}: Removing joint tenancy as there is only 1 person in the household")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("joint")
+        save_lettings_log(attributes, previous_status)
       else
         @logger.error("Log #{lettings_log.old_id}: Failed to import")
         lettings_log.errors.each do |error|

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -322,6 +322,11 @@ module Imports
         @logs_overridden << lettings_log.old_id
         attributes.delete("joint")
         save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:offered, :over_20)
+        @logger.warn("Log #{lettings_log.old_id}: Removing offered as the value is above the maximum of 20")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("offered")
+        save_lettings_log(attributes, previous_status)
       else
         @logger.error("Log #{lettings_log.old_id}: Failed to import")
         lettings_log.errors.each do |error|

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -327,6 +327,11 @@ module Imports
         @logs_overridden << lettings_log.old_id
         attributes.delete("offered")
         save_lettings_log(attributes, previous_status)
+      elsif lettings_log.errors.of_kind?(:earnings, :over_hard_max)
+        @logger.warn("Log #{lettings_log.old_id}: Removing working situation because income is too high for it")
+        @logs_overridden << lettings_log.old_id
+        attributes.delete("ecstat1")
+        save_lettings_log(attributes, previous_status)
       else
         @logger.error("Log #{lettings_log.old_id}: Failed to import")
         lettings_log.errors.each do |error|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,8 @@ en:
           local_authority:
             general_needs: "Enter a value for the support charge between £0 and £60 per week if the landlord is a local authority and it is a general needs letting"
             supported_housing: "Enter a value for the support charge between £0 and £120 per week if the landlord is a local authority and it is a supported housing letting"
+      ecstat:
+        over_hard_max: "Net income of £%{hard_max} per week is too high for given the tenant’s working situation"
       brent:
         below_hard_min: "Rent is below the absolute minimum expected for a property of this type. Please check the rent, rent period, local authority and (if general needs) number of bedrooms"
         above_hard_max: "Rent is higher than the absolute maximum expected for a property of this type. Please check the rent, rent period, local authority and (if general needs) number of bedrooms"

--- a/spec/fixtures/imports/logs/0ead17cb-1668-442d-898c-0d52879ff592.xml
+++ b/spec/fixtures/imports/logs/0ead17cb-1668-442d-898c-0d52879ff592.xml
@@ -119,6 +119,7 @@
       <Q10-g>Yes</Q10-g>
       <Q10-h/>
       <Q10ia>2 No</Q10ia>
+      <joint>2 No</joint>
       <Q10ib-1/>
       <Q10ib-2/>
       <Q10ib-3/>

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -396,6 +396,28 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      context "and the number the property was relet is over 20" do
+        before do
+          lettings_log_xml.at_xpath("//xmlns:Q20").content = "25"
+        end
+
+        it "intercepts the relevant validation error" do
+          expect(logger).to receive(:warn).with(/Removing offered as the value is above the maximum of 20/)
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "clears out the referral answer" do
+          allow(logger).to receive(:warn)
+
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.offered).to be_nil
+        end
+      end
+
       context "and the net income soft validation is triggered (net_income_value_check)" do
         before do
           lettings_log_xml.at_xpath("//xmlns:Q8a").content = "1 Weekly"


### PR DESCRIPTION
- [x] Enter ‘no’ as there are no female tenants aged 11-65 in the household - https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1458
- [ ] You cannot answer the outstanding amount question if you don’t have outstanding rent or charges - TBC
- [x] The tenancy start date must be before the end date for this supported housing scheme - https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1428
- [x] Enter a number between 0 and 20 for the amount of times the property has been re-let - clear the value
- [x] Answer cannot be re-let to tenant who occupied the same property as temporary accommodation as this accommodation is not temporary - clear the value
- [x] Answer cannot be non-temporary accommodation as this is a re-let to a tenant who occupied the same property as temporary accommodation - clear the value
- [x] This cannot be a joint tenancy as you’ve told us there’s only one person in the household - clear the value
- [x] There must be more than one person in the household as you’ve told us this is a joint tenancy - clear the value
- [x] Earnings Net income cannot be greater than £690 per week given the tenant’s working situation - make sure the error displays on ecstat as well, clear ecstat1
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/54268893/227204740-2398da84-7560-4005-8e8e-cd32326be22c.png">

- [x] Enter a value for the service charge between £0 and £55 per week if the landlord is a private registered provider and it is a general needs letting - https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1428