### PR TITLE
Speed up bulk upload with missing memoization

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -340,9 +340,9 @@ class BulkUpload::Lettings::Year2022::RowParser
 
     return true if blank_row?
 
-    super
-
     log.valid?
+
+    super
 
     log.errors.each do |error|
       fields = field_mapping_for_errors[error.attribute] || []
@@ -650,7 +650,7 @@ private
   end
 
   def questions
-    log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
+    @questions ||= log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
   end
 
   def validate_nulls

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -342,9 +342,9 @@ class BulkUpload::Lettings::Year2023::RowParser
 
     return true if blank_row?
 
-    super
-
     log.valid?
+
+    super
 
     log.errors.each do |error|
       fields = field_mapping_for_errors[error.attribute] || []
@@ -826,7 +826,7 @@ private
   end
 
   def questions
-    log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
+    @questions ||= log.form.subsections.flat_map { |ss| ss.applicable_questions(log) }
   end
 
   def attributes_for_log

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -844,12 +844,12 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
     end
 
-    describe "#field_56" do # age3
+    describe "#field_52" do # age2
       context "when null but gender given" do
-        let(:attributes) { setup_section_params.merge({ field_56: "", field_57: "F" }) }
+        let(:attributes) { setup_section_params.merge({ field_52: "", field_53: "F" }) }
 
         it "returns an error" do
-          expect(parser.errors[:field_56]).to be_present
+          expect(parser.errors[:field_52]).to be_present
         end
       end
     end


### PR DESCRIPTION
# Context

- Bulk upload has been acting slow and spent some time actually investigating why

# Changes

- Add missing memoization to bulk upload which causes performance boost
- See evidence below

```
Finished in 4 minutes 0.9 seconds (files took 5.27 seconds to load)
210 examples, 0 failures, 2 pending

Finished in 30.85 seconds (files took 5.23 seconds to load)
210 examples, 0 failures, 2 pending
```