### PR TITLE
CLDC-2163 add validations on whether buyers are living in the property

### DIFF
--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -1,5 +1,7 @@
 module DerivedVariables::SalesLogVariables
   def set_derived_fields!
+    reset_invalidated_derived_values!
+
     self.ethnic = 17 if ethnic_refused?
     self.mscharge = nil if no_monthly_leasehold_charges?
     if exdate.present?
@@ -13,9 +15,6 @@ module DerivedVariables::SalesLogVariables
       self.hoyear = hodate.year
     end
     self.deposit = value if outright_sale? && mortgage_not_used?
-    if mortgage_not_used?
-      self.mortgage = 0
-    end
     self.pcode1, self.pcode2 = postcode_full.split(" ") if postcode_full.present?
     self.totchild = total_child
     self.totadult = total_adult + total_elder
@@ -31,19 +30,72 @@ module DerivedVariables::SalesLogVariables
       self.uprn_known = 0
     end
 
-    if buyers_will_not_live_in?
-      self.buy1livein = 2
-      if joint_purchase?
-        self.buy2livein = 2
-      end
-    end
-
-    if buyers_will_live_in? && not_joint_purchase?
-      self.buy1livein = 1
-    end
+    set_encoded_derived_values!
   end
 
 private
+
+  DEPENDENCIES = [
+    {
+      conditions: {
+        buylivein: 2,
+      },
+      derived_values: {
+        buy1livein: 2,
+      }
+    },
+    {
+      conditions: {
+        buylivein: 2,
+        jointpur: 1,
+      },
+      derived_values: {
+        buy1livein: 2,
+        buy2livein: 2,
+      }
+    },
+    {
+      conditions: {
+        buylivein: 1,
+        jointpur: 2,
+      },
+      derived_values: {
+        buy1livein: 1,
+      },
+    },
+    {
+      conditions: {
+        mortgageused: 2,
+      },
+      derived_values: {
+        mortgage: 0,
+      },
+    },
+  ].freeze
+
+  def reset_invalidated_derived_values!
+    DEPENDENCIES.each do |dependency|
+      any_conditions_changed = dependency[:conditions].any? { |attribute, _value| send("#{attribute}_changed?") }
+      next unless any_conditions_changed
+
+      previously_in_derived_state = dependency[:conditions].all? { |attribute, value| send("#{attribute}_was") == value }
+      next unless previously_in_derived_state
+
+      dependency[:derived_values].each do |derived_attribute, _derived_value|
+        Rails.logger.debug("Cleared derived #{derived_attribute} value")
+        send("#{derived_attribute}=", nil)
+      end
+    end
+  end
+
+  def set_encoded_derived_values!
+    DEPENDENCIES.each do |dependency|
+      derivation_applies = dependency[:conditions].all? { |attribute, value| send(attribute) == value }
+      if derivation_applies
+        dependency[:derived_values].each { |attribute, value| send("#{attribute}=", value) }
+      end
+    end
+  end
 
   def number_of_household_members
     return unless hholdcount.present? && jointpur.present?

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -30,6 +30,17 @@ module DerivedVariables::SalesLogVariables
       self.uprn = nil
       self.uprn_known = 0
     end
