### PR TITLE
CLDC-2055 Add merging organisations merge request page

### DIFF
--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,14 +1,9 @@
 class MergeRequestsController < ApplicationController
   before_action :authenticate_user!
-  # before_action :authenticate_scope!
+  before_action :find_resource, only: %i[organisations update_organisations]
 
-  def create
-    @merge_request = MergeRequest.new
-  end  
-  
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
-
     redirect_to merge_request_organisations_path(@merge_request)
   end
 
@@ -31,7 +26,28 @@ class MergeRequestsController < ApplicationController
     render "organisations"
   end
 
-  private
+  def update_organisations
+    if @merge_request.merging_organisation_ids
+      @merge_request.merging_organisation_ids << params[:merge_request][:merging_organisation].to_i
+      @merge_request.save!
+    else
+      @merge_request.update!(merging_organisation_ids: [params[:merge_request][:merging_organisation]])
+    end
+    @answer_options = organisations_answer_options
+    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
+    render "organisations"
+  end
+
+private
+
+  def organisations_answer_options
+    answer_options = { "" => "Select an option" }
+
+    Organisation.all.pluck(:id, :name).each do |organisation|
+      answer_options[organisation[0]] = organisation[1]
+    end
+    answer_options
+  end
 
   def answer_options
     answer_options = { "" => "Select an option" }
@@ -43,10 +59,13 @@ class MergeRequestsController < ApplicationController
   end
   
   def merge_request_params
-    required_params = params.fetch(:merge_request, {}).permit(:requesting_organisation)
+    merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation)
 
-    required_params[:requesting_organisation] = current_user.organisation
-    required_params
+    merge_params[:requesting_organisation] = current_user.organisation
+    merge_params
   end
 
+  def find_resource
+    @merge_request = MergeRequest.find(params[:merge_request_id])
+  end
 end

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -26,7 +26,6 @@ class MergeRequestsController < ApplicationController
     merge_request_organisation = MergeRequestOrganisation.new(merge_request_organisation_params)
     @answer_options = organisations_answer_options
     if merge_request_organisation.save
-      @merge_request.reload
       @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
       render :organisations
     else
@@ -37,7 +36,6 @@ class MergeRequestsController < ApplicationController
 
   def remove_merging_organisation
     MergeRequestOrganisation.find_by(merge_request_organisation_params)&.destroy!
-    @merge_request.reload
     @answer_options = organisations_answer_options
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
     render :organisations

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -14,17 +14,14 @@ class MergeRequestsController < ApplicationController
   end
 
   def update_organisations
-    if @merge_request.merging_organisation_ids
-      @merge_request.merging_organisation_ids << params[:merge_request][:merging_organisation].to_i
-    else
-      @merge_request.merging_organisation_ids = [params[:merge_request][:merging_organisation]]
-    end
+    merge_request_organisation = MergeRequestOrganisation.new(merge_request_organisation_params)
     @answer_options = organisations_answer_options
-    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
-    if @merge_request.save
+    if merge_request_organisation.save
+      @merge_request.reload
       @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
-      render "organisations"
+      render :organisations
     else
+      @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
       render :organisations, status: :unprocessable_entity
     end
   end
@@ -45,6 +42,10 @@ private
 
     merge_params[:requesting_organisation] = current_user.organisation
     merge_params
+  end
+
+  def merge_request_organisation_params
+    { merge_request: @merge_request, merging_organisation: Organisation.find(params[:merge_request][:merging_organisation]) }
   end
 
   def find_resource

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -36,7 +36,7 @@ class MergeRequestsController < ApplicationController
   end
 
   def remove_merging_organisation
-    MergeRequestOrganisation.find_by(merge_request_organisation_params).destroy!
+    MergeRequestOrganisation.find_by(merge_request_organisation_params)&.destroy!
     @merge_request.reload
     @answer_options = organisations_answer_options
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,6 +1,7 @@
 class MergeRequestsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_resource, only: %i[organisations update_organisations remove_merging_organisation update_other_merging_organisations]
+  before_action :find_resource, only: %i[organisations update_organisations remove_merging_organisation]
+  before_action :find_resource_by_id, only: %i[update]
 
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
@@ -13,6 +14,14 @@ class MergeRequestsController < ApplicationController
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
   end
 
+  def update
+    if @merge_request.update(merge_request_params)
+      redirect_to next_page_path
+    else
+      render previous_template, status: :unprocessable_entity
+    end
+  end
+
   def update_organisations
     merge_request_organisation = MergeRequestOrganisation.new(merge_request_organisation_params)
     @answer_options = organisations_answer_options
@@ -22,14 +31,6 @@ class MergeRequestsController < ApplicationController
       render :organisations
     else
       @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
-      render :organisations, status: :unprocessable_entity
-    end
-  end
-
-  def update_other_merging_organisations
-    if @merge_request.update(other_merging_organisaitions_params)
-      redirect_to merge_request_absorbing_organisation_path(@merge_request)
-    else
       render :organisations, status: :unprocessable_entity
     end
   end
@@ -56,7 +57,7 @@ private
   def merge_request_params
     merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation_id, :other_merging_organisations)
 
-    if current_user.data_coordinator? || current_user.data_provider?
+    if merge_params[:requesting_organisation_id].present? && (current_user.data_coordinator? || current_user.data_provider?)
       merge_params[:requesting_organisation_id] = current_user.organisation.id
     end
 
@@ -67,11 +68,19 @@ private
     { merge_request: @merge_request, merging_organisation_id: params[:merge_request][:merging_organisation] }
   end
 
-  def other_merging_organisaitions_params
-    params.fetch(:merge_request, {}).permit(:other_merging_organisations)
-  end
-
   def find_resource
     @merge_request = MergeRequest.find(params[:merge_request_id])
+  end
+
+  def find_resource_by_id
+    @merge_request = MergeRequest.find(params[:id])
+  end
+
+  def next_page_path
+    merge_request_absorbing_organisation_path(@merge_request)
+  end
+
+  def previous_template
+    :organisations
   end
 end

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,17 +1,15 @@
 class MergeRequestsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_resource, only: %i[organisations update_organisations remove_merging_organisation]
-  before_action :find_resource_by_id, only: %i[update]
+  before_action :find_resource, only: %i[update organisations update_organisations remove_merging_organisation]
 
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
-    redirect_to merge_request_organisations_path(@merge_request)
+    redirect_to organisations_merge_request_path(@merge_request)
   end
 
   def organisations
-    @merge_request = MergeRequest.find(params[:merge_request_id])
+    @merge_request = MergeRequest.find(params[:id])
     @answer_options = organisations_answer_options
-    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
   end
 
   def update
@@ -26,10 +24,8 @@ class MergeRequestsController < ApplicationController
     merge_request_organisation = MergeRequestOrganisation.new(merge_request_organisation_params)
     @answer_options = organisations_answer_options
     if merge_request_organisation.save
-      @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
       render :organisations
     else
-      @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
       render :organisations, status: :unprocessable_entity
     end
   end
@@ -37,7 +33,6 @@ class MergeRequestsController < ApplicationController
   def remove_merging_organisation
     MergeRequestOrganisation.find_by(merge_request_organisation_params)&.destroy!
     @answer_options = organisations_answer_options
