### PR TITLE
CLDC-2127 Permit at least one housing need for bulk upload

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -520,7 +520,7 @@ private
   end
 
   def validate_only_one_housing_needs_type
-    if [field_55, field_56, field_57].compact.count.positive?
+    if [field_55, field_56, field_57].compact.count > 1
       errors.add(:field_55, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_56, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_57, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -419,7 +419,7 @@ private
   end
 
   def validate_only_one_housing_needs_type
-    if [field_83, field_84, field_85].compact.count.positive?
+    if [field_83, field_84, field_85].compact.count > 1
       errors.add(:field_83, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_84, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_85, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -475,6 +475,16 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
     end
 
     describe "#field_55, #field_56, #field_57" do
+      context "when one item selected" do
+        let(:attributes) { { bulk_upload:, field_55: "1" } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_55]).to be_blank
+          expect(parser.errors[:field_56]).to be_blank
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
+
       context "when more than one item selected" do
         let(:attributes) { { bulk_upload:, field_55: "1", field_56: "1" } }
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -438,6 +438,16 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#field_83, #field_84, #field_85" do
+      context "when one item selected" do
+        let(:attributes) { { bulk_upload:, field_83: "1" } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_83]).to be_blank
+          expect(parser.errors[:field_84]).to be_blank
+          expect(parser.errors[:field_85]).to be_blank
+        end
+      end
+
       context "when more than one item selected" do
         let(:attributes) { { bulk_upload:, field_83: "1", field_84: "1" } }
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2127

# Changes

- Bug where for bulk upload could not select one housing need for disabled access as validation was incorrectly implemented