+
+    if buyers_will_not_live_in?
+      self.buy1livein = 2
+      if joint_purchase?
+        self.buy2livein = 2
+      end
+    end
+
+    if buyers_will_live_in? && not_joint_purchase?
+      self.buy1livein = 1
+    end
   end
 
 private

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -42,7 +42,7 @@ private
       },
       derived_values: {
         buy1livein: 2,
-      }
+      },
     },
     {
       conditions: {
@@ -52,7 +52,7 @@ private
       derived_values: {
         buy1livein: 2,
         buy2livein: 2,
-      }
+      },
     },
     {
       conditions: {

--- a/app/models/form/sales/pages/buyer1_live_in_property.rb
+++ b/app/models/form/sales/pages/buyer1_live_in_property.rb
@@ -5,9 +5,21 @@ class Form::Sales::Pages::Buyer1LiveInProperty < ::Form::Page
     @depends_on = [
       {
         "buyer_has_seen_privacy_notice?" => true,
+        "outright_sale?" => false,
       },
       {
         "buyer_not_interviewed?" => true,
+        "outright_sale?" => false,
+      },
+      {
+        "buyer_has_seen_privacy_notice?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
+      },
+      {
+        "buyer_not_interviewed?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
       },
     ]
   end

--- a/app/models/form/sales/pages/buyer2_live_in_property.rb
+++ b/app/models/form/sales/pages/buyer2_live_in_property.rb
@@ -4,12 +4,24 @@ class Form::Sales::Pages::Buyer2LiveInProperty < ::Form::Page
     @id = "buyer_2_live_in_property"
     @depends_on = [
       {
-        "joint_purchase?" => true,
         "buyer_has_seen_privacy_notice?" => true,
+        "outright_sale?" => false,
+        "joint_purchase?" => true,
       },
       {
-        "joint_purchase?" => true,
         "buyer_not_interviewed?" => true,
+        "outright_sale?" => false,
+        "joint_purchase?" => true,
+      },
+      {
+        "buyer_has_seen_privacy_notice?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
+      },
+      {
+        "buyer_not_interviewed?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
       },
     ]
   end

--- a/app/models/form/sales/pages/buyer_company.rb
+++ b/app/models/form/sales/pages/buyer_company.rb
@@ -3,7 +3,7 @@ class Form::Sales::Pages::BuyerCompany < ::Form::Page
     super
     @id = "buyer_company"
     @depends_on = [{
-      "ownershipsch" => 3,
+      "outright_sale?" => true,
     }]
   end
 

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -531,7 +531,6 @@ class LettingsLog < Log
 
 private
 
-  # show in diff
   def reset_derived_questions
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
@@ -549,7 +548,6 @@ private
       end
     end
   end
-  # show in diff
 
   def reset_invalid_unresolved_log_fields!
     return unless unresolved?

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -531,6 +531,7 @@ class LettingsLog < Log
 
 private
 
+  # show in diff
   def reset_derived_questions
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
@@ -548,6 +549,7 @@ private
       end
     end
   end
+  # show in diff
 
   def reset_invalid_unresolved_log_fields!
     return unless unresolved?

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -161,8 +161,24 @@ class SalesLog < Log
     inc1mort == 1
   end
 
+  def buyers_will_live_in?
+    buylivein == 1
+  end
+
+  def buyers_will_not_live_in?
+    buylivein == 2
+  end
+
   def buyer_two_will_live_in_property?
     buy2livein == 1
+  end
+
+  def buyer_two_will_not_live_in_property?
+    buy2livein == 2
+  end
+
+  def buyer_one_will_not_live_in_property?
+    buy1livein == 2
   end
 
   def buyer_two_not_already_living_in_property?

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -403,8 +403,8 @@ private
       any_parent_attributes_changed = dependency[:parent_conditions].any? { |parent_condition| send("#{parent_condition[:attribute]}_changed?") }
       next unless any_parent_attributes_changed
 
-      were_in_derived_state = dependency[:parent_conditions].all? { |parent_condition| send("#{parent_condition[:attribute]}_was") == parent_condition[:value] }
-      next unless were_in_derived_state
+      previously_in_derived_state = dependency[:parent_conditions].all? { |parent_condition| send("#{parent_condition[:attribute]}_was") == parent_condition[:value] }
+      next unless previously_in_derived_state
 
       dependency[:derived_attributes].each do |derived_attribute|
         Rails.logger.debug("Cleared derived #{derived_attribute} value")

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -385,25 +385,25 @@ private
   def reset_derived_questions!
     dependencies = [
       {
-        parent_conditions: [
-          { attribute: :buylivein, value: 2 },
-        ],
+        conditions: {
+          buylivein: 2,
+        },
         derived_attributes: %i[buy1livein buy2livein],
       },
       {
-        parent_conditions: [
-          { attribute: :buylivein, value: 1 },
-          { attribute: :jointpur, value: 1 },
-        ],
+        conditions: {
+          buylivein: 1,
+          jointpur: 1,
+        },
         derived_attributes: [:buy1livein],
       },
     ]
 
     dependencies.each do |dependency|
-      any_parent_attributes_changed = dependency[:parent_conditions].any? { |parent_condition| send("#{parent_condition[:attribute]}_changed?") }
-      next unless any_parent_attributes_changed
+      any_primary_attributes_changed = dependency[:conditions].any? { |attribute, _value| send("#{attribute}_changed?") }
+      next unless any_primary_attributes_changed
 
-      previously_in_derived_state = dependency[:parent_conditions].all? { |parent_condition| send("#{parent_condition[:attribute]}_was") == parent_condition[:value] }
+      previously_in_derived_state = dependency[:conditions].all? { |attribute, value| send("#{attribute}_was") == value }
       next unless previously_in_derived_state
 
       dependency[:derived_attributes].each do |derived_attribute|

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -20,6 +20,18 @@ module Validations::Sales::HouseholdValidations
     end
   end
 
+  def validate_buyers_living_in_property(record)
+    return unless record.form.start_date.year >= 2023
+
+    if record.buyers_will_live_in? &&
+        record.joint_purchase? &&
+        record.buyer_one_will_not_live_in_property? &&
+        record.buyer_two_will_not_live_in_property?
+      record.errors.add :buy1livein, I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
+      record.errors.add :buy2livein, I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
+    end
+  end
+
 private
 
   def validate_person_age_matches_relationship(record, person_num)

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -24,6 +24,7 @@ module Validations::Sales::HouseholdValidations
     return unless record.form.start_date.year >= 2023
 
     if record.buyers_will_live_in? && record.buyer_one_will_not_live_in_property? && record.buyer_two_will_not_live_in_property?
+      record.errors.add :buylivein, I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent_setup")
       record.errors.add :buy1livein, I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
       record.errors.add :buy2livein, I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
     end

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -23,12 +23,9 @@ module Validations::Sales::HouseholdValidations
   def validate_buyers_living_in_property(record)
     return unless record.form.start_date.year >= 2023
 
-    if record.buyers_will_live_in? &&
-        record.joint_purchase? &&
-        record.buyer_one_will_not_live_in_property? &&
-        record.buyer_two_will_not_live_in_property?
-      record.errors.add :buy1livein, I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
-      record.errors.add :buy2livein, I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
+    if record.buyers_will_live_in? && record.buyer_one_will_not_live_in_property? && record.buyer_two_will_not_live_in_property?
+      record.errors.add :buy1livein, I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
+      record.errors.add :buy2livein, I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,6 +443,7 @@ en:
       postcode:
         discounted_ownership: "Last settled accommodation and discounted ownership property postcodes must match"
       buylivein:
+        buyers_will_live_in_property_values_inconsistent_setup: "You have already told us that both buyer 1 and buyer 2 will not live in the property"
         buyers_will_live_in_property_values_inconsistent: "You have already told us that the buyers will live in the property. Either buyer 1 or buyer 2 must live in the property"
 
     tenancy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,6 +442,8 @@ en:
         no_choices: "You cannot answer this question as you told us nobody in the household has a physical or mental health condition (or other illness) expected to last 12 months or more"
       postcode:
         discounted_ownership: "Last settled accommodation and discounted ownership property postcodes must match"
+      buyers_will_live_in_property:
+        buyers_live_but_no_buyers_live: "You have already told us that the buyers will live in the property. Either buyer 1 or buyer 2 must live in the property"
 
     tenancy:
       length:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,8 +442,8 @@ en:
         no_choices: "You cannot answer this question as you told us nobody in the household has a physical or mental health condition (or other illness) expected to last 12 months or more"
       postcode:
         discounted_ownership: "Last settled accommodation and discounted ownership property postcodes must match"
-      buyers_will_live_in_property:
-        buyers_live_but_no_buyers_live: "You have already told us that the buyers will live in the property. Either buyer 1 or buyer 2 must live in the property"
+      buylivein:
+        buyers_will_live_in_property_values_inconsistent: "You have already told us that the buyers will live in the property. Either buyer 1 or buyer 2 must live in the property"
 
     tenancy:
       length:

--- a/spec/models/form/sales/pages/buyer1_live_in_property_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_live_in_property_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe Form::Sales::Pages::Buyer1LiveInProperty, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{ "buyer_has_seen_privacy_notice?" => true }, { "buyer_not_interviewed?" => true }])
+    expect(page.depends_on).to eq([
+      {
+        "buyer_has_seen_privacy_notice?" => true,
+        "outright_sale?" => false,
+      },
+      {
+        "buyer_not_interviewed?" => true,
+        "outright_sale?" => false,
+      },
+      {
+        "buyer_has_seen_privacy_notice?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
+      },
+      {
+        "buyer_not_interviewed?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
+      },
+    ])
   end
 end

