### PR TITLE
Improve typography for collection resources

### DIFF
--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -1,8 +1,8 @@
 <div class="app-card">
-  <p class="govuk-body-l govuk-!-margin-bottom-3">Collection resources</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">For lettings starting during 1 April 2023 - 31 March 2024 and sales completing during the same period, use the 23/24 forms.</p>
+  <h2 class="govuk-heading-m">Collection resources</h2>
+  <p class="govuk-body-s">For lettings starting during 1 April 2023 to 31 March 2024 and sales completing during the same period, use the 2023/24 forms.</p>
 
-  <h2 class="govuk-body-l govuk-!-margin-bottom-3">Lettings 23/24</h2>
+  <h3 class="govuk-heading-s">Lettings 2023/24</h3>
   <%= render DocumentListComponent.new(items: [
     {
       name: "Lettings log for tenants (2023/24)",
@@ -10,7 +10,7 @@
       metadata: "PDF, 278 KB, 8 pages",
     },
     {
-      name: "Lettings bulk upload template (2023/24) *new question ordering*",
+      name: "Lettings bulk upload template (2023/24) – New question ordering",
       href: download_23_24_lettings_bulk_upload_template_path,
       metadata: "Microsoft Excel, 15 KB",
     },
@@ -26,7 +26,7 @@
     },
   ]) %>
 
-  <h2 class="govuk-body-l govuk-!-margin-bottom-3">Lettings 22/23</h2>
+  <h3 class="govuk-heading-s">Lettings 2022/23</h3>
   <%= render DocumentListComponent.new(items: [
     {
       name: "Lettings log for tenants (2022/23)",
@@ -45,7 +45,7 @@
     },
   ]) %>
 
-  <h2 class="govuk-body-l govuk-!-margin-bottom-3">Sales 23/24</h2>
+  <h3 class="govuk-heading-s">Sales 2023/24</h3>
   <%= render DocumentListComponent.new(items: [
     {
       name: "Sales log for buyers (2023/24)",
@@ -54,7 +54,7 @@
     },
   ]) %>
 
-  <h2 class="govuk-body-l govuk-!-margin-bottom-3">Sales 22/23</h2>
+  <h3 class="govuk-heading-s">Sales 2022/23</h3>
   <%= render DocumentListComponent.new(items: [
     {
       name: "Sales log for buyers (2022/23)",


### PR DESCRIPTION
I’m updating the screenshot for [this service on the X-GOV.UK Services list](https://govuk-digital-services.herokuapp.com/projects/submit-social-housing-lettings-and-sales-data), and the typography on the sidebar has been bugging me, so here’s a PR to improve it.

* Ensures list has an overall heading (level 2), demotes subheadings to level 3
* Use standard typography classes, with default spacing
* Spell out full year in ranges, i.e. `2023/24` not `23/24`
* Use `to` not `-` in date range to follow GOV.UK Style guide
* Remove ASCII-like `*` for emphasis in link title

| Before | After |
| - | - |
| ![Before screenshot](https://user-images.githubusercontent.com/813383/233837248-a538d44d-193a-4aef-87dd-137b179088cf.png) | ![After screenshot](https://user-images.githubusercontent.com/813383/233837227-ab2ba8d2-3dba-41b9-b02c-76d322a6ab0c.png) |
