### PR TITLE
CLDC-2201 Add copy to explain username bulk upload field

### DIFF
--- a/app/views/bulk_upload_lettings_logs/forms/prepare_your_file.html.erb
+++ b/app/views/bulk_upload_lettings_logs/forms/prepare_your_file.html.erb
@@ -19,6 +19,7 @@
       <h2 class="govuk-heading-s">Create your file</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>Fill in the template with CORE data from your housing management system according to the <%= govuk_link_to "Lettings #{@form.year_combo} Bulk Upload Specification", @form.specification_path %></li>
+        <li><strong>Username field:</strong> To assign a log to someone else, enter the email address they use to log into CORE</li>
         <li>If you have to manually enter large volumes of data into the bulk upload template, we recommend creating logs directly in the service instead. <%= govuk_link_to "Find out more about exporting your data", bulk_upload_lettings_log_path(id: "guidance", form: { year: @form.year }) %></li>
       </ul>
 

--- a/app/views/bulk_upload_sales_logs/forms/prepare_your_file.html.erb
+++ b/app/views/bulk_upload_sales_logs/forms/prepare_your_file.html.erb
@@ -19,6 +19,7 @@
       <h2 class="govuk-heading-s">Create your file</h2>
       <ul class="govuk-list govuk-list--bullet">
         <li>Fill in the template with CORE data from your housing management system according to the <%= govuk_link_to "Sales #{@form.year_combo} Bulk Upload Specification", @form.specification_path %></li>
+        <li><strong>Username field:</strong> To assign a log to someone else, enter the email address they use to log into CORE</li>
         <li>If you have to manually enter large volumes of data into the bulk upload template, we recommend creating logs directly in the service instead. <%= govuk_link_to "Find out more about exporting your data", bulk_upload_sales_log_path(id: "guidance", form: { year: @form.year }) %></li>
       </ul>
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2201
- Add copy to explain that the `username` field in new core accepts an email which differs from old core

# Changes

- Add copy to lettings and sales `Prepare your file` pages

# Screenshots

## Lettings
![Screenshot 2023-04-14 at 11 56 06](https://user-images.githubusercontent.com/92580/232026343-516c93c0-1c42-4f03-90c3-fe3c534a14cf.png)

## Sales
![Screenshot 2023-04-14 at 11 56 41](https://user-images.githubusercontent.com/92580/232026364-8865f165-beb7-4d00-b0bb-6d308055228b.png)