### PR TITLE
undo testing change that hides rare error

### DIFF
--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Validations::FinancialValidations do
     end
 
     context "when outstanding rent or charges is yes" do
-      let(:record) { FactoryBot.create(:lettings_log, :about_completed, startdate: Time.zone.local(2023, 1, 1)) }
+      let(:record) { FactoryBot.create(:lettings_log, :about_completed, startdate: Time.zone.now) }
 
       it "expects that a shortfall is provided" do
         record.hbrentshortfall = 1

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -898,7 +898,7 @@ RSpec.describe LettingsLogsController, type: :request do
                 owning_organisation: user.organisation,
                 managing_organisation: user.organisation,
                 created_by: user,
-                startdate: Time.zone.local(2023, 1, 1),
+                startdate: Time.zone.now,
                 renewal: 1,
                 needstype: 2,
                 rent_type: 3,


### PR DESCRIPTION
I made a change to some tests in 2017 to stop them failing, but that was fixed better elsewhere, undo that change.