### PR TITLE
CLDC-2267 More errors considered as setup errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -480,7 +480,7 @@ private
       block_log_creation!
 
       if errors[:field_113].blank?
-        errors.add(:field_113, "This managing organisation does not have a relationship with the owning organisation")
+        errors.add(:field_113, "This managing organisation does not have a relationship with the owning organisation", category: :setup)
       end
     end
   end
@@ -490,7 +490,7 @@ private
       block_log_creation!
 
       if errors[:field_113].blank?
-        errors.add(:field_113, "The managing organisation code is incorrect")
+        errors.add(:field_113, "The managing organisation code is incorrect", category: :setup)
       end
     end
   end
@@ -507,7 +507,7 @@ private
       block_log_creation!
 
       if errors[:field_111].blank?
-        errors.add(:field_111, "The owning organisation code provided is for an organisation that does not own stock")
+        errors.add(:field_111, "The owning organisation code provided is for an organisation that does not own stock", category: :setup)
       end
     end
   end
@@ -517,7 +517,7 @@ private
       block_log_creation!
 
       if errors[:field_111].blank?
-        errors.add(:field_111, "The owning organisation code is incorrect")
+        errors.add(:field_111, "The owning organisation code is incorrect", category: :setup)
       end
     end
   end
@@ -537,7 +537,7 @@ private
       block_log_creation!
 
       if errors[:field_111].blank?
-        errors.add(:field_111, "You do not have permission to add logs for this owning organisation")
+        errors.add(:field_111, "You do not have permission to add logs for this owning organisation", category: :setup)
       end
     end
   end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -598,7 +598,7 @@ private
       block_log_creation!
 
       if errors[:field_2].blank?
-        errors.add(:field_2, "This managing organisation does not have a relationship with the owning organisation")
+        errors.add(:field_2, "This managing organisation does not have a relationship with the owning organisation", category: :setup)
       end
     end
   end
@@ -608,7 +608,7 @@ private
       block_log_creation!
 
       if errors[:field_2].blank?
-        errors.add(:field_2, "The managing organisation code is incorrect")
+        errors.add(:field_2, "The managing organisation code is incorrect", category: :setup)
       end
     end
   end
@@ -625,7 +625,7 @@ private
       block_log_creation!
 
       if errors[:field_1].blank?
-        errors.add(:field_1, "The owning organisation code provided is for an organisation that does not own stock")
+        errors.add(:field_1, "The owning organisation code provided is for an organisation that does not own stock", category: :setup)
       end
     end
   end
@@ -635,7 +635,7 @@ private
       block_log_creation!
 
       if errors[:field_1].blank?
-        errors.add(:field_1, "The owning organisation code is incorrect")
+        errors.add(:field_1, "The owning organisation code is incorrect", category: :setup)
       end
     end
   end
@@ -652,7 +652,7 @@ private
       block_log_creation!
 
       if errors[:field_1].blank?
-        errors.add(:field_1, "You do not have permission to add logs for this owning organisation")
+        errors.add(:field_1, "You do not have permission to add logs for this owning organisation", category: :setup)
       end
     end
   end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -710,8 +710,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       context "when cannot find owning org" do
         let(:attributes) { { bulk_upload:, field_111: "donotexist" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_111]).to eql(["The owning organisation code is incorrect"])
+        it "is not permitted as a setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_111 }.message).to eql("The owning organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -724,8 +726,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         let(:attributes) { { bulk_upload:, field_111: owning_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_111]).to eql(["The owning organisation code provided is for an organisation that does not own stock"])
+        it "is not permitted as a setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_111 }.message).to eql("The owning organisation code provided is for an organisation that does not own stock")
         end
 
         it "blocks log creation" do
@@ -738,8 +742,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         let(:attributes) { { bulk_upload:, field_111: unaffiliated_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_111]).to eql(["You do not have permission to add logs for this owning organisation"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_111 }.message).to eql("You do not have permission to add logs for this owning organisation")
         end
 
         it "blocks log creation" do
@@ -804,8 +810,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_113: "" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_113]).to eql(["The managing organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_113 }.message).to eql("The managing organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -816,8 +824,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       context "when cannot find managing org" do
         let(:attributes) { { bulk_upload:, field_113: "donotexist" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_113]).to eql(["The managing organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_113 }.message).to eql("The managing organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -830,8 +840,10 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         let(:attributes) { { bulk_upload:, field_111: owning_org.old_visible_id, field_113: unaffiliated_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_113]).to eql(["This managing organisation does not have a relationship with the owning organisation"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_113 }.message).to eql("This managing organisation does not have a relationship with the owning organisation")
         end
 
         it "blocks log creation" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -674,8 +674,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_1: "" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_1]).to eql(["The owning organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_1 }.message).to eql("The owning organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -686,8 +688,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when cannot find owning org" do
         let(:attributes) { { bulk_upload:, field_1: "donotexist" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_1]).to eql(["The owning organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_1 }.message).to eql("The owning organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -700,8 +704,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_1]).to eql(["The owning organisation code provided is for an organisation that does not own stock"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_1 }.message).to eql("The owning organisation code provided is for an organisation that does not own stock")
         end
 
         it "blocks log creation" do
@@ -714,8 +720,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         let(:attributes) { { bulk_upload:, field_1: unaffiliated_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_1]).to eql(["You do not have permission to add logs for this owning organisation"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_1 }.message).to eql("You do not have permission to add logs for this owning organisation")
         end
 
         it "blocks log creation" do
@@ -728,8 +736,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_2: "" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_2]).to eql(["The managing organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_2 }.message).to eql("The managing organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -740,8 +750,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when cannot find managing org" do
         let(:attributes) { { bulk_upload:, field_2: "donotexist" } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_2]).to eql(["The managing organisation code is incorrect"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_2 }.message).to eql("The managing organisation code is incorrect")
         end
 
         it "blocks log creation" do
@@ -754,8 +766,10 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_2: unaffiliated_org.old_visible_id } }
 
-        it "is not permitted" do
-          expect(parser.errors[:field_2]).to eql(["This managing organisation does not have a relationship with the owning organisation"])
+        it "is not permitted as setup error" do
+          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
+
+          expect(setup_errors.find { |e| e.attribute == :field_2 }.message).to eql("This managing organisation does not have a relationship with the owning organisation")
         end
 
         it "blocks log creation" do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2267
- Consider errors on owning and managing org fields as setup errors
- Otherwise the user is not shown the summary report to highlight these as blocking issues to resolve

# Changes

- if there are problems with owning or managing org fields these are now considered as setup errors