### PR TITLE
Add 23/24 fields to import mappings

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -48,7 +48,7 @@ class Log < ApplicationRecord
       service = UprnClient.new(uprn)
       service.call
 
-      return errors.add(:uprn, service.error) if service.error.present?
+      return errors.add(:uprn, :uprn_error, message: service.error) if service.error.present?
 
       presenter = UprnDataPresenter.new(service.result)
 

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -202,15 +202,13 @@ module Imports
       attributes["first_time_property_let_as_social_housing"] = first_time_let(attributes["rsnvac"])
       attributes["declaration"] = declaration(xml_doc)
 
-      if attributes["startdate"] >= Time.zone.local(2023, 4, 1)
-        attributes["uprn"] = string_or_nil(xml_doc, "UPRN")
-        attributes["uprn_known"] = attributes["uprn"].present? ? 1 : 0
-        attributes["uprn_confirmed"] = attributes["uprn"].present? ? 1 : 0
-        attributes["address_line1"] = string_or_nil(xml_doc, "AddressLine1")
-        attributes["address_line2"] = string_or_nil(xml_doc, "AddressLine2")
-        attributes["town_or_city"] = string_or_nil(xml_doc, "TownCity")
-        attributes["county"] = string_or_nil(xml_doc, "County")
-      end
+      attributes["uprn"] = string_or_nil(xml_doc, "UPRN")
+      attributes["uprn_known"] = attributes["uprn"].present? ? 1 : 0
+      attributes["uprn_confirmed"] = attributes["uprn"].present? ? 1 : 0
+      attributes["address_line1"] = string_or_nil(xml_doc, "AddressLine1")
+      attributes["address_line2"] = string_or_nil(xml_doc, "AddressLine2")
+      attributes["town_or_city"] = string_or_nil(xml_doc, "TownCity")
+      attributes["county"] = string_or_nil(xml_doc, "County")
 
       set_partial_charges_to_zero(attributes)
 
@@ -377,7 +375,7 @@ module Imports
     end
 
     def fields_not_present_in_softwire_data
-      %w[majorrepairs illness_type_0 tshortfall_known pregnancy_value_check retirement_value_check rent_value_check net_income_value_check major_repairs_date_value_check void_date_value_check carehome_charges_value_check housingneeds_type housingneeds_other created_by]
+      %w[majorrepairs illness_type_0 tshortfall_known pregnancy_value_check retirement_value_check rent_value_check net_income_value_check major_repairs_date_value_check void_date_value_check carehome_charges_value_check housingneeds_type housingneeds_other created_by uprn_known uprn_confirmed]
     end
 
     def check_status_completed(lettings_log, previous_status)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -166,6 +166,18 @@ module Imports
         attributes["address_line2"] = string_or_nil(xml_doc, "AddressLine2")
         attributes["town_or_city"] = string_or_nil(xml_doc, "TownCity")
         attributes["county"] = string_or_nil(xml_doc, "County")
+
+        attributes["proplen_asked"] = 0 if attributes["proplen"]&.positive?
+        attributes["proplen_asked"] = 1 if attributes["proplen"]&.zero?
+
+        attributes["prevshared"] = unsafe_string_as_integer(xml_doc, "PREVSHARED")
+        attributes["ethnicbuy2"] = unsafe_string_as_integer(xml_doc, "P2Eth")
+        attributes["ethnic_group2"] = ethnic_group(attributes["ethnicbuy2"])
+        attributes["nationalbuy2"] = unsafe_string_as_integer(xml_doc, "P2Nat")
+        attributes["buy2living"] = unsafe_string_as_integer(xml_doc, "buy2livein")
+
+        attributes["staircasesale"] = unsafe_string_as_integer(xml_doc, "STAIRCASESALE")
+        attributes["prevtenbuy2"] = unsafe_string_as_integer(xml_doc, "PREVTENBUY2")
       end
 
       # Sets the log creator
@@ -297,7 +309,9 @@ module Imports
          student_not_child_value_check
          discounted_sale_value_check
          buyer_livein_value_check
-         percentage_discount_value_check]
+         percentage_discount_value_check
+         uprn_known
+         uprn_confirmed]
     end
 
     def check_status_completed(sales_log, previous_status)
@@ -476,12 +490,14 @@ module Imports
         safe_string_as_decimal(xml_doc, "Q29MonthlyCharges")
       when 2
         safe_string_as_decimal(xml_doc, "Q37MonthlyCharges")
