### PR TITLE
CLDC-2217 Skip inferred LA question

### DIFF
--- a/app/models/form/lettings/pages/property_local_authority.rb
+++ b/app/models/form/lettings/pages/property_local_authority.rb
@@ -8,12 +8,4 @@ class Form::Lettings::Pages::PropertyLocalAuthority < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::La.new(nil, nil, self)]
   end
-
-  def routed_to?(log, _current_user = nil)
-    return false if log.uprn_known.nil? && form.start_date.year >= 2023
-    return false if log.is_la_inferred?
-    return false if log.is_supported_housing?
-
-    true
-  end
 end

--- a/app/models/form/sales/pages/property_local_authority.rb
+++ b/app/models/form/sales/pages/property_local_authority.rb
@@ -14,12 +14,6 @@ class Form::Sales::Pages::PropertyLocalAuthority < ::Form::Page
     ].compact
   end
 
-  def routed_to?(log, _current_user = nil)
-    return false if log.uprn_known.nil? && form.start_date.year >= 2023
-
-    true
-  end
-
   def la_known_question
     if form.start_date.year < 2023
       Form::Sales::Questions::PropertyLocalAuthorityKnown.new(nil, nil, self)

--- a/app/models/form/sales/questions/address_line1.rb
+++ b/app/models/form/sales/questions/address_line1.rb
@@ -9,15 +9,6 @@ class Form::Sales::Questions::AddressLine1 < ::Form::Question
     @check_answer_label = "Q15 - Address"
   end
 
-  def hidden_in_check_answers?(log, _current_user = nil)
-    return true if log.uprn_known.nil?
-    return false if log.uprn_known&.zero?
-    return true if log.uprn_confirmed.nil? && log.uprn.present?
-    return true if log.uprn_known == 1 && log.uprn.blank?
-
-    log.uprn_confirmed == 1
-  end
-
   def answer_label(log, _current_user = nil)
     [
       log.address_line1,

--- a/spec/models/form/lettings/pages/property_local_authority_spec.rb
+++ b/spec/models/form/lettings/pages/property_local_authority_spec.rb
@@ -35,43 +35,4 @@ RSpec.describe Form::Lettings::Pages::PropertyLocalAuthority, type: :model do
   it "has the correct depends_on" do
     expect(page.depends_on).to match([{ "is_general_needs?" => true, "is_la_inferred" => false }])
   end
-
-  describe "has correct routed_to?" do
-    context "when start_date < 2023" do
-      let(:log) { create(:lettings_log, uprn_known: 1) }
-      let(:start_date) { Time.utc(2022, 2, 8) }
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when start_date >= 2023" do
-      let(:log) { create(:lettings_log, uprn_known: 1) }
-      let(:start_date) { Time.utc(2023, 2, 8) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when start_date < 2023 and uprn_known: nil" do
-      let(:log) { create(:lettings_log, uprn_known: nil) }
-      let(:start_date) { Time.utc(2023, 2, 8) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-
-      context "when is_la_inferred: true" do
-        before do
-          allow(log).to receive(:is_la_inferred?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(page.routed_to?(log)).to eq(false)
-        end
-      end
-    end
-  end
 end

--- a/spec/models/form/sales/pages/property_local_authority_spec.rb
+++ b/spec/models/form/sales/pages/property_local_authority_spec.rb
@@ -56,33 +56,4 @@ RSpec.describe Form::Sales::Pages::PropertyLocalAuthority, type: :model do
       "is_la_inferred" => false,
     }])
   end
-
-  describe "has correct routed_to?" do
-    context "when start_date < 2023" do
-      let(:log) { create(:sales_log, uprn_known: 1) }
-      let(:start_date) { Time.utc(2022, 2, 8) }
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when start_date >= 2023" do
-      let(:log) { create(:sales_log, uprn_known: 1) }
-      let(:start_date) { Time.utc(2023, 2, 8) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when start_date < 2023 and uprn_known: nil" do
-      let(:log) { create(:sales_log, uprn_known: nil) }
-      let(:start_date) { Time.utc(2023, 2, 8) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Currently, if we enter a valid postcode or a valid UPRN and the LA gets inferred, we get routed to the LA question

LA pages depend on `is_la_inferred?` being true, so we don't need a separate `routed_to?`
The only time we don't want the LA to get asked is if it's inferred (or supported housing), so `depends_on` should be enough to cover all the cases
