### PR TITLE
CLDC-2170 Bulk upload summary tweaks

### DIFF
--- a/app/components/bulk_upload_error_summary_table_component.html.erb
+++ b/app/components/bulk_upload_error_summary_table_component.html.erb
@@ -1,3 +1,7 @@
+<p class="govuk-body">
+  <%= intro %>
+</p>
+
 <% sorted_errors.each do |error| %>
   <%= govuk_table do |table| %>
     <% table.head do |head| %>

--- a/app/components/bulk_upload_error_summary_table_component.rb
+++ b/app/components/bulk_upload_error_summary_table_component.rb
@@ -24,6 +24,14 @@ class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
     sorted_errors.present?
   end
 
+  def intro
+    if setup_errors.present?
+      "This summary shows important questions that have errors. See full error report for more details."
+    else
+      "This summary shows questions that have more than #{BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD - 1} errors. See full error report for more details."
+    end
+  end
+
 private
 
   def setup_errors
@@ -31,7 +39,6 @@ private
       .bulk_upload_errors
       .where(category: "setup")
       .group(:col, :field, :error)
-      .having("count(*) >= ?", display_threshold)
       .count
       .sort_by { |el| el[0][0].rjust(3, "0") }
   end

--- a/app/components/bulk_upload_error_summary_table_component.rb
+++ b/app/components/bulk_upload_error_summary_table_component.rb
@@ -15,7 +15,7 @@ class BulkUploadErrorSummaryTableComponent < ViewComponent::Base
     @sorted_errors ||= setup_errors.presence || bulk_upload
       .bulk_upload_errors
       .group(:col, :field, :error)
-      .having("count(*) > ?", display_threshold)
+      .having("count(*) >= ?", display_threshold)
       .count
       .sort_by { |el| el[0][0].rjust(3, "0") }
   end
@@ -31,7 +31,7 @@ private
       .bulk_upload_errors
       .where(category: "setup")
       .group(:col, :field, :error)
-      .having("count(*) > ?", display_threshold)
+      .having("count(*) >= ?", display_threshold)
       .count
       .sort_by { |el| el[0][0].rjust(3, "0") }
   end

--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -5,7 +5,6 @@ class BulkUploadMailer < NotifyMailer
   FAILED_CSV_ERRORS_TEMPLATE_ID = "e27abcd4-5295-48c2-b127-e9ee4b781b75".freeze
   FAILED_FILE_SETUP_ERROR_TEMPLATE_ID = "24c9f4c7-96ad-470a-ba31-eb51b7cbafd9".freeze
   FAILED_SERVICE_ERROR_TEMPLATE_ID = "c3f6288c-7a74-4e77-99ee-6c4a0f6e125a".freeze
-  WITH_ERRORS_TEMPLATE_ID = "eb539005-6234-404e-812d-167728cf4274".freeze
   HOW_FIX_UPLOAD_TEMPLATE_ID = "21a07b26-f625-4846-9f4d-39e30937aa24".freeze
 
   def send_how_fix_upload_mail(bulk_upload:)
@@ -123,28 +122,6 @@ class BulkUploadMailer < NotifyMailer
         year_combo: bulk_upload.year_combo,
         errors: errors.map { |e| "- #{e}" }.join("\n"),
         bulk_upload_link:,
-      },
-    )
-  end
-
-  def send_bulk_upload_with_errors_mail(bulk_upload:)
-    count = bulk_upload.logs.where.not(status: %w[completed]).count
-
-    n_logs = pluralize(count, "log")
-
-    title = "We found #{n_logs} with errors"
-
-    error_description = "We created logs from your #{bulk_upload.year_combo} #{bulk_upload.log_type} data. There was a problem with #{count} of the logs. Click the below link to fix these logs."
-
-    send_email(
-      bulk_upload.user.email,
-      WITH_ERRORS_TEMPLATE_ID,
-      {
-        title:,
-        filename: bulk_upload.filename,
-        upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
-        error_description:,
-        summary_report_link: resume_bulk_upload_lettings_result_url(bulk_upload),
       },
     )
   end

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -59,12 +59,6 @@ private
       .deliver_later
   end
 
-  def send_fix_errors_mail
-    BulkUploadMailer
-      .send_bulk_upload_with_errors_mail(bulk_upload:)
-      .deliver_later
-  end
-
   def send_success_mail
     BulkUploadMailer
       .send_bulk_upload_complete_mail(user:, bulk_upload:)

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -17,7 +17,7 @@
   <%= govuk_tabs(title: "Error reports") do |c| %>
     <% c.with_tab(label: "Summary") do %>
       <p class="govuk-body">