+      when 3
+        safe_string_as_decimal(xml_doc, "Q44MonthlyCharges")
       end
     end
 
     def ownership_from_type(attributes)
       case attributes["type"]
-      when 2, 24, 18, 16, 28, 31, 30
+      when 2, 24, 18, 16, 28, 31, 30, 32
         1 # shared ownership
       when 8, 14, 27, 9, 29, 21, 22
         2 # discounted ownership
@@ -564,6 +580,8 @@ module Imports
       attributes["sex1"] ||= "R"
       attributes["ethnic_group"] ||= 17
       attributes["ethnic"] ||= 17
+      # attributes["ethnic_group2"] ||= 17
+      # attributes["ethnicbuy2"] ||= 17
       attributes["national"] ||= 13
       attributes["ecstat1"] ||= 10
       attributes["income1nk"] ||= attributes["income1"].present? ? 0 : 1

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -126,10 +126,6 @@ module Imports
       attributes["postcode_full"] = parse_postcode(string_or_nil(xml_doc, "Q14Postcode"))
       attributes["pcodenk"] = 0 if attributes["postcode_full"].present? # known if given
       attributes["soctenant"] = 0 if attributes["ownershipsch"] == 1
-      attributes["ethnic_group2"] = nil # 23/24 variable
-      attributes["ethnicbuy2"] = nil # 23/24 variable
-      attributes["prevshared"] = nil # 23/24 variable
-      attributes["staircasesale"] = nil # 23/24 variable
 
       attributes["previous_la_known"] = 1 if attributes["prevloc"].present?
       if attributes["la"].present?

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -576,8 +576,6 @@ module Imports
       attributes["sex1"] ||= "R"
       attributes["ethnic_group"] ||= 17
       attributes["ethnic"] ||= 17
-      # attributes["ethnic_group2"] ||= 17
-      # attributes["ethnicbuy2"] ||= 17
       attributes["national"] ||= 13
       attributes["ecstat1"] ||= 10
       attributes["income1nk"] ||= attributes["income1"].present? ? 0 : 1
@@ -591,6 +589,11 @@ module Imports
         attributes["relat2"] ||= "R"
         attributes["inc2mort"] ||= 3
         attributes["buy2livein"] ||= 1 unless attributes["ownershipsch"] == 3
+        if attributes["saledate"] >= Time.zone.local(2023, 4, 1)
+          attributes["ethnic_group2"] ||= 17
+          attributes["ethnicbuy2"] ||= 17
+          attributes["nationalbuy2"] ||= 13
+        end
       end
 
       # other household members characteristics

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -154,27 +154,26 @@ module Imports
       attributes["buyer_livein_value_check"] = 0
       attributes["percentage_discount_value_check"] = 0
 
-      if attributes["saledate"] >= Time.zone.local(2023, 4, 1)
-        attributes["uprn"] = string_or_nil(xml_doc, "UPRN")
-        attributes["uprn_known"] = attributes["uprn"].present? ? 1 : 0
-        attributes["uprn_confirmed"] = attributes["uprn"].present? ? 1 : 0
-        attributes["address_line1"] = string_or_nil(xml_doc, "AddressLine1")
-        attributes["address_line2"] = string_or_nil(xml_doc, "AddressLine2")
-        attributes["town_or_city"] = string_or_nil(xml_doc, "TownCity")
-        attributes["county"] = string_or_nil(xml_doc, "County")
+      # 2023/34 attributes
+      attributes["uprn"] = string_or_nil(xml_doc, "UPRN")
+      attributes["uprn_known"] = attributes["uprn"].present? ? 1 : 0
+      attributes["uprn_confirmed"] = attributes["uprn"].present? ? 1 : 0
+      attributes["address_line1"] = string_or_nil(xml_doc, "AddressLine1")
+      attributes["address_line2"] = string_or_nil(xml_doc, "AddressLine2")
+      attributes["town_or_city"] = string_or_nil(xml_doc, "TownCity")
+      attributes["county"] = string_or_nil(xml_doc, "County")
 
-        attributes["proplen_asked"] = 0 if attributes["proplen"]&.positive?
-        attributes["proplen_asked"] = 1 if attributes["proplen"]&.zero?
+      attributes["proplen_asked"] = 0 if attributes["proplen"]&.positive?
+      attributes["proplen_asked"] = 1 if attributes["proplen"]&.zero?
 
