### PR TITLE
CLDC-2072 changing startdate to another collection year clear invalid answers

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -239,9 +239,9 @@ class Form
 
   def routed_and_not_routed_questions_by_type(log, type: nil, current_user: nil)
     questions_by_type = if type
-                          questions.reject { |q| q.type != type || q.do_not_clear }
+                          questions.reject { |q| q.type != type || q.disable_clearing_if_not_routed_or_dynamic_answer_options }
                         else
-                          questions.reject { |q| %w[radio checkbox].include?(q.type) || q.do_not_clear }
+                          questions.reject { |q| %w[radio checkbox].include?(q.type) || q.disable_clearing_if_not_routed_or_dynamic_answer_options }
                         end
     routed, not_routed = questions_by_type.partition { |q| q.page.routed_to?(log, current_user) || q.derived? }
     { routed:, not_routed: }

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -230,6 +230,21 @@ class Form
     questions.select { |q| q.type == "numeric" }
   end
 
+  def radio_questions_valid_options
+    questions.select { |q| q.type == "radio" }
+             .group_by(:id)
+             .transform_values! do |q_array|
+               q_array.flat_map { |q| q.answer_options.keys }
+             end
+  end
+
+  def previous_page(page_ids, page_index, log, current_user)
+    prev_page = get_page(page_ids[page_index - 1])
+    return prev_page.id if prev_page.routed_to?(log, current_user)
+
+    previous_page(page_ids, page_index - 1, log, current_user)
+  end
+
   def send_chain(arr, log)
     Array(arr).inject(log) { |o, a| o.public_send(*a) }
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -192,7 +192,7 @@ class Form
       valid_options = checkbox_questions[:valid]
                                         .select { |q| q.id == invalidated_question.id }
                                         .flat_map { |q| q.answer_options.keys }
-      invalidated_question.answer_options.keys.each do |invalid_option|
+      invalidated_question.answer_options.each_key do |invalid_option|
         if !log.respond_to?(invalid_option) || valid_options.include?(invalid_option)
           next
         else

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -232,7 +232,7 @@ class Form
 
   def radio_questions_valid_options
     questions.select { |q| q.type == "radio" }
-             .group_by(:id)
+             .group_by(&:id)
              .transform_values! do |q_array|
                q_array.flat_map { |q| q.answer_options.keys }
              end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -230,14 +230,6 @@ class Form
     questions.select { |q| q.type == "numeric" }
   end
 
-  def radio_questions_valid_options
-    questions.select { |q| q.type == "radio" }
-             .group_by(&:id)
-             .transform_values! do |q_array|
-               q_array.flat_map { |q| q.answer_options.keys }
-             end
-  end
-
   def previous_page(page_ids, page_index, log, current_user)
     prev_page = get_page(page_ids[page_index - 1])
     return prev_page.id if prev_page.routed_to?(log, current_user)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -238,12 +238,10 @@ class Form
   end
 
   def routed_and_not_routed_questions_by_type(log, type: nil, current_user: nil)
-    # we're already treating these fields as a special case and reset their values upon saving a log
-    callback_questions = %w[postcode_known la ppcodenk previous_la_known prevloc postcode_full ppostcode_full location_id address_line1 address_line2 town_or_city county]
     questions_to_categorise = if type
-                                questions.reject { |q| q.type != type || callback_questions.include?(q.id) }
+                                questions.reject { |q| q.type != type || q.do_not_clear }
                               else
-                                questions.reject { |q| %w[radio checkbox].include?(q.type) || callback_questions.include?(q.id) }
+                                questions.reject { |q| %w[radio checkbox].include?(q.type) || q.do_not_clear }
                               end
     valid, invalid = questions_to_categorise.partition { |q| q.page.routed_to?(log, current_user) || q.derived? }
     { valid:, invalid: }

--- a/app/models/form/lettings/questions/address_line1.rb
+++ b/app/models/form/lettings/questions/address_line1.rb
@@ -7,6 +7,7 @@ class Form::Lettings::Questions::AddressLine1 < ::Form::Question
     @type = "text"
     @plain_label = true
     @check_answer_label = "Q12 - Address"
+    @do_not_clear = true
   end
 
   def answer_label(log, _current_user = nil)

--- a/app/models/form/lettings/questions/address_line1.rb
+++ b/app/models/form/lettings/questions/address_line1.rb
@@ -7,7 +7,7 @@ class Form::Lettings::Questions::AddressLine1 < ::Form::Question
     @type = "text"
     @plain_label = true
     @check_answer_label = "Q12 - Address"
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_label(log, _current_user = nil)

--- a/app/models/form/lettings/questions/address_line2.rb
+++ b/app/models/form/lettings/questions/address_line2.rb
@@ -5,6 +5,7 @@ class Form::Lettings::Questions::AddressLine2 < ::Form::Question
     @header = "Address line 2 (optional)"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/address_line2.rb
+++ b/app/models/form/lettings/questions/address_line2.rb
@@ -5,7 +5,7 @@ class Form::Lettings::Questions::AddressLine2 < ::Form::Question
     @header = "Address line 2 (optional)"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/county.rb
+++ b/app/models/form/lettings/questions/county.rb
@@ -5,6 +5,7 @@ class Form::Lettings::Questions::County < ::Form::Question
     @header = "County (optional)"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/county.rb
+++ b/app/models/form/lettings/questions/county.rb
@@ -5,7 +5,7 @@ class Form::Lettings::Questions::County < ::Form::Question
     @header = "County (optional)"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/la.rb
+++ b/app/models/form/lettings/questions/la.rb
@@ -8,6 +8,7 @@ class Form::Lettings::Questions::La < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @question_number = 13
+    @do_not_clear = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/la.rb
+++ b/app/models/form/lettings/questions/la.rb
@@ -8,7 +8,7 @@ class Form::Lettings::Questions::La < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @question_number = 13
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -1,6 +1,7 @@
 class Form::Lettings::Questions::LocationId < ::Form::Question
-  def initialize(_id, hsh, page)
-    super("location_id", hsh, page)
+  def initialize(id, hsh, page)
+    super
+    @id = "location_id"
     @check_answer_label = "Location"
     @header = header_text
     @type = "radio"
@@ -11,6 +12,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
       },
     }
     @question_number = 10