--- a/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
@@ -30,12 +30,24 @@ RSpec.describe Form::Sales::Pages::Buyer2LiveInProperty, type: :model do
   it "has correct depends_on" do
     expect(page.depends_on).to eq([
       {
-        "joint_purchase?" => true,
         "buyer_has_seen_privacy_notice?" => true,
+        "outright_sale?" => false,
+        "joint_purchase?" => true,
       },
       {
-        "joint_purchase?" => true,
         "buyer_not_interviewed?" => true,
+        "outright_sale?" => false,
+        "joint_purchase?" => true,
+      },
+      {
+        "buyer_has_seen_privacy_notice?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
+      },
+      {
+        "buyer_not_interviewed?" => true,
+        "joint_purchase?" => true,
+        "buyers_will_live_in?" => true,
       },
     ])
   end

--- a/spec/models/form/sales/pages/buyer_company_spec.rb
+++ b/spec/models/form/sales/pages/buyer_company_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Form::Sales::Pages::BuyerCompany, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to eq([{
-      "ownershipsch" => 3,
-    }])
+    expect(page.depends_on).to eq([{ "outright_sale?" => true }])
   end
 end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -221,6 +221,15 @@ RSpec.describe SalesLog, type: :model do
       expect(record_from_db["mortgage"]).to eq(0.0)
     end
 