-    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
     render :organisations
   end
 
@@ -67,15 +62,11 @@ private
   end
 
   def find_resource
-    @merge_request = MergeRequest.find(params[:merge_request_id])
-  end
-
-  def find_resource_by_id
     @merge_request = MergeRequest.find(params[:id])
   end
 
   def next_page_path
-    merge_request_absorbing_organisation_path(@merge_request)
+    absorbing_organisation_merge_request_path(@merge_request)
   end
 
   def previous_template

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -64,7 +64,7 @@ private
   end
 
   def merge_request_organisation_params
-    { merge_request: @merge_request, merging_organisation: Organisation.find(params[:merge_request][:merging_organisation]) }
+    { merge_request: @merge_request, merging_organisation_id: params[:merge_request][:merging_organisation] }
   end
 
   def other_merging_organisaitions_params

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -5,6 +5,8 @@ class MergeRequestsController < ApplicationController
 
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
+    MergeRequestOrganisation.create!({ merge_request: @merge_request, merging_organisation_id: merge_request_params.fetch(:requesting_organisation_id) })
+
     redirect_to organisations_merge_request_path(@merge_request)
   end
 
@@ -48,7 +50,7 @@ private
   end
 
   def merge_request_params
-    merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation_id, :other_merging_organisations)
+    merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation_id, :other_merging_organisations, :status)
 
     if merge_params[:requesting_organisation_id].present? && (current_user.data_coordinator? || current_user.data_provider?)
       merge_params[:requesting_organisation_id] = current_user.organisation.id

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -9,21 +9,8 @@ class MergeRequestsController < ApplicationController
 
   def organisations
     @merge_request = MergeRequest.find(params[:merge_request_id])
-    @answer_options = answer_options
-    @merging_organisations_list = [@merge_request.requesting_organisation]
-  end
-
-  def update_organisations
-    @merge_request = MergeRequest.find(params[:merge_request_id])
-    if @merge_request.merging_organisation_ids
-      @merge_request.merging_organisation_ids << params[:merge_request][:merging_organisation]
-      @merge_request.save!
-    else
-      @merge_request.update!(merging_organisation_ids:[params[:merge_request][:merging_organisation]])
-    end
-    @answer_options = answer_options
+    @answer_options = organisations_answer_options
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
-    render "organisations"
   end
 
   def update_organisations
@@ -53,15 +40,6 @@ private
     answer_options
   end
 
-  def answer_options
-    answer_options = { "" => "Select an option" }
-
-    Organisation.all.pluck(:id, :name).each do |organisation|
-      answer_options[organisation[0]] = organisation[1]
-    end
-    answer_options
-  end
-  
   def merge_request_params
     merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation)
 

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,0 +1,27 @@
+class MergeRequestsController < ApplicationController
+  before_action :authenticate_user!
+  # before_action :authenticate_scope!
+
+  def create
+    @merge_request = MergeRequest.new
+  end  
+  
+  def create
+    @merge_request = MergeRequest.create!(merge_request_params)
+
+    redirect_to merge_request_organisations_path(@merge_request)
+  end
+
+  def organisations
+  end
+
+  private
+
+  def merge_request_params
+    required_params = {}
+
+    required_params[:requesting_organisation] = current_user.organisation
+    required_params
+  end
+
+end

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,6 +1,6 @@
 class MergeRequestsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_resource, only: %i[organisations update_organisations]
+  before_action :find_resource, only: %i[organisations update_organisations remove_merging_organsiation]
 
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
@@ -24,6 +24,14 @@ class MergeRequestsController < ApplicationController
       @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
       render :organisations, status: :unprocessable_entity
     end
+  end
+
+  def remove_merging_organsiation
+    MergeRequestOrganisation.find_by(merge_request_organisation_params).destroy
+    @merge_request.reload
+    @answer_options = organisations_answer_options
+    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
+    render :organisations
   end
 
 private

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -9,7 +9,6 @@ class MergeRequestsController < ApplicationController
   end
 
   def organisations
-    @merge_request = MergeRequest.find(params[:id])
     @answer_options = organisations_answer_options
   end
 

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -29,13 +29,17 @@ class MergeRequestsController < ApplicationController
   def update_organisations
     if @merge_request.merging_organisation_ids
       @merge_request.merging_organisation_ids << params[:merge_request][:merging_organisation].to_i
-      @merge_request.save!
     else
-      @merge_request.update!(merging_organisation_ids: [params[:merge_request][:merging_organisation]])
+      @merge_request.merging_organisation_ids = [params[:merge_request][:merging_organisation]]
     end
     @answer_options = organisations_answer_options
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
-    render "organisations"
+    if @merge_request.save
+      @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
+      render "organisations"
+    else
+      render :organisations, status: :unprocessable_entity
+    end
   end
 
 private

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -27,7 +27,7 @@ class MergeRequestsController < ApplicationController
   end
 
   def remove_merging_organsiation
-    MergeRequestOrganisation.find_by(merge_request_organisation_params).destroy
+    MergeRequestOrganisation.find_by(merge_request_organisation_params).destroy!
     @merge_request.reload
     @answer_options = organisations_answer_options
     @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
@@ -46,9 +46,12 @@ private
   end
 
   def merge_request_params
-    merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation)
+    merge_params = params.fetch(:merge_request, {}).permit(:requesting_organisation_id)
 
-    merge_params[:requesting_organisation] = current_user.organisation
+    if current_user.data_coordinator? || current_user.data_provider?
+      merge_params[:requesting_organisation_id] = current_user.organisation.id
+    end
+
     merge_params
   end
 

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -13,12 +13,37 @@ class MergeRequestsController < ApplicationController
   end
 
   def organisations
+    @merge_request = MergeRequest.find(params[:merge_request_id])
+    @answer_options = answer_options
+    @merging_organisations_list = [@merge_request.requesting_organisation]
+  end
+
+  def update_organisations
+    @merge_request = MergeRequest.find(params[:merge_request_id])
+    if @merge_request.merging_organisation_ids
+      @merge_request.merging_organisation_ids << params[:merge_request][:merging_organisation]
+      @merge_request.save!
+    else
+      @merge_request.update!(merging_organisation_ids:[params[:merge_request][:merging_organisation]])
+    end
+    @answer_options = answer_options
+    @merging_organisations_list = [@merge_request.requesting_organisation] + @merge_request.merging_organisations
+    render "organisations"
   end
 
   private
 
+  def answer_options
+    answer_options = { "" => "Select an option" }
+
+    Organisation.all.pluck(:id, :name).each do |organisation|
+      answer_options[organisation[0]] = organisation[1]
+    end
+    answer_options
+  end
+  
   def merge_request_params
-    required_params = {}
+    required_params = params.fetch(:merge_request, {}).permit(:requesting_organisation)
 
     required_params[:requesting_organisation] = current_user.organisation
     required_params

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -1,6 +1,7 @@
 class MergeRequestsController < ApplicationController
-  before_action :authenticate_user!
   before_action :find_resource, only: %i[update organisations update_organisations remove_merging_organisation]
