### PR TITLE
Enable collection window validations on all the environments

### DIFF
--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -3,7 +3,7 @@ module Validations::SetupValidations
   include CollectionTimeHelper
 
   def validate_startdate_setup(record)
-    return unless record.startdate && date_valid?("startdate", record) && FeatureToggle.startdate_collection_window_validation_enabled?
+    return unless record.startdate && date_valid?("startdate", record)
 
     unless record.startdate.between?(active_collection_start_date, current_collection_end_date)
       record.errors.add :startdate, startdate_validation_error_message

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -4,10 +4,6 @@ class FeatureToggle
     Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
-  def self.startdate_collection_window_validation_enabled?
-    Rails.env.production? || Rails.env.test?
-  end
-
   def self.startdate_two_week_validation_enabled?
     Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end


### PR DESCRIPTION
Remove the feature flag that was used to test 23/24 logs on staging before they became active.