### PR TITLE
CLDC-2183 Hide blank bulk upload error meta labels

### DIFF
--- a/app/components/bulk_upload_error_row_component.html.erb
+++ b/app/components/bulk_upload_error_row_component.html.erb
@@ -1,9 +1,9 @@
 <div class="x-govuk-summary-card govuk-!-margin-bottom-6">
   <div class="x-govuk-summary-card__header">
     <% if lettings? %>
-      <h3 class="x-govuk-summary-card__title"><strong>Row <%= row %></strong> <span class="govuk-!-margin-left-3">Tenant code: <%= tenant_code %></span> <span class="govuk-!-margin-left-3">Property reference: <%= property_ref %></span></h3>
+      <h3 class="x-govuk-summary-card__title"><strong>Row <%= row %></strong> <%= tenant_code_html %> <%= property_ref_html %></h3>
     <% else %>
-      <h3 class="x-govuk-summary-card__title"><strong>Row <%= row %></strong> <span class="govuk-!-margin-left-3">Purchaser code: <%= purchaser_code %></span></h3>
+      <h3 class="x-govuk-summary-card__title"><strong>Row <%= row %></strong> <%= purchaser_code_html %></h3>
     <% end %>
   </div>
 

--- a/app/components/bulk_upload_error_row_component.rb
+++ b/app/components/bulk_upload_error_row_component.rb
@@ -15,12 +15,36 @@ class BulkUploadErrorRowComponent < ViewComponent::Base
     bulk_upload_errors.first.tenant_code
   end
 
+  def tenant_code_html
+    return if tenant_code.blank?
+
+    content_tag :span, class: "govuk-!-margin-left-3" do
+      "Tenant code: #{tenant_code}"
+    end
+  end
+
   def purchaser_code
     bulk_upload_errors.first.purchaser_code
   end
 
+  def purchaser_code_html
+    return if purchaser_code.blank?
+
+    content_tag :span, class: "govuk-!-margin-left-3" do
+      "Purchaser code: #{purchaser_code}"
+    end
+  end
+
   def property_ref
     bulk_upload_errors.first.property_ref
+  end
+
+  def property_ref_html
+    return if property_ref.blank?
+
+    content_tag :span, class: "govuk-!-margin-left-3" do
+      "Property reference: #{property_ref}"
+    end
   end
 
   def question_for_field(field)

--- a/spec/components/bulk_upload_error_row_component_spec.rb
+++ b/spec/components/bulk_upload_error_row_component_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe BulkUploadErrorRowComponent, type: :component do
     let(:row) { rand(9_999) }
     let(:tenant_code) { SecureRandom.hex(4) }
     let(:property_ref) { SecureRandom.hex(4) }
+    let(:purchaser_code) { nil }
     let(:field) { :field_134 }
     let(:error) { "some error" }
     let(:bulk_upload) { create(:bulk_upload, :lettings) }
@@ -16,6 +17,7 @@ RSpec.describe BulkUploadErrorRowComponent, type: :component do
           row:,
           tenant_code:,
           property_ref:,
+          purchaser_code:,
           field:,
           error:,
         ),
@@ -47,6 +49,33 @@ RSpec.describe BulkUploadErrorRowComponent, type: :component do
       expected = "Is this letting a renewal?"
       result = render_inline(described_class.new(bulk_upload_errors:))
       expect(result).to have_content(expected)
+    end
+
+    context "when tenant_code not present" do
+      let(:tenant_code) { nil }
+
+      it "does not render tenant code label" do
+        result = render_inline(described_class.new(bulk_upload_errors:))
+        expect(result).not_to have_content("Tenant code")
+      end
+    end
+
+    context "when property_ref not present" do
+      let(:property_ref) { nil }
+
+      it "does not render the property_ref label" do
+        result = render_inline(described_class.new(bulk_upload_errors:))
+        expect(result).not_to have_content("Property reference")
+      end
+    end
+
+    context "when purchaser_code not present" do
+      let(:bulk_upload) { create(:bulk_upload, :sales) }
+
+      it "does not render the purchaser_code label" do
+        result = render_inline(described_class.new(bulk_upload_errors:))
+        expect(result).not_to have_content("Purchaser code")
+      end
     end
 
     context "when multiple errors for a row" do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2183
- For bulk upload errors we show meta data such as tenant code or property reference. These values are not always populated with data

# Changes

- When meta data not present for bulk upload error, don't show the label either