+    @do_not_clear = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -12,7 +12,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
       },
     }
     @question_number = 10
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/postcode_for_full_address.rb
+++ b/app/models/form/lettings/questions/postcode_for_full_address.rb
@@ -17,6 +17,7 @@ class Form::Lettings::Questions::PostcodeForFullAddress < ::Form::Question
       },
     }
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/postcode_for_full_address.rb
+++ b/app/models/form/lettings/questions/postcode_for_full_address.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Questions::PostcodeForFullAddress < ::Form::Question
       },
     }
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/postcode_full.rb
+++ b/app/models/form/lettings/questions/postcode_full.rb
@@ -10,5 +10,6 @@ class Form::Lettings::Questions::PostcodeFull < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @inferred_answers = { "la" => { "is_la_inferred" => true } }
+    @do_not_clear = true
   end
 end

--- a/app/models/form/lettings/questions/postcode_full.rb
+++ b/app/models/form/lettings/questions/postcode_full.rb
@@ -10,6 +10,6 @@ class Form::Lettings::Questions::PostcodeFull < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @inferred_answers = { "la" => { "is_la_inferred" => true } }
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 end

--- a/app/models/form/lettings/questions/postcode_known.rb
+++ b/app/models/form/lettings/questions/postcode_known.rb
@@ -8,6 +8,7 @@ class Form::Lettings::Questions::PostcodeKnown < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @answer_options = ANSWER_OPTIONS
+    @do_not_clear = true
     @conditional_for = { "postcode_full" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "postcode_known" => 0 }, { "postcode_known" => 1 }] }
   end

--- a/app/models/form/lettings/questions/postcode_known.rb
+++ b/app/models/form/lettings/questions/postcode_known.rb
@@ -8,7 +8,7 @@ class Form::Lettings::Questions::PostcodeKnown < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = ""
     @answer_options = ANSWER_OPTIONS
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
     @conditional_for = { "postcode_full" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "postcode_known" => 0 }, { "postcode_known" => 1 }] }
   end

--- a/app/models/form/lettings/questions/ppcodenk.rb
+++ b/app/models/form/lettings/questions/ppcodenk.rb
@@ -11,6 +11,7 @@ class Form::Lettings::Questions::Ppcodenk < ::Form::Question
     @conditional_for = { "ppostcode_full" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "ppcodenk" => 0 }, { "ppcodenk" => 1 }] }
     @question_number = 80
+    @do_not_clear = true
   end
 
   ANSWER_OPTIONS = { "1" => { "value" => "Yes" }, "0" => { "value" => "No" } }.freeze

--- a/app/models/form/lettings/questions/ppcodenk.rb
+++ b/app/models/form/lettings/questions/ppcodenk.rb
@@ -11,7 +11,7 @@ class Form::Lettings::Questions::Ppcodenk < ::Form::Question
     @conditional_for = { "ppostcode_full" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "ppcodenk" => 0 }, { "ppcodenk" => 1 }] }
     @question_number = 80
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   ANSWER_OPTIONS = { "1" => { "value" => "Yes" }, "0" => { "value" => "No" } }.freeze

--- a/app/models/form/lettings/questions/ppostcode_full.rb
+++ b/app/models/form/lettings/questions/ppostcode_full.rb
@@ -11,6 +11,6 @@ class Form::Lettings::Questions::PpostcodeFull < ::Form::Question
     @hint_text = ""
     @inferred_answers = { "prevloc" => { "is_previous_la_inferred" => true } }
     @question_number = 80
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 end

--- a/app/models/form/lettings/questions/ppostcode_full.rb
+++ b/app/models/form/lettings/questions/ppostcode_full.rb
@@ -11,5 +11,6 @@ class Form::Lettings::Questions::PpostcodeFull < ::Form::Question
     @hint_text = ""
     @inferred_answers = { "prevloc" => { "is_previous_la_inferred" => true } }
     @question_number = 80
+    @do_not_clear = true
   end
 end

--- a/app/models/form/lettings/questions/previous_la_known.rb
+++ b/app/models/form/lettings/questions/previous_la_known.rb
@@ -11,7 +11,7 @@ class Form::Lettings::Questions::PreviousLaKnown < ::Form::Question
     @conditional_for = { "prevloc" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "previous_la_known" => 0 }, { "previous_la_known" => 1 }] }
     @question_number = 81
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   ANSWER_OPTIONS = { "1" => { "value" => "Yes" }, "0" => { "value" => "No" } }.freeze

--- a/app/models/form/lettings/questions/previous_la_known.rb
+++ b/app/models/form/lettings/questions/previous_la_known.rb
@@ -11,6 +11,7 @@ class Form::Lettings::Questions::PreviousLaKnown < ::Form::Question
     @conditional_for = { "prevloc" => [1] }
     @hidden_in_check_answers = { "depends_on" => [{ "previous_la_known" => 0 }, { "previous_la_known" => 1 }] }
     @question_number = 81
+    @do_not_clear = true
   end
 
   ANSWER_OPTIONS = { "1" => { "value" => "Yes" }, "0" => { "value" => "No" } }.freeze

--- a/app/models/form/lettings/questions/prevloc.rb
+++ b/app/models/form/lettings/questions/prevloc.rb
@@ -9,7 +9,7 @@ class Form::Lettings::Questions::Prevloc < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England."
     @question_number = 81
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/prevloc.rb
+++ b/app/models/form/lettings/questions/prevloc.rb
@@ -9,6 +9,7 @@ class Form::Lettings::Questions::Prevloc < ::Form::Question
     @check_answers_card_number = 0
     @hint_text = "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England."
     @question_number = 81
+    @do_not_clear = true
   end
 
   def answer_options

--- a/app/models/form/lettings/questions/town_or_city.rb
+++ b/app/models/form/lettings/questions/town_or_city.rb
@@ -5,6 +5,7 @@ class Form::Lettings::Questions::TownOrCity < ::Form::Question
     @header = "Town or city"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/lettings/questions/town_or_city.rb
+++ b/app/models/form/lettings/questions/town_or_city.rb
@@ -5,7 +5,7 @@ class Form::Lettings::Questions::TownOrCity < ::Form::Question
     @header = "Town or city"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -1,5 +1,5 @@
 class Form::Question
-  attr_accessor :id, :header, :hint_text, :description, :questions, :do_not_clear,
+  attr_accessor :id, :header, :hint_text, :description, :questions, :disable_clearing_if_not_routed_or_dynamic_answer_options,
                 :type, :min, :max, :step, :width, :fields_to_add, :result_field,
                 :conditional_for, :readonly, :answer_options, :page, :check_answer_label,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
@@ -42,7 +42,7 @@ class Form::Question
       @unresolved_hint_text = hsh["unresolved_hint_text"]
       @question_number = hsh["question_number"]
       @plain_label = hsh["plain_label"]
-      @do_not_clear = hsh["do_not_clear"]
+      @disable_clearing_if_not_routed_or_dynamic_answer_options = hsh["disable_clearing_if_not_routed_or_dynamic_answer_options"]
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -1,5 +1,5 @@
 class Form::Question
