### PR TITLE
CLDC-2302 Rescue bulk upload date parsing errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -1093,6 +1093,8 @@ private
 
   def voiddate
     Date.new(field_91 + 2000, field_90, field_89) if field_91.present? && field_90.present? && field_89.present?
+  rescue Date::Error
+    Date.new
   end
 
   def majorrepairs
@@ -1101,6 +1103,8 @@ private
 
   def mrcdate
     Date.new(field_94 + 2000, field_93, field_92) if field_94.present? && field_93.present? && field_92.present?
+  rescue Date::Error
+    Date.new
   end
 
   def prevloc

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1317,10 +1317,14 @@ private
 
   def mrcdate
     Date.new(field_38 + 2000, field_37, field_36) if field_38.present? && field_37.present? && field_36.present?
+  rescue Date::Error
+    Date.new
   end
 
   def voiddate
     Date.new(field_35 + 2000, field_34, field_33) if field_35.present? && field_34.present? && field_33.present?
+  rescue Date::Error
+    Date.new
   end
 
   def first_time_property_let_as_social_housing

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1346,10 +1346,20 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
     end
 
     describe "#mrcdate" do
-      let(:attributes) { { bulk_upload:, field_92: "13", field_93: "12", field_94: "22" } }
+      context "when valid" do
+        let(:attributes) { { bulk_upload:, field_92: "13", field_93: "12", field_94: "22" } }
 
-      it "sets value given" do
-        expect(parser.log.mrcdate).to eq(Date.new(2022, 12, 13))
+        it "sets value given" do
+          expect(parser.log.mrcdate).to eq(Date.new(2022, 12, 13))
+        end
+      end
+
+      context "when invalid" do
+        let(:attributes) { { bulk_upload:, field_92: "13", field_93: "13", field_94: "22" } }
+
+        it "does not raise an error" do
+          expect { parser.log.mrcdate }.not_to raise_error
+        end
       end
     end
 
@@ -1372,10 +1382,20 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
     end
 
     describe "#voiddate" do
-      let(:attributes) { { bulk_upload:, field_89: "13", field_90: "12", field_91: "22" } }
+      context "when valid" do
+        let(:attributes) { { bulk_upload:, field_89: "13", field_90: "12", field_91: "22" } }
 
-      it "sets value given" do
-        expect(parser.log.voiddate).to eq(Date.new(2022, 12, 13))
+        it "sets value given" do
+          expect(parser.log.voiddate).to eq(Date.new(2022, 12, 13))
+        end
+      end
+
+      context "when invalid" do
+        let(:attributes) { { bulk_upload:, field_89: "13", field_90: "13", field_91: "22" } }
+
+        it "does not raise an error" do
+          expect { parser.log.voiddate }.not_to raise_error
+        end
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1356,10 +1356,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#mrcdate" do
-      let(:attributes) { { bulk_upload:, field_36: "13", field_37: "12", field_38: "22" } }
+      context "when valid" do
+        let(:attributes) { { bulk_upload:, field_36: "13", field_37: "12", field_38: "22" } }
 
-      it "sets value given" do
-        expect(parser.log.mrcdate).to eq(Date.new(2022, 12, 13))
+        it "sets value given" do
+          expect(parser.log.mrcdate).to eq(Date.new(2022, 12, 13))
+        end
+      end
+
+      context "when invalid" do
+        let(:attributes) { { bulk_upload:, field_36: "13", field_37: "13", field_38: "22" } }
+
+        it "does not raise an error" do
+          expect { parser.log.mrcdate }.not_to raise_error
+        end
       end
     end
 
@@ -1382,10 +1392,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#voiddate" do
-      let(:attributes) { { bulk_upload:, field_33: "13", field_34: "12", field_35: "22" } }
+      context "when valid" do
+        let(:attributes) { { bulk_upload:, field_33: "13", field_34: "12", field_35: "22" } }
 
-      it "sets value given" do
-        expect(parser.log.voiddate).to eq(Date.new(2022, 12, 13))
+        it "sets value given" do
+          expect(parser.log.voiddate).to eq(Date.new(2022, 12, 13))
+        end
+      end
+
+      context "when invalid" do
+        let(:attributes) { { bulk_upload:, field_33: "13", field_34: "13", field_35: "22" } }
+
+        it "does not raise an error" do
+          expect { parser.log.voiddate }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2302
- Error when users bulk upload an invalid date

# Changes

- Rescue and blank bulk upload dates so they can at least continue with the upload journey