+  before_action :authenticate_user!
+  before_action :authenticate_scope!, except: [:create]
 
   def create
     @merge_request = MergeRequest.create!(merge_request_params)
@@ -71,5 +72,11 @@ private
 
   def previous_template
     :organisations
+  end
+
+  def authenticate_scope!
+    if current_user.organisation != @merge_request.requesting_organisation && !current_user.support?
+      render_not_found
+    end
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -137,6 +137,10 @@ class OrganisationsController < ApplicationController
     end
   end
 
+  def merge_request
+    @merge_request = MergeRequest.new
+  end
+
 private
 
   def org_params

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1,0 +1,3 @@
+class MergeRequest < ApplicationRecord
+  belongs_to :requesting_organisation, class_name: "Organisation"
+end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -2,18 +2,4 @@ class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
   has_many :merge_request_organisations
   has_many :merging_organisations, through: :merge_request_organisations, source: :merging_organisation
-
-  validate :validate_merging_organisations
-
-private
-
-  def validate_merging_organisations
-    if MergeRequest.where(requesting_organisation_id: merging_organisation_ids).count.positive?
-      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
-    end
-
-    if merging_organisation_ids&.any? { |org_id| MergeRequest.where("merging_organisation_ids @> ARRAY[?]", org_id).exists? }
-      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
-    end
-  end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1,12 +1,9 @@
 class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
-  # has_many :merging_organisations, class_name: "Organisation", primary_key: "merging_organisation_ids", foreign_key: "id"
-  # default_scope -> { select(column_names + ["merging_organisation_ids"]) }
-  validate :validate_merging_organisations
+  has_many :merge_request_organisations
+  has_many :merging_organisations, through: :merge_request_organisations, source: :merging_organisation
 
-  def merging_organisations
-    Organisation.where(id: merging_organisation_ids)
-  end
+  validate :validate_merging_organisations
 
 private
 

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1,3 +1,7 @@
 class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
+
+  def merging_organisations
+    Organisation.where(id: merging_organisation_ids)
+  end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1,5 +1,7 @@
 class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
+  # has_many :merging_organisations, class_name: "Organisation", primary_key: "merging_organisation_ids", foreign_key: "id"
+  # default_scope -> { select(column_names + ["merging_organisation_ids"]) }
 
   def merging_organisations
     Organisation.where(id: merging_organisation_ids)

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -2,8 +2,21 @@ class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
   # has_many :merging_organisations, class_name: "Organisation", primary_key: "merging_organisation_ids", foreign_key: "id"
   # default_scope -> { select(column_names + ["merging_organisation_ids"]) }
+  validate :validate_merging_organisations
 
   def merging_organisations
     Organisation.where(id: merging_organisation_ids)
+  end
+
+private
+
+  def validate_merging_organisations
+    if MergeRequest.where(requesting_organisation_id: merging_organisation_ids).count.positive?
+      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
+
+    if merging_organisation_ids&.any? { |org_id| MergeRequest.where("merging_organisation_ids @> ARRAY[?]", org_id).exists? }
+      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
   end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -2,4 +2,11 @@ class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
   has_many :merge_request_organisations
   has_many :merging_organisations, through: :merge_request_organisations, source: :merging_organisation
+  scope :unsubmitted, -> { where.not(status: "unsubmitted") }
+
+  STATUS = {
+    "unsubmitted" => 0,
+    "submitted" => 1,
+  }.freeze
+  enum status: STATUS
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -2,7 +2,6 @@ class MergeRequest < ApplicationRecord
   belongs_to :requesting_organisation, class_name: "Organisation"
   has_many :merge_request_organisations
   has_many :merging_organisations, through: :merge_request_organisations, source: :merging_organisation
-  scope :unsubmitted, -> { where.not(status: "unsubmitted") }
 
   STATUS = {
     "unsubmitted" => 0,

--- a/app/models/merge_request_organisation.rb
+++ b/app/models/merge_request_organisation.rb
@@ -1,8 +1,8 @@
 class MergeRequestOrganisation < ApplicationRecord
   belongs_to :merge_request, class_name: "MergeRequest"
   belongs_to :merging_organisation, class_name: "Organisation"
-  validates :merge_request_id, presence: { message: I18n.t("validations.merge_request.merge_request_id.blank") }
-  validates :merging_organisation_id, presence: { message: I18n.t("validations.merge_request.merging_organisation_id.blank") }
+  validates :merge_request, presence: { message: I18n.t("validations.merge_request.merge_request_id.blank") }
+  validates :merging_organisation, presence: { message: I18n.t("validations.merge_request.merging_organisation_id.blank") }
   validate :validate_merging_organisations
 
   has_paper_trail
@@ -10,16 +10,16 @@ class MergeRequestOrganisation < ApplicationRecord
 private
 
   def validate_merging_organisations
-    if MergeRequestOrganisation.where(merge_request_id:, merging_organisation_id:).count.positive?
+    if MergeRequestOrganisation.where(merge_request:, merging_organisation:).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequestOrganisation.where.not(merge_request_id:).where(merging_organisation_id:).count.positive?
+    if MergeRequestOrganisation.where.not(merge_request:).where(merging_organisation:).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequest.where(requesting_organisation_id: merging_organisation_id).count.positive?
+    if MergeRequest.where(requesting_organisation: merging_organisation).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end

--- a/app/models/merge_request_organisation.rb
+++ b/app/models/merge_request_organisation.rb
@@ -5,6 +5,9 @@ class MergeRequestOrganisation < ApplicationRecord
   validates :merging_organisation, presence: { message: I18n.t("validations.merge_request.merging_organisation_id.blank") }
   validate :validate_merging_organisations
 
+  scope :not_unsubmitted, -> { joins(:merge_request).where.not(merge_requests: { status: "unsubmitted" }) }
+  scope :with_merging_organisation, ->(merging_organisation) { where(merging_organisation:) }
+
   has_paper_trail
 
 private
@@ -14,12 +17,12 @@ private
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequestOrganisation.where.not(merge_request:).where(merging_organisation:).count.positive?
+    if MergeRequestOrganisation.not_unsubmitted.with_merging_organisation(merging_organisation).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequest.where(requesting_organisation: merging_organisation).count.positive?
+    if MergeRequest.not_unsubmitted.where.not(id: merge_request_id).where(requesting_organisation: merging_organisation).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end

--- a/app/models/merge_request_organisation.rb
+++ b/app/models/merge_request_organisation.rb
@@ -1,0 +1,8 @@
+class MergeRequestOrganisation < ApplicationRecord
+  belongs_to :merge_request, class_name: "MergeRequest"
+  belongs_to :merging_organisation, class_name: "Organisation"
+  validates :merge_request_id, presence: { message: I18n.t("validations.organisation.stock_owner.blank") }
+  validates :merging_organisation_id, presence: { message: I18n.t("validations.organisation.managing_agent.blank") }
+
+  has_paper_trail
+end

--- a/app/models/merge_request_organisation.rb
+++ b/app/models/merge_request_organisation.rb
@@ -1,8 +1,8 @@
 class MergeRequestOrganisation < ApplicationRecord
   belongs_to :merge_request, class_name: "MergeRequest"
   belongs_to :merging_organisation, class_name: "Organisation"
-  validates :merge_request_id, presence: { message: I18n.t("validations.organisation.stock_owner.blank") }
-  validates :merging_organisation_id, presence: { message: I18n.t("validations.organisation.managing_agent.blank") }
+  validates :merge_request_id, presence: { message: I18n.t("validations.merge_request.merge_request_id.blank") }
+  validates :merging_organisation_id, presence: { message: I18n.t("validations.merge_request.merging_organisation_id.blank") }
   validate :validate_merging_organisations
 
   has_paper_trail
@@ -10,18 +10,22 @@ class MergeRequestOrganisation < ApplicationRecord
 private
 
   def validate_merging_organisations
-    if MergeRequestOrganisation.where(merge_request_id:, merging_organisation:).count.positive?
+    if MergeRequestOrganisation.where(merge_request_id:, merging_organisation_id:).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequestOrganisation.where.not(merge_request_id:).where(merging_organisation_id: merging_organisation.id).count.positive?
+    if MergeRequestOrganisation.where.not(merge_request_id:).where(merging_organisation_id:).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
     end
 
-    if MergeRequest.where(requesting_organisation: merging_organisation).count.positive?
+    if MergeRequest.where(requesting_organisation_id: merging_organisation_id).count.positive?
       errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
       merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
+
+    if merging_organisation_id.blank? || !Organisation.where(id: merging_organisation_id).exists?
+      merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_not_selected"))
     end
   end
 end

--- a/app/models/merge_request_organisation.rb
+++ b/app/models/merge_request_organisation.rb
@@ -3,6 +3,25 @@ class MergeRequestOrganisation < ApplicationRecord
   belongs_to :merging_organisation, class_name: "Organisation"
   validates :merge_request_id, presence: { message: I18n.t("validations.organisation.stock_owner.blank") }
   validates :merging_organisation_id, presence: { message: I18n.t("validations.organisation.managing_agent.blank") }
+  validate :validate_merging_organisations
 
   has_paper_trail
+
+private
+
+  def validate_merging_organisations
+    if MergeRequestOrganisation.where(merge_request_id:, merging_organisation:).count.positive?
+      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
+
+    if MergeRequestOrganisation.where.not(merge_request_id:).where(merging_organisation_id: merging_organisation.id).count.positive?
+      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+      merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
+
+    if MergeRequest.where(requesting_organisation: merging_organisation).count.positive?
+      errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+      merge_request.errors.add(:merging_organisation, I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+    end
+  end
 end

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -42,7 +42,7 @@
   <%= govuk_details(summary_text: "I cannot find an organisation on the list") do %>
     <%= f.govuk_text_area :other_merging_organisations, label: { text: "Other organisations" }, hint: { text: "List other organisations that are part of the merge but not registered on CORE." }, rows: 9 %>
   <% end %>
-  <% if @merge_request.merging_organisations.count.positive? %>
+  <% if @merge_request.merging_organisations.count > 1 %>
     <%= f.govuk_submit "Continue" %>
   <% end %>
 <% end %>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -38,7 +38,7 @@
             scope: "row",
             class: "govuk-!-text-align-right",
           }) do %>
