### PR TITLE
CLDC-2309 Bulk upload declaration validated as setup field

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -329,6 +329,8 @@ class BulkUpload::Lettings::Year2022::RowParser
   validate :validate_created_by_related, on: :after_log
   validate :validate_rent_type, on: :after_log
 
+  validate :validate_declaration_acceptance, on: :after_log
+
   validate :validate_valid_radio_option, on: :before_log
 
   def self.question_for_field(field)
@@ -391,6 +393,12 @@ class BulkUpload::Lettings::Year2022::RowParser
   end
 
 private
+
+  def validate_declaration_acceptance
+    unless field_132 == 1
+      errors.add(:field_132, I18n.t("validations.declaration.missing"), category: :setup)
+    end
+  end
 
   def validate_valid_radio_option
     log.attributes.each do |question_id, _v|

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -332,6 +332,8 @@ class BulkUpload::Lettings::Year2023::RowParser
   validate :validate_created_by_exists, on: :after_log
   validate :validate_created_by_related, on: :after_log
 
+  validate :validate_declaration_acceptance, on: :after_log
+
   validate :validate_valid_radio_option, on: :before_log
 
   def self.question_for_field(field)
@@ -394,6 +396,12 @@ class BulkUpload::Lettings::Year2023::RowParser
   end
 
 private
+
+  def validate_declaration_acceptance
+    unless field_45 == 1
+      errors.add(:field_45, I18n.t("validations.declaration.missing"), category: :setup)
+    end
+  end
 
   def validate_valid_radio_option
     log.attributes.each do |question_id, _v|

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
     end
 
-    context "when a log has incomplete setup secion" do
+    context "when a log has incomplete setup section" do
       let(:log) { build(:lettings_log, :in_progress, created_by: user, startdate: Time.zone.local(2022, 5, 1)) }
 
       before do
@@ -225,52 +225,6 @@ RSpec.describe BulkUpload::Lettings::Validator do
       it "returns false" do
         validator.call
         expect(validator).not_to be_create_logs
-      end
-    end
-
-    context "when a column has error rate below absolute threshold" do
-      context "when a column is over 60% error threshold" do
-        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-        let(:log_2) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-
-        before do
-          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.close
-        end
-
-        it "returns true" do
-          validator.call
-          expect(validator).to be_create_logs
-        end
-      end
-
-      context "when a column is under 60% error threshold" do
-        let(:log_1) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-        let(:log_2) { build(:lettings_log, :completed, renttype: 1, created_by: user) }
-        let(:log_3) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-        let(:log_4) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-        let(:log_5) { build(:lettings_log, renttype: 2, created_by: user, builtype: nil, startdate: Time.zone.local(2022, 5, 1)) }
-
-        before do
-          file.write(BulkUpload::LogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::LogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.close
-        end
-
-        it "returns true" do
-          validator.call
-          expect(validator).to be_create_logs
-        end
       end
     end
   end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       field_97: now.month.to_s,
       field_98: now.strftime("%g"),
       field_134: "2",
+      field_132: "1",
     }
   end
 
@@ -224,7 +225,7 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       it "has errors on setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_1 field_98 field_97 field_96 field_111 field_113])
+        expect(errors).to eql(%i[field_1 field_98 field_97 field_96 field_111 field_113 field_132])
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       field_7: now.day.to_s,
       field_8: now.month.to_s,
       field_9: now.strftime("%g"),
+      field_45: "1",
     }
   end
 
@@ -244,7 +245,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       it "has errors on setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_2 field_4 field_5 field_6 field_7 field_8 field_9])
+        expect(errors).to eql(%i[field_1 field_2 field_4 field_45 field_5 field_6 field_7 field_8 field_9])
       end
     end
 

--- a/spec/services/bulk_upload/processor_spec.rb
+++ b/spec/services/bulk_upload/processor_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe BulkUpload::Processor do
           managing_organisation: owning_org,
           startdate: Time.zone.local(2022, 10, 1),
           renewal: 2,
+          declaration: 1,
         )
       end
 
@@ -258,6 +259,7 @@ RSpec.describe BulkUpload::Processor do
           startdate: Time.zone.local(2022, 10, 1),
           renewal: 2,
           created_by: other_user, # unaffiliated user
+          declaration: 1,
         )
       end
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2309
- At the moment we are not validating `declaration` as a required setup field for bulk upload

# Changes

- `declaration` for bulk upload is now validated against as a setup field
- removed old tests which tested for 16/60% rule which is no longer used and superseded by "how to fix" journey