### PR TITLE
Make the collection period end at the end of the day

### DIFF
--- a/app/helpers/collection_time_helper.rb
+++ b/app/helpers/collection_time_helper.rb
@@ -22,11 +22,11 @@ module CollectionTimeHelper
   end
 
   def collection_end_date(date)
-    Time.zone.local(collection_start_year(date) + 1, 3, 31)
+    Time.zone.local(collection_start_year(date) + 1, 3, 31).end_of_day
   end
 
   def current_collection_end_date
-    Time.zone.local(current_collection_start_year + 1, 3, 31)
+    Time.zone.local(current_collection_start_year + 1, 3, 31).end_of_day
   end
 
   def previous_collection_end_date

--- a/spec/helpers/collection_time_helper_spec.rb
+++ b/spec/helpers/collection_time_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CollectionTimeHelper do
       end
 
       it "returns the correct current end date" do
-        expect(current_collection_end_date).to eq(Time.zone.local(2023, 3, 31))
+        expect(current_collection_end_date).to eq(Time.zone.local(2023, 3, 31).end_of_day)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe CollectionTimeHelper do
       end
 
       it "returns the correct current end date" do
-        expect(current_collection_end_date).to eq(Time.zone.local(2022, 3, 31))
+        expect(current_collection_end_date).to eq(Time.zone.local(2022, 3, 31).end_of_day)
       end
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe CollectionTimeHelper do
       end
 
       it "returns the correct current end date" do
-        expect(collection_end_date(now)).to eq(Time.zone.local(2023, 3, 31))
+        expect(collection_end_date(now)).to eq(Time.zone.local(2023, 3, 31).end_of_day)
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe CollectionTimeHelper do
       end
 
       it "returns the correct current end date" do
-        expect(collection_end_date(now)).to eq(Time.zone.local(2022, 3, 31))
+        expect(collection_end_date(now)).to eq(Time.zone.local(2022, 3, 31).end_of_day)
       end
     end
   end


### PR DESCRIPTION
This PR updates the collection end time, which was previously set to the start of the day on the collection end date, but it should have been the end of the day.

```irb
irb(main):005:0> current_collection_end_date
=> Fri, 31 Mar 2023 00:00:00.000000000 BST +01:00
irb(main):006:0> current_collection_end_date.end_of_day
=> Fri, 31 Mar 2023 23:59:59.999999999 BST +01:00
```