-            <%= govuk_link_to("Remove", merge_request_organisations_path) %>
+            <%= govuk_link_to("Remove", merge_request_organisations_remove_path(merge_request: { merging_organisation: merging_organisation.id })) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -1,7 +1,7 @@
 <% title = "Tell us if your organisation is merging" %>
 <% content_for :title, title %>
 <%# <%= govuk_back_link href: merge_request_organisation_path %>
-<h2 class="govuk-heading-l">Tell us if your organisation is merging</h2>
+<h2 class="govuk-heading-l">Which organisations are merging?</h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -5,11 +5,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-   <p class="govuk-body">Add all organisations to be merged - we have already added your own.</p>
+   <p class="govuk-body">Which organisations are merging?</p>
 
 <%= form_with model: @merge_request, url: merge_request_organisations_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
-  <p class="govuk-body">Start typing to search</p>
   <%= render partial: "organisation_relationships/related_organisation_select_question", locals: {
     field: :merging_organisation,
     question: Form::Question.new("", { "answer_options" => @answer_options }, nil),
@@ -40,8 +39,11 @@
       <% end %>
     <% end %>
   <% end %>
-  <%= govuk_details(summary_text: "I cannot find an organisation on the list") do %>
-  <% end %>
 <% end %>
-<%= govuk_button_link_to "Continue", "#", button: true %>
+<%= form_with model: @merge_request, url: merge_request_other_merging_organisations_path, method: :patch do |f| %>
+  <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
+    <%= f.govuk_text_area :other_merging_organisations, label: { text: "Other organisations" }, hint: { text: "List other organisations that are part of the merge but not registered on CORE." }, rows: 9 %>
+  <% end %>
+    <%= f.govuk_submit "Continue" %>
+<% end %>
 </div>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -5,10 +5,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-   <p class="govuk-body">Which organisations are merging?</p>
+   <p class="govuk-body">Add all organisations to be merged - we have already added your own.</p>
 
 <%= form_with model: @merge_request, url: merge_request_organisations_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
+  <p class="govuk-body">Start typing to search</p>
   <%= render partial: "organisation_relationships/related_organisation_select_question", locals: {
     field: :merging_organisation,
     question: Form::Question.new("", { "answer_options" => @answer_options }, nil),
@@ -39,8 +40,7 @@
       <% end %>
     <% end %>
   <% end %>
-   <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
-      <p>List other organisations that are part of the merge but not registered on CORE.</li>
+  <%= govuk_details(summary_text: "I cannot find an organisation on the list") do %>
   <% end %>
 <% end %>
 <%= govuk_button_link_to "Continue", "#", button: true %>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -30,7 +30,7 @@
                 }) %>
         <% end %>
     <% end %>
-  <% @merge_request.merging_organisations&.each do |merging_organisation| %>
+  <% @merge_request.merging_organisations.each do |merging_organisation| %>
       <%= table.body do |body| %>
         <%= body.row do |row| %>
           <% row.cell(text: merging_organisation.name) %>
@@ -46,7 +46,7 @@
   <% end %>
 <% end %>
 <%= form_with model: @merge_request, url: merge_request_path(id: @merge_request.id), method: :patch do |f| %>
-  <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
+  <%= govuk_details(summary_text: "Can’t find the managing agent you’re looking for?") do %>
     <%= f.govuk_text_area :other_merging_organisations, label: { text: "Other organisations" }, hint: { text: "List other organisations that are part of the merge but not registered on CORE." }, rows: 9 %>
   <% end %>
     <%= f.govuk_submit "Continue" %>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
    <p class="govuk-body">Add all organisations to be merged - we have already added your own.</p>
 
-<%= form_with model: @merge_request, url: merge_request_organisations_path, method: :patch do |f| %>
+<%= form_with model: @merge_request, url: organisations_merge_request_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
   <p class="govuk-body">Start typing to search</p>
   <%= render partial: "organisation_relationships/related_organisation_select_question", locals: {
@@ -38,7 +38,7 @@
             scope: "row",
             class: "govuk-!-text-align-right",
           }) do %>
