### PR TITLE
Stop storing errors in session

### DIFF
--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div data-controller="govukfrontend"></div>
-<%= form_with model: @log, url: form_lettings_log_path(@log), method: "post", local: true do |f| %>
+<%= form_with model: @log, url: request.original_url, method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-<%= @page.questions[0].type == "interruption_screen" ? "full-from-desktop" : "two-thirds-from-desktop" %>">
       <% remove_other_page_errors(@log, @page) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
     FormHandler.instance.lettings_forms.each do |_key, form|
       form.pages.map do |page|
         get page.id.to_s.dasherize, to: "form#show_page"
+        post page.id.to_s.dasherize, to: "form#submit_form"
       end
 
       form.subsections.map do |subsection|
@@ -190,6 +191,7 @@ Rails.application.routes.draw do
     FormHandler.instance.sales_forms.each do |_key, form|
       form.pages.map do |page|
         get page.id.to_s.dasherize, to: "form#show_page"
+        post page.id.to_s.dasherize, to: "form#submit_form"
       end
 
       form.subsections.map do |subsection|

--- a/spec/features/form/page_routing_spec.rb
+++ b/spec/features/form/page_routing_spec.rb
@@ -85,11 +85,11 @@ RSpec.describe "Form Page Routing" do
     context "when answer is invalid" do
       it "shows error with invalid value in the field" do
         visit("/lettings-logs/#{id}/property-postcode")
-        fill_in("lettings-log-postcode-full-field", with: "fake_postcode")
+        fill_in("lettings-log-postcode-full-field", with: "FAKE_POSTCODE")
         click_button("Save and continue")
 
         expect(page).to have_current_path("/lettings-logs/#{id}/property-postcode")
-        expect(find("#lettings-log-postcode-full-field-error").value).to eq("fake_postcode")
+        expect(find("#lettings-log-postcode-full-field-error").value).to eq("FAKE_POSTCODE")
       end
 
       it "does not reset the displayed date" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FormController, type: :request do
 
     describe "POST" do
       it "does not let you post form answers to lettings logs you don't have access to" do
-        post "/lettings-logs/#{lettings_log.id}/form", params: {}
+        post "/lettings-logs/#{lettings_log.id}/net-income", params: {}
         expect(response).to redirect_to("/account/sign-in")
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe FormController, type: :request do
       end
 
       it "resets created by and renders the next page" do
-        post "/lettings-logs/#{lettings_log.id}/form", params: params
+        post "/lettings-logs/#{lettings_log.id}/net-income", params: params
         expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/created-by")
         follow_redirect!
         lettings_log.reload
@@ -127,7 +127,7 @@ RSpec.describe FormController, type: :request do
       end
 
       it "does not reset created by" do
-        post "/lettings-logs/#{lettings_log.id}/form", params: params
+        post "/lettings-logs/#{lettings_log.id}/net-income", params: params
         expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/created-by")
         follow_redirect!
         lettings_log.reload
@@ -152,7 +152,7 @@ RSpec.describe FormController, type: :request do
       end
 
       it "does not reset created by" do
-        post "/lettings-logs/#{lettings_log.id}/form", params: params
+        post "/lettings-logs/#{lettings_log.id}/stock-owner", params: params
         expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/managing-organisation")
         follow_redirect!
         lettings_log.reload
@@ -177,7 +177,7 @@ RSpec.describe FormController, type: :request do
       end
 
       it "does not reset created by" do
-        post "/lettings-logs/#{lettings_log.id}/form", params: params
+        post "/lettings-logs/#{lettings_log.id}/stock-owner", params: params
         expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/managing-organisation")
         follow_redirect!
         lettings_log.reload
@@ -400,22 +400,21 @@ RSpec.describe FormController, type: :request do
           end
 
           it "re-renders the same page with errors if validation fails" do
-            post "/lettings-logs/#{lettings_log.id}/form", params: params
-            expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}")
-            follow_redirect!
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
             expect(page).to have_content("There is a problem")
+            expect(page).to have_content("Error: What is the tenant’s age?")
           end
 
           it "resets errors when fixed" do
-            post "/lettings-logs/#{lettings_log.id}/form", params: params
-            post "/lettings-logs/#{lettings_log.id}/form", params: valid_params
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: valid_params
             get "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}"
             expect(page).not_to have_content("There is a problem")
           end
 
           it "logs that validation was triggered" do
             expect(Rails.logger).to receive(:info).with("User triggered validation(s) on: age1").once
-            post "/lettings-logs/#{lettings_log.id}/form", params:
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params:
           end
 
           context "when the number of days is too high for the month" do
@@ -433,8 +432,7 @@ RSpec.describe FormController, type: :request do
             end
 
             it "validates the date correctly" do
-              post "/lettings-logs/#{lettings_log.id}/form", params: params
-              follow_redirect!
+              post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
               expect(page).to have_content("There is a problem")
             end
           end
