### PR TITLE
CLDC-1893 Support username as email for bulk upload

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -325,6 +325,9 @@ class BulkUpload::Lettings::Year2022::RowParser
   validate :validate_location_exists
   validate :validate_location_data_given
 
+  validate :validate_created_by_exists
+  validate :validate_created_by_related
+
   def self.question_for_field(field)
     QUESTIONS[field]
   end
@@ -381,6 +384,28 @@ class BulkUpload::Lettings::Year2022::RowParser
   end
 
 private
+
+  def validate_created_by_exists
+    return if field_112.blank?
+
+    unless created_by
+      block_log_creation!
+      errors.add(:field_112, "User with the specified email could not be found")
+    end
+  end
+
+  def validate_created_by_related
+    return unless created_by
+
+    unless (created_by.organisation == owning_organisation) || (created_by.organisation == managing_organisation)
+      block_log_creation!
+      errors.add(:field_112, "User must be related to owning organisation or managing organisation")
+    end
+  end
+
+  def created_by
+    @created_by ||= User.find_by(email: field_112)
+  end
 
   def validate_location_related
     return if scheme.blank? || location.blank?
@@ -641,7 +666,7 @@ private
       managing_organisation_id: [:field_113],
       renewal: [:field_134],
       scheme: %i[field_4 field_5],
-      created_by: [],
+      created_by: [:field_112],
       needstype: [],
       rent_type: %i[field_1 field_129 field_130],
       startdate: %i[field_98 field_97 field_96],
@@ -851,7 +876,7 @@ private
     attributes["renewal"] = renewal
     attributes["scheme"] = scheme
     attributes["location"] = location
-    attributes["created_by"] = bulk_upload.user
+    attributes["created_by"] = created_by || bulk_upload.user
     attributes["needstype"] = bulk_upload.needstype
     attributes["rent_type"] = rent_type
     attributes["startdate"] = startdate

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -389,7 +389,6 @@ private
     return if field_112.blank?
 
     unless created_by
-      block_log_creation!
       errors.add(:field_112, "User with the specified email could not be found")
     end
   end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -392,7 +392,6 @@ private
     return if field_3.blank?
 
     unless created_by
-      block_log_creation!
       errors.add(:field_3, "User with the specified email could not be found")
     end
   end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -716,10 +716,6 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
         it "is not permitted" do
           expect(parser.errors[:field_112]).to be_present
         end
-
-        it "blocks log creation" do
-          expect(parser).to be_block_log_creation
-        end
       end
 
       context "when an unaffiliated user" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -242,6 +242,62 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
     end
 
+    describe "#field_3" do # created_by
+      context "when blank" do
+        let(:attributes) { { bulk_upload:, field_3: "" } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_3]).to be_blank
+        end
+      end
+
+      context "when user could not be found" do
+        let(:attributes) { { bulk_upload:, field_3: "idonotexist@example.com" } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_3]).to be_present
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+
+      context "when an unaffiliated user" do
+        let(:other_user) { create(:user) }
+
+        let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email, field_2: managing_org.old_visible_id } }
+
+        it "is not permitted" do
+          expect(parser.errors[:field_3]).to be_present
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+
+      context "when an user part of owning org" do
+        let(:other_user) { create(:user, organisation: owning_org) }
+
+        let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email, field_2: managing_org.old_visible_id } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_3]).to be_blank
+        end
+      end
+
+      context "when an user part of managing org" do
+        let(:other_user) { create(:user, organisation: managing_org) }
+
+        let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email, field_2: managing_org.old_visible_id } }
+
+        it "is permitted" do
+          expect(parser.errors[:field_3]).to be_blank
+        end
+      end
+    end
+
     describe "#field_5" do
       context "when null" do
         let(:attributes) { { bulk_upload:, field_5: nil, field_15: "1" } }
@@ -767,6 +823,26 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
   end
 
   describe "#log" do
+    describe "#created_by" do
+      context "when blank" do
+        let(:attributes) { setup_section_params }
+
+        it "takes the user that is uploading" do
+          expect(parser.log.created_by).to eql(bulk_upload.user)
+        end
+      end
+
+      context "when email specified" do
+        let(:other_user) { create(:user, organisation: owning_org) }
+
+        let(:attributes) { setup_section_params.merge(field_3: other_user.email) }
+
+        it "sets to user with specified email" do
+          expect(parser.log.created_by).to eql(other_user)
+        end
+      end
+    end
+
     describe "#uprn" do
       let(:attributes) { { bulk_upload:, field_18: "100023336956" } }
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -257,10 +257,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "is not permitted" do
           expect(parser.errors[:field_3]).to be_present
         end
-
-        it "blocks log creation" do
-          expect(parser).to be_block_log_creation
-        end
       end
 
       context "when an unaffiliated user" do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1893
- Support `created_by` for bulk upload

# Changes

- Given an email for username in bulk upload assign them as the `created_by`
- If no user is found we user the uploader
- Validations for error reporting
- Also prevent log creation if there is bad data