-  attr_accessor :id, :header, :hint_text, :description, :questions,
+  attr_accessor :id, :header, :hint_text, :description, :questions, :do_not_clear,
                 :type, :min, :max, :step, :width, :fields_to_add, :result_field,
                 :conditional_for, :readonly, :answer_options, :page, :check_answer_label,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
@@ -42,6 +42,7 @@ class Form::Question
       @unresolved_hint_text = hsh["unresolved_hint_text"]
       @question_number = hsh["question_number"]
       @plain_label = hsh["plain_label"]
+      @do_not_clear = hsh["do_not_clear"]
     end
   end
 

--- a/app/models/form/sales/pages/extra_borrowing_value_check.rb
+++ b/app/models/form/sales/pages/extra_borrowing_value_check.rb
@@ -9,8 +9,7 @@ class Form::Sales::Pages::ExtraBorrowingValueCheck < Form::Page
     @title_text = {
       "translation" => "soft_validations.extra_borrowing.title",
     }
-    @informative_text = {
-    }
+    @informative_text = {}
   end
 
   def questions

--- a/app/models/form/sales/questions/address_line1.rb
+++ b/app/models/form/sales/questions/address_line1.rb
@@ -7,7 +7,7 @@ class Form::Sales::Questions::AddressLine1 < ::Form::Question
     @type = "text"
     @plain_label = true
     @check_answer_label = "Q15 - Address"
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_label(log, _current_user = nil)

--- a/app/models/form/sales/questions/address_line1.rb
+++ b/app/models/form/sales/questions/address_line1.rb
@@ -7,6 +7,7 @@ class Form::Sales::Questions::AddressLine1 < ::Form::Question
     @type = "text"
     @plain_label = true
     @check_answer_label = "Q15 - Address"
+    @do_not_clear = true
   end
 
   def answer_label(log, _current_user = nil)

--- a/app/models/form/sales/questions/address_line2.rb
+++ b/app/models/form/sales/questions/address_line2.rb
@@ -5,6 +5,7 @@ class Form::Sales::Questions::AddressLine2 < ::Form::Question
     @header = "Address line 2 (optional)"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/address_line2.rb
+++ b/app/models/form/sales/questions/address_line2.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::AddressLine2 < ::Form::Question
     @header = "Address line 2 (optional)"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/age2.rb
+++ b/app/models/form/sales/questions/age2.rb
@@ -13,6 +13,7 @@ class Form::Sales::Questions::Age2 < ::Form::Question
     @check_answers_card_number = 2
     @max = 110
     @min = 0
+    @step = 1
     @question_number = 28
   end
 end

--- a/app/models/form/sales/questions/county.rb
+++ b/app/models/form/sales/questions/county.rb
@@ -5,6 +5,7 @@ class Form::Sales::Questions::County < ::Form::Question
     @header = "County (optional)"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/county.rb
+++ b/app/models/form/sales/questions/county.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::County < ::Form::Question
     @header = "County (optional)"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/person_age.rb
+++ b/app/models/form/sales/questions/person_age.rb
@@ -12,6 +12,7 @@ class Form::Sales::Questions::PersonAge < ::Form::Question
     @check_answers_card_number = person_index
     @min = 0
     @max = 110
+    @step = 1
     @question_number = 29 + (4 * person_index)
   end
 end

--- a/app/models/form/sales/questions/postcode.rb
+++ b/app/models/form/sales/questions/postcode.rb
@@ -17,6 +17,6 @@ class Form::Sales::Questions::Postcode < ::Form::Question
         "is_la_inferred" => true,
       },
     }
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 end

--- a/app/models/form/sales/questions/postcode.rb
+++ b/app/models/form/sales/questions/postcode.rb
@@ -17,5 +17,6 @@ class Form::Sales::Questions::Postcode < ::Form::Question
         "is_la_inferred" => true,
       },
     }
+    @do_not_clear = true
   end
 end

--- a/app/models/form/sales/questions/postcode_for_full_address.rb
+++ b/app/models/form/sales/questions/postcode_for_full_address.rb
@@ -17,6 +17,7 @@ class Form::Sales::Questions::PostcodeForFullAddress < ::Form::Question
       },
     }
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/postcode_for_full_address.rb
+++ b/app/models/form/sales/questions/postcode_for_full_address.rb
@@ -17,7 +17,7 @@ class Form::Sales::Questions::PostcodeForFullAddress < ::Form::Question
       },
     }
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/previous_la_known.rb
+++ b/app/models/form/sales/questions/previous_la_known.rb
@@ -21,7 +21,7 @@ class Form::Sales::Questions::PreviousLaKnown < ::Form::Question
       "prevloc" => [1],
     }
     @question_number = 58
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/previous_la_known.rb
+++ b/app/models/form/sales/questions/previous_la_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::PreviousLaKnown < ::Form::Question
       "prevloc" => [1],
     }
     @question_number = 58
+    @do_not_clear = true
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/previous_postcode.rb
+++ b/app/models/form/sales/questions/previous_postcode.rb
@@ -18,6 +18,6 @@ class Form::Sales::Questions::PreviousPostcode < ::Form::Question
       },
     }
     @question_number = 57
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 end

--- a/app/models/form/sales/questions/previous_postcode.rb
+++ b/app/models/form/sales/questions/previous_postcode.rb
@@ -18,5 +18,6 @@ class Form::Sales::Questions::PreviousPostcode < ::Form::Question
       },
     }
     @question_number = 57
+    @do_not_clear = true
   end
 end

--- a/app/models/form/sales/questions/previous_postcode_known.rb
+++ b/app/models/form/sales/questions/previous_postcode_known.rb
@@ -21,6 +21,7 @@ class Form::Sales::Questions::PreviousPostcodeKnown < ::Form::Question
       ],
     }
     @question_number = 57
+    @do_not_clear = true
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/previous_postcode_known.rb
+++ b/app/models/form/sales/questions/previous_postcode_known.rb
@@ -21,7 +21,7 @@ class Form::Sales::Questions::PreviousPostcodeKnown < ::Form::Question
       ],
     }
     @question_number = 57
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   ANSWER_OPTIONS = {

--- a/app/models/form/sales/questions/prevloc.rb
+++ b/app/models/form/sales/questions/prevloc.rb
@@ -12,7 +12,7 @@ class Form::Sales::Questions::Prevloc < ::Form::Question
       "value" => "Not known",
     }]
     @question_number = 58
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_options

--- a/app/models/form/sales/questions/prevloc.rb
+++ b/app/models/form/sales/questions/prevloc.rb
@@ -12,6 +12,7 @@ class Form::Sales::Questions::Prevloc < ::Form::Question
       "value" => "Not known",
     }]
     @question_number = 58