-        attributes["prevshared"] = unsafe_string_as_integer(xml_doc, "PREVSHARED")
-        attributes["ethnicbuy2"] = unsafe_string_as_integer(xml_doc, "P2Eth")
-        attributes["ethnic_group2"] = ethnic_group(attributes["ethnicbuy2"])
-        attributes["nationalbuy2"] = unsafe_string_as_integer(xml_doc, "P2Nat")
-        attributes["buy2living"] = unsafe_string_as_integer(xml_doc, "buy2livein")
+      attributes["prevshared"] = unsafe_string_as_integer(xml_doc, "PREVSHARED")
+      attributes["ethnicbuy2"] = unsafe_string_as_integer(xml_doc, "P2Eth")
+      attributes["ethnic_group2"] = ethnic_group(attributes["ethnicbuy2"])
+      attributes["nationalbuy2"] = unsafe_string_as_integer(xml_doc, "P2Nat")
+      attributes["buy2living"] = unsafe_string_as_integer(xml_doc, "buy2livein")
 
-        attributes["staircasesale"] = unsafe_string_as_integer(xml_doc, "STAIRCASESALE")
-        attributes["prevtenbuy2"] = unsafe_string_as_integer(xml_doc, "PREVTENBUY2")
-      end
+      attributes["staircasesale"] = unsafe_string_as_integer(xml_doc, "STAIRCASESALE")
+      attributes["prevtenbuy2"] = unsafe_string_as_integer(xml_doc, "PREVTENBUY2")
 
       # Sets the log creator
       owner_id = meta_field_value(xml_doc, "owner-user-id").strip
@@ -589,11 +588,9 @@ module Imports
         attributes["relat2"] ||= "R"
         attributes["inc2mort"] ||= 3
         attributes["buy2livein"] ||= 1 unless attributes["ownershipsch"] == 3
-        if attributes["saledate"] >= Time.zone.local(2023, 4, 1)
-          attributes["ethnic_group2"] ||= 17
-          attributes["ethnicbuy2"] ||= 17
-          attributes["nationalbuy2"] ||= 13
-        end
+        attributes["ethnic_group2"] ||= 17
+        attributes["ethnicbuy2"] ||= 17
+        attributes["nationalbuy2"] ||= 13
       end
 
       # other household members characteristics

--- a/spec/fixtures/imports/logs/00d2343e-d5fa-4c89-8400-ec3854b0f2b4.xml
+++ b/spec/fixtures/imports/logs/00d2343e-d5fa-4c89-8400-ec3854b0f2b4.xml
@@ -131,6 +131,11 @@
     <_2cYears/>
   </Group>
   <Group>
+    <UPRN>12345678</UPRN>
+    <AddressLine1/>
+    <AddressLine2/>
+    <TownCity/>
+    <County/>
     <Q28pc override-field="">SR8 3HF</Q28pc>
     <Q28Auth>Durham</Q28Auth>
     <Q28ONS>E06000047</Q28ONS>

--- a/spec/fixtures/imports/sales_logs/outright_sale_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/outright_sale_sales_log.xml
@@ -280,6 +280,7 @@
     <Q41b/>
     <Q42Borrowing/>
     <Q43CashDeposit override-field="">300000</Q43CashDeposit>
+    <Q44MonthlyCharges/>
   </Group>
   <Group>
     <HHMEMB>1</HHMEMB>

--- a/spec/fixtures/imports/sales_logs/outright_sale_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/outright_sale_sales_log.xml
@@ -32,6 +32,11 @@
     <Q11Bedrooms override-field="">1</Q11Bedrooms>
     <Q12PropertyType>1 Flat or maisonette</Q12PropertyType>
     <Q13BuildingType>1 Purpose built</Q13BuildingType>
+    <UPRN/>
+    <AddressLine1/>
+    <AddressLine2/>
+    <TownCity/>
+    <County/>
     <Q14Postcode override-field="">SW1A 1AA</Q14Postcode>
     <Q14PropertyLocation>Westminster</Q14PropertyLocation>
     <Q14ONSLACode>E09000033</Q14ONSLACode>

--- a/spec/fixtures/imports/sales_logs/shared_ownership_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/shared_ownership_sales_log.xml
@@ -24,6 +24,7 @@
     <Q38OtherSale/>
     <company>2 No</company>
     <LiveInBuyer>1 Yes</LiveInBuyer>
