### PR TITLE
CLDC-2226 Update UPRN validations in bulk upload

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -334,7 +334,7 @@ class BulkUpload::Lettings::Year2023::RowParser
 
   validate :validate_valid_radio_option, on: :before_log
 
-  validate :validate_uprn_exists_if_any_key_adddress_fields_are_blank
+  validate :validate_uprn_exists_if_any_key_adddress_fields_are_blank, on: :after_log
 
   def self.question_for_field(field)
     QUESTIONS[field]

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -292,6 +292,7 @@ class BulkUpload::Lettings::Year2023::RowParser
   validates :field_72, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }, allow_blank: true, on: :after_log
   validates :field_76, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }, allow_blank: true, on: :after_log
 
+  validates :field_4, presence: { message: I18n.t("validations.not_answered", question: "needs type") }, on: :after_log
   validates :field_6, presence: { message: I18n.t("validations.not_answered", question: "property renewal") }, on: :after_log
   validates :field_7, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (day)") }, on: :after_log
   validates :field_8, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (month)") }, on: :after_log
@@ -299,7 +300,6 @@ class BulkUpload::Lettings::Year2023::RowParser
 
   validates :field_9, format: { with: /\A\d{2}\z/, message: I18n.t("validations.setup.startdate.year_not_two_digits") }, on: :after_log
 
-  validate :validate_needs_type_present, on: :after_log
   validate :validate_data_types, on: :after_log
   validate :validate_nulls, on: :after_log
   validate :validate_relevant_collection_window, on: :after_log
@@ -436,12 +436,6 @@ private
   def validate_uprn_exists_if_any_key_adddress_fields_are_blank
     if field_18.blank? && (field_19.blank? || field_21.blank?)
       errors.add(:field_18, I18n.t("validations.not_answered", question: "UPRN"))
-    end
-  end
-
-  def validate_needs_type_present
-    if field_4.blank?
-      errors.add(:field_4, I18n.t("validations.not_answered", question: "needs type"))
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -548,13 +548,15 @@ private
       if setup_question?(question)
         fields.each do |field|
           if errors[field].present?
-            errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase), category: :setup)
+            question_text = question.check_answer_label.presence || question.header
+            errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase), category: :setup)
           end
         end
       else
         fields.each do |field|
           unless errors.any? { |e| fields.include?(e.attribute) }
-            errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase))
+            question_text = question.check_answer_label.presence || question.header
+            errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase))
           end
         end
       end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -435,7 +435,7 @@ private
 
   def validate_uprn_exists_if_address_does_not
     if field_18.blank? && field_19.blank? && field_21.blank?
-      errors.add(:field_18, I18n.t("validations.not_answered", question: "UPRN known"))
+      errors.add(:field_18, I18n.t("validations.not_answered", question: "UPRN"))
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -835,6 +835,7 @@ private
   end
 
   def questions
+    # binding.pry if log.form.subsections.count == 1
     @questions ||= log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -542,15 +542,15 @@ private
       if setup_question?(question)
         fields.each do |field|
           if errors[field].present?
-            question_text = question.check_answer_label.presence || question.header || "this question"
-            errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase), category: :setup)
+            question_text = question.check_answer_label.presence || question.header.presence || "this question"
+            errors.add(field, I18n.t("validations.not_answered", question: question_text.downcase), category: :setup)
           end
         end
       else
         fields.each do |field|
           unless errors.any? { |e| fields.include?(e.attribute) }
-            question_text = question.check_answer_label.presence || question.header || "this question"
-            errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase))
+            question_text = question.check_answer_label.presence || question.header.presence || "this question"
+            errors.add(field, I18n.t("validations.not_answered", question: question_text.downcase))
           end
         end
       end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -334,6 +334,8 @@ class BulkUpload::Lettings::Year2023::RowParser
 
   validate :validate_valid_radio_option, on: :before_log
 
+  validate :validate_uprn_exists_if_address_does_not
+
   def self.question_for_field(field)
     QUESTIONS[field]
   end
@@ -429,6 +431,12 @@ private
 
   def created_by
     @created_by ||= User.find_by(email: field_3)
+  end
+
+  def validate_uprn_exists_if_address_does_not
+    if field_18.blank? && field_19.blank? && field_21.blank?
+      errors.add(:field_18, I18n.t("validations.not_answered", question: "UPRN known"))
+    end
   end
 
   def validate_needs_type_present

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -542,14 +542,14 @@ private
       if setup_question?(question)
         fields.each do |field|
           if errors[field].present?