+    @do_not_clear = true
   end
 
   def answer_options

--- a/app/models/form/sales/questions/property_local_authority.rb
+++ b/app/models/form/sales/questions/property_local_authority.rb
@@ -6,7 +6,7 @@ class Form::Sales::Questions::PropertyLocalAuthority < ::Form::Question
     @header = "What is the property’s local authority?"
     @type = "select"
     @question_number = 16
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def answer_options

--- a/app/models/form/sales/questions/property_local_authority.rb
+++ b/app/models/form/sales/questions/property_local_authority.rb
@@ -6,6 +6,7 @@ class Form::Sales::Questions::PropertyLocalAuthority < ::Form::Question
     @header = "What is the property’s local authority?"
     @type = "select"
     @question_number = 16
+    @do_not_clear = true
   end
 
   def answer_options

--- a/app/models/form/sales/questions/town_or_city.rb
+++ b/app/models/form/sales/questions/town_or_city.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::TownOrCity < ::Form::Question
     @header = "Town or city"
     @type = "text"
     @plain_label = true
-    @do_not_clear = true
+    @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/form/sales/questions/town_or_city.rb
+++ b/app/models/form/sales/questions/town_or_city.rb
@@ -5,6 +5,7 @@ class Form::Sales::Questions::TownOrCity < ::Form::Question
     @header = "Town or city"
     @type = "text"
     @plain_label = true
+    @do_not_clear = true
   end
 
   def hidden_in_check_answers?(_log = nil, _current_user = nil)

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -26,6 +26,7 @@ class LettingsLog < Log
 
   validates_with LettingsLogValidator
   before_validation :recalculate_start_year!, if: :startdate_changed?
+  before_validation :clear_invalid_radio_answers!, if: :startdate_changed?
   before_validation :reset_scheme_location!, if: :scheme_changed?, unless: :location_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
@@ -78,6 +79,10 @@ class LettingsLog < Log
     return unless startdate
 
     FormHandler.instance.form_name_from_start_year(collection_start_year, "lettings")
+  end
+
+  def clear_invalid_radio_answers!
+    super if startdate_was && @start_year != FormHandler.instance.collection_start_year(startdate_was)
   end
 
   def self.editable_fields

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -26,7 +26,6 @@ class LettingsLog < Log
 
   validates_with LettingsLogValidator
   before_validation :recalculate_start_year!, if: :startdate_changed?
-  before_validation :clear_invalid_radio_answers!, if: :startdate_changed?
   before_validation :reset_scheme_location!, if: :scheme_changed?, unless: :location_changed?
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
@@ -79,10 +78,6 @@ class LettingsLog < Log
     return unless startdate
 
     FormHandler.instance.form_name_from_start_year(collection_start_year, "lettings")
-  end
-
-  def clear_invalid_radio_answers!
-    super if startdate_was && @start_year != FormHandler.instance.collection_start_year(startdate_was)
   end
 
   def self.editable_fields

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -63,14 +63,6 @@ class Log < ApplicationRecord
     end
   end
 
-  def clear_invalid_radio_answers!
-    form.radio_questions_valid_options.each do |question_id, valid_options|
-      next unless (value = self[question_id])
-
-      self[question_id] = nil unless valid_options.include?(value.to_s)
-    end
-  end
-
   def collection_start_year
     return @start_year if @start_year
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -174,7 +174,7 @@ private
   def reset_invalidated_dependent_fields!
     return unless form
 
-    form.reset_not_routed_questions(self)
+    form.reset_not_routed_questions_and_invalid_answers(self)
     reset_created_by!
   end
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -63,6 +63,14 @@ class Log < ApplicationRecord
     end
   end
 
+  def clear_invalid_radio_answers!
+    form.radio_questions_valid_options.each do |question_id, valid_options|
+      next unless (value = self[question_id])
+
+      self[question_id] = nil unless valid_options.include?(value.to_s)
+    end
+  end
+
   def collection_start_year
     return @start_year if @start_year
 

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -26,7 +26,6 @@ class SalesLog < Log
 
   validates_with SalesLogValidator
   before_validation :recalculate_start_year!, if: :saledate_changed?
-  before_validation :clear_invalid_radio_answers!, if: :saledate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
@@ -75,10 +74,6 @@ class SalesLog < Log
 
   def optional_fields
     OPTIONAL_FIELDS + dynamically_not_required
-  end
-
-  def clear_invalid_radio_answers!
-    super if saledate_was && @start_year != FormHandler.instance.collection_start_year(saledate_was)
   end
 
   def dynamically_not_required

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -26,6 +26,7 @@ class SalesLog < Log
 
   validates_with SalesLogValidator
   before_validation :recalculate_start_year!, if: :saledate_changed?
+  before_validation :clear_invalid_radio_answers!, if: :saledate_changed?
   before_validation :reset_invalidated_dependent_fields!
   before_validation :process_postcode_changes!, if: :postcode_full_changed?
   before_validation :process_previous_postcode_changes!, if: :ppostcode_full_changed?
@@ -74,6 +75,10 @@ class SalesLog < Log
 
   def optional_fields
     OPTIONAL_FIELDS + dynamically_not_required
+  end
+
+  def clear_invalid_radio_answers!
+    super if saledate_was && @start_year != FormHandler.instance.collection_start_year(saledate_was)
   end
 
   def dynamically_not_required

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -6,14 +6,14 @@
     hint: { text: question.hint_text&.html_safe } do %>
     <% after_divider = false %>
 
-    <% question.displayed_answer_options(@log).map do |key, options| %>
+    <% question.displayed_answer_options(@log).map do |key, option| %>
       <% if key.starts_with?("divider") %>
-      <% after_divider = true %>
-      <%= f.govuk_check_box_divider %>
+        <% after_divider = true %>
+        <%= f.govuk_check_box_divider %>
       <% else %>
         <%= f.govuk_check_box question.id, key,