+    <buy2livein/>
     <joint>2 No</joint>
     <JointMore/>
     <PartAPurchaser>2 Yes</PartAPurchaser>
@@ -32,6 +33,12 @@
     <Q11Bedrooms override-field="">2</Q11Bedrooms>
     <Q12PropertyType>1 Flat or maisonette</Q12PropertyType>
     <Q13BuildingType>1 Purpose built</Q13BuildingType>
+    <UPRN/>
+    <AddressLine1/>
+    <AddressLine2/>
+    <TownCity/>
+    <County/>
+    <PREVSHARED/>
     <Q14Postcode override-field="">SW1A 1AA</Q14Postcode>
     <Q14PropertyLocation>Westminster</Q14PropertyLocation>
     <Q14ONSLACode>E09000033</Q14ONSLACode>
@@ -47,6 +54,8 @@
     <P2Sex override-field=""/>
     <P2Rel/>
     <P2Eco/>
+    <P2Eth/>
+    <P2Nat/>
     <P3Age/>
     <P3Sex override-field=""/>
     <P3Rel/>

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -220,6 +220,87 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "with 23/24 logs" do
+      around do |example|
+        Timecop.freeze(Time.zone.local(2023, 4, 1)) do
+          Singleton.__init__(FormHandler)
+          example.run
+        end
+        Timecop.return
+        Singleton.__init__(FormHandler)
+      end
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:DAY").content = "10"
+        sales_log_xml.at_xpath("//xmlns:MONTH").content = "4"
+        sales_log_xml.at_xpath("//xmlns:YEAR").content = "2023"
+        sales_log_xml.at_xpath("//xmlns:UPRN").content = ""
+        sales_log_xml.at_xpath("//xmlns:AddressLine1").content = "address 1"
+        sales_log_xml.at_xpath("//xmlns:AddressLine2").content = "address 2"
+        sales_log_xml.at_xpath("//xmlns:TownCity").content = "towncity"
+        sales_log_xml.at_xpath("//xmlns:County").content = "county"
+        sales_log_xml.at_xpath("//xmlns:Q14Postcode").content = "A1 1AA"
+      end
+
+      context "with outright sale type" do
+        let(:sales_log_id) { "outright_sale_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:Q44MonthlyCharges").content = "40"
+        end
+
+        it "successfully creates a completed outright sale log" do
+          expect(logger).not_to receive(:error)
+          expect(logger).not_to receive(:warn)
+          expect(logger).not_to receive(:info)
+          expect { sales_log_service.send(:create_log, sales_log_xml) }
+            .to change(SalesLog, :count).by(1)
+        end
+      end
+
+      context "with shared sale type" do
+        let(:sales_log_id) { "shared_ownership_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:joint").content = "1 Yes"
+          sales_log_xml.at_xpath("//xmlns:JointMore").content = "2 No"
+          sales_log_xml.at_xpath("//xmlns:PREVSHARED").content = "1"
+          sales_log_xml.at_xpath("//xmlns:Q16aProplen2").content = "0"
+          sales_log_xml.at_xpath("//xmlns:Q20Bedrooms").content = "2"
+          sales_log_xml.at_xpath("//xmlns:P2Eth").content = "2 White: Irish"
+          sales_log_xml.at_xpath("//xmlns:P2Nat").content = "18 United Kingdom"
+          sales_log_xml.at_xpath("//xmlns:buy2livein").content = "1"
+        end
+
+        it "successfully creates a completed shared sale log" do
+          expect(logger).not_to receive(:error)
+          expect(logger).not_to receive(:warn)
+          expect(logger).not_to receive(:info)
+          expect { sales_log_service.send(:create_log, sales_log_xml) }
+            .to change(SalesLog, :count).by(1)
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log.proplen_asked).to eq(1)
+        end
+      end
+
+      context "with discounted sale type" do
+        let(:sales_log_id) { "shared_ownership_sales_log" }
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:PREVSHARED").content = "1"
+          sales_log_xml.at_xpath("//xmlns:Q20Bedrooms").content = "2"
+        end
+
+        it "successfully creates a completed shared sale log" do
+          expect(logger).not_to receive(:error)
+          expect(logger).not_to receive(:warn)
+          expect(logger).not_to receive(:info)
+          expect { sales_log_service.send(:create_log, sales_log_xml) }
+            .to change(SalesLog, :count).by(1)
+        end
+      end
+    end
+
     context "and the mortgage soft validation is triggered (mortgage_value_check)" do
       let(:sales_log_id) { "discounted_ownership_sales_log" }
 

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -1336,6 +1336,97 @@ RSpec.describe Imports::SalesLogsImportService do
         end
       end
 