+    it "clears mortgage value if mortgage used is changed from no to yes" do
+      # to avoid log failing validations when mortgage value is removed:
+      new_grant_value = sales_log.grant + sales_log.mortgage
+      sales_log.update!(mortgageused: 2, grant: new_grant_value)
+      sales_log.update!(mortgageused: 1)
+      record_from_db = ActiveRecord::Base.connection.execute("select mortgage from sales_logs where id=#{sales_log.id}").to_a[0]
+      expect(record_from_db["mortgage"]).to eq(nil)
+    end
+
     context "when outright sale and buyers will live in the property" do
       let(:sales_log) { create(:sales_log, :outright_sale_setup_complete, buylivein: 1, jointpur:) }
 

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -238,8 +238,8 @@ RSpec.describe Validations::Sales::HouseholdValidations do
         it "triggers a validation if buyer two will also not live in the property" do
           sales_log.buy2livein = 2
           household_validator.validate_buyers_living_in_property(sales_log)
-          expect(sales_log.errors[:buy2livein]).to include I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
-          expect(sales_log.errors[:buy1livein]).to include I18n.t("validations.household.buyers_will_live_in_property.buyers_live_but_no_buyers_live")
+          expect(sales_log.errors[:buy2livein]).to include I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
+          expect(sales_log.errors[:buy1livein]).to include I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
         end
       end
 

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -238,6 +238,7 @@ RSpec.describe Validations::Sales::HouseholdValidations do
         it "triggers a validation if buyer two will also not live in the property" do
           sales_log.buy2livein = 2
           household_validator.validate_buyers_living_in_property(sales_log)
+          expect(sales_log.errors[:buylivein]).to include I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent_setup")
           expect(sales_log.errors[:buy2livein]).to include I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
           expect(sales_log.errors[:buy1livein]).to include I18n.t("validations.household.buylivein.buyers_will_live_in_property_values_inconsistent")
         end

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Validations::Sales::HouseholdValidations do
   end
 
   describe "validating fields about buyers living in the property" do
-    let(:sales_log) { FactoryBot.create(:sales_log, :outright_sale, noint: 1, companybuy: 2, buylivein:, jointpur:, jointmore:, buy1livein:) }
+    let(:sales_log) { FactoryBot.create(:sales_log, :outright_sale_setup_complete, noint: 1, companybuy: 2, buylivein:, jointpur:, jointmore:, buy1livein:) }
 
     context "when buyers will live in the property and the sale is a joint purchase" do
       let(:buylivein) { 1 }


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2163

the naming in this ticket is a little bit confusing in places since the fields being checked against each other are really close in meaning.
There is a question in the setup section 'buylivein' that asks "Will the buyers live in the property?" that is only asked under certain conditions and then there are the fields 'buy1livein' and 'buy2livein' that ask respectively whether buyer 1 and buyer 2 specifically will live in the property.

In most situations the values in the setup questions logically allow buy1livein and buy2livein to be derived.
Iff buylivein is yes and joint purchase is yes we only know that at least one buyer must live in so marking both as no triggers a validation.