-            <%= govuk_link_to("Remove", merge_request_organisations_remove_path(merge_request: { merging_organisation: merging_organisation.id })) %>
+            <%= govuk_link_to("Remove", organisations_remove_merge_request_path(merge_request: { merging_organisation: merging_organisation.id })) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -1,0 +1,47 @@
+<% title = "Tell us if your organisation is merging" %>
+<% content_for :title, title %>
+<%# <%= govuk_back_link href: merge_request_organisation_path %>
+<h2 class="govuk-heading-l">Tell us if your organisation is merging</h2>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+   <p class="govuk-body">Which organisations are merging?</p>
+
+<%= form_with model: @merge_request, url: merge_request_organisations_path, method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= render partial: "organisation_relationships/related_organisation_select_question", locals: {
+    field: :merging_organisation,
+    question: Form::Question.new("", { "answer_options" => @answer_options }, nil),
+    f:,
+  } %>
+  <%= f.govuk_submit "Add organisation", classes: "govuk-button--secondary" %>
+  <%= govuk_table do |table| %>
+    <%= table.body do |body| %>
+        <%= body.row do |row| %>
+            <% row.cell(text: @merge_request.requesting_organisation.name) %>
+            <% row.cell(html_attributes: {
+                scope: "row",
+                class: "govuk-!-text-align-right",
+                }) %>
+        <% end %>
+    <% end %>
+  <% @merge_request.merging_organisations&.each do |merging_organisation| %>
+      <%= table.body do |body| %>
+        <%= body.row do |row| %>
+          <% row.cell(text: merging_organisation.name) %>
+          <% row.cell(html_attributes: {
+            scope: "row",
+            class: "govuk-!-text-align-right",
+          }) do %>
+            <%= govuk_link_to("Remove", merge_request_organisations_path) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+   <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
+      <p>List other organisations that are part of the merge but not registered on CORE.</li>
+  <% end %>
+<% end %>
+<%= govuk_button_link_to "Continue", "#", button: true %>
+</div>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -21,15 +21,6 @@
   } %>
   <%= f.govuk_submit "Add organisation", classes: "govuk-button--secondary" %>
   <%= govuk_table do |table| %>
-    <%= table.body do |body| %>
-        <%= body.row do |row| %>
-            <% row.cell(text: @merge_request.requesting_organisation.name) %>
-            <% row.cell(html_attributes: {
-                scope: "row",
-                class: "govuk-!-text-align-right",
-                }) %>
-        <% end %>
-    <% end %>
   <% @merge_request.merging_organisations.each do |merging_organisation| %>
       <%= table.body do |body| %>
         <%= body.row do |row| %>
@@ -38,7 +29,9 @@
             scope: "row",
             class: "govuk-!-text-align-right",
           }) do %>
-            <%= govuk_link_to("Remove", organisations_remove_merge_request_path(merge_request: { merging_organisation: merging_organisation.id })) %>
+            <% if @merge_request.requesting_organisation != merging_organisation %>
+              <%= govuk_link_to("Remove", organisations_remove_merge_request_path(merge_request: { merging_organisation: merging_organisation.id })) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
@@ -46,9 +39,11 @@
   <% end %>
 <% end %>
 <%= form_with model: @merge_request, url: merge_request_path(id: @merge_request.id), method: :patch do |f| %>
-  <%= govuk_details(summary_text: "Can’t find the managing agent you’re looking for?") do %>
+  <%= govuk_details(summary_text: "I cannot find an organisation on the list") do %>
     <%= f.govuk_text_area :other_merging_organisations, label: { text: "Other organisations" }, hint: { text: "List other organisations that are part of the merge but not registered on CORE." }, rows: 9 %>
   <% end %>
+  <% if @merge_request.merging_organisations.count.positive? %>
     <%= f.govuk_submit "Continue" %>
+  <% end %>
 <% end %>
 </div>

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -1,14 +1,19 @@
-<% title = "Tell us if your organisation is merging" %>
-<% content_for :title, title %>
-<%# <%= govuk_back_link href: merge_request_organisation_path %>
+<% content_for :before_content do %>
+
+  <% title = "Tell us if your organisation is merging" %>
+  <% content_for :title, title %>
+  <%= govuk_back_link href: merge_request_organisation_path(id: @merge_request.requesting_organisation_id) %>
+<% end %>
+
 <h2 class="govuk-heading-l">Which organisations are merging?</h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-   <p class="govuk-body">Which organisations are merging?</p>
+   <p class="govuk-body">Add all organisations to be merged - we have already added your own.</p>
 
 <%= form_with model: @merge_request, url: merge_request_organisations_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
