### PR TITLE
CLDC-2222 Update access needs mapping and validations

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -533,29 +533,25 @@ private
 
   def validate_dont_know_disabled_needs_conjunction
     if field_60 == 1 && [field_55, field_56, field_57, field_58].count(1).positive?
-      errors.add(:field_60, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction"))
-      errors.add(:field_55, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_55 == 1
-      errors.add(:field_56, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_56 == 1
-      errors.add(:field_57, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_57 == 1
-      errors.add(:field_58, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_58 == 1
+      %i[field_60 field_55 field_56 field_57 field_58].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if send(field) == 1
+      end
     end
   end
 
   def validate_no_disabled_needs_conjunction
     if field_59 == 1 && [field_55, field_56, field_57, field_58].count(1).positive?
-      errors.add(:field_59, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction"))
-      errors.add(:field_55, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_55 == 1
-      errors.add(:field_56, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_56 == 1
-      errors.add(:field_57, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_57 == 1
-      errors.add(:field_58, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_58 == 1
+      %i[field_59 field_55 field_56 field_57 field_58].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if send(field) == 1
+      end
     end
   end
 
   def validate_only_one_housing_needs_type
     if [field_55, field_56, field_57].count(1) > 1
-      errors.add(:field_55, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_55 == 1
-      errors.add(:field_56, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_56 == 1
-      errors.add(:field_57, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_57 == 1
+      %i[field_55 field_56 field_57].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if send(field) == 1
+      end
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -532,8 +532,12 @@ private
   end
 
   def validate_dont_know_disabled_needs_conjunction
-    if field_60 == 1 && [field_55, field_56, field_57, field_58].compact.count.positive?
+    if field_60 == 1 && [field_55, field_56, field_57, field_58].count(1).positive?
       errors.add(:field_60, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction"))
+      errors.add(:field_55, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_55 == 1
+      errors.add(:field_56, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_56 == 1
+      errors.add(:field_57, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_57 == 1
+      errors.add(:field_58, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if field_58 == 1
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -544,7 +544,7 @@ private
   end
 
   def validate_only_one_housing_needs_type
-    if [field_55, field_56, field_57].compact.count > 1
+    if [field_55, field_56, field_57].count(1) > 1
       errors.add(:field_55, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_56, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
       errors.add(:field_57, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
@@ -1240,8 +1240,8 @@ private
       2
     elsif field_60 == 1
       3
-    else
-      2
+    elsif field_59&.zero?
+      1
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -545,9 +545,9 @@ private
 
   def validate_only_one_housing_needs_type
     if [field_55, field_56, field_57].count(1) > 1
-      errors.add(:field_55, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
-      errors.add(:field_56, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
-      errors.add(:field_57, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
+      errors.add(:field_55, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_55 == 1
+      errors.add(:field_56, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_56 == 1
+      errors.add(:field_57, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if field_57 == 1
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -538,8 +538,12 @@ private
   end
 
   def validate_no_disabled_needs_conjunction
-    if field_59 == 1 && [field_55, field_56, field_57, field_58].compact.count.positive?
+    if field_59 == 1 && [field_55, field_56, field_57, field_58].count(1).positive?
       errors.add(:field_59, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction"))
+      errors.add(:field_55, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_55 == 1
+      errors.add(:field_56, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_56 == 1
+      errors.add(:field_57, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_57 == 1
+      errors.add(:field_58, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if field_58 == 1
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -431,22 +431,26 @@ private
   end
 
   def validate_dont_know_disabled_needs_conjunction
-    if field_88 == 1 && [field_83, field_84, field_85, field_86].compact.count.positive?
-      errors.add(:field_88, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction"))
+    if field_88 == 1 && [field_83, field_84, field_85, field_86].count(1).positive?
+      %i[field_88 field_83 field_84 field_85 field_86].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds.dont_know_disabled_needs_conjunction")) if send(field) == 1
+      end
     end
   end
 
   def validate_no_disabled_needs_conjunction
-    if field_87 == 1 && [field_83, field_84, field_85, field_86].compact.count.positive?
-      errors.add(:field_87, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction"))
+    if field_87 == 1 && [field_83, field_84, field_85, field_86].count(1).positive?
+      %i[field_87 field_83 field_84 field_85 field_86].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds.no_disabled_needs_conjunction")) if send(field) == 1
+      end
     end
   end
 
   def validate_only_one_housing_needs_type
-    if [field_83, field_84, field_85].compact.count > 1
-      errors.add(:field_83, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
-      errors.add(:field_84, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
-      errors.add(:field_85, I18n.t("validations.household.housingneeds_type.only_one_option_permitted"))
+    if [field_83, field_84, field_85].count(1) > 1
+      %i[field_83 field_84 field_85].each do |field|
+        errors.add(field, I18n.t("validations.household.housingneeds_type.only_one_option_permitted")) if send(field) == 1
+      end
     end
   end
 
@@ -1173,8 +1177,8 @@ private
       2
     elsif field_88 == 1
       3
-    else
-      2
+    elsif field_87&.zero?
+      1
     end
   end
 

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1462,6 +1462,30 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
           expect(parser.errors[:field_55]).to be_blank
         end
       end
+
+      context "when housingneeds a and g are selected" do
+        let(:attributes) { { bulk_upload:, field_55: "1", field_59: "1" } }
+
+        it "sets error on housingneeds a and g" do
+          parser.valid?
+          expect(parser.errors[:field_59]).to include("No disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_55]).to include("No disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_56]).to be_blank
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
+
+      context "when only housingneeds g is selected" do
+        let(:attributes) { { bulk_upload:, field_55: "0", field_59: "1" } }
+
+        it "does not add any housingneeds errors" do
+          parser.valid?
+          expect(parser.errors[:field_59]).to be_blank
+          expect(parser.errors[:field_55]).to be_blank
+          expect(parser.errors[:field_56]).to be_blank
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
     end
 
     describe "#housingneeds_type" do

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -507,7 +507,6 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
         it "is not permitted" do
           expect(parser.errors[:field_55]).to be_present
           expect(parser.errors[:field_56]).to be_present
-          expect(parser.errors[:field_57]).to be_present
         end
       end
     end
@@ -1428,6 +1427,39 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
           expect(parser.log.housingneeds).to eq(1)
           expect(parser.log.housingneeds_type).to eq(2)
           expect(parser.log.housingneeds_other).to eq(1)
+        end
+      end
+
+      context "when housingneeds a and b are selected" do
+        let(:attributes) { { bulk_upload:, field_55: "1", field_56: "1" } }
+
+        it "sets error on housingneeds a and b" do
+          parser.valid?
+          expect(parser.errors[:field_55]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_56]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
+
+      context "when housingneeds a and c are selected" do
+        let(:attributes) { { bulk_upload:, field_55: "1", field_57: "1" } }
+
+        it "sets error on housingneeds a and c" do
+          parser.valid?
+          expect(parser.errors[:field_55]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_57]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_56]).to be_blank
+        end
+      end
+
+      context "when housingneeds b and c are selected" do
+        let(:attributes) { { bulk_upload:, field_56: "1", field_57: "1" } }
+
+        it "sets error on housingneeds b and c" do
+          parser.valid?
+          expect(parser.errors[:field_56]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_57]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_55]).to be_blank
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
       field_118: "2",
 
+      field_55: "1",
+      field_56: "0",
+      field_57: "0",
+      field_58: "1",
+      field_59: "0",
+
       field_66: "5",
       field_67: "2",
       field_52: "31",
@@ -1412,6 +1418,16 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         it "sets to 3" do
           expect(parser.log.housingneeds).to eq(3)
+        end
+      end
+
+      context "when housingneeds are given" do
+        let(:attributes) { { bulk_upload:, field_59: "0", field_57: "1", field_58: "1" } }
+
+        it "sets correct housingneeds" do
+          expect(parser.log.housingneeds).to eq(1)
+          expect(parser.log.housingneeds_type).to eq(2)
+          expect(parser.log.housingneeds_other).to eq(1)
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1486,6 +1486,30 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
           expect(parser.errors[:field_57]).to be_blank
         end
       end
+
+      context "when housingneeds a and h are selected" do
+        let(:attributes) { { bulk_upload:, field_55: "1", field_60: "1" } }
+
+        it "sets error on housingneeds a and h" do
+          parser.valid?
+          expect(parser.errors[:field_60]).to include("Don’t know disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_55]).to include("Don’t know disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_56]).to be_blank
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
+
+      context "when only housingneeds h is selected" do
+        let(:attributes) { { bulk_upload:, field_55: "0", field_60: "1" } }
+
+        it "does not add any housingneeds errors" do
+          parser.valid?
+          expect(parser.errors[:field_60]).to be_blank
+          expect(parser.errors[:field_55]).to be_blank
+          expect(parser.errors[:field_56]).to be_blank
+          expect(parser.errors[:field_57]).to be_blank
+        end
+      end
     end
 
     describe "#housingneeds_type" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -165,6 +165,12 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
             field_82: "1",
 
+            field_83: "1",
+            field_84: "0",
+            field_85: "0",
+            field_86: "1",
+            field_87: "0",
+
             field_89: "2",
 
             field_100: "5",
@@ -517,7 +523,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "is not permitted" do
           expect(parser.errors[:field_83]).to be_present
           expect(parser.errors[:field_84]).to be_present
-          expect(parser.errors[:field_85]).to be_present
         end
       end
     end
@@ -1450,6 +1455,97 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         it "sets to 3" do
           expect(parser.log.housingneeds).to eq(3)
+        end
+      end
+
+      context "when housingneeds are given" do
+        let(:attributes) { { bulk_upload:, field_87: "0", field_85: "1", field_86: "1" } }
+
+        it "sets correct housingneeds" do
+          expect(parser.log.housingneeds).to eq(1)
+          expect(parser.log.housingneeds_type).to eq(2)
+          expect(parser.log.housingneeds_other).to eq(1)
+        end
+      end
+
+      context "when housingneeds a and b are selected" do
+        let(:attributes) { { bulk_upload:, field_83: "1", field_84: "1" } }
+
+        it "sets error on housingneeds a and b" do
+          parser.valid?
+          expect(parser.errors[:field_83]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_84]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_85]).to be_blank
+        end
+      end
+
+      context "when housingneeds a and c are selected" do
+        let(:attributes) { { bulk_upload:, field_83: "1", field_85: "1" } }
+
+        it "sets error on housingneeds a and c" do
+          parser.valid?
+          expect(parser.errors[:field_83]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_85]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_84]).to be_blank
+        end
+      end
+
+      context "when housingneeds b and c are selected" do
+        let(:attributes) { { bulk_upload:, field_84: "1", field_85: "1" } }
+
+        it "sets error on housingneeds b and c" do
+          parser.valid?
+          expect(parser.errors[:field_84]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_85]).to include("Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected")
+          expect(parser.errors[:field_83]).to be_blank
+        end
+      end
+
+      context "when housingneeds a and g are selected" do
+        let(:attributes) { { bulk_upload:, field_83: "1", field_87: "1" } }
+
+        it "sets error on housingneeds a and g" do
+          parser.valid?
+          expect(parser.errors[:field_87]).to include("No disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_83]).to include("No disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_84]).to be_blank
+          expect(parser.errors[:field_85]).to be_blank
+        end
+      end
+
+      context "when only housingneeds g is selected" do
+        let(:attributes) { { bulk_upload:, field_83: "0", field_87: "1" } }
+
+        it "does not add any housingneeds errors" do
+          parser.valid?
+          expect(parser.errors[:field_59]).to be_blank
+          expect(parser.errors[:field_83]).to be_blank
+          expect(parser.errors[:field_84]).to be_blank
+          expect(parser.errors[:field_85]).to be_blank
+        end
+      end
+
+      context "when housingneeds a and h are selected" do
+        let(:attributes) { { bulk_upload:, field_83: "1", field_88: "1" } }
+
+        it "sets error on housingneeds a and h" do
+          parser.valid?
+          expect(parser.errors[:field_88]).to include("Don’t know disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_83]).to include("Don’t know disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs")
+          expect(parser.errors[:field_84]).to be_blank
+          expect(parser.errors[:field_85]).to be_blank
+        end
+      end
+
+      context "when only housingneeds h is selected" do
+        let(:attributes) { { bulk_upload:, field_83: "0", field_88: "1" } }
+
+        it "does not add any housingneeds errors" do
+          parser.valid?
+          expect(parser.errors[:field_88]).to be_blank
+          expect(parser.errors[:field_83]).to be_blank
+          expect(parser.errors[:field_84]).to be_blank
+          expect(parser.errors[:field_85]).to be_blank
         end
       end
     end


### PR DESCRIPTION
- Set housingneeds to yes if `field_59` (No disabled access needs) is `0` (No), we need to set housing needs to yes so that the other housingneeds answers don't get cleared
- Add housingneeds validation errors to relevant fields 
- Only count the housingneeds options as yes if they're answered `1` in validations (previously we counted `0` as well)