### PR TITLE
Add error to main field when validating other field

### DIFF
--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -7,6 +7,7 @@ module Validations::SharedValidations
     main_field_label = main_label || main_field.to_s.humanize(capitalize: false)
     other_field_label = other_label || other_field.to_s.humanize(capitalize: false)
     if record[main_field] == value_other && record[other_field].blank?
+      record.errors.add main_field.to_sym, I18n.t("validations.other_field_missing", main_field_label:, other_field_label:)
       record.errors.add other_field.to_sym, I18n.t("validations.other_field_missing", main_field_label:, other_field_label:)
     end
 

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -323,6 +323,34 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      context "and is a other tenancy but missing tenancyother" do
+        let(:lettings_log_id) { "0b4a68df-30cc-474a-93c0-a56ce8fdad3b" }
+
+        before do
+          lettings_log_xml.at_xpath("//meta:status").content = "saved"
+          lettings_log_xml.at_xpath("//xmlns:Q2b").content = "3"
+          lettings_log_xml.at_xpath("//xmlns:Q2ba").content = ""
+        end
+
+        it "intercepts the relevant validation error" do
+          allow(logger).to receive(:warn)
+
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "clears out the invalid answers" do
+          allow(logger).to receive(:warn)
+
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.tenancy).to be_nil
+          expect(lettings_log.tenancyother).to be_nil
+        end
+      end
+
       context "and this is an internal transfer from a non social housing" do
         before do
           lettings_log_xml.at_xpath("//xmlns:Q11").content = "9 Residential care home"


### PR DESCRIPTION
During import, if the log is in progress (saved) and there are any errors in the log, we clear the problematic fields upon import.
When validate_other_field validation fails it adds an error to `other` field. `Other` field gets cleared, but the validation still fails because the main field is still selected as `other`. 
We should add the error to the main field as well so that it gets cleared if  validate_other_field fails during the import