### PR TITLE
Add `reset_password_token` to sensitive parameters list

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,5 +2,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[
-  passw secret token crypt salt certificate otp ssn
+  passw secret token crypt salt certificate otp ssn reset_password_token
 ]


### PR DESCRIPTION
- Remove `reset_password_token` from LogIt.