@@ -465,10 +463,9 @@ RSpec.describe FormController, type: :request do
           end
 
           it "re-renders the same page with errors if validation fails" do
-            post "/lettings-logs/#{lettings_log.id}/form", params: params
-            expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/managing-organisation")
-            follow_redirect!
+            post "/lettings-logs/#{lettings_log.id}/managing-organisation", params: params
             expect(page).to have_content("There is a problem")
+            expect(page).to have_content("Error: Which organisation manages this letting?")
           end
         end
 
@@ -486,7 +483,7 @@ RSpec.describe FormController, type: :request do
           end
 
           before do
-            post "/lettings-logs/#{lettings_log.id}/form", params:
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params:
           end
 
           it "re-renders the same page with errors if validation fails" do
@@ -524,7 +521,7 @@ RSpec.describe FormController, type: :request do
 
               before do
                 lettings_log.update!(postcode_known: 1, postcode_full: "NW1 8RR")
-                post "/lettings-logs/#{lettings_log.id}/form", params: valid_params
+                post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: valid_params
               end
 
               it "does not require you to answer that question" do
@@ -558,14 +555,14 @@ RSpec.describe FormController, type: :request do
         end
 
         it "sets checked items to true" do
-          post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_params
+          post "/lettings-logs/#{lettings_log.id}/accessibility-requirements", params: lettings_log_form_params
           lettings_log.reload
 
           expect(lettings_log.housingneeds_b).to eq(1)
         end
 
         it "sets previously submitted items to false when resubmitted with new values" do
-          post "/lettings-logs/#{lettings_log.id}/form", params: new_lettings_log_form_params
+          post "/lettings-logs/#{lettings_log.id}/accessibility-requirements", params: new_lettings_log_form_params
           lettings_log.reload
 
           expect(lettings_log.housingneeds_b).to eq(0)
@@ -609,7 +606,7 @@ RSpec.describe FormController, type: :request do
 
           it "updates both question fields" do
             allow(page).to receive(:questions).and_return(questions_for_page)
-            post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_params
+            post "/lettings-logs/#{lettings_log.id}/#{page.id.dasherize}", params: lettings_log_form_params
             lettings_log.reload
 
             expect(lettings_log.housingneeds_a).to eq(1)
@@ -650,16 +647,16 @@ RSpec.describe FormController, type: :request do
         end
 
         it "routes to the appropriate conditional page based on the question answer of the current page" do
-          post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_conditional_question_yes_params
+          post "/lettings-logs/#{lettings_log.id}/property-wheelchair-accessible", params: lettings_log_form_conditional_question_yes_params
           expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/conditional-question-yes-page")
 
-          post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_conditional_question_no_params
+          post "/lettings-logs/#{lettings_log.id}/property-wheelchair-accessible", params: lettings_log_form_conditional_question_no_params
           expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/conditional-question-no-page")
         end
 
         it "routes to the page if at least one of the condition sets is met" do
-          post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_conditional_question_wchair_yes_params
-          post "/lettings-logs/#{lettings_log.id}/form", params: lettings_log_form_conditional_question_no_params
+          post "/lettings-logs/#{lettings_log.id}/property-wheelchair-accessible", params: lettings_log_form_conditional_question_wchair_yes_params
+          post "/lettings-logs/#{lettings_log.id}/property-wheelchair-accessible", params: lettings_log_form_conditional_question_no_params
           expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/conditional-question-yes-page")
         end
       end
@@ -690,7 +687,7 @@ RSpec.describe FormController, type: :request do
             completed_lettings_log.update!(ecstat1: 1, earnings: 130, hhmemb: 1) # we're not routing to that page, so it gets cleared?
             allow(completed_lettings_log).to receive(:net_income_soft_validation_triggered?).and_return(true)
             allow(completed_lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
-            post "/lettings-logs/#{completed_lettings_log.id}/form", params: interrupt_params, headers: headers.merge({ "HTTP_REFERER" => referrer })
+            post "/lettings-logs/#{completed_lettings_log.id}/net-income-value-check", params: interrupt_params, headers: headers.merge({ "HTTP_REFERER" => referrer })
           end
 
           context "when yes is answered" do
@@ -722,7 +719,7 @@ RSpec.describe FormController, type: :request do
         end
 
         before do
-          post "/lettings-logs/#{unauthorized_lettings_log.id}/form", params: {}
+          post "/lettings-logs/#{unauthorized_lettings_log.id}/net-income", params: {}
         end
 
         it "does not let you post form answers to lettings logs you don't have access to" do


### PR DESCRIPTION
Instead of storing errors in session and repopulating them from session when the page gets reloaded we re-render the same page with existing errors.

Storing errors in session has caused some cookie overflows as the errors would get to large in some instances.