### PR TITLE
Import support type as missing

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -170,7 +170,7 @@ module Imports
       attributes["ethnicbuy2"] = unsafe_string_as_integer(xml_doc, "P2Eth")
       attributes["ethnic_group2"] = ethnic_group(attributes["ethnicbuy2"])
       attributes["nationalbuy2"] = unsafe_string_as_integer(xml_doc, "P2Nat")
-      attributes["buy2living"] = unsafe_string_as_integer(xml_doc, "buy2livein")
+      attributes["buy2living"] = unsafe_string_as_integer(xml_doc, "BUY2LIVEIN")
 
       attributes["staircasesale"] = unsafe_string_as_integer(xml_doc, "STAIRCASESALE")
       attributes["prevtenbuy2"] = unsafe_string_as_integer(xml_doc, "PREVTENBUY2")

--- a/app/services/imports/scheme_location_import_service.rb
+++ b/app/services/imports/scheme_location_import_service.rb
@@ -208,6 +208,8 @@ module Imports
 
     def support_type(xml_doc)
       type = safe_string_as_integer(xml_doc, "support-type")
+      return unless type
+
       Scheme::SUPPORT_TYPE.value?(type) ? type : 0
     end
   end

--- a/app/services/imports/scheme_location_import_service.rb
+++ b/app/services/imports/scheme_location_import_service.rb
@@ -77,7 +77,7 @@ module Imports
       attributes["scheme_type"] = safe_string_as_integer(xml_doc, "scheme-type")
       registered_under_care_act = safe_string_as_integer(xml_doc, "reg-home-type")
       attributes["registered_under_care_act"] = registered_under_care_act&.zero? ? nil : registered_under_care_act
-      attributes["support_type"] = safe_string_as_integer(xml_doc, "support-type")
+      attributes["support_type"] = support_type(xml_doc)
       attributes["intended_stay"] = string_or_nil(xml_doc, "intended-stay")
       attributes["mobility_type"] = string_or_nil(xml_doc, "mobility-type")
       attributes["primary_client_group"] = string_or_nil(xml_doc, "client-group-1")
@@ -204,6 +204,11 @@ module Imports
     def parse_date(xml_doc, attribute)
       date = string_or_nil(xml_doc, attribute)
       Time.zone.parse(date) if date
+    end
+
+    def support_type(xml_doc)
+      type = safe_string_as_integer(xml_doc, "support-type")
+      Scheme::SUPPORT_TYPE.value?(type) ? type : 0
     end
   end
 end

--- a/spec/fixtures/imports/sales_logs/shared_ownership_sales_log.xml
+++ b/spec/fixtures/imports/sales_logs/shared_ownership_sales_log.xml
@@ -24,7 +24,7 @@
     <Q38OtherSale/>
     <company>2 No</company>
     <LiveInBuyer>1 Yes</LiveInBuyer>
-    <buy2livein/>
+    <BUY2LIVEIN/>
     <joint>2 No</joint>
     <JointMore/>
     <PartAPurchaser>2 Yes</PartAPurchaser>

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe Imports::SalesLogsImportService do
           sales_log_xml.at_xpath("//xmlns:Q20Bedrooms").content = "2"
           sales_log_xml.at_xpath("//xmlns:P2Eth").content = "2 White: Irish"
           sales_log_xml.at_xpath("//xmlns:P2Nat").content = "18 United Kingdom"
-          sales_log_xml.at_xpath("//xmlns:buy2livein").content = "1"
+          sales_log_xml.at_xpath("//xmlns:BUY2LIVEIN").content = "1"
         end
 
         it "successfully creates a completed shared sale log" do

--- a/spec/services/imports/scheme_location_import_service_spec.rb
+++ b/spec/services/imports/scheme_location_import_service_spec.rb
@@ -217,5 +217,14 @@ RSpec.describe Imports::SchemeLocationImportService do
         expect(location.scheme.support_type).to eq("Missing")
       end
     end
+
+    context "and support_type is not answered" do
+      before { location_xml.at_xpath("//scheme:support-type").content = "" }
+
+      it "sets the support type to nil" do
+        location = location_service.create_scheme_location(location_xml)
+        expect(location.scheme.support_type).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/services/imports/scheme_location_import_service_spec.rb
+++ b/spec/services/imports/scheme_location_import_service_spec.rb
@@ -208,5 +208,14 @@ RSpec.describe Imports::SchemeLocationImportService do
         expect(location.scheme.confirmed).to be_falsey
       end
     end
+
+    context "and support_type is not a valid one" do
+      before { location_xml.at_xpath("//scheme:support-type").content = "1" }
+
+      it "sets the support type to missing" do
+        location = location_service.create_scheme_location(location_xml)
+        expect(location.scheme.support_type).to eq("Missing")
+      end
+    end
   end
 end


### PR DESCRIPTION
If a support_type for the scheme is not one of the options on our service we import it as missing/0