-          label: { text: options["value"] },
-          hint: { text: options["hint"] },
+          label: { text: option["value"] },
+          hint: { text: option["hint"] },
           checked: @log[key] == 1,
           exclusive: after_divider,
           **stimulus_html_attributes(question) %>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -24,7 +24,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -55,7 +55,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -84,7 +84,7 @@
                   "header": "What is the local authority of the property?",
                   "hint_text": "",
                   "type": "select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -6485,7 +6485,7 @@
                   "header": "Do you know the postcode of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -6516,7 +6516,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "inferred_answers": {
                     "prevloc": {
                       "is_previous_la_inferred": true
@@ -6540,7 +6540,7 @@
                   "header": "Do you know the local authority of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "hidden_in_check_answers": {
                     "depends_on": [
                       {
@@ -6570,7 +6570,7 @@
                   "header": "Select a local authority",
                   "hint_text": "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England.",
                   "type": "select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "S12000033": "Aberdeen City",

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -24,6 +24,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -54,6 +55,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
+                  "do_not_clear": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -82,6 +84,7 @@
                   "header": "What is the local authority of the property?",
                   "hint_text": "",
                   "type": "select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -6482,6 +6485,7 @@
                   "header": "Do you know the postcode of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -6512,6 +6516,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
+                  "do_not_clear": true,
                   "inferred_answers": {
                     "prevloc": {
                       "is_previous_la_inferred": true
@@ -6535,6 +6540,7 @@
                   "header": "Do you know the local authority of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
+                  "do_not_clear": true,
                   "hidden_in_check_answers": {
                     "depends_on": [
                       {
@@ -6564,6 +6570,7 @@
                   "header": "Select a local authority",
                   "hint_text": "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England.",
                   "type": "select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "S12000033": "Aberdeen City",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -24,7 +24,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -55,7 +55,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -84,7 +84,7 @@
                   "header": "What is the local authority of the property?",
                   "hint_text": "",
                   "type": "select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -6438,7 +6438,7 @@
                   "header": "Do you know the postcode of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -6469,7 +6469,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "inferred_answers": {
                     "prevloc": {
                       "is_previous_la_inferred": true
@@ -6493,7 +6493,7 @@
                   "header": "Do you know the local authority of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "hidden_in_check_answers": {
                     "depends_on": [
                       {
@@ -6523,7 +6523,7 @@
                   "header": "Select a local authority",
                   "hint_text": "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England.",
                   "type": "select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "S12000033": "Aberdeen City",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -24,6 +24,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -54,6 +55,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
+                  "do_not_clear": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -82,6 +84,7 @@
                   "header": "What is the local authority of the property?",
                   "hint_text": "",
                   "type": "select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -6435,6 +6438,7 @@
                   "header": "Do you know the postcode of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -6465,6 +6469,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
+                  "do_not_clear": true,
                   "inferred_answers": {
                     "prevloc": {
                       "is_previous_la_inferred": true
@@ -6488,6 +6493,7 @@
                   "header": "Do you know the local authority of the household’s last settled accommodation?",
                   "hint_text": "This is also known as the household’s ‘last settled home’.",
                   "type": "radio",
+                  "do_not_clear": true,
                   "hidden_in_check_answers": {
                     "depends_on": [
                       {
@@ -6517,6 +6523,7 @@
                   "header": "Select a local authority",
                   "hint_text": "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England.",
                   "type": "select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "S12000033": "Aberdeen City",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,7 +365,7 @@ en:
           over_20: "The lead tenant must be under 20 as you told us their housing situation immediately before this letting was a children’s home or foster care"
       ecstat:
         retired_over_70: "Person %{person_num} must be retired if over 70"
-        child_under_16: "Person’s %{person_num} working situation must be ’child under 16‘ as you told us they’re under 16"
+        child_under_16: "Person %{person_num}’s working situation must be ‘child under 16’ as you told us they’re under 16"
         child_over_16: "Answer cannot be ‘child under 16’ as you told us the person %{person_num} is older than 16"
         not_student_16_19: "Person’s %{person_num} working situation must be full-time student or prefers not to say as you told us they’re between 16 and 19."
         student_16_19:

--- a/spec/factories/lettings_log.rb
+++ b/spec/factories/lettings_log.rb
@@ -161,6 +161,9 @@ FactoryBot.define do
     trait :sheltered_housing do
       needstype { 2 }
     end
+    trait :startdate_today do
+      startdate { Time.zone.today }
+    end
     created_at { Time.zone.today }
     updated_at { Time.zone.today }
   end

--- a/spec/factories/lettings_log.rb
+++ b/spec/factories/lettings_log.rb
@@ -158,6 +158,9 @@ FactoryBot.define do
       sheltered { 0 }
       household_charge { 0 }
     end
+    trait :sheltered_housing do
+      needstype { 2 }
+    end
     created_at { Time.zone.today }
     updated_at { Time.zone.today }
   end

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
       type { 8 }
       saledate { Time.utc(2023, 2, 2, 10, 36, 49) }
     end
+    trait :shared_ownership do
+      ownershipsch { 1 }
+    end
     trait :completed do
       ownershipsch { 2 }
       type { 8 }

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -12,6 +12,27 @@ FactoryBot.define do
     end
     trait :shared_ownership do
       ownershipsch { 1 }
+      type { 30 }
+    end
+    trait :privacy_notice_seen do
+      privacynotice { 1 }
+    end
+    trait :saledate_today do
+      saledate { Time.zone.today }
+    end
+    trait :shared_ownership_setup_complete do
+      saledate { Time.zone.today }
+      ownershipsch { 1 }
+      type { 30 }
+      jointpur { 2 }
+    end
+    trait :outright_sale_setup_complete do
+      saledate { Time.zone.today }
+      ownershipsch { 3 }
+      type { 10 }
+      companybuy { 2 }
+      buylivein { 1 }
+      jointpur { 2 }
     end
     trait :completed do
       ownershipsch { 2 }

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -21,13 +21,13 @@ FactoryBot.define do
       saledate { Time.zone.today }
     end
     trait :shared_ownership_setup_complete do
-      saledate { Time.zone.today }
+      saledate_today
       ownershipsch { 1 }
       type { 30 }
       jointpur { 2 }
     end
     trait :outright_sale_setup_complete do
-      saledate { Time.zone.today }
+      saledate_today
       ownershipsch { 3 }
       type { 10 }
       companybuy { 2 }

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -411,6 +411,7 @@
                   "hint_text": "Type ahead to filter the options",
                   "type": "select",
                   "check_answer_label": "Accessible Select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -473,6 +474,7 @@
                   "hint_text": "Type ahead to filter the options",
                   "type": "select",
                   "check_answer_label": "Accessible Select",
+                  "do_not_clear": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -500,6 +502,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -521,6 +524,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
+                  "do_not_clear": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -544,6 +548,7 @@
                   "header": "Do you know what local authority the property is located in?",
                   "hint_text": "",
                   "type": "radio",
+                  "do_not_clear": true,
                   "answer_options": {
                     "0": {
                       "value": "No"
@@ -1151,6 +1156,7 @@
                   "header": "Postcode for the previous accommodation",
                   "hint_text": "If the household has moved from settled accommodation immediately prior to being re-housed",
                   "type": "text",
+                  "do_not_clear": true,
                   "width": 5
                 }
               }

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -411,7 +411,7 @@
                   "hint_text": "Type ahead to filter the options",
                   "type": "select",
                   "check_answer_label": "Accessible Select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -474,7 +474,7 @@
                   "hint_text": "Type ahead to filter the options",
                   "type": "select",
                   "check_answer_label": "Accessible Select",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "": "Select an option",
                     "E07000223": "Adur",
@@ -502,7 +502,7 @@
                   "header": "Do you know the property’s postcode?",
                   "hint_text": "",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "1": {
                       "value": "Yes"
@@ -524,7 +524,7 @@
                   "hint_text": "",
                   "type": "text",
                   "width": 5,
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "inferred_answers": {
                     "la": {
                       "is_la_inferred": true
@@ -548,7 +548,7 @@
                   "header": "Do you know what local authority the property is located in?",
                   "hint_text": "",
                   "type": "radio",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "answer_options": {
                     "0": {
                       "value": "No"
@@ -1156,7 +1156,7 @@
                   "header": "Postcode for the previous accommodation",
                   "hint_text": "If the household has moved from settled accommodation immediately prior to being re-housed",
                   "type": "text",
-                  "do_not_clear": true,
+                  "disable_clearing_if_not_routed_or_dynamic_answer_options": true,
                   "width": 5
                 }
               }

--- a/spec/models/form/sales/questions/age2_spec.rb
+++ b/spec/models/form/sales/questions/age2_spec.rb
@@ -59,4 +59,8 @@ RSpec.describe Form::Sales::Questions::Age2, type: :model do
   it "has the correct max" do
     expect(question.max).to eq(110)
   end
+
+  it "has the correct step" do
+    expect(question.step).to be 1
+  end
 end

--- a/spec/models/form/sales/questions/person_age_spec.rb
+++ b/spec/models/form/sales/questions/person_age_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Form::Sales::Questions::PersonAge, type: :model do
     expect(question.width).to eq(3)
   end
 
+  it "has the correct step" do
+    expect(question.step).to be 1
+  end
+
   context "with person 2" do
     let(:person_index) { 2 }
     let(:question_id) { "age2" }

--- a/spec/models/form/sales/questions/uprn_confirmation_spec.rb
+++ b/spec/models/form/sales/questions/uprn_confirmation_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Form::Sales::Questions::UprnConfirmation, type: :model do
 
     context "when address is present" do
       it "returns formatted value" do
-        log = create(:sales_log, address_line1: "1, Test Street", town_or_city: "Test Town", county: "Test County", postcode_full: "AA1 1AA", uprn: "1234", uprn_known: 1)
+        log = build(:sales_log, :outright_sale_setup_complete, address_line1: "1, Test Street", town_or_city: "Test Town", county: "Test County", postcode_full: "AA1 1AA", uprn: "1234", uprn_known: 1)
 
         expect(question.notification_banner(log)).to eq(
           {

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Form, type: :model do
 
     context "when there are multiple radio questions for attribute X" do
       context "and attribute Y is changed such that a different question for X is routed to" do
-        let(:log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, renewal: 0, prevten:) }
+        let(:log) { FactoryBot.create(:lettings_log, :setup_completed, :sheltered_housing, startdate: now, renewal: 0, prevten:) }
 
         context "and the value of X remains valid" do
           let(:prevten) { 36 }
@@ -244,7 +244,7 @@ RSpec.describe Form, type: :model do
 
     context "when there is one radio question for attribute X" do
       context "and the start date or sale date is changed such that the collection year changes and there are different options" do
-        let(:log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, sheltered:) }
+        let(:log) { FactoryBot.create(:lettings_log, :setup_completed, :sheltered_housing, startdate: now, sheltered:) }
 
         context "and the value of X remains valid" do
           let(:sheltered) { 2 }
@@ -305,7 +305,7 @@ RSpec.describe Form, type: :model do
     end
 
     context "when a value is changed such that a checkbox question is no longer routed to" do
-      let(:log) { FactoryBot.create(:lettings_log, :about_completed, startdate: now, reasonpref: 1, rp_homeless: 1, rp_medwel: 1, rp_hardship: 1) }
+      let(:log) { FactoryBot.create(:lettings_log, :setup_completed, startdate: now, reasonpref: 1, rp_homeless: 1, rp_medwel: 1, rp_hardship: 1) }
 
       it "all attributes relating to that checkbox question are cleared" do
         expect(log.rp_homeless).to be 1

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -204,32 +204,140 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "invalidated_page_questions" do
-    let(:lettings_log) { FactoryBot.create(:lettings_log, :in_progress, needstype: 1) }
-    let(:expected_invalid) { %w[scheme_id retirement_value_check condition_effects cbl conditional_question_no_second_question net_income_value_check dependent_question offered layear declaration] }
+  describe "#reset_not_routed_questions_and_invalid_answers" do
+    around do |example|
+      Singleton.__init__(FormHandler)
+      Timecop.freeze(now) do
+        FormHandler.instance.use_real_forms!
+        example.run
+      end
+      FormHandler.instance.use_fake_forms!
+    end
 
-    context "when dependencies are not met" do
-      it "returns an array of question keys whose pages conditions are not met" do
-        expect(form.invalidated_page_questions(lettings_log).map(&:id).uniq).to eq(expected_invalid)
+    let(:now) { Time.zone.local(2023, 5, 5) }
+
+    context "when there are multiple radio questions for attribute X" do
+      context "and attribute Y is changed such that a different question for X is routed to" do
+        let(:log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, renewal: 0, prevten:) }
+
+        context "and the value of X remains valid" do
+          let(:prevten) { 36 }
+
+          it "the value of this attribute is not cleared" do
+            log.renewal = 1
+            log.form.reset_not_routed_questions_and_invalid_answers(log)
+            expect(log.prevten).to be 36
+          end
+        end
+
+        context "and the value of X is now invalid" do
+          let(:prevten) { 30 }
+
+          it "the value of this attribute is cleared" do
+            log.renewal = 1
+            log.form.reset_not_routed_questions_and_invalid_answers(log)
+            expect(log.prevten).to be nil
+          end
+        end
       end
     end
 
-    context "with two pages having the same question and only one has dependencies met" do
-      it "returns an array of question keys whose pages conditions are not met" do
-        lettings_log["preg_occ"] = "No"
-        expect(form.invalidated_page_questions(lettings_log).map(&:id).uniq).to eq(expected_invalid)
+    context "when there is one radio question for attribute X" do
+      context "and the start date or sale date is changed such that the collection year changes and there are different options" do
+        let(:log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, sheltered:) }
+
+        context "and the value of X remains valid" do
+          let(:sheltered) { 2 }
+
+          it "the value of this attribute is not cleared" do
+            log.update!(startdate: Time.zone.local(2023, 1, 1))
+            expect(log.sheltered).to be 2
+          end
+        end
+
+        context "and the value of X is now invalid" do
+          let(:sheltered) { 5 }
+
+          it "the value of this attribute is cleared" do
+            log.update!(startdate: Time.zone.local(2023, 1, 1))
+            expect(log.sheltered).to be nil
+          end
+        end
       end
     end
 
-    context "when a question is marked as `derived` and `depends_on: false`" do
-      let(:lettings_log) { FactoryBot.build(:lettings_log, :in_progress, startdate: Time.utc(2022, 4, 2, 10, 36, 49)) }
+    context "when there is one free user input question for an attribute X" do
+      let(:log) { FactoryBot.create(:sales_log, :shared_ownership_setup_complete, staircase: 1, stairbought: 25) }
 
-      it "does not count it's questions as invalidated" do
-        expect(form.enabled_page_questions(lettings_log).map(&:id).uniq).to include("tshortfall_known")
+      context "and attribute Y is changed such that it is no longer routed to" do
+        it "the value of this attribute is cleared" do
+          expect(log.stairbought).to be 25
+          log.staircase = 2
+          log.form.reset_not_routed_questions_and_invalid_answers(log)
+          expect(log.stairbought).to be nil
+        end
+      end
+    end
+
+    context "when there are multiple free user input questions for attribute X" do
+      context "and attribute Y is changed such that a different question for X is routed to" do
+        let(:log) { FactoryBot.create(:sales_log, :saledate_today, :shared_ownership, :privacy_notice_seen, jointpur: 1, jointmore: 2, hholdcount: expected_hholdcount) }
+        let(:expected_hholdcount) { 2 }
+
+        it "the value of this attribute is not cleared" do
+          log.jointpur = 2
+          log.form.reset_not_routed_questions_and_invalid_answers(log)
+          expect(log.hholdcount).to eq expected_hholdcount
+        end
       end
 
-      it "does not route to the page" do
-        expect(form.invalidated_pages(lettings_log).map(&:id)).to include("outstanding_amount_known")
+      context "and attribute Y is changed such that no questions for X are routed to" do
+        let(:log) { FactoryBot.create(:sales_log, :shared_ownership_setup_complete, value: initial_value) }
+        let(:initial_value) { 200_000.to_d }
+
+        it "the value of this attribute is cleared" do
+          expect(log.value).to eq initial_value
+          log.ownershipsch = 2
+          log.form.reset_not_routed_questions_and_invalid_answers(log)
+          expect(log.value).to be nil
+        end
+      end
+    end
+
+    context "when a value is changed such that a checkbox question is no longer routed to" do
+      let(:log) { FactoryBot.create(:lettings_log, :about_completed, startdate: now, reasonpref: 1, rp_homeless: 1, rp_medwel: 1, rp_hardship: 1) }
+
+      it "all attributes relating to that checkbox question are cleared" do
+        expect(log.rp_homeless).to be 1
+        log.reasonpref = 2
+        log.form.reset_not_routed_questions_and_invalid_answers(log)
+        expect(log.rp_homeless).to be nil
+        expect(log.rp_medwel).to be nil
+        expect(log.rp_hardship).to be nil
+      end
+    end
+
+    context "when an attribute is derived, but no questions for that attribute are routed to" do
+      let(:log) { FactoryBot.create(:sales_log, :outright_sale_setup_complete, value: 200_000) }
+
+      it "the value of this attribute is not cleared" do
+        expect(log.deposit).to be nil
+        log.update!(mortgageused: 2)
+        expect(log.form.questions.any? { |q| q.id == "deposit" && q.page.routed_to?(log, nil) }).to be false
+        expect(log.deposit).not_to be nil
+      end
+    end
+
+    context "when an attribute is related to a callback question with no set answer options, and no questions for that attribute are routed to" do
+      let(:location) { FactoryBot.create(:location) }
+      let(:log) { FactoryBot.create(:lettings_log, :startdate_today) }
+
+      # Pages::PropertyPostcode and questions inside have been removed from form. do we not want to delete and migration delete_column?
+      it "the value of this attribute is not cleared" do
+        expect(log.form.questions.find { |q| q.id == "location_id" }.answer_options.keys).to be_empty
+        log.location_id = location.id
+        log.form.reset_not_routed_questions_and_invalid_answers(log)
+        expect(log.location_id).not_to be nil
       end
     end
   end

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2620,6 +2620,40 @@ RSpec.describe LettingsLog do
         end
       end
     end
+
+    context "when the collection year is changed" do
+      around do |example|
+        Timecop.freeze(now) do
+          Singleton.__init__(FormHandler)
+          FormHandler.instance.use_real_forms!
+          example.run
+        end
+        Timecop.return
+      end
+
+      let(:lettings_log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, sheltered:) }
+      let(:now) { Time.zone.local(2023, 6, 1) }
+
+      context "and selected answer options are no longer valid" do
+        let(:sheltered) { 5 }
+
+        it "clears those values" do
+          expect(lettings_log.sheltered).to be 5
+          lettings_log.update!(startdate: Time.zone.local(2023, 1, 1))
+          expect(lettings_log.sheltered).to be nil
+        end
+      end
+
+      context "and selected answer options are still valid" do
+        let(:sheltered) { 2 }
+
+        it "does not clear those values" do
+          expect(lettings_log.sheltered).to be 2
+          lettings_log.update!(startdate: Time.zone.local(2023, 1, 1))
+          expect(lettings_log.sheltered).to be 2
+        end
+      end
+    end
   end
 
   describe "tshortfall_unknown?" do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2620,6 +2620,7 @@ RSpec.describe LettingsLog do
         end
       end
     end
+  end
 
   describe "tshortfall_unknown?" do
     context "when tshortfall is nil" do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2621,41 +2621,6 @@ RSpec.describe LettingsLog do
       end
     end
 
-    context "when the collection year is changed" do
-      around do |example|
-        Timecop.freeze(now) do
-          Singleton.__init__(FormHandler)
-          FormHandler.instance.use_real_forms!
-          example.run
-        end
-        Timecop.return
-      end
-
-      let(:lettings_log) { FactoryBot.create(:lettings_log, :about_completed, :sheltered_housing, startdate: now, sheltered:) }
-      let(:now) { Time.zone.local(2023, 6, 1) }
-
-      context "and selected answer options are no longer valid" do
-        let(:sheltered) { 5 }
-
-        it "clears those values" do
-          expect(lettings_log.sheltered).to be 5
-          lettings_log.update!(startdate: Time.zone.local(2023, 1, 1))
-          expect(lettings_log.sheltered).to be nil
-        end
-      end
-
-      context "and selected answer options are still valid" do
-        let(:sheltered) { 2 }
-
-        it "does not clear those values" do
-          expect(lettings_log.sheltered).to be 2
-          lettings_log.update!(startdate: Time.zone.local(2023, 1, 1))
-          expect(lettings_log.sheltered).to be 2
-        end
-      end
-    end
-  end
-
   describe "tshortfall_unknown?" do
     context "when tshortfall is nil" do
       let(:lettings_log) { create(:lettings_log, :in_progress, tshortfall_known: nil) }

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -222,42 +222,6 @@ RSpec.describe SalesLog, type: :model do
     end
   end
 
-  describe "resetting invalidated fields" do
-    context "when the collection year is changed" do
-      around do |example|
-        Timecop.freeze(now) do
-          Singleton.__init__(FormHandler)
-          FormHandler.instance.use_real_forms!
-          example.run
-        end
-        Timecop.return
-      end
-
-      let(:sales_log) { FactoryBot.create(:sales_log, :shared_ownership, saledate: now, type:) }
-      let(:now) { Time.zone.local(2023, 6, 1) }
-
-      context "and selected answer options are no longer valid" do
-        let(:type) { 32 }
-
-        it "clears those values" do
-          expect(sales_log.type).to be 32
-          sales_log.update!(saledate: Time.zone.local(2023, 1, 1))
-          expect(sales_log.type).to be nil
-        end
-      end
-
-      context "and selected answer options are still valid" do
-        let(:type) { 24 }
-
-        it "does not clear those values" do
-          expect(sales_log.type).to be 24
-          sales_log.update!(saledate: Time.zone.local(2023, 1, 1))
-          expect(sales_log.type).to be 24
-        end
-      end
-    end
-  end
-
   context "when saving addresses" do
     before do
       stub_request(:get, /api.postcodes.io/)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -222,6 +222,42 @@ RSpec.describe SalesLog, type: :model do
     end
   end
 
+  describe "resetting invalidated fields" do
+    context "when the collection year is changed" do
+      around do |example|
+        Timecop.freeze(now) do
+          Singleton.__init__(FormHandler)
+          FormHandler.instance.use_real_forms!
+          example.run
+        end
+        Timecop.return
+      end
+
+      let(:sales_log) { FactoryBot.create(:sales_log, :shared_ownership, saledate: now, type:) }
+      let(:now) { Time.zone.local(2023, 6, 1) }
+
+      context "and selected answer options are no longer valid" do
+        let(:type) { 32 }
+
+        it "clears those values" do
+          expect(sales_log.type).to be 32
+          sales_log.update!(saledate: Time.zone.local(2023, 1, 1))
+          expect(sales_log.type).to be nil
+        end
+      end
+
+      context "and selected answer options are still valid" do
+        let(:type) { 24 }
+
+        it "does not clear those values" do
+          expect(sales_log.type).to be 24
+          sales_log.update!(saledate: Time.zone.local(2023, 1, 1))
+          expect(sales_log.type).to be 24
+        end
+      end
+    end
+  end
+
   context "when saving addresses" do
     before do
       stub_request(:get, /api.postcodes.io/)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -571,8 +571,8 @@ RSpec.describe SalesLog, type: :model do
       end
     end
 
-    context "when service errors" do
-      let(:sales_log) { create(:sales_log, uprn_known: 1, uprn: "123456789", uprn_confirmed: 1) }
+    context "when the API returns an error" do
+      let(:sales_log) { build(:sales_log, :outright_sale_setup_complete, uprn_known: 1, uprn: "123456789", uprn_confirmed: 1) }
       let(:error_message) { "error" }
 
       it "adds error to sales log" do

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe SalesLog, type: :model do
     let(:sales_log) { create(:sales_log, :completed) }
 
     it "correctly derives and saves exday, exmonth and exyear" do
-      sales_log.update!(exdate: Time.gm(2022, 5, 4), saledate: Time.gm(2022, 7, 4), ownershipsch: 1, staircase: 2, resale: 2)
+      sales_log.update!(exdate: Time.gm(2022, 5, 4), saledate: Time.gm(2022, 7, 4), ownershipsch: 1, type: 18, staircase: 2, resale: 2, proplen: 0)
       record_from_db = ActiveRecord::Base.connection.execute("select exday, exmonth, exyear from sales_logs where id=#{sales_log.id}").to_a[0]
       expect(record_from_db["exday"]).to eq(4)
       expect(record_from_db["exmonth"]).to eq(5)

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -852,16 +852,6 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       end
     end
 
-    describe "#field_134" do
-      context "when an unpermitted value" do
-        let(:attributes) { { bulk_upload:, field_134: "3" } }
-
-        it "has errors on the field" do
-          expect(parser.errors[:field_134]).to be_present
-        end
-      end
-    end
-
     describe "#field_103" do
       context "when null" do
         let(:attributes) { setup_section_params.merge({ field_103: nil }) }
@@ -872,14 +862,6 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         it "populates with correct error message" do
           expect(parser.errors[:field_103]).to eql(["You must answer type of building"])
-        end
-      end
-
-      context "when unpermitted values" do
-        let(:attributes) { setup_section_params.merge({ field_103: "4" }) }
-
-        it "returns an error" do
-          expect(parser.errors[:field_103]).to be_present
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -842,14 +842,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(parser.errors[:field_30]).to eql(["You must answer type of building"])
         end
       end
-
-      context "when unpermitted values" do
-        let(:attributes) { setup_section_params.merge({ field_30: "4" }) }
-
-        it "returns an error" do
-          expect(parser.errors[:field_30]).to be_present
-        end
-      end
     end
 
     describe "#field_52" do # age2

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -793,14 +793,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#field_6" do # renewal
-      context "when an unpermitted value" do
-        let(:attributes) { { bulk_upload:, field_6: "3" } }
-
-        it "has errors on the field" do
-          expect(parser.errors[:field_6]).to be_present
-        end
-      end
-
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_6: "" } }
 


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2072

Having previously written a small method that did this independently. On reflection it was better to incorporate this behaviour into some adjacent logic, take that opportunity to revamp the existing code to improve readability, and write more comprehensive tests to go with it.

I recommend reading the tests first as they describe the intended behaviour well I think.
I have written comments in line in the form.rb diff to explain changes there
I have ended up with around 30 lines more code, but I hope that is at the gain of much more readability, I am happy to talk through why the original `invalidated_page_questions` method was confusing if that would help