### PR TITLE
CLDC-2184 Fix bulk upload summary error ordering

### DIFF
--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <% c.with_tab(label: "Full error report") do %>
-      <% @bulk_upload.bulk_upload_errors.group_by(&:row).each do |_row, errors_for_row| %>
+      <% @bulk_upload.bulk_upload_errors.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
         <%= render BulkUploadErrorRowComponent.new(bulk_upload_errors: errors_for_row) %>
       <% end %>
     <% end %>

--- a/spec/views/bulk_upload_lettings_results/summary.html.erb_spec.rb
+++ b/spec/views/bulk_upload_lettings_results/summary.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "bulk_upload_lettings_results/summary.html.erb" do
+  let(:bulk_upload) { create(:bulk_upload, :lettings) }
+
+  before do
+    create(:bulk_upload_error, bulk_upload:, cell: "AA100", row: "100", col: "AA")
+    create(:bulk_upload_error, bulk_upload:, cell: "Z100", row: "100", col: "Z")
+  end
+
+  it "renders errors ordered by cell" do
+    assign(:bulk_upload, bulk_upload)
+
+    render
+
+    fragment = Capybara::Node::Simple.new(rendered)
+
+    expect(fragment.find_css("table tbody th").map(&:inner_text)).to eql(%w[Z100 AA100])
+  end
+end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2184
- The correct ordering scope was missing off the summary report and was only applied to the full report

# Changes

- Add correct ordering scope to summary report