### PR TITLE
Always route to uprn page on sales for 23/24

### DIFF
--- a/app/models/form/sales/pages/uprn.rb
+++ b/app/models/form/sales/pages/uprn.rb
@@ -11,10 +11,6 @@ class Form::Sales::Pages::Uprn < ::Form::Page
     ]
   end
 
-  def routed_to?(log, _current_user = nil)
-    log.uprn_known == 1
-  end
-
   def skip_text
     "Enter address instead"
   end

--- a/spec/models/form/sales/pages/uprn_spec.rb
+++ b/spec/models/form/sales/pages/uprn_spec.rb
@@ -35,25 +35,6 @@ RSpec.describe Form::Sales::Pages::Uprn, type: :model do
     expect(page.skip_text).to eq("Enter address instead")
   end
 
-  describe "has correct routed_to?" do
-    context "when uprn_known != 1" do
-      let(:log) { create(:sales_log, uprn_known: 0) }
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
-
-    context "when uprn_known == 1" do
-      let(:log) { create(:sales_log) }
-
-      it "returns true" do
-        log.uprn_known = 1
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-  end
-
   describe "has correct skip_href" do
     context "when log is nil" do
       it "is nil" do

--- a/spec/models/form/sales/questions/uprn_spec.rb
+++ b/spec/models/form/sales/questions/uprn_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
       let(:log) do
         create(
           :sales_log,
+          :completed,
           address_line1: "1, Test Street",
           town_or_city: "Test Town",
           county: "Test County",


### PR DESCRIPTION
Remove a routed_to? method from uprn page for sales