+  <p class="govuk-body">Start typing to search</p>
   <%= render partial: "organisation_relationships/related_organisation_select_question", locals: {
     field: :merging_organisation,
     question: Form::Question.new("", { "answer_options" => @answer_options }, nil),

--- a/app/views/merge_requests/organisations.html.erb
+++ b/app/views/merge_requests/organisations.html.erb
@@ -45,7 +45,7 @@
     <% end %>
   <% end %>
 <% end %>
-<%= form_with model: @merge_request, url: merge_request_other_merging_organisations_path, method: :patch do |f| %>
+<%= form_with model: @merge_request, url: merge_request_path(id: @merge_request.id), method: :patch do |f| %>
   <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
     <%= f.govuk_text_area :other_merging_organisations, label: { text: "Other organisations" }, hint: { text: "List other organisations that are part of the merge but not registered on CORE." }, rows: 9 %>
   <% end %>

--- a/app/views/organisations/merge_request.html.erb
+++ b/app/views/organisations/merge_request.html.erb
@@ -43,7 +43,6 @@
 
     <%= form_for @merge_request, url: merge_requests_path do |f| %>
       <%= f.hidden_field :requesting_organisation_id, value: @organisation.id %>
-            <%= f.hidden_field :status, value: "unsubmitted" %>
       <%= f.submit "Start now", class: "govuk-button govuk-button--start" %>
     <% end %>
   </div>

--- a/app/views/organisations/merge_request.html.erb
+++ b/app/views/organisations/merge_request.html.erb
@@ -42,6 +42,7 @@
     <%= govuk_warning_text text: "You will not be able to submit your request without the above information. Do not start the form until you have obtained all of the information. " %>
 
     <%= form_for @merge_request, url: merge_requests_path do |f| %>
+      <%= f.hidden_field :requesting_organisation_id, value: @organisation.id %>
       <%= f.submit "Start now", class: "govuk-button govuk-button--start" %>
     <% end %>
   </div>

--- a/app/views/organisations/merge_request.html.erb
+++ b/app/views/organisations/merge_request.html.erb
@@ -43,6 +43,7 @@
 
     <%= form_for @merge_request, url: merge_requests_path do |f| %>
       <%= f.hidden_field :requesting_organisation_id, value: @organisation.id %>
+            <%= f.hidden_field :status, value: "unsubmitted" %>
       <%= f.submit "Start now", class: "govuk-button govuk-button--start" %>
     <% end %>
   </div>

--- a/app/views/organisations/merge_request.html.erb
+++ b/app/views/organisations/merge_request.html.erb
@@ -40,9 +40,9 @@
     </ul>
 
     <%= govuk_warning_text text: "You will not be able to submit your request without the above information. Do not start the form until you have obtained all of the information. " %>
-    <%= govuk_start_button(
-      text: "Start now",
-      href: "#",
-    ) %>
+
+    <%= form_for @merge_request, url: merge_requests_path do |f| %>
+      <%= f.submit "Start now", class: "govuk-button govuk-button--start" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -36,7 +36,7 @@
       <% end %>
     <% end %>
     <% if FeatureToggle.merge_organisations_enabled? %>
-      <p>Is your organisation merging with another? <%= govuk_link_to "Let us know using this form", merge_organisation_path %></p>
+      <p>Is your organisation merging with another? <%= govuk_link_to "Let us know using this form", merge_request_organisation_path %></p>
     <% end %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,8 @@ en:
       discounted_ownership_value: "Mortgage, deposit, and grant total must equal %{value_with_discount}"
       monthly_rent:
         higher_than_expected: "Basic monthly rent must be between £0.00 and £9,999.00"
+    merge_request:
+      organisation_part_of_another_merge: "This organisation is part of another merge - select a different one"
 
   soft_validations:
     net_income:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,6 +505,7 @@ en:
         higher_than_expected: "Basic monthly rent must be between £0.00 and £9,999.00"
     merge_request:
       organisation_part_of_another_merge: "This organisation is part of another merge - select a different one"
+      organisation_not_selected: "Select an organisation from the search list"
 
   soft_validations:
     net_income:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
     post "merge-request", to: "merge_request#create_merge_request"
     get "organisations", to: "merge_requests#organisations"
     patch "organisations", to: "merge_requests#update_organisations"
+    get "organisations/remove", to: "merge_requests#remove_merging_organsiation"
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,7 +127,9 @@ Rails.application.routes.draw do
     post "merge-request", to: "merge_request#create_merge_request"
     get "organisations", to: "merge_requests#organisations"
     patch "organisations", to: "merge_requests#update_organisations"
-    get "organisations/remove", to: "merge_requests#remove_merging_organsiation"
+    get "organisations/remove", to: "merge_requests#remove_merging_organisation"
+    patch "other-merging-organisations", to: "merge_requests#update_other_merging_organisations"
+    get "absorbing_organisation", to: "merge_requests#absorbing_organisation"
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,8 +119,13 @@ Rails.application.routes.draw do
       get "managing-agents/remove", to: "organisation_relationships#remove_managing_agent"
       post "managing-agents", to: "organisation_relationships#create_managing_agent"
       delete "managing-agents", to: "organisation_relationships#delete_managing_agent"
-      get "merge", to: "organisations#merge"
+      get "merge-request", to: "organisations#merge_request"
     end
+  end
+
+  resources :merge_requests, path: "/merge-request" do   
+    post "merge-request", to: "merge_request#create_merge_request"
+    get "organisations", to: "merge_requests#organisations"
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,11 +124,9 @@ Rails.application.routes.draw do
   end
 
   resources :merge_requests, path: "/merge-request" do
-    post "merge-request", to: "merge_request#create_merge_request"
     get "organisations", to: "merge_requests#organisations"
     patch "organisations", to: "merge_requests#update_organisations"
     get "organisations/remove", to: "merge_requests#remove_merging_organisation"
-    patch "other-merging-organisations", to: "merge_requests#update_other_merging_organisations"
     get "absorbing-organisation", to: "merge_requests#absorbing_organisation"
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,10 +124,12 @@ Rails.application.routes.draw do
   end
 
   resources :merge_requests, path: "/merge-request" do
-    get "organisations", to: "merge_requests#organisations"
-    patch "organisations", to: "merge_requests#update_organisations"
-    get "organisations/remove", to: "merge_requests#remove_merging_organisation"
-    get "absorbing-organisation", to: "merge_requests#absorbing_organisation"
+    member do
+      get "organisations"
+      patch "organisations", to: "merge_requests#update_organisations"
+      get "organisations/remove", to: "merge_requests#remove_merging_organisation"
+      get "absorbing-organisation"
+    end
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
   resources :merge_requests, path: "/merge-request" do   
     post "merge-request", to: "merge_request#create_merge_request"
     get "organisations", to: "merge_requests#organisations"
+    patch "organisations", to: "merge_requests#update_organisations"
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :merge_requests, path: "/merge-request" do   
+  resources :merge_requests, path: "/merge-request" do
     post "merge-request", to: "merge_request#create_merge_request"
     get "organisations", to: "merge_requests#organisations"
     patch "organisations", to: "merge_requests#update_organisations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,7 +129,7 @@ Rails.application.routes.draw do
     patch "organisations", to: "merge_requests#update_organisations"
     get "organisations/remove", to: "merge_requests#remove_merging_organisation"
     patch "other-merging-organisations", to: "merge_requests#update_other_merging_organisations"
-    get "absorbing_organisation", to: "merge_requests#absorbing_organisation"
+    get "absorbing-organisation", to: "merge_requests#absorbing_organisation"
   end
 
   resources :lettings_logs, path: "/lettings-logs" do

--- a/db/migrate/20230412111338_add_merge_requests_table.rb
+++ b/db/migrate/20230412111338_add_merge_requests_table.rb
@@ -2,7 +2,7 @@ class AddMergeRequestsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :merge_requests do |t|
       t.integer :requesting_organisation_id
-      t.integer :merging_organisations, array: true
+      t.integer :merging_organisation_ids, array: true
       t.timestamps
     end
   end

--- a/db/migrate/20230412111338_add_merge_requests_table.rb
+++ b/db/migrate/20230412111338_add_merge_requests_table.rb
@@ -1,0 +1,9 @@
+class AddMergeRequestsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :merge_requests do |t|
+      t.integer :requesting_organisation_id
+      t.integer :merging_organisations, array: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230412111338_add_merge_requests_table.rb
+++ b/db/migrate/20230412111338_add_merge_requests_table.rb
@@ -2,7 +2,6 @@ class AddMergeRequestsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :merge_requests do |t|
       t.integer :requesting_organisation_id
-      t.integer :merging_organisation_ids, array: true
       t.timestamps
     end
   end

--- a/db/migrate/20230412111338_add_merge_requests_table.rb
+++ b/db/migrate/20230412111338_add_merge_requests_table.rb
@@ -2,6 +2,7 @@ class AddMergeRequestsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :merge_requests do |t|
       t.integer :requesting_organisation_id
+      t.text :other_merging_organisations
       t.timestamps
     end
   end

--- a/db/migrate/20230413135407_add_merge_organisations.rb
+++ b/db/migrate/20230413135407_add_merge_organisations.rb
@@ -1,0 +1,9 @@
+class AddMergeOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :merge_request_organisations do |t|
+      t.integer :merge_request_id, foreign_key: true
+      t.integer :merging_organisation_id, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230418095819_add_status_to_merge_request.rb
+++ b/db/migrate/20230418095819_add_status_to_merge_request.rb
@@ -1,0 +1,5 @@
+class AddStatusToMergeRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merge_requests, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_095819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -366,6 +366,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
     t.text "other_merging_organisations"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
   end
 
   create_table "organisation_relationships", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -354,6 +354,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_12_143245) do
     t.string "collection"
   end
 
