### PR TITLE
Disable start date validation for staging

### DIFF
--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -5,7 +5,7 @@ class FeatureToggle
   end
 
   def self.startdate_collection_window_validation_enabled?
-    Rails.env.production? || Rails.env.test? || Rails.env.staging?
+    Rails.env.production? || Rails.env.test?
   end
 
   def self.startdate_two_week_validation_enabled?


### PR DESCRIPTION
# Context

- In staging we can't test new collection window data because start date lies outside of collection window
- We want to test new log submissions prior to the window coming into play

# Change

- Disable start date validation on staging