-            question_text = question.check_answer_label.presence || question.header
+            question_text = question.check_answer_label.presence || question.header || "this question"
             errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase), category: :setup)
           end
         end
       else
         fields.each do |field|
           unless errors.any? { |e| fields.include?(e.attribute) }
-            question_text = question.check_answer_label.presence || question.header
+            question_text = question.check_answer_label.presence || question.header || "this question"
             errors.add(field, I18n.t("validations.not_answered", question: question_text&.downcase))
           end
         end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -835,7 +835,6 @@ private
   end
 
   def questions
-    # binding.pry if log.form.subsections.count == 1
     @questions ||= log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -334,7 +334,7 @@ class BulkUpload::Lettings::Year2023::RowParser
 
   validate :validate_valid_radio_option, on: :before_log
 
-  validate :validate_uprn_exists_if_address_does_not
+  validate :validate_uprn_exists_if_any_key_adddress_fields_are_blank
 
   def self.question_for_field(field)
     QUESTIONS[field]
@@ -433,8 +433,8 @@ private
     @created_by ||= User.find_by(email: field_3)
   end
 
-  def validate_uprn_exists_if_address_does_not
-    if field_18.blank? && field_19.blank? && field_21.blank?
+  def validate_uprn_exists_if_any_key_adddress_fields_are_blank
+    if field_18.blank? && (field_19.blank? || field_21.blank?)
       errors.add(:field_18, I18n.t("validations.not_answered", question: "UPRN"))
     end
   end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -830,7 +830,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
 
         it "adds an appropriate error" do
-          expect(parser.errors[:field_18]).to eql(["You must answer UPRN known"])
+          expect(parser.errors[:field_18]).to eql(["You must answer UPRN"])
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
 
       describe "#validate_nulls" do
-        let(:attributes) { { bulk_upload:, field_19: "", field_21: "" } }
+        let(:attributes) { { bulk_upload:, field_18: "", field_19: "", field_21: "" } }
 
         it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
           parser.valid?

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -236,6 +236,16 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(questions.map(&:id)).to eql([])
         end
       end
+
+      describe "#validate_nulls" do
+        let(:attributes) { { bulk_upload:, field_19: "", field_21: "" } }
+
+        it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
+          parser.valid?
+          expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
+          expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
+        end
+      end
     end
 
     context "when setup section not complete" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         context "for non-setup questions" do
           let(:attributes) { { bulk_upload:, field_1: "", field_18: "", field_19: "", field_21: "" } }
 
-          it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
+          it "fetches the question's check_answer_label if it exists, otherwise it gets the question's header" do
             parser.valid?
             expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
             expect(parser.errors[:field_21]).to eql(["You must answer town or city"])

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -829,8 +829,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           }
         end
 
-        it "adds an appropriate error" do
+        it "adds appropriate errors" do
           expect(parser.errors[:field_18]).to eql(["You must answer UPRN"])
+          expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
+          expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -806,8 +806,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when over 12 characters" do
         let(:attributes) { { bulk_upload:, field_18: "1234567890123" } }
 
-        it "has errors on the field" do
-          expect(parser.errors[:field_18]).to be_present
+        it "adds an appropriate error" do
+          expect(parser.errors[:field_18]).to eql(["UPRN must be 12 digits or less"])
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
       describe "#validate_nulls" do
         context "for non-setup questions" do
-          let(:attributes) { { bulk_upload:, field_1: "", field_18: "", field_19: "", field_21: "" } }
+          let(:attributes) { { bulk_upload:, field_1: "a", field_18: "", field_19: "", field_21: "" } }
 
           it "fetches the question's check_answer_label if it exists, otherwise it gets the question's header" do
             parser.valid?

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -810,6 +810,46 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(parser.errors[:field_18]).to be_present
         end
       end
+
+      context "when neither UPRN nor address given" do
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_1: "1",
+          }
+        end
+
+        it "adds an appropriate error" do
+          expect(parser.errors[:field_18]).to eql(["You must answer UPRN known"])
+        end
+      end
+
+      context "when UPRN is given but address is not" do
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_18: "123456789012",
+          }
+        end
+
+        it "doesn't add an error" do
+          expect(parser.errors[:field_18]).to be_empty
+        end
+      end
+
+      context "when address is given but UPRN is not" do
+        let(:attributes) do
+          {
+            bulk_upload:,
+            field_19: "1 Example Rd",
+            field_21: "Example Town/City",
+          }
+        end
+
+        it "doesn't add an error" do
+          expect(parser.errors[:field_18]).to be_empty
+        end
+      end
     end
 
     describe "#field_26" do # unitletas

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
 
       describe "#validate_nulls" do
