### PR TITLE
Enable bulk upload lettings feature toggle

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -37,7 +37,7 @@ class FeatureToggle
   end
 
   def self.bulk_upload_lettings_logs?
-    !Rails.env.production?
+    true
   end
 
   def self.bulk_upload_sales_logs?


### PR DESCRIPTION
# Context

- Bulk upload for lettings is not enabled in production

# Changes

- Enable bulk upload lettings log feature flag