+      context "when setting location fields for 23/24 logs" do
+        let(:sales_log_id) { "outright_sale_sales_log" }
+
+        around do |example|
+          Timecop.freeze(Time.zone.local(2023, 4, 1)) do
+            Singleton.__init__(FormHandler)
+            example.run
+          end
+          Timecop.return
+          Singleton.__init__(FormHandler)
+        end
+
+        before do
+          sales_log_xml.at_xpath("//xmlns:DAY").content = "10"
+          sales_log_xml.at_xpath("//xmlns:MONTH").content = "4"
+          sales_log_xml.at_xpath("//xmlns:YEAR").content = "2023"
+          sales_log_xml.at_xpath("//xmlns:UPRN").content = "123456781234"
+          sales_log_xml.at_xpath("//xmlns:AddressLine1").content = "address 1"
+          sales_log_xml.at_xpath("//xmlns:AddressLine2").content = "address 2"
+          sales_log_xml.at_xpath("//xmlns:TownCity").content = "towncity"
+          sales_log_xml.at_xpath("//xmlns:County").content = "county"
+          sales_log_xml.at_xpath("//xmlns:Q14Postcode").content = "A1 1AA"
+
+          body = {
+            results: [
+              {
+                DPA: {
+                  "POSTCODE": "LS16 6FT",
+                  "POST_TOWN": "Westminster",
+                  "PO_BOX_NUMBER": "321",
+                  "DOUBLE_DEPENDENT_LOCALITY": "Double Dependent Locality",
+                },
+              },
+            ],
+          }.to_json
+
+          stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123456781234")
+            .to_return(status: 200, body:, headers: {})
+          stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123")
+            .to_return(status: 500, body: "{}", headers: {})
+
+          WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/LS166FT/)
+            .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Westminster","codes":{"admin_district":"E08000035"}}}', headers: {})
+
+          allow(logger).to receive(:warn).and_return(nil)
+        end
+
+        it "correctly sets address if uprn is not given" do
+          sales_log_xml.at_xpath("//xmlns:UPRN").content = ""
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.uprn_known).to eq(0) # no
+          expect(sales_log&.uprn).to be_nil
+          expect(sales_log&.address_line1).to eq("address 1")
+          expect(sales_log&.address_line2).to eq("address 2")
+          expect(sales_log&.town_or_city).to eq("towncity")
+          expect(sales_log&.county).to eq("county")
+          expect(sales_log&.postcode_full).to eq("A1 1AA")
+        end
+
+        it "correctly sets address and uprn if uprn is given" do
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.uprn_known).to eq(1)
+          expect(sales_log&.uprn).to eq("123456781234")
+          expect(sales_log&.address_line1).to eq("321")
+          expect(sales_log&.address_line2).to eq("Double Dependent Locality")
+          expect(sales_log&.town_or_city).to eq("Westminster")
+          expect(sales_log&.postcode_full).to eq("LS16 6FT")
+          expect(sales_log&.la).to eq("E08000035")
+        end
+
+        it "correctly sets address and uprn if uprn is given but not recognised" do
+          sales_log_xml.at_xpath("//xmlns:UPRN").content = "123"
+
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.uprn_known).to eq(0)
+          expect(sales_log&.uprn).to be_nil
+          expect(sales_log&.address_line1).to eq("address 1")
+          expect(sales_log&.address_line2).to eq("address 2")
+          expect(sales_log&.town_or_city).to eq("towncity")
+          expect(sales_log&.county).to eq("county")
+          expect(sales_log&.postcode_full).to eq("A1 1AA")
+          expect(sales_log&.la).to eq("E09000033")
+        end
+      end
+
       context "when setting default buyer 1 previous tenancy" do
         let(:sales_log_id) { "outright_sale_sales_log" }
 


### PR DESCRIPTION
We need to ensure that new questions/fields for 2023/24 collection period are being imported and any changes to answer options are mapped correctly.
So far we have only mapped out 2022/23 logs fields.
This PR adds any missing mappings to the import based on the annual form changes both for lettings and sales imports.