### PR TITLE
Enable managing_owning_enabled? and managing_for_other_user_enabled? feature flags on all environments

### DIFF
--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -33,7 +33,7 @@ class FeatureToggle
   end
 
   def self.managing_for_other_user_enabled?
-    !Rails.env.production?
+    true
   end
 
   def self.bulk_upload_logs?

--- a/config/initializers/feature_toggle.rb
+++ b/config/initializers/feature_toggle.rb
@@ -21,7 +21,7 @@ class FeatureToggle
   end
 
   def self.managing_owning_enabled?
-    !Rails.env.production?
+    true
   end
 
   def self.scheme_toggle_enabled?

--- a/spec/models/form/lettings/subsections/setup_spec.rb
+++ b/spec/models/form/lettings/subsections/setup_spec.rb
@@ -56,27 +56,4 @@ RSpec.describe Form::Lettings::Subsections::Setup, type: :model do
       )
     end
   end
-
-  context "when production" do
-    before do
-      allow(Rails.env).to receive(:production?).and_return(true)
-    end
-
-    it "has the correct pages" do
-      expect(setup.pages.map(&:id)).to eq(
-        %w[
-          organisation
-          created_by
-          needs_type
-          scheme
-          location
-          renewal
-          tenancy_start_date
-          rent_type
-          tenant_code
-          property_reference
-        ],
-      )
-    end
-  end
 end


### PR DESCRIPTION
- Enable `managing_owning_enabled` on production.
- Enable `managing_for_other_user_enabled` on production.

These feature flags should have been enabled long ago, but were unfortunately missed.