-        context "for non-setup questions" do
+        context "when non-setup questions are null" do
           let(:attributes) { { bulk_upload:, field_1: "a", field_18: "", field_19: "", field_21: "" } }
 
           it "fetches the question's check_answer_label if it exists, otherwise it gets the question's header" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -30,11 +30,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
   before do
     create(:organisation_relationship, parent_organisation: owning_org, child_organisation: managing_org)
-    allow(form).to receive(:subsections).and_return([setup_subsection])
-    allow(FormHandler.instance).to receive(:current_lettings_form).and_return(form)
-    allow(setup_subsection).to receive(:pages).and_return([setup_page])
-    allow(setup_page).to receive(:questions).and_return([setup_question])
-    allow(setup_question).to receive(:check_answer_label).and_return(nil)
   end
 
   around do |example|
@@ -243,36 +238,12 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
 
       describe "#validate_nulls" do
-        context "for setup questions" do
-          let(:attributes) { { bulk_upload:, field_1: "a", field_4: nil, field_6: nil }  }
-          let(:form) { Form.new(nil, 2023, [], "lettings") }
-          let(:setup_subsection) { Form::Lettings::Subsections::Setup.new(nil, nil, form.setup_sections.first) }
-          let(:setup_page) { Form::Lettings::Pages::NeedsType.new(nil, nil, setup_subsection) }
-          let(:setup_question) { Form::Lettings::Questions::NeedsType.new(nil, nil, setup_page) }
+        let(:attributes) { { bulk_upload:, field_18: "", field_19: "", field_21: "" } }
 
-          # before do
-          #   allow(form).to receive(:subsections).and_return([setup_subsection])
-          #   allow(FormHandler.instance).to receive(:current_lettings_form).and_return(form)
-          #   allow(setup_subsection).to receive(:pages).and_return([setup_page])
-          #   allow(setup_page).to receive(:questions).and_return([setup_question])
-          # end
-
-          it "fetches the question's check_answer_label if it exists, otherwise it gets the question's header" do
-            binding.pry
-            parser.valid?
-            expect(parser.errors[:field_4]).to eql(["You must answer what is the needs type?"])
-            expect(parser.errors[:field_6]).to eql(["You must answer property renewal"])
-          end
-        end
-
-        context "for non-setup questions" do
-          let(:attributes) { { bulk_upload:, field_1: "a", field_18: "", field_19: "", field_21: "" } }
-
-          it "fetches the question's check_answer_label if it exists, otherwise it gets the question's header" do
-            parser.valid?
-            expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
-            expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
-          end
+        it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
+          parser.valid?
+          expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
+          expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -238,12 +238,14 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
 
       describe "#validate_nulls" do
-        let(:attributes) { { bulk_upload:, field_18: "", field_19: "", field_21: "" } }
+        context "for non-setup questions" do
+          let(:attributes) { { bulk_upload:, field_1: "", field_18: "", field_19: "", field_21: "" } }
 
-        it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
-          parser.valid?
-          expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
-          expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
+          it "fetches the question's check_answer_label if it exists, otherwise it get's the question's header" do
+            parser.valid?
+            expect(parser.errors[:field_19]).to eql(["You must answer q12 - address"])
+            expect(parser.errors[:field_21]).to eql(["You must answer town or city"])
+          end
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -821,7 +821,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
-      context "when neither UPRN nor address given" do
+      context "when neither UPRN nor address fields are given" do
         let(:attributes) do
           {
             bulk_upload:,
@@ -834,7 +834,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
-      context "when UPRN is given but address is not" do
+      context "when UPRN is given but address fields are not" do
         let(:attributes) do
           {
             bulk_upload:,


### PR DESCRIPTION
## Context
- https://digital.dclg.gov.uk/jira/browse/CLDC-2226

## The changes
- If the UPRN question is not answered and either of address line 1 and town/city are unanswered, make sure that a bulk upload error is created for the UPRN question (not just the unanswered address field question).
- If any compulsory field is missing in a bulk upload, normally the error message in the error report just references the question's `check_answer_label`. Sometimes a question doesn't have a `check_answer_label` though - in which case we now display the question's `header` instead.
- Added appropriate tests for the above.
- Also made an improvement to the existing "UPRN must be 12 digits or less" test.

## Note
- @kosiakkatrina and I paired on trying to write a test for the setup questions part of the ´validate_nulls' method in the row parser, but it ended up being too complex and we didn't think it was worth the time investment in the end.

## Remaining to do
- There are other bits of error message logic that need updating I believe, but I'll spin them out into separate tickets. Thread for context: https://softwire.slack.com/archives/C01QGR78H9S/p1681397427245309