### PR TITLE
CLDC-2167 Validate rent_type

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -129,7 +129,7 @@ class BulkUpload::Lettings::Year2022::RowParser
     field_124: "Memory",
     field_125: "Mental health",
     field_126: "Stamina or breathing or fatigue",
-    field_127: "Socially or behaviourally, for example  associated with autism spectral disorder (ASD) which includes Aspergers' or attention deficit hyperactivity disorder (ADHD)",
+    field_127: "Socially or behaviourally, for example  associated with autism spectral disorder (ASD) which include Aspergers' or attention deficit hyperactivity disorder (ADHD)",
     field_128: "Other",
     field_129: "Is this letting a London Affordable Rent letting?",
     field_130: "Which type of Intermediate Rent is this letting?",
@@ -327,6 +327,7 @@ class BulkUpload::Lettings::Year2022::RowParser
 
   validate :validate_created_by_exists
   validate :validate_created_by_related
+  validate :validate_rent_type
 
   def self.question_for_field(field)
     QUESTIONS[field]
@@ -604,6 +605,14 @@ private
   def validate_data_types
     unless attribute_set["field_1"].value_before_type_cast&.match?(/\A\d+\z/)
       errors.add(:field_1, I18n.t("validations.invalid_number", question: "letting type"))
+    end
+  end
+
+  def validate_rent_type
+    if [9, 10, 11, 12].include?(field_1) && field_130.blank?
+      errors.add(:field_130, I18n.t("validations.not_answered", question: "intermediate rent type"), category: :setup)
+    elsif [5, 6, 7, 8].include?(field_1) && field_129.blank?
+      errors.add(:field_129, I18n.t("validations.not_answered", question: "affordable rent type"), category: :setup)
     end
   end
 

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -222,6 +222,26 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       end
     end
 
+    context "when lettype is intermediate rent and intermediate rent type is not selected" do
+      let(:attributes) { valid_attributes.merge(field_1: "11", field_130: nil) }
+
+      it "has errors on setup field" do
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+
+        expect(errors).to eql(%i[field_130])
+      end
+    end
+
+    context "when lettype is affordable rent and affordable rent type is not selected" do
+      let(:attributes) { valid_attributes.merge(field_1: "5", field_130: nil) }
+
+      it "has errors on setup field" do
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+
+        expect(errors).to eql(%i[field_129])
+      end
+    end
+
     describe "#field_1" do
       context "when null" do
         let(:attributes) { { bulk_upload:, field_1: nil, field_4: "1" } }


### PR DESCRIPTION
When lettype `field_1` is selected as intermediate rent but intermediate rent type `field_130` is not given, add error in the setup section
When lettype `field_1` is selected as affordable rent but affordable rent type `field_129` is not given, add error in the setup section 