+  create_table "merge_requests", force: :cascade do |t|
+    t.integer "requesting_organisation_id"
+    t.integer "merging_organisations", array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "organisation_relationships", force: :cascade do |t|
     t.integer "child_organisation_id"
     t.integer "parent_organisation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -356,7 +356,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_12_143245) do
 
   create_table "merge_requests", force: :cascade do |t|
     t.integer "requesting_organisation_id"
-    t.integer "merging_organisations", array: true
+    t.integer "merging_organisation_ids", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -363,6 +363,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
 
   create_table "merge_requests", force: :cascade do |t|
     t.integer "requesting_organisation_id"
+    t.text "other_merging_organisations"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -532,6 +533,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
     t.integer "prevten"
     t.integer "mortgageused"
     t.integer "wchair"
+    t.integer "income2_value_check"
     t.integer "armedforcesspouse"
     t.datetime "hodate", precision: nil
     t.integer "hoday"
@@ -556,14 +558,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
     t.integer "retirement_value_check"
     t.integer "hodate_check"
     t.integer "extrabor_value_check"
-    t.integer "grant_value_check"
-    t.integer "staircase_bought_value_check"
     t.integer "deposit_and_mortgage_value_check"
     t.integer "shared_ownership_deposit_value_check"
-    t.integer "old_persons_shared_ownership_value_check"
-    t.integer "income2_value_check"
-    t.integer "monthly_charges_value_check"
+    t.integer "grant_value_check"
     t.integer "value_value_check"
+    t.integer "old_persons_shared_ownership_value_check"
+    t.integer "staircase_bought_value_check"
+    t.integer "monthly_charges_value_check"
     t.integer "details_known_5"
     t.integer "details_known_6"
     t.integer "saledate_check"
@@ -573,10 +574,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
     t.integer "ethnicbuy2"
     t.integer "proplen_asked"
     t.string "old_id"
-    t.integer "pregblank"
     t.integer "buy2living"
     t.integer "prevtenbuy2"
-    t.integer "nationalbuy2"
+    t.integer "pregblank"
     t.string "uprn"
     t.integer "uprn_known"
     t.integer "uprn_confirmed"
@@ -584,10 +584,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
     t.string "address_line2"
     t.string "town_or_city"
     t.string "county"
+    t.integer "nationalbuy2"
     t.integer "discounted_sale_value_check"
     t.integer "student_not_child_value_check"
-    t.integer "buyer_livein_value_check"
     t.integer "percentage_discount_value_check"
+    t.integer "buyer_livein_value_check"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_12_143245) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_135407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -354,9 +354,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_12_143245) do
     t.string "collection"
   end
 
+  create_table "merge_request_organisations", force: :cascade do |t|
+    t.integer "merge_request_id"
+    t.integer "merging_organisation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "merge_requests", force: :cascade do |t|
     t.integer "requesting_organisation_id"
-    t.integer "merging_organisation_ids", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe MergeRequestsController, type: :request do
+  let(:organisation) { user.organisation }
+  let!(:other_organisation) { FactoryBot.create(:organisation) }
+  let(:headers) { { "Accept" => "text/html" } }
+  let(:page) { Capybara::Node::Simple.new(response.body) }
+  let(:user) { FactoryBot.create(:user, :data_coordinator) }
+  let(:merge_request) { MergeRequest.create!(requesting_organisation: organisation) }
+
+  context "when user is signed in with a data coordinator user" do
+    before do
+      sign_in user
+    end
+
+    describe "#organisations" do
+      before do
+        organisation.update!(name: "Test Org")
+        post "/merge-request", headers:, params: {}
+      end
+
+      it "creates merge request with requesting organisation" do
+        follow_redirect!
+        expect(page).to have_content("Which organisations are merging?")
+        expect(page).to have_content("Test Org")
+        expect(page).not_to have_link("Remove")
+      end
+    end
+
+    describe "#update_organisations" do
+      let(:params) { { merge_request: { merging_organisation: other_organisation.id } } }
+
+      before do
+        other_organisation.update!(name: "Other Test Org")
+        patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+      end
+
+      it "updates the merge request" do
+        merge_request.reload
+        expect(merge_request.merging_organisations.count).to eq(1)
+        expect(page).to have_content("Test Org")
+        expect(page).to have_content("Other Test Org")
+        expect(page).to have_link("Remove")
+      end
+    end
+  end
+end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MergeRequestsController, type: :request do
     end
 
     describe "#organisations" do
-      let(:params) { {} }
+      let(:params) { { merge_request: { requesting_organisation_id: "9" } } }
 
       before do
         organisation.update!(name: "Test Org")
@@ -159,7 +159,7 @@ RSpec.describe MergeRequestsController, type: :request do
       context "when adding other merging organisations" do
         before do
           MergeRequestOrganisation.create!(merge_request_id: merge_request.id, merging_organisation_id: other_organisation.id)
-          patch "/merge-request/#{merge_request.id}/other-merging-organisations", headers:, params:
+          patch "/merge-request/#{merge_request.id}", headers:, params:
         end
 
         it "updates the merge request" do

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe MergeRequestsController, type: :request do
   let(:organisation) { user.organisation }
