### PR TITLE
CLDC-2178 Bulk upload would create log if owning or managing data bad

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -308,14 +308,14 @@ class BulkUpload::Lettings::Year2022::RowParser
   validate :validate_dont_know_disabled_needs_conjunction
   validate :validate_no_and_dont_know_disabled_needs_conjunction
 
-  validate :validate_owning_org_permitted
-  validate :validate_owning_org_owns_stock
-  validate :validate_owning_org_exists
   validate :validate_owning_org_data_given
+  validate :validate_owning_org_exists
+  validate :validate_owning_org_owns_stock
+  validate :validate_owning_org_permitted
 
-  validate :validate_managing_org_related
-  validate :validate_managing_org_exists
   validate :validate_managing_org_data_given
+  validate :validate_managing_org_exists
+  validate :validate_managing_org_related
 
   validate :validate_scheme_related
   validate :validate_scheme_exists
@@ -436,19 +436,26 @@ private
   def validate_managing_org_related
     if owning_organisation && managing_organisation && !owning_organisation.can_be_managed_by?(organisation: managing_organisation)
       block_log_creation!
-      errors.add(:field_113, "This managing organisation does not have a relationship with the owning organisation")
+
+      if errors[:field_113].blank?
+        errors.add(:field_113, "This managing organisation does not have a relationship with the owning organisation")
+      end
     end
   end
 
   def validate_managing_org_exists
     if managing_organisation.nil?
-      errors.delete(:field_113)
-      errors.add(:field_113, "The managing organisation code is incorrect")
+      block_log_creation!
+
+      if errors[:field_113].blank?
+        errors.add(:field_113, "The managing organisation code is incorrect")
+      end
     end
   end
 
   def validate_managing_org_data_given
     if field_113.blank?
+      block_log_creation!
       errors.add(:field_113, "The managing organisation code is incorrect", category: :setup)
     end
   end
@@ -456,29 +463,40 @@ private
   def validate_owning_org_owns_stock
     if owning_organisation && !owning_organisation.holds_own_stock?
       block_log_creation!
-      errors.delete(:field_111)
-      errors.add(:field_111, "The owning organisation code provided is for an organisation that does not own stock")
+
+      if errors[:field_111].blank?
+        errors.add(:field_111, "The owning organisation code provided is for an organisation that does not own stock")
+      end
     end
   end
 
   def validate_owning_org_exists
     if owning_organisation.nil?
-      errors.delete(:field_111)
-      errors.add(:field_111, "The owning organisation code is incorrect")
+      block_log_creation!
+
+      if errors[:field_111].blank?
+        errors.add(:field_111, "The owning organisation code is incorrect")
+      end
     end
   end
 
   def validate_owning_org_data_given
     if field_111.blank?
-      errors.add(:field_111, "The owning organisation code is incorrect", category: :setup)
+      block_log_creation!
+
+      if errors[:field_111].blank?
+        errors.add(:field_111, "The owning organisation code is incorrect", category: :setup)
+      end
     end
   end
 
   def validate_owning_org_permitted
     if owning_organisation && !bulk_upload.user.organisation.affiliated_stock_owners.include?(owning_organisation)
       block_log_creation!
-      errors.delete(:field_111)
-      errors.add(:field_111, "You do not have permission to add logs for this owning organisation")
+
+      if errors[:field_111].blank?
+        errors.add(:field_111, "You do not have permission to add logs for this owning organisation")
+      end
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -311,14 +311,14 @@ class BulkUpload::Lettings::Year2023::RowParser
   validate :validate_dont_know_disabled_needs_conjunction
   validate :validate_no_and_dont_know_disabled_needs_conjunction
 
-  validate :validate_owning_org_permitted
-  validate :validate_owning_org_owns_stock
-  validate :validate_owning_org_exists
   validate :validate_owning_org_data_given
+  validate :validate_owning_org_exists
+  validate :validate_owning_org_owns_stock
+  validate :validate_owning_org_permitted
 
-  validate :validate_managing_org_related
-  validate :validate_managing_org_exists
   validate :validate_managing_org_data_given
+  validate :validate_managing_org_exists
+  validate :validate_managing_org_related
 
   validate :validate_scheme_related
   validate :validate_scheme_exists
