### PR TITLE
CLDC-2223 Bulk upload 23/24 renewal now mandatory

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -292,6 +292,7 @@ class BulkUpload::Lettings::Year2023::RowParser
   validates :field_72, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }, allow_blank: true
   validates :field_76, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }, allow_blank: true
 
+  validates :field_6, presence: { message: I18n.t("validations.not_answered", question: "property renewal") }
   validates :field_7, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (day)") }
   validates :field_8, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (month)") }
   validates :field_9, presence: { message: I18n.t("validations.not_answered", question: "tenancy start date (year)") }
@@ -1050,8 +1051,6 @@ private
       1
     when 2
       0
-    when nil
-      rsnvac == 14 ? 1 : 0
     else
       field_6
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -242,9 +242,9 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       let(:attributes) { { bulk_upload:, field_13: "123" } }
 
       it "has errors on setup fields" do
-        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_4 field_5 field_7 field_8 field_9 field_1 field_2])
+        expect(errors).to eql(%i[field_1 field_2 field_4 field_5 field_6 field_7 field_8 field_9])
       end
     end
 
@@ -792,12 +792,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
     end
 
-    describe "#field_6" do
+    describe "#field_6" do # renewal
       context "when an unpermitted value" do
         let(:attributes) { { bulk_upload:, field_6: "3" } }
 
         it "has errors on the field" do
           expect(parser.errors[:field_6]).to be_present
+        end
+      end
+
+      context "when blank" do
+        let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_6: "" } }
+
+        it "has errors on the field" do
+          expect(parser.errors[:field_6]).to include("You must answer property renewal")
         end
       end
     end
@@ -1101,14 +1109,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         it "sets value to 0" do
           expect(parser.log.renewal).to eq(0)
-        end
-      end
-
-      context "when field_6 is null but rsnvac/field_27 is 14" do
-        let(:attributes) { { bulk_upload:, field_6: "", field_27: "14" } }
-
-        it "sets renewal to 1" do
-          expect(parser.log.renewal).to eq(1)
         end
       end
     end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2223
- Change how `renewal` works for bulk upload in 2023 compared to 2022

# Changes

- `renewal` is mandatory and must be filled in otherwise there is an error
- it is no longer inferred from another field and we just use the value from the user