-  let!(:other_organisation) { FactoryBot.create(:organisation) }
+  let!(:other_organisation) { FactoryBot.create(:organisation, name: "Other Test Org") }
   let(:headers) { { "Accept" => "text/html" } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
   let(:user) { FactoryBot.create(:user, :data_coordinator) }
@@ -30,17 +30,51 @@ RSpec.describe MergeRequestsController, type: :request do
     describe "#update_organisations" do
       let(:params) { { merge_request: { merging_organisation: other_organisation.id } } }
 
-      before do
-        other_organisation.update!(name: "Other Test Org")
-        patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+      context "when updating a merge request with a new organisation" do
+        before do
+          patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+        end
+
+        it "updates the merge request" do
+          merge_request.reload
+          expect(merge_request.merging_organisations.count).to eq(1)
+          expect(page).to have_content("Test Org")
+          expect(page).to have_content("Other Test Org")
+          expect(page).to have_link("Remove")
+        end
       end
 
-      it "updates the merge request" do
-        merge_request.reload
-        expect(merge_request.merging_organisations.count).to eq(1)
-        expect(page).to have_content("Test Org")
-        expect(page).to have_content("Other Test Org")
-        expect(page).to have_link("Remove")
+      context "when the user selects an organisation that requested another merge" do
+        let(:params) { { merge_request: { merging_organisation: other_organisation.id } } }
+
+        before do
+          MergeRequest.create!(requesting_organisation_id: other_organisation.id)
+          patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+        end
+
+        it "does not update the merge request" do
+          merge_request.reload
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+        end
+      end
+
+      context "when the user selects an organisation that is a part of another merge" do
+        let(:another_organisation) { FactoryBot.create(:organisation, name: "Other Test Org") }
+        let(:params) { { merge_request: { merging_organisation: another_organisation.id } } }
+
+        before do
+          MergeRequest.create!(requesting_organisation_id: other_organisation.id, merging_organisation_ids: [another_organisation.id])
+          patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+        end
+
+        it "does not update the merge request" do
+          merge_request.reload
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.merge_request.organisation_part_of_another_merge"))
+        end
       end
     end
   end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -122,6 +122,22 @@ RSpec.describe MergeRequestsController, type: :request do
         end
       end
     end
+
+    describe "#other_merging_organisations" do
+      let(:params) { { merge_request: { other_merging_organisations: "A list of other merging organisations" } } }
+
+      context "when adding other merging organisations" do
+        before do
+          MergeRequestOrganisation.create!(merge_request_id: merge_request.id, merging_organisation_id: other_organisation.id)
+          patch "/merge-request/#{merge_request.id}/other-merging-organisations", headers:, params:
+        end
+
+        it "updates the merge request" do
+          merge_request.reload
+          expect(merge_request.other_merging_organisations).to eq("A list of other merging organisations")
+        end
+      end
+    end
   end
 
   context "when user is signed in as a support user" do

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -140,13 +140,24 @@ RSpec.describe MergeRequestsController, type: :request do
     describe "#remove_organisation" do
       let(:params) { { merge_request: { merging_organisation: other_organisation.id } } }
 
-      context "when removing an organisation from merge request " do
+      context "when removing an organisation from merge request" do
         before do
           MergeRequestOrganisation.create!(merge_request_id: merge_request.id, merging_organisation_id: other_organisation.id)
           get "/merge-request/#{merge_request.id}/organisations/remove", headers:, params:
         end
 
         it "updates the merge request" do
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(page).not_to have_link("Remove")
+        end
+      end
+
+      context "when removing an organisation that is not part of a merge from merge request" do
+        before do
+          get "/merge-request/#{merge_request.id}/organisations/remove", headers:, params:
+        end
+
+        it "does not throw an error" do
           expect(merge_request.merging_organisations.count).to eq(0)
           expect(page).not_to have_link("Remove")
         end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -105,6 +105,36 @@ RSpec.describe MergeRequestsController, type: :request do
           expect(merge_request.merging_organisations.count).to eq(1)
         end
       end
+
+      context "when the user does not select an organisation" do
+        let(:params) { { merge_request: { merging_organisation: nil } } }
+
+        before do
+          patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+        end
+
+        it "does not update the merge request" do
+          merge_request.reload
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.merge_request.organisation_not_selected"))
+        end
+      end
+
+      context "when the user selects non existent id" do
+        let(:params) { { merge_request: { merging_organisation: "clearly_not_an_id" } } }
+
+        before do
+          patch "/merge-request/#{merge_request.id}/organisations", headers:, params:
+        end
+
+        it "does not update the merge request" do
+          merge_request.reload
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page).to have_content(I18n.t("validations.merge_request.organisation_not_selected"))
+        end
+      end
     end
 
     describe "#remove_organisation" do

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe MergeRequestsController, type: :request do
   let(:organisation) { user.organisation }
-  let!(:other_organisation) { FactoryBot.create(:organisation, name: "Other Test Org") }
+  let(:other_organisation) { FactoryBot.create(:organisation, name: "Other Test Org") }
   let(:headers) { { "Accept" => "text/html" } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
   let(:user) { FactoryBot.create(:user, :data_coordinator) }

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -93,5 +93,21 @@ RSpec.describe MergeRequestsController, type: :request do
         end
       end
     end
+
+    describe "#remove_organisation" do
+      let(:params) { { merge_request: {merging_organisation: other_organisation.id } }} 
+
+      context "when removing an organisation from merge request " do
+        before do
+          MergeRequestOrganisation.create!(merge_request_id: merge_request.id, merging_organisation_id: other_organisation.id)
+          get "/merge-request/#{merge_request.id}/organisations/remove", headers:, params:
+        end
+
+        it "updates the merge request" do
+          expect(merge_request.merging_organisations.count).to eq(0)
+          expect(page).not_to have_link("Remove")
+        end
+      end
+    end
   end
 end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe OrganisationsController, type: :request do
         end
       end
 
-      fdescribe "#merge" do
+      describe "#merge" do
         context "with an organisation that the user belongs to" do
           before do
             get "/organisations/#{organisation.id}/merge-request", headers:, params: {}
@@ -455,8 +455,8 @@ RSpec.describe OrganisationsController, type: :request do
             expect(page).to have_link("Back", href: "/organisations/#{organisation.id}")
           end
 
-          it "has a correct start no button" do
-            expect(page).to have_link("Start now", href: "/merge-request/new")
+          it "has a correct start now button" do
+            expect(page).to have_button("Start now")
           end
         end
 

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe OrganisationsController, type: :request do
 
           it "displays a link to merge organisations" do
             expect(page).to have_content("Is your organisation merging with another?")
-            expect(page).to have_link("Let us know using this form", href: "/organisations/#{organisation.id}/merge")
+            expect(page).to have_link("Let us know using this form", href: "/organisations/#{organisation.id}/merge-request")
           end
         end
 
@@ -441,10 +441,10 @@ RSpec.describe OrganisationsController, type: :request do
         end
       end
 
-      describe "#merge" do
+      fdescribe "#merge" do
         context "with an organisation that the user belongs to" do
           before do
-            get "/organisations/#{organisation.id}/merge", headers:, params: {}
+            get "/organisations/#{organisation.id}/merge-request", headers:, params: {}
           end
 
           it "shows the correct content" do
@@ -456,13 +456,13 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "has a correct start no button" do
-            expect(page).to have_link("Start now", href: "#")
+            expect(page).to have_link("Start now", href: "/merge-request/new")
           end
         end
 
         context "with organisation that are not in scope for the user, i.e. that they do not belong to" do
           before do
-            get "/organisations/#{unauthorised_organisation.id}/merge", headers:, params: {}
+            get "/organisations/#{unauthorised_organisation.id}/merge-request", headers:, params: {}
           end
 
           it "returns not found 404 from org details route" do


### PR DESCRIPTION
This PR build on top of https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1519

When we click Start Now from the merge-request page, a new merge request it created and persisted with the current user organisation as the organisation requesting the merge. We didn't want to persist the merge request based on the ticket description, but it's easier to persist it and mark it as "submitted" etc. later on.

This PR also adds a table for storing merging organisations against the merge request and other merging organisations, which are just free text (in case those organisations don't exist on the service).

<img width="1778" alt="image" src="https://user-images.githubusercontent.com/54268893/232076085-7cf6a6ec-9d46-4cd9-84d6-0f1f2b383ced.png">

There are some validation errors:
- When a merging organisation that is involved in another merge is added we display this error:
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/54268893/232072981-4c7cc2e7-73ac-42bf-b5c1-c07a98cb47c6.png">

- When add organisation is clicked without selecting an organisation we get this: 
<img width="1633" alt="image" src="https://user-images.githubusercontent.com/54268893/232079468-cbf0c89e-fad8-43e6-bdc8-8cecbfbb202d.png">


- When we try to add an organisation that is already added, nothing happens, we don't add the organisation twice.