@@ -551,19 +551,26 @@ private
   def validate_managing_org_related
     if owning_organisation && managing_organisation && !owning_organisation.can_be_managed_by?(organisation: managing_organisation)
       block_log_creation!
-      errors.add(:field_2, "This managing organisation does not have a relationship with the owning organisation")
+
+      if errors[:field_2].blank?
+        errors.add(:field_2, "This managing organisation does not have a relationship with the owning organisation")
+      end
     end
   end
 
   def validate_managing_org_exists
     if managing_organisation.nil?
-      errors.delete(:field_2)
-      errors.add(:field_2, "The managing organisation code is incorrect")
+      block_log_creation!
+
+      if errors[:field_2].blank?
+        errors.add(:field_2, "The managing organisation code is incorrect")
+      end
     end
   end
 
   def validate_managing_org_data_given
     if field_2.blank?
+      block_log_creation!
       errors.add(:field_2, "The managing organisation code is incorrect", category: :setup)
     end
   end
@@ -571,20 +578,26 @@ private
   def validate_owning_org_owns_stock
     if owning_organisation && !owning_organisation.holds_own_stock?
       block_log_creation!
-      errors.delete(:field_1)
-      errors.add(:field_1, "The owning organisation code provided is for an organisation that does not own stock")
+
+      if errors[:field_1].blank?
+        errors.add(:field_1, "The owning organisation code provided is for an organisation that does not own stock")
+      end
     end
   end
 
   def validate_owning_org_exists
     if owning_organisation.nil?
-      errors.delete(:field_1)
-      errors.add(:field_1, "The owning organisation code is incorrect")
+      block_log_creation!
+
+      if errors[:field_1].blank?
+        errors.add(:field_1, "The owning organisation code is incorrect")
+      end
     end
   end
 
   def validate_owning_org_data_given
     if field_1.blank?
+      block_log_creation!
       errors.add(:field_1, "The owning organisation code is incorrect", category: :setup)
     end
   end
@@ -592,8 +605,10 @@ private
   def validate_owning_org_permitted
     if owning_organisation && !bulk_upload.user.organisation.affiliated_stock_owners.include?(owning_organisation)
       block_log_creation!
-      errors.delete(:field_1)
-      errors.add(:field_1, "You do not have permission to add logs for this owning organisation")
+
+      if errors[:field_1].blank?
+        errors.add(:field_1, "You do not have permission to add logs for this owning organisation")
+      end
     end
   end
 

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -634,6 +634,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
           expect(setup_errors.find { |e| e.attribute == :field_111 }.message).to eql("The owning organisation code is incorrect")
         end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
       end
 
       context "when cannot find owning org" do
@@ -641,6 +645,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         it "is not permitted" do
           expect(parser.errors[:field_111]).to eql(["The owning organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
         end
       end
 
@@ -674,11 +682,27 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
     end
 
     describe "#field_113" do # managing org
+      context "when blank" do
+        let(:attributes) { { bulk_upload:, field_113: "" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_113]).to eql(["The managing organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+
       context "when cannot find managing org" do
         let(:attributes) { { bulk_upload:, field_113: "donotexist" } }
 
         it "is not permitted" do
           expect(parser.errors[:field_113]).to eql(["The managing organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -580,11 +580,27 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#field_1" do # owning org
+      context "when blank" do
+        let(:attributes) { { bulk_upload:, field_1: "" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_1]).to eql(["The owning organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+
       context "when cannot find owning org" do
         let(:attributes) { { bulk_upload:, field_1: "donotexist" } }
 
         it "is not permitted" do
           expect(parser.errors[:field_1]).to eql(["The owning organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
         end
       end
 
@@ -618,11 +634,27 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#field_2" do # managing org
+      context "when blank" do
+        let(:attributes) { { bulk_upload:, field_2: "" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_2]).to eql(["The managing organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+
       context "when cannot find managing org" do
         let(:attributes) { { bulk_upload:, field_2: "donotexist" } }
 
         it "is not permitted" do
           expect(parser.errors[:field_2]).to eql(["The managing organisation code is incorrect"])
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
         end
       end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2178
- Bug where for bulk upload could create a log with bad owning or managing org data

# Changes

- If there is bad owning or managing org data prevent logs from being created
- This forces the user to see the error report and we never create the logs