-        This summary shows questions that have at least <%= BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD %> errors or more. See full error report for more details.
+        This summary shows questions that have more than <%= BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD - 1 %> errors. See full error report for more details.
       </p>
 
       <%= render BulkUploadErrorSummaryTableComponent.new(bulk_upload: @bulk_upload) %>

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -16,10 +16,6 @@
 <div class="govuk-grid-row">
   <%= govuk_tabs(title: "Error reports") do |c| %>
     <% c.with_tab(label: "Summary") do %>
-      <p class="govuk-body">
-        This summary shows questions that have more than <%= BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD - 1 %> errors. See full error report for more details.
-      </p>
-
       <%= render BulkUploadErrorSummaryTableComponent.new(bulk_upload: @bulk_upload) %>
     <% end %>
 

--- a/spec/components/bulk_upload_error_summary_table_component_spec.rb
+++ b/spec/components/bulk_upload_error_summary_table_component_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
         result = render_inline(component)
         expect(result).to have_selector("table", count: 1)
       end
+
+      it "renders intro with threshold" do
+        result = render_inline(component)
+
+        expect(result).to have_content("This summary shows questions that have more than 0 errors. See full error report for more details.")
+      end
     end
 
     context "when there are 2 independent errors" do
@@ -112,6 +118,8 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
 
       before do
         create(:bulk_upload_error, bulk_upload:, col: "B", row: 2, category: nil)
+
+        stub_const("BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD", 16)
       end
 
       it "only returns the setup errors" do
@@ -129,6 +137,12 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
           error_1.error,
           "1 error",
         ])
+      end
+
+      it "renders intro with setup errors" do
+        result = render_inline(component)
+
+        expect(result).to have_content("This summary shows important questions that have errors. See full error report for more details.")
       end
     end
   end

--- a/spec/components/bulk_upload_error_summary_table_component_spec.rb
+++ b/spec/components/bulk_upload_error_summary_table_component_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe BulkUploadErrorSummaryTableComponent, type: :component do
       end
     end
 
+    context "when on threshold" do
+      before do
+        stub_const("BulkUploadErrorSummaryTableComponent::DISPLAY_THRESHOLD", 1)
+
+        create(:bulk_upload_error, bulk_upload:, col: "A", row: 1)
+      end
+
+      it "renders tables" do
+        result = render_inline(component)
+        expect(result).to have_selector("table", count: 1)
+      end
+    end
+
     context "when there are 2 independent errors" do
       let!(:error_2) { create(:bulk_upload_error, bulk_upload:, col: "B", row: 2) }
       let!(:error_1) { create(:bulk_upload_error, bulk_upload:, col: "A", row: 1) }

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -81,34 +81,6 @@ RSpec.describe BulkUploadMailer do
     end
   end
 
-  context "when bulk upload has log which is not completed" do
-    before do
-      create(:lettings_log, :in_progress, bulk_upload:)
-    end
-
-    describe "#send_bulk_upload_with_errors_mail" do
-      let(:error_description) do
-        "We created logs from your 2022/23 lettings data. There was a problem with 1 of the logs. Click the below link to fix these logs."
-      end
-
-      it "sends correctly formed email" do
-        expect(notify_client).to receive(:send_email).with(
-          email_address: bulk_upload.user.email,
-          template_id: described_class::WITH_ERRORS_TEMPLATE_ID,
-          personalisation: {
-            title: "We found 1 log with errors",
-            filename: bulk_upload.filename,
-            upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
-            error_description:,
-            summary_report_link: "http://localhost:3000/lettings-logs/bulk-upload-results/#{bulk_upload.id}/resume",
-          },
-        )
-
-        mailer.send_bulk_upload_with_errors_mail(bulk_upload:)
-      end
-    end
-  end
-
   describe "#send_correct_and_upload_again_mail" do
     context "when 2 columns with errors" do
       before do

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe BulkUploadMailer do
       create(:bulk_upload_error, bulk_upload:, col: "F", field: "field_5")
     end
 
-    let(:expected_errors) do
-      [
-        "- What is the letting type? (Column A)",
-        "- Management group code (Column E)",
-      ]
-    end
-
     it "sends correctly formed email" do
       expect(notify_client).to receive(:send_email).with(
         email_address: bulk_upload.user.email,
@@ -35,8 +28,7 @@ RSpec.describe BulkUploadMailer do
           upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
           lettings_or_sales: bulk_upload.log_type,
           year_combo: bulk_upload.year_combo,
-          errors_list: expected_errors.join("\n"),
-          bulk_upload_link: start_bulk_upload_lettings_logs_url,
+          bulk_upload_link: summary_bulk_upload_lettings_result_url(bulk_upload),
         },
       )
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2170
- Some minor issues with the bulk upload summary report

# Changes

- Removed unused bulk upload mailer template
- Offset by 1 bug. So if there are 16 errors or more we show the summary report
- If there are setup errors, we only show the setup errors on summary report
- Depending if setup errors present or not show different copy on the summary report
- Setup email no longer takes list of error and simply sends user to relevant report