### PR TITLE
CLDC-2248 Improve soft validations

### DIFF
--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -36,7 +36,7 @@
             <% if @log.collection_period_open? %>
               <% row.action(
                 text: question.action_text(log),
-                href: question.action_href(log, question.page.id),
+                href: action_href(log, question.page.id),
                 visually_hidden_text: question.check_answer_label.to_s.downcase,
               ) %>
             <% end %>

--- a/app/components/check_answers_summary_list_card_component.rb
+++ b/app/components/check_answers_summary_list_card_component.rb
@@ -28,8 +28,8 @@ class CheckAnswersSummaryListCardComponent < ViewComponent::Base
     "Person #{question.check_answers_card_number}"
   end
 
-  def action_href(log, page_id)
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "check_answers")
+  def action_href(log, page_id, referrer = "check_answers")
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer:)
   end
 
 private

--- a/app/components/check_answers_summary_list_card_component.rb
+++ b/app/components/check_answers_summary_list_card_component.rb
@@ -28,6 +28,10 @@ class CheckAnswersSummaryListCardComponent < ViewComponent::Base
     "Person #{question.check_answers_card_number}"
   end
 
+  def action_href(log, page_id)
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "check_answers")
+  end
+
 private
 
   def unanswered_value

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -127,13 +127,13 @@ private
 
   def referrer_from_query
     referrer = request.headers["HTTP_REFERER"]
-    return nil unless referrer
+    return unless referrer
 
     query_params = URI.parse(referrer).query
-    return nil unless query_params
+    return unless query_params
 
     parsed_params = CGI.parse(query_params)
-    return nil unless parsed_params["referrer"]
+    return unless parsed_params["referrer"]
 
     parsed_params["referrer"][0]
   end
@@ -143,7 +143,7 @@ private
   end
 
   def previous_interruption_screen_referrer
-    params[@log.model_name.param_key]["interruption_page_referrer_type"]
+    params[@log.model_name.param_key]["interruption_page_referrer_type"].presence
   end
 
   def successful_redirect_path
@@ -159,11 +159,7 @@ private
       end
     end
     if previous_interruption_screen_page_id.present?
-      if previous_interruption_screen_referrer.present?
-        return send("#{@log.class.name.underscore}_#{previous_interruption_screen_page_id}_path", @log, referrer: previous_interruption_screen_referrer)
-      else
-        return send("#{@log.class.name.underscore}_#{previous_interruption_screen_page_id}_path", @log)
-      end
+      return send("#{@log.class.name.underscore}_#{previous_interruption_screen_page_id}_path", @log, { referrer: previous_interruption_screen_referrer }.compact)
     end
 
     redirect_path = form.next_page_redirect_path(@page, @log, current_user)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -47,7 +47,7 @@ class FormController < ApplicationController
 
   def show_page
     if request.params["referrer"] == "interruption_screen"
-      @interruption_page_id = request.headers["HTTP_REFERER"].split("/")[-1].split("?")[0].underscore
+      @interruption_page_id = URI.parse(request.headers["HTTP_REFERER"]).path.split("/").last.underscore
     end
 
     if @log

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -11,7 +11,7 @@ class FormController < ApplicationController
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
       if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page.merge(updated_by: current_user))
-        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).join(', ')}" if interruption_screen_referrer.present?
+        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).join(', ').downcase}" if interruption_screen_referrer.present?
         redirect_to(successful_redirect_path)
       else
         mandatory_questions_with_no_response.map do |question|
@@ -47,7 +47,7 @@ class FormController < ApplicationController
 
   def show_page
     if request.params["referrer"] == "interruption_screen"
-      @interruption_page_id = request.headers["HTTP_REFERER"].split("/")[-1].underscore
+      @interruption_page_id = request.headers["HTTP_REFERER"].split("/")[-1].split("?")[0].underscore
     end
 
     if @log

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -11,7 +11,7 @@ class FormController < ApplicationController
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
       if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page.merge(updated_by: current_user))
-        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).join(', ').downcase}" if previous_interruption_screen_page_id.present?
+        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).first.downcase}" if previous_interruption_screen_page_id.present?
         redirect_to(successful_redirect_path)
       else
         mandatory_questions_with_no_response.map do |question|

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -11,7 +11,7 @@ class FormController < ApplicationController
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
       if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page.merge(updated_by: current_user))
-        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).join(', ')}" if interruprion_screen_referrer.present?
+        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).join(', ')}" if interruption_screen_referrer.present?
         redirect_to(successful_redirect_path)
       else
         mandatory_questions_with_no_response.map do |question|
@@ -121,7 +121,7 @@ private
     referrer.present? && CGI.parse(referrer.split("?")[-1]).present? && CGI.parse(referrer.split("?")[-1])["referrer"][0] == "check_answers"
   end
 
-  def interruprion_screen_referrer
+  def interruption_screen_referrer
     referrer = request.headers["HTTP_REFERER"].presence || ""
     return CGI.parse(referrer.split("?")[-1])["referrer"][0] if referrer.present? && CGI.parse(referrer.split("?")[-1]).present?
   end
@@ -138,8 +138,8 @@ private
         return send("#{@log.model_name.param_key}_#{form.subsection_for_page(@page).id}_check_answers_path", @log)
       end
     end
-    if interruprion_screen_referrer.present?
-      return send("#{@log.class.name.underscore}_#{interruprion_screen_referrer}_path", @log)
+    if interruption_screen_referrer.present?
+      return send("#{@log.class.name.underscore}_#{interruption_screen_referrer}_path", @log)
     end
 
     redirect_path = form.next_page_redirect_path(@page, @log, current_user)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -141,6 +141,7 @@ private
     if interruprion_screen_referrer.present?
       return send("#{@log.class.name.underscore}_#{interruprion_screen_referrer}_path", @log)
     end
+
     redirect_path = form.next_page_redirect_path(@page, @log, current_user)
     send(redirect_path, @log)
   end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -46,6 +46,10 @@ class FormController < ApplicationController
   end
 
   def show_page
+    if request.params["referrer"] == "interruption_screen"
+      @interruption_page_id = request.headers["HTTP_REFERER"].split("/")[-1].underscore
+    end
+
     if @log
       page_id = request.path.split("/")[-1].underscore
       @page = form.get_page(page_id)
@@ -122,8 +126,7 @@ private
   end
 
   def interruption_screen_referrer
-    referrer = request.headers["HTTP_REFERER"].presence || ""
-    return CGI.parse(referrer.split("?")[-1])["referrer"][0] if referrer.present? && CGI.parse(referrer.split("?")[-1]).present?
+    params[@log.model_name.param_key]["interruption_page_id"]
   end
 
   def successful_redirect_path

--- a/app/helpers/form_page_helper.rb
+++ b/app/helpers/form_page_helper.rb
@@ -1,0 +1,5 @@
+module FormPageHelper
+  def action_href(log, page_id)
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "check_answers")
+  end
+end

--- a/app/helpers/form_page_helper.rb
+++ b/app/helpers/form_page_helper.rb
@@ -1,5 +1,5 @@
 module FormPageHelper
-  def action_href(log, page_id)
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "check_answers")
+  def action_href(log, page_id, referrer = "check_answers")
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer:)
   end
 end

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -30,7 +30,7 @@ module InterruptionScreenHelper
   end
 
   def soft_validation_affected_questions(question, log)
-    question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
+    question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }.compact
   end
 
   def interruption_action_href(log, page_id)

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -29,6 +29,10 @@ module InterruptionScreenHelper
     I18n.t(title_text["translation"], **translation_params).to_s
   end
 
+  def soft_validation_affected_questions(question, log)
+    question.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
+  end
+
 private
 
   def get_value_from_argument(log, argument)

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -33,10 +33,6 @@ module InterruptionScreenHelper
     question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }.compact
   end
 
-  def interruption_action_href(log, page_id)
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "interruption_screen")
-  end
-
 private
 
   def get_value_from_argument(log, argument)

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -30,7 +30,7 @@ module InterruptionScreenHelper
   end
 
   def soft_validation_affected_questions(question, log)
-    question.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
+    question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
   end
 
 private

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -33,8 +33,8 @@ module InterruptionScreenHelper
     question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
   end
 
-  def interruption_action_href(log, page_id, current_page_id)
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: current_page_id)
+  def interruption_action_href(log, page_id)
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "interruption_screen")
   end
 
 private

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -30,7 +30,7 @@ module InterruptionScreenHelper
   end
 
   def soft_validation_affected_questions(question, log)
-    question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }.compact
+    question.page.interruption_screen_question_ids.map { |question_id| log.form.get_question(question_id, log) }.compact
   end
 
 private

--- a/app/helpers/interruption_screen_helper.rb
+++ b/app/helpers/interruption_screen_helper.rb
@@ -33,6 +33,10 @@ module InterruptionScreenHelper
     question.page.affected_question_ids.map { |question_id| log.form.get_question(question_id, log) }
   end
 
+  def interruption_action_href(log, page_id, current_page_id)
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: current_page_id)
+  end
+
 private
 
   def get_value_from_argument(log, argument)

--- a/app/models/form/lettings/pages/care_home_charges_value_check.rb
+++ b/app/models/form/lettings/pages/care_home_charges_value_check.rb
@@ -13,7 +13,7 @@ class Form::Lettings::Pages::CareHomeChargesValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::CareHomeChargesValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[chcharge is_carehome]
   end
 end

--- a/app/models/form/lettings/pages/care_home_charges_value_check.rb
+++ b/app/models/form/lettings/pages/care_home_charges_value_check.rb
@@ -12,4 +12,8 @@ class Form::Lettings::Pages::CareHomeChargesValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::CareHomeChargesValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[chcharge is_carehome]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_age_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_age_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadAgeValu
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_age_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_age_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadAgeValu
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadHhmembV
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadHhmembV
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadValueCh
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_lead_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadValueCh
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_age_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_age_value_check.rb
@@ -33,4 +33,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdPersonAgeVa
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_age_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_age_value_check.rb
@@ -34,7 +34,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdPersonAgeVa
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_value_check.rb
@@ -34,7 +34,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdPersonValue
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_person_value_check.rb
@@ -33,4 +33,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdPersonValue
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdValueCheck 
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
   end
 end

--- a/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_value_check.rb
+++ b/app/models/form/lettings/pages/females_in_soft_age_range_in_pregnant_household_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdValueCheck 
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8 age1 age2 age3 age4 age5 age6 age7 age8]
+  end
 end

--- a/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
@@ -30,7 +30,7 @@ class Form::Lettings::Pages::LeadTenantOverRetirementValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[ecstat1 sex1 age1]
   end
 end

--- a/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
@@ -29,4 +29,8 @@ class Form::Lettings::Pages::LeadTenantOverRetirementValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[ecstat1 sex1 age1]
+  end
 end

--- a/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_over_retirement_value_check.rb
@@ -27,7 +27,7 @@ class Form::Lettings::Pages::LeadTenantOverRetirementValueCheck < ::Form::Page
   end
 
   def questions
-    @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
+    @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self, person_index: 1)]
   end
 
   def interruption_screen_question_ids

--- a/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
@@ -30,7 +30,7 @@ class Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[ecstat1 sex1 age1]
   end
 end

--- a/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
@@ -29,4 +29,8 @@ class Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[ecstat1 sex1 age1]
+  end
 end

--- a/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
@@ -7,23 +7,13 @@ class Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck < ::Form::Page
       "translation" => "soft_validations.retirement.min.title",
       "arguments" => [
         {
-          "key" => "retirement_age_for_person_1",
-          "label" => false,
+          "key" => "age1",
+          "label" => true,
           "i18n_template" => "age",
         },
       ],
     }
-    @informative_text = {
-      "translation" => "soft_validations.retirement.min.hint_text",
-      "arguments" => [
-        { "key" => "plural_gender_for_person_1", "label" => false, "i18n_template" => "gender" },
-        {
-          "key" => "retirement_age_for_person_1",
-          "label" => false,
-          "i18n_template" => "age",
-        },
-      ],
-    }
+    @informative_text = {}
   end
 
   def questions
@@ -31,6 +21,6 @@ class Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    %w[ecstat1 sex1 age1]
+    %w[ecstat1 age1]
   end
 end

--- a/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/lead_tenant_under_retirement_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck < ::Form::Page
   end
 
   def questions
-    @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
+    @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self, person_index: 1)]
   end
 
   def interruption_screen_question_ids

--- a/app/models/form/lettings/pages/max_rent_value_check.rb
+++ b/app/models/form/lettings/pages/max_rent_value_check.rb
@@ -29,7 +29,7 @@ class Form::Lettings::Pages::MaxRentValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::RentValueCheck.new(nil, nil, self, check_answers_card_number: @check_answers_card_number)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[brent startdate la beds rent_type needstype]
   end
 end

--- a/app/models/form/lettings/pages/max_rent_value_check.rb
+++ b/app/models/form/lettings/pages/max_rent_value_check.rb
@@ -28,4 +28,8 @@ class Form::Lettings::Pages::MaxRentValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::RentValueCheck.new(nil, nil, self, check_answers_card_number: @check_answers_card_number)]
   end
+
+  def affected_question_ids
+    %w[brent startdate la beds rent_type needstype]
+  end
 end

--- a/app/models/form/lettings/pages/min_rent_value_check.rb
+++ b/app/models/form/lettings/pages/min_rent_value_check.rb
@@ -24,4 +24,8 @@ class Form::Lettings::Pages::MinRentValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::RentValueCheck.new(nil, nil, self, check_answers_card_number: @check_answers_card_number)]
   end
+
+  def affected_question_ids
+    %w[brent startdate la beds rent_type needstype]
+  end
 end

--- a/app/models/form/lettings/pages/min_rent_value_check.rb
+++ b/app/models/form/lettings/pages/min_rent_value_check.rb
@@ -25,7 +25,7 @@ class Form::Lettings::Pages::MinRentValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::RentValueCheck.new(nil, nil, self, check_answers_card_number: @check_answers_card_number)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[brent startdate la beds rent_type needstype]
   end
 end

--- a/app/models/form/lettings/pages/net_income_value_check.rb
+++ b/app/models/form/lettings/pages/net_income_value_check.rb
@@ -8,8 +8,8 @@ class Form::Lettings::Pages::NetIncomeValueCheck < ::Form::Page
       "translation" => "soft_validations.net_income.hint_text",
       "arguments" => [
         {
-          "key" => "field_formatted_as_currency",
-          "arguments_for_key" => "ecstat1",
+          "key" => "ecstat1",
+          "label" => true,
           "i18n_template" => "ecstat1",
         },
         {

--- a/app/models/form/lettings/pages/net_income_value_check.rb
+++ b/app/models/form/lettings/pages/net_income_value_check.rb
@@ -24,4 +24,8 @@ class Form::Lettings::Pages::NetIncomeValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::NetIncomeValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[incfreq earnings ecstat1]
+  end
 end

--- a/app/models/form/lettings/pages/net_income_value_check.rb
+++ b/app/models/form/lettings/pages/net_income_value_check.rb
@@ -3,19 +3,29 @@ class Form::Lettings::Pages::NetIncomeValueCheck < ::Form::Page
     super
     @id = "net_income_value_check"
     @depends_on = [{ "net_income_soft_validation_triggered?" => true }]
-    @title_text = { "translation" => "soft_validations.net_income.title_text" }
-    @informative_text = {
-      "translation" => "soft_validations.net_income.hint_text",
+    @title_text = {
+      "translation" => "soft_validations.net_income.title_text",
       "arguments" => [
         {
-          "key" => "ecstat1",
+          "key" => "incfreq",
           "label" => true,
-          "i18n_template" => "ecstat1",
+          "i18n_template" => "incfreq",
         },
         {
           "key" => "field_formatted_as_currency",
           "arguments_for_key" => "earnings",
           "i18n_template" => "earnings",
+        },
+      ],
+    }
+
+    @informative_text = {
+      "translation" => "soft_validations.net_income.hint_text",
+      "arguments" => [
+        {
+          "key" => "net_income_higher_or_lower_text",
+          "label" => false,
+          "i18n_template" => "net_income_higher_or_lower_text",
         },
       ],
     }

--- a/app/models/form/lettings/pages/net_income_value_check.rb
+++ b/app/models/form/lettings/pages/net_income_value_check.rb
@@ -25,7 +25,7 @@ class Form::Lettings::Pages::NetIncomeValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::NetIncomeValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[incfreq earnings ecstat1]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_age_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_age_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadAgeValueCheck < ::For
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_age_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_age_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadAgeValueCheck < ::For
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_hhmemb_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_hhmemb_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadHhmembValueCheck < ::
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_hhmemb_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_hhmemb_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadHhmembValueCheck < ::
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadValueCheck < ::Form::
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_lead_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_lead_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadValueCheck < ::Form::
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_person_age_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_person_age_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdPersonAgeValueCheck < ::F
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_person_age_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_person_age_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdPersonAgeValueCheck < ::F
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_person_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_person_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdPersonValueCheck < ::Form
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_person_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_person_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdPersonValueCheck < ::Form
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_value_check.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
   end
 end

--- a/app/models/form/lettings/pages/no_females_pregnant_household_value_check.rb
+++ b/app/models/form/lettings/pages/no_females_pregnant_household_value_check.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::NoFemalesPregnantHouseholdValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::PregnancyValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/pages/person_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_over_retirement_value_check.rb
@@ -28,9 +28,14 @@ class Form::Lettings::Pages::PersonOverRetirementValueCheck < ::Form::Page
         },
       ],
     }
+    @person_index = person_index
   end
 
   def questions
     @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
+  end
+
+  def affected_question_ids
+    ["ecstat#{@person_index}", "sex#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/lettings/pages/person_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_over_retirement_value_check.rb
@@ -32,7 +32,7 @@ class Form::Lettings::Pages::PersonOverRetirementValueCheck < ::Form::Page
   end
 
   def questions
-    @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
+    @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self, person_index: @person_index)]
   end
 
   def interruption_screen_question_ids

--- a/app/models/form/lettings/pages/person_over_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_over_retirement_value_check.rb
@@ -35,7 +35,7 @@ class Form::Lettings::Pages::PersonOverRetirementValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::RetirementValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     ["ecstat#{@person_index}", "sex#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/lettings/pages/person_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_under_retirement_value_check.rb
@@ -28,9 +28,14 @@ class Form::Lettings::Pages::PersonUnderRetirementValueCheck < ::Form::Page
         },
       ],
     }
+    @person_index = person_index
   end
 
   def questions
     @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
+  end
+
+  def affected_question_ids
+    ["ecstat#{@person_index}", "sex#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/lettings/pages/person_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_under_retirement_value_check.rb
@@ -7,27 +7,13 @@ class Form::Lettings::Pages::PersonUnderRetirementValueCheck < ::Form::Page
       "translation" => "soft_validations.retirement.min.title",
       "arguments" => [
         {
-          "key" => "retirement_age_for_person_#{person_index}",
-          "label" => false,
+          "key" => "age#{person_index}",
+          "label" => true,
           "i18n_template" => "age",
         },
       ],
     }
-    @informative_text = {
-      "translation" => "soft_validations.retirement.min.hint_text",
-      "arguments" => [
-        {
-          "key" => "plural_gender_for_person_#{person_index}",
-          "label" => false,
-          "i18n_template" => "gender",
-        },
-        {
-          "key" => "retirement_age_for_person_#{person_index}",
-          "label" => false,
-          "i18n_template" => "age",
-        },
-      ],
-    }
+    @informative_text = {}
     @person_index = person_index
   end
 
@@ -36,6 +22,6 @@ class Form::Lettings::Pages::PersonUnderRetirementValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    ["ecstat#{@person_index}", "sex#{@person_index}", "age#{@person_index}"]
+    ["ecstat#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/lettings/pages/person_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_under_retirement_value_check.rb
@@ -35,7 +35,7 @@ class Form::Lettings::Pages::PersonUnderRetirementValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     ["ecstat#{@person_index}", "sex#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/lettings/pages/person_under_retirement_value_check.rb
+++ b/app/models/form/lettings/pages/person_under_retirement_value_check.rb
@@ -18,7 +18,7 @@ class Form::Lettings::Pages::PersonUnderRetirementValueCheck < ::Form::Page
   end
 
   def questions
-    @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self)]
+    @questions ||= [Form::Lettings::Questions::NoRetirementValueCheck.new(nil, nil, self, person_index: @person_index)]
   end
 
   def interruption_screen_question_ids

--- a/app/models/form/lettings/pages/property_major_repairs_value_check.rb
+++ b/app/models/form/lettings/pages/property_major_repairs_value_check.rb
@@ -4,7 +4,10 @@ class Form::Lettings::Pages::PropertyMajorRepairsValueCheck < ::Form::Page
     @id = "property_major_repairs_value_check"
     @depends_on = [{ "major_repairs_date_in_soft_range?" => true }]
     @title_text = { "translation" => "soft_validations.major_repairs_date.title_text" }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.major_repairs_date.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/lettings/pages/property_major_repairs_value_check.rb
+++ b/app/models/form/lettings/pages/property_major_repairs_value_check.rb
@@ -11,7 +11,7 @@ class Form::Lettings::Pages::PropertyMajorRepairsValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::MajorRepairsDateValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[mrcdate startdate]
   end
 end

--- a/app/models/form/lettings/pages/property_major_repairs_value_check.rb
+++ b/app/models/form/lettings/pages/property_major_repairs_value_check.rb
@@ -10,4 +10,8 @@ class Form::Lettings::Pages::PropertyMajorRepairsValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::MajorRepairsDateValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[mrcdate startdate]
+  end
 end

--- a/app/models/form/lettings/pages/void_date_value_check.rb
+++ b/app/models/form/lettings/pages/void_date_value_check.rb
@@ -10,4 +10,8 @@ class Form::Lettings::Pages::VoidDateValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Lettings::Questions::VoidDateValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[voiddate startdate]
+  end
 end

--- a/app/models/form/lettings/pages/void_date_value_check.rb
+++ b/app/models/form/lettings/pages/void_date_value_check.rb
@@ -4,7 +4,10 @@ class Form::Lettings::Pages::VoidDateValueCheck < ::Form::Page
     @id = "void_date_value_check"
     @depends_on = [{ "voiddate_in_soft_range?" => true }]
     @title_text = { "translation" => "soft_validations.void_date.title_text" }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.void_date.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/lettings/pages/void_date_value_check.rb
+++ b/app/models/form/lettings/pages/void_date_value_check.rb
@@ -11,7 +11,7 @@ class Form::Lettings::Pages::VoidDateValueCheck < ::Form::Page
     @questions ||= [Form::Lettings::Questions::VoidDateValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[voiddate startdate]
   end
 end

--- a/app/models/form/lettings/questions/no_retirement_value_check.rb
+++ b/app/models/form/lettings/questions/no_retirement_value_check.rb
@@ -1,11 +1,11 @@
 class Form::Lettings::Questions::NoRetirementValueCheck < ::Form::Question
-  def initialize(id, hsh, page)
-    super
+  def initialize(id, hsh, page, person_index:)
+    super(id, hsh, page)
     @id = "retirement_value_check"
     @check_answer_label = "Retirement confirmation"
     @header = "Are you sure this person is retired?"
     @type = "interruption_screen"
-    @check_answers_card_number = 8
+    @check_answers_card_number = person_index
     @answer_options = ANSWER_OPTIONS
     @hidden_in_check_answers = {
       "depends_on" => [

--- a/app/models/form/lettings/questions/pregnancy_value_check.rb
+++ b/app/models/form/lettings/questions/pregnancy_value_check.rb
@@ -11,4 +11,8 @@ class Form::Lettings::Questions::PregnancyValueCheck < ::Form::Question
   end
 
   ANSWER_OPTIONS = { "0" => { "value" => "Yes" }, "1" => { "value" => "No" } }.freeze
+
+  def affected_question_ids
+    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
+  end
 end

--- a/app/models/form/lettings/questions/pregnancy_value_check.rb
+++ b/app/models/form/lettings/questions/pregnancy_value_check.rb
@@ -11,8 +11,4 @@ class Form::Lettings::Questions::PregnancyValueCheck < ::Form::Question
   end
 
   ANSWER_OPTIONS = { "0" => { "value" => "Yes" }, "1" => { "value" => "No" } }.freeze
-
-  def affected_question_ids
-    %w[preg_occ sex1 sex2 sex3 sex4 sex5 sex6 sex7 sex8]
-  end
 end

--- a/app/models/form/lettings/questions/retirement_value_check.rb
+++ b/app/models/form/lettings/questions/retirement_value_check.rb
@@ -1,11 +1,11 @@
 class Form::Lettings::Questions::RetirementValueCheck < ::Form::Question
-  def initialize(id, hsh, page)
-    super
+  def initialize(id, hsh, page, person_index:)
+    super(id, hsh, page)
     @id = "retirement_value_check"
     @check_answer_label = "Retirement confirmation"
     @header = "Are you sure this person isn’t retired?"
     @type = "interruption_screen"
-    @check_answers_card_number = 8
+    @check_answers_card_number = person_index
     @answer_options = ANSWER_OPTIONS
     @hidden_in_check_answers = {
       "depends_on" => [

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -1,7 +1,7 @@
 class Form::Page
   attr_accessor :id, :header, :header_partial, :description, :questions, :depends_on, :title_text,
                 :informative_text, :subsection, :hide_subsection_label, :next_unresolved_page_id,
-                :skip_text, :affected_question_ids
+                :skip_text, :interruption_screen_question_ids
 
   def initialize(id, hsh, subsection)
     @id = id
@@ -17,7 +17,7 @@ class Form::Page
       @hide_subsection_label = hsh["hide_subsection_label"]
       @next_unresolved_page_id = hsh["next_unresolved_page_id"]
       @skip_text = hsh["skip_text"]
-      @affected_question_ids = hsh["affected_question_ids"] || []
+      @interruption_screen_question_ids = hsh["interruption_screen_question_ids"] || []
     end
   end
 

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -1,7 +1,7 @@
 class Form::Page
   attr_accessor :id, :header, :header_partial, :description, :questions, :depends_on, :title_text,
                 :informative_text, :subsection, :hide_subsection_label, :next_unresolved_page_id,
-                :skip_text
+                :skip_text, :affected_question_ids
 
   def initialize(id, hsh, subsection)
     @id = id
@@ -17,6 +17,7 @@ class Form::Page
       @hide_subsection_label = hsh["hide_subsection_label"]
       @next_unresolved_page_id = hsh["next_unresolved_page_id"]
       @skip_text = hsh["skip_text"]
+      @affected_question_ids = hsh["affected_question_ids"] || []
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -4,7 +4,8 @@ class Form::Question
                 :conditional_for, :readonly, :answer_options, :page, :check_answer_label,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
                 :guidance_partial, :prefix, :suffix, :requires_js, :fields_added, :derived,
-                :check_answers_card_number, :unresolved_hint_text, :question_number, :plain_label
+                :check_answers_card_number, :unresolved_hint_text, :question_number, :plain_label,
+                :affected_question_ids
 
   module GuidancePosition
     TOP = 1
@@ -43,6 +44,7 @@ class Form::Question
       @question_number = hsh["question_number"]
       @plain_label = hsh["plain_label"]
       @disable_clearing_if_not_routed_or_dynamic_answer_options = hsh["disable_clearing_if_not_routed_or_dynamic_answer_options"]
+      @affected_question_ids = hsh["affected_question_ids"] || []
     end
   end
 
@@ -122,6 +124,10 @@ class Form::Question
 
   def action_href(log, page_id)
     "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=check_answers"
+  end
+
+  def interruption_action_href(log, page_id)
+    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}"
   end
 
   def unanswered?(log)

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -120,14 +120,6 @@ class Form::Question
     end
   end
 
-  def action_href(log, page_id)
-    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=check_answers"
-  end
-
-  def interruption_action_href(log, page_id, current_page_id)
-    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=#{current_page_id}"
-  end
-
   def unanswered?(log)
     return answer_options.keys.none? { |key| value_is_yes?(log[key]) } if type == "checkbox"
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -4,8 +4,7 @@ class Form::Question
                 :conditional_for, :readonly, :answer_options, :page, :check_answer_label,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
                 :guidance_partial, :prefix, :suffix, :requires_js, :fields_added, :derived,
-                :check_answers_card_number, :unresolved_hint_text, :question_number, :plain_label,
-                :affected_question_ids
+                :check_answers_card_number, :unresolved_hint_text, :question_number, :plain_label
 
   module GuidancePosition
     TOP = 1
@@ -44,7 +43,6 @@ class Form::Question
       @question_number = hsh["question_number"]
       @plain_label = hsh["plain_label"]
       @disable_clearing_if_not_routed_or_dynamic_answer_options = hsh["disable_clearing_if_not_routed_or_dynamic_answer_options"]
-      @affected_question_ids = hsh["affected_question_ids"] || []
     end
   end
 

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -126,8 +126,8 @@ class Form::Question
     "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=check_answers"
   end
 
-  def interruption_action_href(log, page_id)
-    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}"
+  def interruption_action_href(log, page_id, current_page_id)
+    "/#{log.model_name.param_key.dasherize}s/#{log.id}/#{page_id.to_s.dasherize}?referrer=#{current_page_id}"
   end
 
   def unanswered?(log)

--- a/app/models/form/sales/pages/about_price_value_check.rb
+++ b/app/models/form/sales/pages/about_price_value_check.rb
@@ -38,7 +38,7 @@ class Form::Sales::Pages::AboutPriceValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[value beds la]
   end
 end

--- a/app/models/form/sales/pages/about_price_value_check.rb
+++ b/app/models/form/sales/pages/about_price_value_check.rb
@@ -37,4 +37,8 @@ class Form::Sales::Pages::AboutPriceValueCheck < ::Form::Page
       Form::Sales::Questions::AboutPriceValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[value beds la]
+  end
 end

--- a/app/models/form/sales/pages/about_price_value_check.rb
+++ b/app/models/form/sales/pages/about_price_value_check.rb
@@ -25,8 +25,8 @@ class Form::Sales::Pages::AboutPriceValueCheck < ::Form::Page
           "i18n_template" => "soft_min_or_soft_max",
         },
         {
-          "key" => "purchase_price_min_or_max_text",
-          "i18n_template" => "min_or_max",
+          "key" => "purchase_price_higher_or_lower_text",
+          "i18n_template" => "higher_or_lower",
         },
       ],
     }

--- a/app/models/form/sales/pages/buyer1_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer1_income_value_check.rb
@@ -7,7 +7,7 @@ class Form::Sales::Pages::Buyer1IncomeValueCheck < ::Form::Page
       },
     ]
     @title_text = {
-      "translation" => "soft_validations.income.under_soft_min_for_economic_status",
+      "translation" => "soft_validations.income.under_soft_min_for_economic_status.title_text",
       "arguments" => [
         {
           "key" => "field_formatted_as_currency",
@@ -21,7 +21,10 @@ class Form::Sales::Pages::Buyer1IncomeValueCheck < ::Form::Page
         },
       ],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.income.under_soft_min_for_economic_status.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/buyer1_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer1_income_value_check.rb
@@ -30,7 +30,7 @@ class Form::Sales::Pages::Buyer1IncomeValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[ecstat1 income1]
   end
 end

--- a/app/models/form/sales/pages/buyer1_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer1_income_value_check.rb
@@ -29,4 +29,8 @@ class Form::Sales::Pages::Buyer1IncomeValueCheck < ::Form::Page
       Form::Sales::Questions::Buyer1IncomeValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[ecstat1 income1]
+  end
 end

--- a/app/models/form/sales/pages/buyer2_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer2_income_value_check.rb
@@ -33,7 +33,7 @@ class Form::Sales::Pages::Buyer2IncomeValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[ecstat2 income2]
   end
 end

--- a/app/models/form/sales/pages/buyer2_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer2_income_value_check.rb
@@ -32,4 +32,8 @@ class Form::Sales::Pages::Buyer2IncomeValueCheck < ::Form::Page
       Form::Sales::Questions::Buyer2IncomeValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[ecstat2 income2]
+  end
 end

--- a/app/models/form/sales/pages/buyer2_income_value_check.rb
+++ b/app/models/form/sales/pages/buyer2_income_value_check.rb
@@ -10,7 +10,7 @@ class Form::Sales::Pages::Buyer2IncomeValueCheck < ::Form::Page
       },
     ]
     @title_text = {
-      "translation" => "soft_validations.income.under_soft_min_for_economic_status",
+      "translation" => "soft_validations.income.under_soft_min_for_economic_status.title_text",
       "arguments" => [
         {
           "key" => "field_formatted_as_currency",
@@ -24,7 +24,10 @@ class Form::Sales::Pages::Buyer2IncomeValueCheck < ::Form::Page
         },
       ],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.income.under_soft_min_for_economic_status.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/buyer_live_in_value_check.rb
+++ b/app/models/form/sales/pages/buyer_live_in_value_check.rb
@@ -10,7 +10,10 @@ class Form::Sales::Pages::BuyerLiveInValueCheck < Form::Sales::Pages::Person
       "translation" => "soft_validations.buyer#{person_index}_livein_wrong_for_ownership_type.title_text",
       "arguments" => [{ "key" => "ownership_scheme", "label" => false, "i18n_template" => "ownership_scheme" }],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.buyer#{person_index}_livein_wrong_for_ownership_type.hint_text",
+      "arguments" => [{ "key" => "ownership_scheme", "label" => false, "i18n_template" => "ownership_scheme" }],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/buyer_live_in_value_check.rb
+++ b/app/models/form/sales/pages/buyer_live_in_value_check.rb
@@ -18,4 +18,8 @@ class Form::Sales::Pages::BuyerLiveInValueCheck < Form::Sales::Pages::Person
       Form::Sales::Questions::BuyerLiveInValueCheck.new(nil, nil, self, person_index: @person_index),
     ]
   end
+
+  def affected_question_ids
+    ["ownershipsch", "buy#{@person_index}livein"]
+  end
 end

--- a/app/models/form/sales/pages/buyer_live_in_value_check.rb
+++ b/app/models/form/sales/pages/buyer_live_in_value_check.rb
@@ -19,7 +19,7 @@ class Form::Sales::Pages::BuyerLiveInValueCheck < Form::Sales::Pages::Person
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     ["ownershipsch", "buy#{@person_index}livein"]
   end
 end

--- a/app/models/form/sales/pages/deposit_and_mortgage_value_check.rb
+++ b/app/models/form/sales/pages/deposit_and_mortgage_value_check.rb
@@ -14,4 +14,8 @@ class Form::Sales::Pages::DepositAndMortgageValueCheck < ::Form::Page
       Form::Sales::Questions::DepositAndMortgageValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[mortgage deposit value discount]
+  end
 end

--- a/app/models/form/sales/pages/deposit_and_mortgage_value_check.rb
+++ b/app/models/form/sales/pages/deposit_and_mortgage_value_check.rb
@@ -15,7 +15,7 @@ class Form::Sales::Pages::DepositAndMortgageValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[mortgage deposit value discount]
   end
 end

--- a/app/models/form/sales/pages/deposit_value_check.rb
+++ b/app/models/form/sales/pages/deposit_value_check.rb
@@ -6,9 +6,24 @@ class Form::Sales::Pages::DepositValueCheck < ::Form::Page
         "deposit_over_soft_max?" => true,
       },
     ]
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.deposit.hint_text",
+      "arguments" => [],
+    }
     @title_text = {
       "translation" => "soft_validations.deposit.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "deposit",
+          "i18n_template" => "deposit",
+        },
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "savings",
+          "i18n_template" => "savings",
+        },
+      ],
     }
   end
 

--- a/app/models/form/sales/pages/deposit_value_check.rb
+++ b/app/models/form/sales/pages/deposit_value_check.rb
@@ -18,7 +18,7 @@ class Form::Sales::Pages::DepositValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[savings deposit]
   end
 end

--- a/app/models/form/sales/pages/deposit_value_check.rb
+++ b/app/models/form/sales/pages/deposit_value_check.rb
@@ -14,4 +14,8 @@ class Form::Sales::Pages::DepositValueCheck < ::Form::Page
       Form::Sales::Questions::DepositValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[savings deposit]
+  end
 end

--- a/app/models/form/sales/pages/deposit_value_check.rb
+++ b/app/models/form/sales/pages/deposit_value_check.rb
@@ -7,6 +7,9 @@ class Form::Sales::Pages::DepositValueCheck < ::Form::Page
       },
     ]
     @informative_text = {}
+    @title_text = {
+      "translation" => "soft_validations.deposit.title_text",
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/discounted_sale_value_check.rb
+++ b/app/models/form/sales/pages/discounted_sale_value_check.rb
@@ -36,7 +36,7 @@ class Form::Sales::Pages::DiscountedSaleValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[value deposit ownershipsch mortgage mortgageused discount grant type]
   end
 end

--- a/app/models/form/sales/pages/discounted_sale_value_check.rb
+++ b/app/models/form/sales/pages/discounted_sale_value_check.rb
@@ -35,4 +35,8 @@ class Form::Sales::Pages::DiscountedSaleValueCheck < ::Form::Page
       Form::Sales::Questions::DiscountedSaleValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[value deposit ownershipsch mortgage mortgageused discount grant type]
+  end
 end

--- a/app/models/form/sales/pages/extra_borrowing_value_check.rb
+++ b/app/models/form/sales/pages/extra_borrowing_value_check.rb
@@ -7,9 +7,19 @@ class Form::Sales::Pages::ExtraBorrowingValueCheck < Form::Page
       },
     ]
     @title_text = {
-      "translation" => "soft_validations.extra_borrowing.title",
+      "translation" => "soft_validations.extra_borrowing.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "mortgage_and_deposit_total",
+          "i18n_template" => "mortgage_and_deposit_total",
+        },
+      ],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.extra_borrowing.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/extra_borrowing_value_check.rb
+++ b/app/models/form/sales/pages/extra_borrowing_value_check.rb
@@ -17,4 +17,8 @@ class Form::Sales::Pages::ExtraBorrowingValueCheck < Form::Page
       Form::Sales::Questions::ExtraBorrowingValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[extrabor mortgage deposit value discount]
+  end
 end

--- a/app/models/form/sales/pages/extra_borrowing_value_check.rb
+++ b/app/models/form/sales/pages/extra_borrowing_value_check.rb
@@ -18,7 +18,7 @@ class Form::Sales::Pages::ExtraBorrowingValueCheck < Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[extrabor mortgage deposit value discount]
   end
 end

--- a/app/models/form/sales/pages/grant_value_check.rb
+++ b/app/models/form/sales/pages/grant_value_check.rb
@@ -7,6 +7,7 @@ class Form::Sales::Pages::GrantValueCheck < ::Form::Page
         "grant_outside_common_range?" => true,
       },
     ]
+    @title_text = { "translation" => "soft_validations.grant.title_text" }
     @informative_text = {}
   end
 

--- a/app/models/form/sales/pages/grant_value_check.rb
+++ b/app/models/form/sales/pages/grant_value_check.rb
@@ -7,8 +7,20 @@ class Form::Sales::Pages::GrantValueCheck < ::Form::Page
         "grant_outside_common_range?" => true,
       },
     ]
-    @title_text = { "translation" => "soft_validations.grant.title_text" }
-    @informative_text = {}
+    @title_text = {
+      "translation" => "soft_validations.grant.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "grant",
+          "i18n_template" => "grant",
+        },
+      ],
+    }
+    @informative_text = {
+      "translation" => "soft_validations.grant.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/grant_value_check.rb
+++ b/app/models/form/sales/pages/grant_value_check.rb
@@ -17,7 +17,7 @@ class Form::Sales::Pages::GrantValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[grant]
   end
 end

--- a/app/models/form/sales/pages/grant_value_check.rb
+++ b/app/models/form/sales/pages/grant_value_check.rb
@@ -15,4 +15,8 @@ class Form::Sales::Pages::GrantValueCheck < ::Form::Page
       Form::Sales::Questions::GrantValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[grant]
+  end
 end

--- a/app/models/form/sales/pages/handover_date_check.rb
+++ b/app/models/form/sales/pages/handover_date_check.rb
@@ -16,4 +16,8 @@ class Form::Sales::Pages::HandoverDateCheck < ::Form::Page
       Form::Sales::Questions::HandoverDateCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[hodate saledate]
+  end
 end

--- a/app/models/form/sales/pages/handover_date_check.rb
+++ b/app/models/form/sales/pages/handover_date_check.rb
@@ -17,7 +17,7 @@ class Form::Sales::Pages::HandoverDateCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[hodate saledate]
   end
 end

--- a/app/models/form/sales/pages/household_wheelchair_check.rb
+++ b/app/models/form/sales/pages/household_wheelchair_check.rb
@@ -16,7 +16,7 @@ class Form::Sales::Pages::HouseholdWheelchairCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[disabled wheel]
   end
 end

--- a/app/models/form/sales/pages/household_wheelchair_check.rb
+++ b/app/models/form/sales/pages/household_wheelchair_check.rb
@@ -7,6 +7,7 @@ class Form::Sales::Pages::HouseholdWheelchairCheck < ::Form::Page
       },
     ]
     @informative_text = {}
+    @title_text = { "translation" => "soft_validations.wheelchair.title_text" }
   end
 
   def questions

--- a/app/models/form/sales/pages/household_wheelchair_check.rb
+++ b/app/models/form/sales/pages/household_wheelchair_check.rb
@@ -14,4 +14,8 @@ class Form::Sales::Pages::HouseholdWheelchairCheck < ::Form::Page
       Form::Sales::Questions::HouseholdWheelchairCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[disabled wheel]
+  end
 end

--- a/app/models/form/sales/pages/monthly_charges_value_check.rb
+++ b/app/models/form/sales/pages/monthly_charges_value_check.rb
@@ -19,7 +19,7 @@ class Form::Sales::Pages::MonthlyChargesValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[type mscharge proptype]
   end
 end

--- a/app/models/form/sales/pages/monthly_charges_value_check.rb
+++ b/app/models/form/sales/pages/monthly_charges_value_check.rb
@@ -18,4 +18,8 @@ class Form::Sales::Pages::MonthlyChargesValueCheck < ::Form::Page
       Form::Sales::Questions::MonthlyChargesValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[type mscharge proptype]
+  end
 end

--- a/app/models/form/sales/pages/monthly_charges_value_check.rb
+++ b/app/models/form/sales/pages/monthly_charges_value_check.rb
@@ -8,9 +8,18 @@ class Form::Sales::Pages::MonthlyChargesValueCheck < ::Form::Page
     ]
     @title_text = {
       "translation" => "soft_validations.monthly_charges_over_soft_max.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "mscharge",
+          "i18n_template" => "mscharge",
+        },
+      ],
+    }
+    @informative_text = {
+      "translation" => "soft_validations.monthly_charges_over_soft_max.hint_text",
       "arguments" => [],
     }
-    @informative_text = {}
   end
 
   def questions

--- a/app/models/form/sales/pages/mortgage_value_check.rb
+++ b/app/models/form/sales/pages/mortgage_value_check.rb
@@ -28,4 +28,8 @@ class Form::Sales::Pages::MortgageValueCheck < ::Form::Page
       ]
     end
   end
+
+  def affected_question_ids
+    %w[mortgage inc1mort inc2mort jointpur income1 income2 inc1mort inc2mort]
+  end
 end

--- a/app/models/form/sales/pages/mortgage_value_check.rb
+++ b/app/models/form/sales/pages/mortgage_value_check.rb
@@ -30,7 +30,7 @@ class Form::Sales::Pages::MortgageValueCheck < ::Form::Page
     end
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[mortgage inc1mort inc2mort jointpur income1 income2 inc1mort inc2mort]
   end
 end

--- a/app/models/form/sales/pages/mortgage_value_check.rb
+++ b/app/models/form/sales/pages/mortgage_value_check.rb
@@ -4,6 +4,7 @@ class Form::Sales::Pages::MortgageValueCheck < ::Form::Page
     @depends_on = depends_on
     @informative_text = {}
     @person_index = person_index
+    @title_text = { "translation" => "soft_validations.mortgage.title_text" }
   end
 
   def questions

--- a/app/models/form/sales/pages/mortgage_value_check.rb
+++ b/app/models/form/sales/pages/mortgage_value_check.rb
@@ -4,7 +4,20 @@ class Form::Sales::Pages::MortgageValueCheck < ::Form::Page
     @depends_on = depends_on
     @informative_text = {}
     @person_index = person_index
-    @title_text = { "translation" => "soft_validations.mortgage.title_text" }
+    @title_text = {
+      "translation" => "soft_validations.mortgage.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "mortgage",
+          "i18n_template" => "mortgage",
+        },
+      ],
+    }
+    @informative_text = {
+      "translation" => "soft_validations.mortgage.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
+++ b/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
@@ -19,7 +19,7 @@ class Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[type jointpur age1 age2]
   end
 end

--- a/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
+++ b/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
@@ -18,4 +18,8 @@ class Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck < ::Form::Page
       Form::Sales::Questions::OldPersonsSharedOwnershipValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[type jointpur age1 age2]
+  end
 end

--- a/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
+++ b/app/models/form/sales/pages/old_persons_shared_ownership_value_check.rb
@@ -7,10 +7,13 @@ class Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck < ::Form::Page
       },
     ]
     @title_text = {
-      "translation" => "soft_validations.old_persons_shared_ownership",
+      "translation" => "soft_validations.old_persons_shared_ownership.title_text",
       "arguments" => [],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.old_persons_shared_ownership.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/percentage_discount_value_check.rb
+++ b/app/models/form/sales/pages/percentage_discount_value_check.rb
@@ -13,7 +13,7 @@ class Form::Sales::Pages::PercentageDiscountValueCheck < ::Form::Page
     @questions ||= [Form::Sales::Questions::PercentageDiscountValueCheck.new(nil, nil, self)]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[discount proptype]
   end
 end

--- a/app/models/form/sales/pages/percentage_discount_value_check.rb
+++ b/app/models/form/sales/pages/percentage_discount_value_check.rb
@@ -12,4 +12,8 @@ class Form::Sales::Pages::PercentageDiscountValueCheck < ::Form::Page
   def questions
     @questions ||= [Form::Sales::Questions::PercentageDiscountValueCheck.new(nil, nil, self)]
   end
+
+  def affected_question_ids
+    %w[discount proptype]
+  end
 end

--- a/app/models/form/sales/pages/percentage_discount_value_check.rb
+++ b/app/models/form/sales/pages/percentage_discount_value_check.rb
@@ -5,7 +5,10 @@ class Form::Sales::Pages::PercentageDiscountValueCheck < ::Form::Page
       "translation" => "soft_validations.percentage_discount_value.title_text",
       "arguments" => [{ "key" => "discount", "label" => true, "i18n_template" => "discount" }],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.percentage_discount_value.hint_text",
+      "arguments" => [],
+    }
     @depends_on = [{ "percentage_discount_invalid?" => true }]
   end
 

--- a/app/models/form/sales/pages/person_student_not_child_value_check.rb
+++ b/app/models/form/sales/pages/person_student_not_child_value_check.rb
@@ -20,6 +20,6 @@ class Form::Sales::Pages::PersonStudentNotChildValueCheck < Form::Sales::Pages::
   end
 
   def interruption_screen_question_ids
-    ["relat#{@person_index}", "exstat#{@person_index}", "age#{@person_index}"]
+    ["relat#{@person_index}", "ecstat#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/sales/pages/person_student_not_child_value_check.rb
+++ b/app/models/form/sales/pages/person_student_not_child_value_check.rb
@@ -18,4 +18,8 @@ class Form::Sales::Pages::PersonStudentNotChildValueCheck < Form::Sales::Pages::
       Form::Sales::Questions::PersonStudentNotChildValueCheck.new(nil, nil, self, person_index: @person_index),
     ]
   end
+
+  def affected_question_ids
+    ["relat#{@person_index}", "exstat#{@person_index}", "age#{@person_index}"]
+  end
 end

--- a/app/models/form/sales/pages/person_student_not_child_value_check.rb
+++ b/app/models/form/sales/pages/person_student_not_child_value_check.rb
@@ -19,7 +19,7 @@ class Form::Sales::Pages::PersonStudentNotChildValueCheck < Form::Sales::Pages::
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     ["relat#{@person_index}", "exstat#{@person_index}", "age#{@person_index}"]
   end
 end

--- a/app/models/form/sales/pages/retirement_value_check.rb
+++ b/app/models/form/sales/pages/retirement_value_check.rb
@@ -40,7 +40,7 @@ class Form::Sales::Pages::RetirementValueCheck < Form::Sales::Pages::Person
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     ["age#{@person_index}", "exstat#{@person_index}", "sex#{@person_index}"]
   end
 end

--- a/app/models/form/sales/pages/retirement_value_check.rb
+++ b/app/models/form/sales/pages/retirement_value_check.rb
@@ -11,27 +11,13 @@ class Form::Sales::Pages::RetirementValueCheck < Form::Sales::Pages::Person
       "translation" => "soft_validations.retirement.min.title",
       "arguments" => [
         {
-          "key" => "retirement_age_for_person_#{person_index}",
-          "label" => false,
+          "key" => "age#{person_index}",
+          "label" => true,
           "i18n_template" => "age",
         },
       ],
     }
-    @informative_text = {
-      "translation" => "soft_validations.retirement.min.hint_text",
-      "arguments" => [
-        {
-          "key" => "plural_gender_for_person_#{person_index}",
-          "label" => false,
-          "i18n_template" => "gender",
-        },
-        {
-          "key" => "retirement_age_for_person_#{person_index}",
-          "label" => false,
-          "i18n_template" => "age",
-        },
-      ],
-    }
+    @informative_text = {}
   end
 
   def questions
@@ -41,6 +27,6 @@ class Form::Sales::Pages::RetirementValueCheck < Form::Sales::Pages::Person
   end
 
   def interruption_screen_question_ids
-    ["age#{@person_index}", "ecstat#{@person_index}", "sex#{@person_index}"]
+    ["age#{@person_index}", "ecstat#{@person_index}"]
   end
 end

--- a/app/models/form/sales/pages/retirement_value_check.rb
+++ b/app/models/form/sales/pages/retirement_value_check.rb
@@ -39,4 +39,8 @@ class Form::Sales::Pages::RetirementValueCheck < Form::Sales::Pages::Person
       Form::Sales::Questions::RetirementValueCheck.new(nil, nil, self, person_index: @person_index),
     ]
   end
+
+  def affected_question_ids
+    ["age#{@person_index}", "exstat#{@person_index}", "sex#{@person_index}"]
+  end
 end

--- a/app/models/form/sales/pages/retirement_value_check.rb
+++ b/app/models/form/sales/pages/retirement_value_check.rb
@@ -41,6 +41,6 @@ class Form::Sales::Pages::RetirementValueCheck < Form::Sales::Pages::Person
   end
 
   def interruption_screen_question_ids
-    ["age#{@person_index}", "exstat#{@person_index}", "sex#{@person_index}"]
+    ["age#{@person_index}", "ecstat#{@person_index}", "sex#{@person_index}"]
   end
 end

--- a/app/models/form/sales/pages/savings_value_check.rb
+++ b/app/models/form/sales/pages/savings_value_check.rb
@@ -6,6 +6,9 @@ class Form::Sales::Pages::SavingsValueCheck < ::Form::Page
         "savings_over_soft_max?" => true,
       },
     ]
+    @title_text = {
+      "translation" => "soft_validations.savings.title_text",
+    }
     @informative_text = {}
   end
 

--- a/app/models/form/sales/pages/savings_value_check.rb
+++ b/app/models/form/sales/pages/savings_value_check.rb
@@ -18,7 +18,7 @@ class Form::Sales::Pages::SavingsValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[savings]
   end
 end

--- a/app/models/form/sales/pages/savings_value_check.rb
+++ b/app/models/form/sales/pages/savings_value_check.rb
@@ -14,4 +14,8 @@ class Form::Sales::Pages::SavingsValueCheck < ::Form::Page
       Form::Sales::Questions::SavingsValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[savings]
+  end
 end

--- a/app/models/form/sales/pages/savings_value_check.rb
+++ b/app/models/form/sales/pages/savings_value_check.rb
@@ -8,8 +8,18 @@ class Form::Sales::Pages::SavingsValueCheck < ::Form::Page
     ]
     @title_text = {
       "translation" => "soft_validations.savings.title_text",
+      "arguments" => [
+        {
+          "key" => "field_formatted_as_currency",
+          "arguments_for_key" => "savings",
+          "i18n_template" => "savings",
+        },
+      ],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.savings.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
+++ b/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
@@ -24,4 +24,8 @@ class Form::Sales::Pages::SharedOwnershipDepositValueCheck < ::Form::Page
       Form::Sales::Questions::SharedOwnershipDepositValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[mortgage mortgageused cashdis type deposit value equity]
+  end
 end

--- a/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
+++ b/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
@@ -25,7 +25,7 @@ class Form::Sales::Pages::SharedOwnershipDepositValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[mortgage mortgageused cashdis type deposit value equity]
   end
 end

--- a/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
+++ b/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
@@ -12,8 +12,8 @@ class Form::Sales::Pages::SharedOwnershipDepositValueCheck < ::Form::Page
       "arguments" => [
         {
           "key" => "field_formatted_as_currency",
-          "arguments_for_key" => "expected_shared_ownership_deposit_value",
-          "i18n_template" => "expected_shared_ownership_deposit_value",
+          "arguments_for_key" => "mortgage_deposit_and_discount_total",
+          "i18n_template" => "mortgage_deposit_and_discount_total",
         },
       ],
     }

--- a/app/models/form/sales/pages/staircase_bought_value_check.rb
+++ b/app/models/form/sales/pages/staircase_bought_value_check.rb
@@ -24,4 +24,8 @@ class Form::Sales::Pages::StaircaseBoughtValueCheck < ::Form::Page
       Form::Sales::Questions::StaircaseBoughtValueCheck.new(nil, nil, self),
     ]
   end
+
+  def affected_question_ids
+    %w[stairbought]
+  end
 end

--- a/app/models/form/sales/pages/staircase_bought_value_check.rb
+++ b/app/models/form/sales/pages/staircase_bought_value_check.rb
@@ -25,7 +25,7 @@ class Form::Sales::Pages::StaircaseBoughtValueCheck < ::Form::Page
     ]
   end
 
-  def affected_question_ids
+  def interruption_screen_question_ids
     %w[stairbought]
   end
 end

--- a/app/models/form/sales/pages/staircase_bought_value_check.rb
+++ b/app/models/form/sales/pages/staircase_bought_value_check.rb
@@ -8,7 +8,7 @@ class Form::Sales::Pages::StaircaseBoughtValueCheck < ::Form::Page
       },
     ]
     @title_text = {
-      "translation" => "soft_validations.staircase_bought_seems_high",
+      "translation" => "soft_validations.staircase_bought_seems_high.title_text",
       "arguments" => [
         {
           "key" => "stairbought",
@@ -16,7 +16,10 @@ class Form::Sales::Pages::StaircaseBoughtValueCheck < ::Form::Page
         },
       ],
     }
-    @informative_text = {}
+    @informative_text = {
+      "translation" => "soft_validations.staircase_bought_seems_high.hint_text",
+      "arguments" => [],
+    }
   end
 
   def questions

--- a/app/models/form/sales/questions/household_wheelchair_check.rb
+++ b/app/models/form/sales/questions/household_wheelchair_check.rb
@@ -3,7 +3,7 @@ class Form::Sales::Questions::HouseholdWheelchairCheck < ::Form::Question
     super
     @id = "wheel_value_check"
     @check_answer_label = "Does anyone in the household use a wheelchair?"
-    @header = "Are you sure? You said previously that somebody in household uses a wheelchair"
+    @header = "You told us that someone in the household uses a wheelchair."
     @type = "interruption_screen"
     @answer_options = {
       "0" => { "value" => "Yes" },

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -219,6 +219,12 @@ class SalesLog < Log
     value * equity / 100
   end
 
+  def mortgage_and_deposit_total
+    return unless mortgage && deposit
+
+    mortgage + deposit
+  end
+
   def process_postcode(postcode, postcode_known_key, la_inferred_key, la_key)
     return if postcode.blank?
 

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -219,6 +219,14 @@ class SalesLog < Log
     value * equity / 100
   end
 
+  def mortgage_deposit_and_discount_total
+    mortgage_amount = mortgage || 0
+    deposit_amount = deposit || 0
+    cashdis_amount = cashdis || 0
+
+    mortgage_amount + deposit_amount + cashdis_amount
+  end
+
   def mortgage_and_deposit_total
     return unless mortgage && deposit
 

--- a/app/models/validations/sales/soft_validations.rb
+++ b/app/models/validations/sales/soft_validations.rb
@@ -82,8 +82,8 @@ module Validations::Sales::SoftValidations
     saledate - hodate >= 3.years
   end
 
-  def purchase_price_min_or_max_text
-    value < sale_range.soft_min ? "minimum" : "maximum"
+  def purchase_price_higher_or_lower_text
+    value < sale_range.soft_min ? "lower" : "higher"
   end
 
   def purchase_price_soft_min_or_soft_max

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -93,6 +93,10 @@ module Validations::SoftValidations
     voiddate.present? && startdate.present? && voiddate.between?(startdate.to_date - TEN_YEARS_IN_DAYS, startdate.to_date - TWO_YEARS_IN_DAYS)
   end
 
+  def net_income_higher_or_lower_text
+    net_income_in_soft_max_range? ? "higher" : "lower"
+  end
+
 private
 
   def details_known_or_lead_tenant?(tenant_number)

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -124,11 +124,9 @@ private
   def retired_under_soft_min_age?(person_num)
     age = public_send("age#{person_num}")
     economic_status = public_send("ecstat#{person_num}")
-    gender = public_send("sex#{person_num}")
-    return unless age && economic_status && gender
+    return unless age && economic_status
 
-    %w[M X].include?(gender) && tenant_is_retired?(economic_status) && age < retirement_age_for_person(person_num) ||
-      gender == "F" && tenant_is_retired?(economic_status) && age < 60
+    tenant_is_retired?(economic_status) && age < 60
   end
 
   def not_retired_over_soft_max_age?(person_num)

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% total_applicable_questions(subsection, @log, current_user).each do |question| %>
+  <% questions.each do |question| %>
     <% summary_list.row do |row| %>
       <% row.key { get_question_label(question) } %>
       <% row.value do %>

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -23,7 +23,7 @@
       <% if @log.collection_period_open? %>
         <% row.action(
           text: question.action_text(@log),
-          href: action_href(@log, question.page.id),
+          href: action_href(@log, question.page.id, referrer),
           visually_hidden_text: question.check_answer_label.to_s.downcase,
         ) %>
       <% end %>

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -23,7 +23,7 @@
       <% if @log.collection_period_open? %>
         <% row.action(
           text: question.action_text(@log),
-          href: question.action_href(@log, question.page.id),
+          href: action_href(@log, question.page.id),
           visually_hidden_text: question.check_answer_label.to_s.downcase,
         ) %>
       <% end %>

--- a/app/views/form/_interruption_screen_banner.html.erb
+++ b/app/views/form/_interruption_screen_banner.html.erb
@@ -1,0 +1,13 @@
+<% if question.page.routed_to?(@log, current_user) %>
+  <%= govuk_panel(
+    classes: "app-panel--interruption",
+  ) do %>
+    <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
+    <% if informative_text.present? %>
+      <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
+    <% end %>
+    <% if question.hint_text.present? %>
+      <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "form/interruption_screen_banner", locals: { question:, title_text:, informative_text:, lettings_log: } %>
 
 <h1 class="govuk-heading-m">
-  Make sure these answers are all correct
+  Make sure these answers are correct:
 </h1>
 <div class="x-govuk-summary-card govuk-!-margin-bottom-6">
   <div class="x-govuk-summary-card__body">

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -5,40 +5,12 @@
 </h1>
 <div class="x-govuk-summary-card govuk-!-margin-bottom-6">
   <div class="x-govuk-summary-card__body">
-    <%= govuk_summary_list do |summary_list| %>
-      <% soft_validation_affected_questions(question, @log).each do |affected_question| %>
-      <% if affected_question.page.routed_to?(@log, current_user) %>
-          <% summary_list.row do |row| %>
-            <% row.key { get_question_label(affected_question) } %>
-            <% row.value do %>
-                <%= simple_format(
-                  get_answer_label(affected_question, @log),
-                  wrapper_tag: "span",
-                  class: "govuk-!-margin-right-4",
-                ) %>
-              <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
-              <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
-                <%= simple_format(
-                  extra_value,
-                  wrapper_tag: "span",
-                  class: "govuk-!-font-weight-regular app-!-colour-muted",
-                ) %>
-              <% end %>
-              <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
-                <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
-              <% end %>
-            <% end %>
-            <% if @log.collection_period_open? %>
-              <% row.action(
-                text: affected_question.action_text(@log),
-                href: action_href(@log, affected_question.page.id, "interruption_screen"),
-                visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
-              ) %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
+
+    <%= render partial: "form/check_answers_summary_list", locals: {
+        lettings_log:,
+        questions: soft_validation_affected_questions(question, @log).filter { |q| q.page.routed_to?(@log, current_user) },
+        referrer: "interruption_screen",
+    } %>
   </div>
 </div>
 

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -38,7 +38,7 @@
         <% if @log.collection_period_open? %>
           <% row.action(
             text: affected_question.action_text(@log),
-            href: affected_question.interruption_action_href(@log, affected_question.page.id, question.page.id),
+            href: interruption_action_href(@log, affected_question.page.id, question.page.id),
             visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
           ) %>
         <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -1,16 +1,4 @@
-<% if question.page.routed_to?(@log, current_user) %>
-  <%= govuk_panel(
-    classes: "app-panel--interruption",
-  ) do %>
-    <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
-    <% if informative_text.present? %>
-      <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
-    <% end %>
-    <% if question.hint_text.present? %>
-      <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
-    <% end %>
-  <% end %>
-<% end %>
+<%= render partial: "form/interruption_screen_banner", locals: { question:, title_text:, informative_text:, lettings_log: } %>
 
 <h1 class="govuk-heading-m">
   Make sure these answers are all correct

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -4,7 +4,6 @@
   ) do %>
     <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
     <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
-    <p class="govuk-body-l"><%= question.header %></p>
     <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
   <% end %>
 <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -31,7 +31,7 @@
             <% if @log.collection_period_open? %>
               <% row.action(
                 text: affected_question.action_text(@log),
-                href: interruption_action_href(@log, affected_question.page.id),
+                href: action_href(@log, affected_question.page.id, "interruption_screen"),
                 visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
               ) %>
             <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -48,4 +48,10 @@
 <% end %>
 
 <%= f.hidden_field question.id, value: "0" %>
-<%= f.govuk_submit "Save and continue" %>
+<div class="govuk-button-group">
+  <%= f.govuk_submit "Save and continue" %>
+  <%= govuk_link_to(
+    (@page.skip_text || "Skip for now"),
+    (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
+  ) %>
+</div>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -14,32 +14,34 @@
 </h1>
 <%= govuk_summary_list do |summary_list| %>
   <% soft_validation_affected_questions(question, @log).each do |affected_question| %>
-    <% summary_list.row do |row| %>
-      <% row.key { get_question_label(affected_question) } %>
-      <% row.value do %>
-          <%= simple_format(
-            get_answer_label(affected_question, @log),
-            wrapper_tag: "span",
-            class: "govuk-!-margin-right-4",
-          ) %>
-        <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
-        <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
-          <%= simple_format(
-            extra_value,
-            wrapper_tag: "span",
-            class: "govuk-!-font-weight-regular app-!-colour-muted",
+  <% if affected_question.page.routed_to?(@log, current_user) %>
+      <% summary_list.row do |row| %>
+        <% row.key { get_question_label(affected_question) } %>
+        <% row.value do %>
+            <%= simple_format(
+              get_answer_label(affected_question, @log),
+              wrapper_tag: "span",
+              class: "govuk-!-margin-right-4",
+            ) %>
+          <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
+          <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
+            <%= simple_format(
+              extra_value,
+              wrapper_tag: "span",
+              class: "govuk-!-font-weight-regular app-!-colour-muted",
+            ) %>
+          <% end %>
+          <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
+            <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
+          <% end %>
+        <% end %>
+        <% if @log.collection_period_open? %>
+          <% row.action(
+            text: affected_question.action_text(@log),
+            href: affected_question.interruption_action_href(@log, affected_question.page.id, question.page.id),
+            visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
           ) %>
         <% end %>
-        <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
-          <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
-        <% end %>
-      <% end %>
-      <% if @log.collection_period_open? %>
-        <% row.action(
-          text: affected_question.action_text(@log),
-          href: affected_question.interruption_action_href(@log, affected_question.page.id, question.page.id),
-          visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
-        ) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -1,22 +1,48 @@
 <%= govuk_panel(
-  title_text: display_title_text(title_text, lettings_log),
   classes: "app-panel--interruption",
 ) do %>
-  <p class="govuk-panel__body"><%= display_informative_text(informative_text, lettings_log) %></p>
-  <%= f.govuk_radio_buttons_fieldset question.id.to_sym,
-    legend: { text: question.header },
-    hint: { text: question.hint_text&.html_safe } do %>
-    <% question.answer_options.map do |key, options| %>
-      <% if key.starts_with?("divider") %>
-        <%= f.govuk_radio_divider %>
-      <% else %>
-        <%= f.govuk_radio_button question.id,
-          key,
-          label: { text: options["value"] },
-          hint: { text: options["hint"] },
-          **stimulus_html_attributes(question) %>
+  <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
+  <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
+  <p class="govuk-body-l"><%= question.header %></p>
+  <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
+
+<% end %>
+
+<h1 class="govuk-heading-l">
+  Make sure these answers are all correct
+</h1>
+<%= govuk_summary_list do |summary_list| %>
+  <% soft_validation_affected_questions(question, @log).each do |affected_question| %>
+    <% summary_list.row do |row| %>
+      <% row.key { get_question_label(affected_question) } %>
+      <% row.value do %>
+          <%= simple_format(
+            get_answer_label(affected_question, @log),
+            wrapper_tag: "span",
+            class: "govuk-!-margin-right-4",
+          ) %>
+        <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
+        <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
+          <%= simple_format(
+            extra_value,
+            wrapper_tag: "span",
+            class: "govuk-!-font-weight-regular app-!-colour-muted",
+          ) %>
+        <% end %>
+        <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
+          <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
+        <% end %>
+      <% end %>
+      <% if @log.collection_period_open? %>
+        <% row.action(
+          text: affected_question.action_text(@log),
+          href: affected_question.interruption_action_href(@log, affected_question.page.id),
+          visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
+        ) %>
       <% end %>
     <% end %>
   <% end %>
-  <%= f.govuk_submit "Save and continue", accesskey: "s", class: "app-button--inverse govuk-!-margin-bottom-0" %>
 <% end %>
+
+<%= f.hidden_field question.id, value: "0" %>
+<%= f.govuk_submit "Save and continue" %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -3,48 +3,56 @@
     classes: "app-panel--interruption",
   ) do %>
     <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
-    <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
-    <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
-  <% end %>
-<% end %>
-
-<h1 class="govuk-heading-l">
-  Make sure these answers are all correct
-</h1>
-<%= govuk_summary_list do |summary_list| %>
-  <% soft_validation_affected_questions(question, @log).each do |affected_question| %>
-  <% if affected_question.page.routed_to?(@log, current_user) %>
-      <% summary_list.row do |row| %>
-        <% row.key { get_question_label(affected_question) } %>
-        <% row.value do %>
-            <%= simple_format(
-              get_answer_label(affected_question, @log),
-              wrapper_tag: "span",
-              class: "govuk-!-margin-right-4",
-            ) %>
-          <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
-          <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
-            <%= simple_format(
-              extra_value,
-              wrapper_tag: "span",
-              class: "govuk-!-font-weight-regular app-!-colour-muted",
-            ) %>
-          <% end %>
-          <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
-            <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
-          <% end %>
-        <% end %>
-        <% if @log.collection_period_open? %>
-          <% row.action(
-            text: affected_question.action_text(@log),
-            href: interruption_action_href(@log, affected_question.page.id),
-            visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
-          ) %>
-        <% end %>
-      <% end %>
+    <% if informative_text.present? %>
+      <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
+    <% end %>
+    <% if question.hint_text.present? %>
+      <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
     <% end %>
   <% end %>
 <% end %>
+
+<h1 class="govuk-heading-m">
+  Make sure these answers are all correct
+</h1>
+<div class="x-govuk-summary-card govuk-!-margin-bottom-6">
+  <div class="x-govuk-summary-card__body">
+    <%= govuk_summary_list do |summary_list| %>
+      <% soft_validation_affected_questions(question, @log).each do |affected_question| %>
+      <% if affected_question.page.routed_to?(@log, current_user) %>
+          <% summary_list.row do |row| %>
+            <% row.key { get_question_label(affected_question) } %>
+            <% row.value do %>
+                <%= simple_format(
+                  get_answer_label(affected_question, @log),
+                  wrapper_tag: "span",
+                  class: "govuk-!-margin-right-4",
+                ) %>
+              <% extra_value = affected_question.get_extra_check_answer_value(@log) %>
+              <% if extra_value && affected_question.answer_label(@log, current_user).present? %>
+                <%= simple_format(
+                  extra_value,
+                  wrapper_tag: "span",
+                  class: "govuk-!-font-weight-regular app-!-colour-muted",
+                ) %>
+              <% end %>
+              <% affected_question.get_inferred_answers(@log).each do |inferred_answer| %>
+                <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
+              <% end %>
+            <% end %>
+            <% if @log.collection_period_open? %>
+              <% row.action(
+                text: affected_question.action_text(@log),
+                href: interruption_action_href(@log, affected_question.page.id),
+                visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
+              ) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
 
 <%= f.hidden_field question.id, value: "0" %>
 <div class="govuk-button-group">

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -38,7 +38,7 @@
         <% if @log.collection_period_open? %>
           <% row.action(
             text: affected_question.action_text(@log),
-            href: interruption_action_href(@log, affected_question.page.id, question.page.id),
+            href: interruption_action_href(@log, affected_question.page.id),
             visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
           ) %>
         <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -1,11 +1,12 @@
-<%= govuk_panel(
-  classes: "app-panel--interruption",
-) do %>
-  <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
-  <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
-  <p class="govuk-body-l"><%= question.header %></p>
-  <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
-
+<% if question.page.routed_to?(@log, current_user) %>
+  <%= govuk_panel(
+    classes: "app-panel--interruption",
+  ) do %>
+    <p class="govuk-heading-l"><%= display_title_text(title_text, lettings_log) %></p>
+    <p class="govuk-body-l"><%= display_informative_text(informative_text, lettings_log) %></p>
+    <p class="govuk-body-l"><%= question.header %></p>
+    <p class="govuk-body-l"><%= question.hint_text&.html_safe %></p>
+  <% end %>
 <% end %>
 
 <h1 class="govuk-heading-l">
@@ -36,7 +37,7 @@
       <% if @log.collection_period_open? %>
         <% row.action(
           text: affected_question.action_text(@log),
-          href: affected_question.interruption_action_href(@log, affected_question.page.id),
+          href: affected_question.interruption_action_href(@log, affected_question.page.id, question.page.id),
           visually_hidden_text: affected_question.check_answer_label.to_s.downcase,
         ) %>
       <% end %>

--- a/app/views/form/_interruption_screen_question.html.erb
+++ b/app/views/form/_interruption_screen_question.html.erb
@@ -49,7 +49,7 @@
 
 <%= f.hidden_field question.id, value: "0" %>
 <div class="govuk-button-group">
-  <%= f.govuk_submit "Save and continue" %>
+  <%= f.govuk_submit "Confirm and continue" %>
   <%= govuk_link_to(
     (@page.skip_text || "Skip for now"),
     (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -25,7 +25,8 @@
       <%= render partial: "form/check_answers_summary_list", locals: {
         subsection:,
         lettings_log: @log,
-        questions: total_applicable_questions(subsection, @log, current_user)
+        questions: total_applicable_questions(subsection, @log, current_user),
+        referrer: "check_answers",
       } %>
     <% end %>
 

--- a/app/views/form/check_answers.html.erb
+++ b/app/views/form/check_answers.html.erb
@@ -25,6 +25,7 @@
       <%= render partial: "form/check_answers_summary_list", locals: {
         subsection:,
         lettings_log: @log,
+        questions: total_applicable_questions(subsection, @log, current_user)
       } %>
     <% end %>
 

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -7,7 +7,7 @@
 <div data-controller="govukfrontend"></div>
 <%= form_with model: @log, url: request.original_url, method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-<%= @page.questions[0].type == "interruption_screen" ? "full-from-desktop" : "two-thirds-from-desktop" %>">
+    <div class="govuk-grid-column-two-thirds-from-desktop" %>
       <% remove_other_page_errors(@log, @page) %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -7,7 +7,7 @@
 <div data-controller="govukfrontend"></div>
 <%= form_with model: @log, url: request.original_url, method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop" %>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <% remove_other_page_errors(@log, @page) %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -60,6 +60,7 @@
 
       <%= f.hidden_field :page, value: @page.id %>
       <%= f.hidden_field :interruption_page_id, value: @interruption_page_id %>
+      <%= f.hidden_field :interruption_page_referrer_type, value: @interruption_page_referrer_type %>
 
       <div class="govuk-button-group">
         <% if !@page.interruption_screen? && if request.query_parameters["referrer"] != "check_answers" %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -59,6 +59,7 @@
       <% end %>
 
       <%= f.hidden_field :page, value: @page.id %>
+      <%= f.hidden_field :interruption_page_id, value: @interruption_page_id %>
 
       <div class="govuk-button-group">
         <% if !@page.interruption_screen? && if request.query_parameters["referrer"] != "check_answers" %>

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -23,7 +23,7 @@
               <h3 class="x-govuk-summary-card__title"><%= subsection.label %></h3>
             </div>
             <div class="x-govuk-summary-card__body">
-              <%= render partial: "form/check_answers_summary_list", locals: { subsection: } %>
+              <%= render partial: "form/check_answers_summary_list", locals: { subsection:, questions: total_applicable_questions(subsection, @log, current_user), } %>
             </div>
           </div>
         <% end %>

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -23,7 +23,7 @@
               <h3 class="x-govuk-summary-card__title"><%= subsection.label %></h3>
             </div>
             <div class="x-govuk-summary-card__body">
-              <%= render partial: "form/check_answers_summary_list", locals: { subsection:, questions: total_applicable_questions(subsection, @log, current_user), } %>
+              <%= render partial: "form/check_answers_summary_list", locals: { subsection:, questions: total_applicable_questions(subsection, @log, current_user), referrer: "check_answers" } %>
             </div>
           </div>
         <% end %>

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -8331,7 +8331,7 @@
                     ]
                   },
                   "header": "Are you sure this is correct?",
-                  "hint_text": "This rent is lower than expected for this property type, in this area. Check:<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
+                  "hint_text": "This is lower than we would expect. Check:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
@@ -8376,7 +8376,7 @@
                     ]
                   },
                   "header": "Are you sure this is correct?",
-                  "hint_text": "This rent is higher than expected for this property type, in this area. Check:<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
+                  "hint_text": "This is higher than we would expect. Check:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1853,8 +1853,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_1",
-                    "label": false,
+                    "key": "age1",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -2383,8 +2383,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_2",
-                    "label": false,
+                    "key": "age2",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -2910,8 +2910,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_3",
-                    "label": false,
+                    "key": "age3",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -3434,8 +3434,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_4",
-                    "label": false,
+                    "key": "age4",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -3955,8 +3955,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_5",
-                    "label": false,
+                    "key": "age5",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -4473,8 +4473,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_6",
-                    "label": false,
+                    "key": "age6",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -4988,8 +4988,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_7",
-                    "label": false,
+                    "key": "age7",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]
@@ -5500,8 +5500,8 @@
                 "translation": "soft_validations.retirement.min.title",
                 "arguments": [
                   {
-                    "key": "retirement_age_for_person_8",
-                    "label": false,
+                    "key": "age8",
+                    "label": true,
                     "i18n_template": "age"
                   }
                 ]

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -7299,20 +7299,27 @@
                 }
               ],
               "title_text": {
-                "translation": "soft_validations.net_income.title_text"
+                "translation": "soft_validations.net_income.title_text",
+                "arguments" :[
+                  {
+                    "key": "incfreq",
+                    "label": true,
+                    "i18n_template": "incfreq"
+                  },
+                  {
+                    "key": "field_formatted_as_currency",
+                    "arguments_for_key": "earnings",
+                    "i18n_template": "earnings"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.net_income.hint_text",
                 "arguments": [
                   {
-                    "key": "ecstat1",
-                    "label": true,
-                    "i18n_template": "ecstat1"
-                  },
-                  {
-                    "key": "earnings",
-                    "label": true,
-                    "i18n_template": "earnings"
+                    "key": "net_income_higher_or_lower_text",
+                    "label": false,
+                    "i18n_template": "net_income_higher_or_lower_text"
                   }
                 ]
               },

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1859,21 +1859,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_1",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_1",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -1900,7 +1886,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat1", "sex1", "age1"]
+              "interruption_screen_question_ids": ["ecstat1", "age1"]
             },
             "lead_tenant_over_retirement_value_check": {
               "depends_on": [
@@ -2403,21 +2389,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_2",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_2",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -2444,7 +2416,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat2", "sex2", "age2"]
+              "interruption_screen_question_ids": ["ecstat2", "age2"]
             },
             "person_2_over_retirement_value_check": {
               "depends_on": [
@@ -2944,21 +2916,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_3",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_3",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -2985,7 +2943,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat3", "sex3", "age3"]
+              "interruption_screen_question_ids": ["ecstat3", "age3"]
             },
             "person_3_over_retirement_value_check": {
               "depends_on": [
@@ -3482,21 +3440,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_4",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_4",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -3523,7 +3467,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat4", "sex4", "age4"]
+              "interruption_screen_question_ids": ["ecstat4", "age4"]
             },
             "person_4_over_retirement_value_check": {
               "depends_on": [
@@ -4017,21 +3961,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_5",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_5",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -4058,7 +3988,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat5", "sex5", "age5"]
+              "interruption_screen_question_ids": ["ecstat5", "age5"]
             },
             "person_5_over_retirement_value_check": {
               "depends_on": [
@@ -4549,21 +4479,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_6",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_6",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -4590,7 +4506,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat6", "sex6", "age6"]
+              "interruption_screen_question_ids": ["ecstat6", "age6"]
             },
             "person_6_over_retirement_value_check": {
               "depends_on": [
@@ -5078,21 +4994,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_7",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_7",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -5119,7 +5021,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat7", "sex7", "age7"]
+              "interruption_screen_question_ids": ["ecstat7", "age7"]
             },
             "person_7_over_retirement_value_check": {
               "depends_on": [
@@ -5604,21 +5506,7 @@
                   }
                 ]
               },
-              "informative_text": {
-                "translation": "soft_validations.retirement.min.hint_text",
-                "arguments": [
-                  {
-                    "key": "plural_gender_for_person_8",
-                    "label": false,
-                    "i18n_template": "gender"
-                  },
-                  {
-                    "key": "retirement_age_for_person_8",
-                    "label": false,
-                    "i18n_template": "age"
-                  }
-                ]
-              },
+              "informative_text": {},
               "questions": {
                 "retirement_value_check": {
                   "check_answer_label": "Retirement confirmation",
@@ -5645,7 +5533,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["ecstat8", "sex8", "age8"]
+              "interruption_screen_question_ids": ["ecstat8", "age8"]
             },
             "person_8_over_retirement_value_check": {
               "depends_on": [

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -815,7 +815,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["voiddate", "startdate"]
+              "interruption_screen_question_ids": ["voiddate", "startdate"]
             },
             "property_major_repairs": {
               "header": "",
@@ -925,7 +925,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["mrcdate", "startdate"]
+              "interruption_screen_question_ids": ["mrcdate", "startdate"]
             }
           },
           "displayed_in_tasklist": [
@@ -1240,7 +1240,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check": {
               "depends_on": [
@@ -1284,7 +1284,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_age": {
               "header": "",
@@ -1384,7 +1384,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_age_value_check": {
               "depends_on": [
@@ -1428,7 +1428,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_gender_identity": {
               "header": "",
@@ -1507,7 +1507,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_value_check": {
               "depends_on": [
@@ -1551,7 +1551,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_ethnic_group": {
               "header": "",
@@ -1894,7 +1894,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat1", "sex1", "age1"]
+              "interruption_screen_question_ids": ["ecstat1", "sex1", "age1"]
             },
             "lead_tenant_over_retirement_value_check": {
               "depends_on": [
@@ -1953,7 +1953,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat1", "sex1", "age1"]
+              "interruption_screen_question_ids": ["ecstat1", "sex1", "age1"]
             },
             "person_2_known": {
               "header": "You’ve given us the details for 1 person in the household",
@@ -2134,7 +2134,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_2_age_value_check": {
               "depends_on": [
@@ -2179,7 +2179,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_2_gender_identity": {
               "header": "",
@@ -2259,7 +2259,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_2_value_check": {
               "depends_on": [
@@ -2304,7 +2304,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_2_working_situation": {
               "header": "",
@@ -2438,7 +2438,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat2", "sex2", "age2"]
+              "interruption_screen_question_ids": ["ecstat2", "sex2", "age2"]
             },
             "person_2_over_retirement_value_check": {
               "depends_on": [
@@ -2497,7 +2497,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat2", "sex2", "age2"]
+              "interruption_screen_question_ids": ["ecstat2", "sex2", "age2"]
             },
             "person_3_known": {
               "header": "You’ve given us the details for 2 people in the household",
@@ -2675,7 +2675,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_3_age_value_check": {
               "depends_on": [
@@ -2720,7 +2720,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_3_gender_identity": {
               "header": "",
@@ -2800,7 +2800,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_3_value_check": {
               "depends_on": [
@@ -2845,7 +2845,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_3_working_situation": {
               "header": "",
@@ -2979,7 +2979,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat3", "sex3", "age3"]
+              "interruption_screen_question_ids": ["ecstat3", "sex3", "age3"]
             },
             "person_3_over_retirement_value_check": {
               "depends_on": [
@@ -3038,7 +3038,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat3", "sex3", "age3"]
+              "interruption_screen_question_ids": ["ecstat3", "sex3", "age3"]
             },
             "person_4_known": {
               "header": "You’ve given us the details for 3 people in the household",
@@ -3213,7 +3213,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_4_age_value_check": {
               "depends_on": [
@@ -3258,7 +3258,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_4_gender_identity": {
               "header": "",
@@ -3338,7 +3338,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_4_value_check": {
               "depends_on": [
@@ -3383,7 +3383,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_4_working_situation": {
               "header": "",
@@ -3517,7 +3517,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat4", "sex4", "age4"]
+              "interruption_screen_question_ids": ["ecstat4", "sex4", "age4"]
             },
             "person_4_over_retirement_value_check": {
               "depends_on": [
@@ -3576,7 +3576,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat4", "sex4", "age4"]
+              "interruption_screen_question_ids": ["ecstat4", "sex4", "age4"]
             },
             "person_5_known": {
               "header": "You’ve given us the details for 4 people in the household",
@@ -3748,7 +3748,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_5_age_value_check": {
               "depends_on": [
@@ -3793,7 +3793,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_5_gender_identity": {
               "header": "",
@@ -3873,7 +3873,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_5_value_check": {
               "depends_on": [
@@ -3918,7 +3918,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_5_working_situation": {
               "header": "",
@@ -4052,7 +4052,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat5", "sex5", "age5"]
+              "interruption_screen_question_ids": ["ecstat5", "sex5", "age5"]
             },
             "person_5_over_retirement_value_check": {
               "depends_on": [
@@ -4111,7 +4111,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat5", "sex5", "age5"]
+              "interruption_screen_question_ids": ["ecstat5", "sex5", "age5"]
             },
             "person_6_known": {
               "header": "You’ve given us the details for 5 people in the household",
@@ -4280,7 +4280,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_6_age_value_check": {
               "depends_on": [
@@ -4325,7 +4325,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_6_gender_identity": {
               "header": "",
@@ -4405,7 +4405,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_6_value_check": {
               "depends_on": [
@@ -4450,7 +4450,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_6_working_situation": {
               "header": "",
@@ -4584,7 +4584,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat6", "sex6", "age6"]
+              "interruption_screen_question_ids": ["ecstat6", "sex6", "age6"]
             },
             "person_6_over_retirement_value_check": {
               "depends_on": [
@@ -4643,7 +4643,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat6", "sex6", "age6"]
+              "interruption_screen_question_ids": ["ecstat6", "sex6", "age6"]
             },
             "person_7_known": {
               "header": "You’ve given us the details for 6 people in the household",
@@ -4809,7 +4809,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_7_age_value_check": {
               "depends_on": [
@@ -4854,7 +4854,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_7_gender_identity": {
               "header": "",
@@ -4934,7 +4934,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_7_value_check": {
               "depends_on": [
@@ -4979,7 +4979,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_7_working_situation": {
               "header": "",
@@ -5113,7 +5113,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat7", "sex7", "age7"]
+              "interruption_screen_question_ids": ["ecstat7", "sex7", "age7"]
             },
             "person_7_over_retirement_value_check": {
               "depends_on": [
@@ -5172,7 +5172,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat7", "sex7", "age7"]
+              "interruption_screen_question_ids": ["ecstat7", "sex7", "age7"]
             },
             "person_8_known": {
               "header": "You’ve given us the details for 7 people in the household",
@@ -5335,7 +5335,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_8_age_value_check": {
               "depends_on": [
@@ -5380,7 +5380,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_8_gender_identity": {
               "header": "",
@@ -5460,7 +5460,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_8_value_check": {
               "depends_on": [
@@ -5505,7 +5505,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_8_working_situation": {
               "header": "",
@@ -5639,7 +5639,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat8", "sex8", "age8"]
+              "interruption_screen_question_ids": ["ecstat8", "sex8", "age8"]
             },
             "person_8_over_retirement_value_check": {
               "depends_on": [
@@ -5698,7 +5698,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat8", "sex8", "age8"]
+              "interruption_screen_question_ids": ["ecstat8", "sex8", "age8"]
             }
           }
         },
@@ -5881,7 +5881,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_value_check": {
               "depends_on": [
@@ -5934,7 +5934,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
+              "interruption_screen_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "access_needs_exist": {
               "header": "",
@@ -7447,7 +7447,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["incfreq", "earnings", "ecstat1"]
+              "interruption_screen_question_ids": ["incfreq", "earnings", "ecstat1"]
             },
             "housing_benefit": {
               "header": "",
@@ -7810,7 +7810,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["chcharge", "is_carehome"]
+              "interruption_screen_question_ids": ["chcharge", "is_carehome"]
             },
             "rent_weekly": {
               "header": "Household rent and charges",
@@ -8337,7 +8337,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
+              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "max_rent_value_check": {
               "depends_on": [
@@ -8382,7 +8382,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
+              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "outstanding": {
               "header": "",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -8324,8 +8324,8 @@
                       }
                     ]
                   },
-                  "header": "This rent is lower than expected for this property type, in this area. Check:",
-                  "hint_text": "<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul><p>Are you sure this is correct?</p>",
+                  "header": "Are you sure this is correct?",
+                  "hint_text": "This rent is lower than expected for this property type, in this area. Check:<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {
@@ -8369,8 +8369,8 @@
                       }
                     ]
                   },
-                  "header": "This rent is higher than expected for this property type, in this area. Check:",
-                  "hint_text": "<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul><p>Are you sure this is correct?</p>",
+                  "header": "Are you sure this is correct?",
+                  "hint_text": "This rent is higher than expected for this property type, in this area. Check:<ul><li>the decimal point is not missing (£X.XX)</li><li>the frequency is correct, for example weekly, monthly</li><li>the rent type is correct, for example affordable or social rent</li></ul>",
                   "type": "interruption_screen",
                   "answer_options": {
                     "0": {

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -814,7 +814,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["voiddate", "startdate"]
             },
             "property_major_repairs": {
               "header": "",
@@ -923,7 +924,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["mrcdate", "startdate"]
             }
           },
           "displayed_in_tasklist": [
@@ -1237,7 +1239,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_hhmemb_value_check": {
               "depends_on": [
@@ -1280,7 +1283,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_age": {
               "header": "",
@@ -1379,7 +1383,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_age_value_check": {
               "depends_on": [
@@ -1422,7 +1427,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_gender_identity": {
               "header": "",
@@ -1500,7 +1506,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_lead_value_check": {
               "depends_on": [
@@ -1543,7 +1550,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "lead_tenant_ethnic_group": {
               "header": "",
@@ -1885,7 +1893,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat1", "sex1", "age1"]
             },
             "lead_tenant_over_retirement_value_check": {
               "depends_on": [
@@ -1943,7 +1952,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat1", "sex1", "age1"]
             },
             "person_2_known": {
               "header": "You’ve given us the details for 1 person in the household",
@@ -2123,7 +2133,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_2_age_value_check": {
               "depends_on": [
@@ -2167,7 +2178,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_2_gender_identity": {
               "header": "",
@@ -2246,7 +2258,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_2_value_check": {
               "depends_on": [
@@ -2290,7 +2303,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_2_working_situation": {
               "header": "",
@@ -2423,7 +2437,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat2", "sex2", "age2"]
             },
             "person_2_over_retirement_value_check": {
               "depends_on": [
@@ -2481,7 +2496,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat2", "sex2", "age2"]
             },
             "person_3_known": {
               "header": "You’ve given us the details for 2 people in the household",
@@ -2658,7 +2674,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_3_age_value_check": {
               "depends_on": [
@@ -2702,7 +2719,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_3_gender_identity": {
               "header": "",
@@ -2781,7 +2799,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_3_value_check": {
               "depends_on": [
@@ -2825,7 +2844,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_3_working_situation": {
               "header": "",
@@ -2958,7 +2978,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat3", "sex3", "age3"]
             },
             "person_3_over_retirement_value_check": {
               "depends_on": [
@@ -3016,7 +3037,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat3", "sex3", "age3"]
             },
             "person_4_known": {
               "header": "You’ve given us the details for 3 people in the household",
@@ -3190,7 +3212,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_4_age_value_check": {
               "depends_on": [
@@ -3234,7 +3257,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_4_gender_identity": {
               "header": "",
@@ -3313,7 +3337,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_4_value_check": {
               "depends_on": [
@@ -3357,7 +3382,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_4_working_situation": {
               "header": "",
@@ -3490,7 +3516,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat4", "sex4", "age4"]
             },
             "person_4_over_retirement_value_check": {
               "depends_on": [
@@ -3548,7 +3575,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat4", "sex4", "age4"]
             },
             "person_5_known": {
               "header": "You’ve given us the details for 4 people in the household",
@@ -3719,7 +3747,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_5_age_value_check": {
               "depends_on": [
@@ -3763,7 +3792,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_5_gender_identity": {
               "header": "",
@@ -3842,7 +3872,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_5_value_check": {
               "depends_on": [
@@ -3886,7 +3917,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_5_working_situation": {
               "header": "",
@@ -4019,7 +4051,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat5", "sex5", "age5"]
             },
             "person_5_over_retirement_value_check": {
               "depends_on": [
@@ -4077,7 +4110,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat5", "sex5", "age5"]
             },
             "person_6_known": {
               "header": "You’ve given us the details for 5 people in the household",
@@ -4245,7 +4279,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_6_age_value_check": {
               "depends_on": [
@@ -4289,7 +4324,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_6_gender_identity": {
               "header": "",
@@ -4368,7 +4404,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_6_value_check": {
               "depends_on": [
@@ -4412,7 +4449,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_6_working_situation": {
               "header": "",
@@ -4545,7 +4583,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat6", "sex6", "age6"]
             },
             "person_6_over_retirement_value_check": {
               "depends_on": [
@@ -4603,7 +4642,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat6", "sex6", "age6"]
             },
             "person_7_known": {
               "header": "You’ve given us the details for 6 people in the household",
@@ -4768,7 +4808,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_7_age_value_check": {
               "depends_on": [
@@ -4812,7 +4853,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_7_gender_identity": {
               "header": "",
@@ -4891,7 +4933,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_7_value_check": {
               "depends_on": [
@@ -4935,7 +4978,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_7_working_situation": {
               "header": "",
@@ -5068,7 +5112,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat7", "sex7", "age7"]
             },
             "person_7_over_retirement_value_check": {
               "depends_on": [
@@ -5126,7 +5171,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat7", "sex7", "age7"]
             },
             "person_8_known": {
               "header": "You’ve given us the details for 7 people in the household",
@@ -5288,7 +5334,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_8_age_value_check": {
               "depends_on": [
@@ -5332,7 +5379,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_8_gender_identity": {
               "header": "",
@@ -5411,7 +5459,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_person_8_value_check": {
               "depends_on": [
@@ -5455,7 +5504,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "person_8_working_situation": {
               "header": "",
@@ -5588,7 +5638,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat8", "sex8", "age8"]
             },
             "person_8_over_retirement_value_check": {
               "depends_on": [
@@ -5646,7 +5697,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat8", "sex8", "age8"]
             }
           }
         },
@@ -5828,7 +5880,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8"]
             },
             "females_in_soft_age_range_in_pregnant_household_value_check": {
               "depends_on": [
@@ -5880,7 +5933,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["preg_occ", "sex1", "sex2", "sex3", "sex4", "sex5", "sex6", "sex7", "sex8", "age1", "age2", "age3", "age4", "age5", "age6", "age7", "age8"]
             },
             "access_needs_exist": {
               "header": "",
@@ -7392,7 +7446,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["incfreq", "earnings", "ecstat1"]
             },
             "housing_benefit": {
               "header": "",
@@ -7754,7 +7809,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["chcharge", "is_carehome"]
             },
             "rent_weekly": {
               "header": "Household rent and charges",
@@ -8280,7 +8336,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "max_rent_value_check": {
               "depends_on": [
@@ -8324,7 +8381,8 @@
                     }
                   }
                 }
-              }
+              },
+              "affected_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "outstanding": {
               "header": "",

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -789,7 +789,10 @@
               "title_text": {
                 "translation": "soft_validations.void_date.title_text"
               },
-              "informative_text": {},
+              "informative_text": {
+                "translation": "soft_validations.void_date.hint_text",
+                "arguments": []
+              },
               "questions": {
                 "void_date_value_check": {
                   "check_answer_label": "Void date confirmation",
@@ -899,7 +902,10 @@
               "title_text": {
                 "translation": "soft_validations.major_repairs_date.title_text"
               },
-              "informative_text": {},
+              "informative_text": {
+                "translation": "soft_validations.major_repairs_date.hint_text",
+                "arguments": []
+              },
               "questions": {
                 "major_repairs_date_value_check": {
                   "check_answer_label": "Major repairs date confirmation",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,9 +566,11 @@ en:
     care_home_charges:
       title_text: "Care home charges should be provided if this is a care home accommodation"
     buyer1_livein_wrong_for_ownership_type:
-      title_text: "You told us that buyer 1 will not live in the property. For %{ownership_scheme} types, the buyer usually lives in the property."
+      title_text: "You told us that buyer 1 will not live in the property."
+      hint_text: " For %{ownership_scheme} types, the buyer usually lives in the property."
     buyer2_livein_wrong_for_ownership_type:
-      title_text: "You told us that buyer 2 will not live in the property. For %{ownership_scheme} types, the buyer usually lives in the property."
+      title_text: "You told us that buyer 2 will not live in the property."
+      hint_text: " For %{ownership_scheme} types, the buyer usually lives in the property."
     percentage_discount_value:
       title_text: "You told us that the percentage discount was %{discount}. This seems high for this type of property."
     savings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,7 +537,7 @@ en:
       hint_text: "This is %{higher_or_lower} than we would expect"
     retirement:
       min:
-        title: "You told us this person is under %{age} and retired"
+        title: "You told us this person is aged %{age} years and retired."
         hint_text: "The minimum expected retirement age for %{gender} in England is %{age}."
       max:
         title: "You told us this person is %{age} or over and not retired"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -578,7 +578,8 @@ en:
     percentage_discount_value:
       title_text: "You told us that the percentage discount was %{discount}. This seems high for this type of property."
     savings:
-      title_text: "Are you sure the savings are higher than £100,000?"
+      title_text: "You told us the buyer’s savings were %{savings}."
+      hint_text: "This is higher than we would expect."
     deposit:
       title_text: "Are you sure that the deposit is this much higher than the buyer's savings?"
     grant:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,7 +586,8 @@ en:
       title_text: "You told us the buyer’s savings were %{savings}."
       hint_text: "This is higher than we would expect."
     deposit:
-      title_text: "Are you sure that the deposit is this much higher than the buyer's savings?"
+      title_text: "You told us the buyer’s deposit was %{deposit} and their savings were %{savings}."
+      hint_text: "The deposit amount is higher than we would expect for the amount of savings they have."
     grant:
       title_text: "You told us that the grant amount is %{grant}"
       hint_text: "Loans, grants and subsidies are usually between £9,000 and £16,000."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,7 +525,9 @@ en:
       in_soft_max_range:
         message: "Net income is higher than expected based on the lead tenant’s working situation. Are you sure this is correct?"
     income:
-      under_soft_min_for_economic_status: "You said income was %{income}, which is below this working situation's minimum (%{minimum})"
+      under_soft_min_for_economic_status: 
+        title_text: "You told us income was %{income}."
+        hint_text: "This is less than we would expect for someone in this working situation."
     rent:
       outside_range_title: "You told us the rent is %{brent}"
       min_hint_text: "The minimum rent expected for this type of property in this local authority is %{soft_min_for_period}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,7 +580,8 @@ en:
       title_text: "You told us that buyer 2 will not live in the property."
       hint_text: " For %{ownership_scheme} types, the buyer usually lives in the property."
     percentage_discount_value:
-      title_text: "You told us that the percentage discount was %{discount}. This seems high for this type of property."
+      title_text: "You told us that the percentage discount is %{discount}."
+      hint_text: "This is higher than we would expect."
     savings:
       title_text: "You told us the buyer’s savings were %{savings}."
       hint_text: "This is higher than we would expect."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,7 +555,9 @@ en:
     shared_ownership_deposit:
       title_text: "Mortgage, deposit and cash discount total should equal %{expected_shared_ownership_deposit_value}"
     old_persons_shared_ownership: "At least one buyer should be aged over 64 for Older persons’ shared ownership scheme"
-    staircase_bought_seems_high: "You said %{percentage}% was bought in this staircasing transaction, which seems high. Are you sure?"
+    staircase_bought_seems_high: 
+      title_text: "You told us that %{percentage}% was bought in this staircasing transaction."
+      hint_text: "Most staircasing transactions are less than 50%"
     monthly_charges_over_soft_max:
       title_text: "The amount of monthly charges is high for this type of property and sale type"
     student_not_child:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,7 +590,8 @@ en:
     wheelchair:
       title_text: "You told us that someone in the household uses a wheelchair."
     mortgage:
-      title_text: "Are you sure that the mortgage is more than 5 times the income used for the mortgage application?"
+      title_text: "You told us that the mortgage amount is %{mortgage}"
+      hint_text: "This is more than 5 times the income, which is higher than we would expect."
 
   devise:
     two_factor_authentication:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -556,7 +556,7 @@ en:
       title_text: "You told us that the property has been vacant for more than 2 years."
       hint_text: "This is higher than we would expect."
     shared_ownership_deposit:
-      title_text: "Mortgage, deposit and cash discount total should equal %{expected_shared_ownership_deposit_value}"
+      title_text: "You told us that the mortgage, deposit and discount add up to %{mortgage_deposit_and_discount_total}"
     old_persons_shared_ownership: 
       title_text: "You told us the buyer is using the Older Persons Shared Ownership scheme."
       hint_text: "At least one buyer must be aged 65 years and over to use this scheme."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,8 +518,8 @@ en:
 
   soft_validations:
     net_income:
-      title_text: "Net income is outside the expected range based on the lead tenant’s working situation"
-      hint_text: "<p>You told us the lead tenant’s working situation is: <strong>%{ecstat1}</strong>.</p><p>The household income you have entered is <strong>%{earnings}</strong>.</p>"
+      title_text: "You told us the lead tenant’s income is %{earnings} %{incfreq}."
+      hint_text: "This is %{net_income_higher_or_lower_text} than we would expect for their working situation."
       in_soft_min_range:
         message: "Net income is lower than expected based on the lead tenant’s working situation. Are you sure this is correct?"
       in_soft_max_range:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -562,7 +562,8 @@ en:
       title_text: "You told us that %{percentage}% was bought in this staircasing transaction."
       hint_text: "Most staircasing transactions are less than 50%"
     monthly_charges_over_soft_max:
-      title_text: "The amount of monthly charges is high for this type of property and sale type"
+      title_text: "You told us that the monthly charges were %{mscharge}."
+      hint_text: "This is higher than we would expect."
     student_not_child:
       title_text: "You told us this person is a student aged beween 16 and 19"
     discounted_sale_value:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -532,7 +532,7 @@ en:
       max_hint_text: "The maximum rent expected for this type of property in this local authority is %{soft_max_for_period}."
     purchase_price:
       title_text: "You told us the purchase price is %{value}"
-      hint_text: "The %{min_or_max} purchase price expected for this type of property in this local authority is %{soft_min_or_soft_max}"
+      hint_text: "This is %{higher_or_lower} than we would expect"
     retirement:
       min:
         title: "You told us this person is under %{age} and retired"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -587,7 +587,7 @@ en:
       title_text: "You told us that the grant amount is %{grant}"
       hint_text: "Loans, grants and subsidies are usually between £9,000 and £16,000."
     wheelchair:
-      title_text: "Are you sure? You said previously that somebody in household uses a wheelchair"
+      title_text: "You told us that someone in the household uses a wheelchair."
     mortgage:
       title_text: "Are you sure that the mortgage is more than 5 times the income used for the mortgage application?"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -569,6 +569,16 @@ en:
       title_text: "You told us that buyer 2 will not live in the property. For %{ownership_scheme} types, the buyer usually lives in the property."
     percentage_discount_value:
       title_text: "You told us that the percentage discount was %{discount}. This seems high for this type of property."
+    savings:
+      title_text: "Are you sure the savings are higher than £100,000?"
+    deposit:
+      title_text: "Are you sure that the deposit is this much higher than the buyer's savings?"
+    grant:
+      title_text: "Are you sure? Grants are usually £9,000 - £16,000"
+    wheelchair:
+      title_text: "Are you sure? You said previously that somebody in household uses a wheelchair"
+    mortgage:
+      title_text: "Are you sure that the mortgage is more than 5 times the income used for the mortgage application?"
 
   devise:
     two_factor_authentication:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -557,7 +557,9 @@ en:
       hint_text: "This is higher than we would expect."
     shared_ownership_deposit:
       title_text: "Mortgage, deposit and cash discount total should equal %{expected_shared_ownership_deposit_value}"
-    old_persons_shared_ownership: "At least one buyer should be aged over 64 for Older persons’ shared ownership scheme"
+    old_persons_shared_ownership: 
+      title_text: "You told us the buyer is using the Older Persons Shared Ownership scheme."
+      hint_text: "At least one buyer must be aged 65 years and over to use this scheme."
     staircase_bought_seems_high: 
       title_text: "You told us that %{percentage}% was bought in this staircasing transaction."
       hint_text: "Most staircasing transactions are less than 50%"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,7 +543,8 @@ en:
         title: "You told us this person is %{age} or over and not retired"
         hint_text: "The minimum expected retirement age for %{gender} in England is %{age}."
     extra_borrowing:
-      title: "The mortgage and deposit are higher than the purchase minus the discount"
+      title_text: "You told us that the mortgage and deposit total is %{mortgage_and_deposit_total}"
+      hint_text: "This is higher than the purchase price minus the discount."
     pregnancy:
       title: "You told us somebody in the household is pregnant"
       no_females: "You also told us there are no female tenants living at the property."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -584,7 +584,8 @@ en:
     deposit:
       title_text: "Are you sure that the deposit is this much higher than the buyer's savings?"
     grant:
-      title_text: "Are you sure? Grants are usually £9,000 - £16,000"
+      title_text: "You told us that the grant amount is %{grant}"
+      hint_text: "Loans, grants and subsidies are usually between £9,000 and £16,000."
     wheelchair:
       title_text: "Are you sure? You said previously that somebody in household uses a wheelchair"
     mortgage:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,9 +547,11 @@ en:
       no_females: "You also told us there are no female tenants living at the property."
       females_not_in_soft_age_range: "You also told us that any female tenants living at the property are in the following age ranges:<ul><li>under 16 years old</li><li>over 50 years old</li></ul>"
     major_repairs_date:
-      title_text: "You told us the time between the start of the tenancy and the major repairs completion date is more than 2 years"
+      title_text: "You told us the property has been vacant for 2 years."
+      hint_text: "This is higher than we would expect."
     void_date:
-      title_text: "You told us the time between the start of the tenancy and the void date is more than 2 years"
+      title_text: "You told us that the property has been vacant for more than 2 years."
+      hint_text: "This is higher than we would expect."
     shared_ownership_deposit:
       title_text: "Mortgage, deposit and cash discount total should equal %{expected_shared_ownership_deposit_value}"
     old_persons_shared_ownership: "At least one buyer should be aged over 64 for Older persons’ shared ownership scheme"

--- a/spec/components/check_answers_summary_list_card_component_spec.rb
+++ b/spec/components/check_answers_summary_list_card_component_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe CheckAnswersSummaryListCardComponent, type: :component do
       let(:subsection) { log.form.get_subsection(subsection_id) }
       let(:questions) { subsection.applicable_questions(log) }
 
+      around do |example|
+        Timecop.freeze(Time.zone.local(2023, 5, 1))
+        Singleton.__init__(FormHandler)
+        example.run
+        Timecop.return
+        Singleton.__init__(FormHandler)
+      end
+
       it "renders a summary list card including question numbers for the answers to those questions" do
         expect(rendered).to have_content(questions.first.answer_label(log))
         expect(rendered).to have_content("Q32 - Lead tenant’s age")

--- a/spec/components/check_answers_summary_list_card_component_spec.rb
+++ b/spec/components/check_answers_summary_list_card_component_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe CheckAnswersSummaryListCardComponent, type: :component do
 
   context "when in 23/24 collection" do
     context "when given a set of questions" do
-      let(:user) { build(:user) }
-      let(:log) { build(:lettings_log, :completed, age2: 99, startdate: Time.zone.local(2023, 5, 1)) }
+      let(:user) { create(:user) }
+      let(:log) { create(:lettings_log, :completed, age2: 99, startdate: Time.zone.local(2023, 5, 1)) }
       let(:subsection_id) { "household_characteristics" }
       let(:subsection) { log.form.get_subsection(subsection_id) }
       let(:questions) { subsection.applicable_questions(log) }
 
-      it "renders a summary list card includinq question numbers for the answers to those questions" do
+      it "renders a summary list card including question numbers for the answers to those questions" do
         expect(rendered).to have_content(questions.first.answer_label(log))
         expect(rendered).to have_content("Q32 - Lead tenant’s age")
       end

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -150,17 +150,17 @@ RSpec.describe "validations" do
         expect(page).to have_content("Net income is outside the expected range based on the lead tenant’s working situation")
         expect(page).to have_content("You told us the lead tenant’s working situation is: full-time – 30 hours or more")
         expect(page).to have_content("The household income you have entered is £750.00 every week")
-        click_button("Save and continue")
+        click_button("Confirm and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion")
       end
 
       it "allows to fix the questions that trigger the soft validation" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check").twice
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen").twice
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=interruption_screen")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check", match: :first)
-        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen", match: :first)
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen")
         fill_in("lettings-log-earnings-field", with: income_under_soft_limit)
         choose("lettings-log-incfreq-1-field", allow_label_click: true)
         click_button("Save and continue")
@@ -171,11 +171,11 @@ RSpec.describe "validations" do
 
       it "allows to fix the questions from different sections" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check").twice
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen").twice
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=interruption_screen")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
-        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=interruption_screen")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=interruption_screen")
         choose("lettings-log-ecstat1-10-field", allow_label_click: true)
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -147,9 +147,8 @@ RSpec.describe "validations" do
 
       it "prompts the user to confirm the value is correct with an interruption screen" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        expect(page).to have_content("Net income is outside the expected range based on the lead tenant’s working situation")
-        expect(page).to have_content("You told us the lead tenant’s working situation is: full-time – 30 hours or more")
-        expect(page).to have_content("The household income you have entered is £750.00 every week")
+        expect(page).to have_content("You told us the lead tenant’s income is £750.00 weekly.")
+        expect(page).to have_content("This is higher than we would expect for their working situation.")
         click_button("Confirm and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion")
       end
@@ -165,7 +164,7 @@ RSpec.describe "validations" do
         choose("lettings-log-incfreq-1-field", allow_label_click: true)
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        expect(page).not_to have_content("Net income is outside the expected range based on the lead tenant’s working situation")
+        expect(page).not_to have_content("You told us the lead tenant’s income is £750.00 weekly.")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       end
 

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -138,28 +138,33 @@ RSpec.describe "validations" do
       let(:income_over_soft_limit) { 750 }
       let(:income_under_soft_limit) { 700 }
 
-      it "prompts the user to confirm the value is correct with an interruption screen" do
+      before do
         visit("/lettings-logs/#{lettings_log.id}/net-income")
         fill_in("lettings-log-earnings-field", with: income_over_soft_limit)
         choose("lettings-log-incfreq-1-field", allow_label_click: true)
         click_button("Save and continue")
+      end
+
+      it "prompts the user to confirm the value is correct with an interruption screen" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
         expect(page).to have_content("Net income is outside the expected range based on the lead tenant’s working situation")
         expect(page).to have_content("You told us the lead tenant’s working situation is: full-time – 30 hours or more")
         expect(page).to have_content("The household income you have entered is £750.00 every week")
-        choose("lettings-log-net-income-value-check-0-field", allow_label_click: true)
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion")
       end
 
-      it "returns the user to the previous question if they do not confirm the value as correct on the interruption screen" do
-        visit("/lettings-logs/#{lettings_log.id}/net-income")
-        fill_in("lettings-log-earnings-field", with: income_over_soft_limit)
+      it "allows to fix the questions that trigger the soft validation" do
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income").twice
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income", match: :first)
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income")
+        fill_in("lettings-log-earnings-field", with: income_under_soft_limit)
         choose("lettings-log-incfreq-1-field", allow_label_click: true)
         click_button("Save and continue")
-        choose("lettings-log-net-income-value-check-1-field", allow_label_click: true)
-        click_button("Save and continue")
-        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion") # will need change to the interruption screen
       end
     end
   end

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -156,15 +156,30 @@ RSpec.describe "validations" do
 
       it "allows to fix the questions that trigger the soft validation" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income").twice
-        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation")
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check").twice
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
-        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income", match: :first)
-        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check", match: :first)
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check")
         fill_in("lettings-log-earnings-field", with: income_under_soft_limit)
         choose("lettings-log-incfreq-1-field", allow_label_click: true)
         click_button("Save and continue")
-        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion") # will need change to the interruption screen
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        expect(page).not_to have_content("Net income is outside the expected range based on the lead tenant’s working situation")
+        expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+      end
+
+      it "allows to fix the questions from different sections" do
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=net_income_value_check").twice
+        expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/person-1-working-situation?referrer=net_income_value_check")
+        choose("lettings-log-ecstat1-10-field", allow_label_click: true)
+        click_button("Save and continue")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
+        expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       end
     end
   end

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -180,6 +180,21 @@ RSpec.describe "validations" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       end
+
+      it "returns the user back to the check_your_answers after fixing a validation from check_your_anwers" do
+        lettings_log.update!(earnings: income_over_soft_limit, incfreq: 1)
+        visit("/lettings-logs/#{lettings_log.id}/income-and-benefits/check-answers")
+        click_link("Answer", href: "/lettings-logs/#{lettings_log.id}/net-income-value-check?referrer=check_answers")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check?referrer=check_answers")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen", match: :first)
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income?referrer=interruption_screen")
+        fill_in("lettings-log-earnings-field", with: income_under_soft_limit)
+        choose("lettings-log-incfreq-1-field", allow_label_click: true)
+        click_button("Save and continue")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check?referrer=check_answers")
+        click_button("Confirm and continue")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/income-and-benefits/check-answers")
+      end
     end
   end
 

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -770,10 +770,10 @@
                     "1": {
                       "value": "No"
                     }
-                  },
-                  "affected_question_ids": ["ecstat1", "incfreq", "earnings"]
+                  }
                 }
-              }
+              },
+              "affected_question_ids": ["ecstat1", "incfreq", "earnings"]
             },
             "net_income_uc_proportion": {
               "questions": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -741,20 +741,27 @@
                 }
               ],
               "title_text": {
-                "translation": "soft_validations.net_income.title_text"
+                "translation": "soft_validations.net_income.title_text",
+                "arguments": [
+                  {
+                    "key": "incfreq",
+                    "label": true,
+                    "i18n_template": "incfreq"
+                  },
+                  {
+                    "key": "field_formatted_as_currency",
+                    "arguments_for_key": "earnings",
+                    "i18n_template": "earnings"
+                  }
+                ]
               },
               "informative_text": {
                 "translation": "soft_validations.net_income.hint_text",
                 "arguments": [
                   {
-                    "key": "ecstat1",
-                    "label": true,
-                    "i18n_template": "ecstat1"
-                  },
-                  {
-                    "key": "earnings",
-                    "label": true,
-                    "i18n_template": "earnings"
+                    "key": "net_income_higher_or_lower_text",
+                    "label": false,
+                    "i18n_template": "net_income_higher_or_lower_text"
                   }
                 ]
               },

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -768,7 +768,16 @@
               "questions": {
                 "net_income_value_check": {
                   "check_answer_label": "Net income soft validation",
-                  "hidden_in_check_answers": true,
+                  "hidden_in_check_answers": {
+                    "depends_on": [
+                    {
+                      "net_income_value_check": 0
+                    },
+                    {
+                      "net_income_value_check": 1
+                    }
+                  ]
+                  },
                   "header": "Are you sure this is correct?",
                   "type": "interruption_screen",
                   "answer_options": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -227,7 +227,7 @@
                   }
                 }
               ],
-              "affected_question_ids": ["age1", "ecstat1"]
+              "interruption_screen_question_ids": ["age1", "ecstat1"]
             },
             "person_2_working_situation": {
               "header": "",
@@ -774,7 +774,7 @@
                   }
                 }
               },
-              "affected_question_ids": ["ecstat1", "incfreq", "earnings"]
+              "interruption_screen_question_ids": ["ecstat1", "incfreq", "earnings"]
             },
             "net_income_uc_proportion": {
               "questions": {

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -770,7 +770,8 @@
                     "1": {
                       "value": "No"
                     }
-                  }
+                  },
+                  "affected_question_ids": ["ecstat1", "incfreq", "earnings"]
                 }
               }
             },

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -226,7 +226,8 @@
                     "operand": 50
                   }
                 }
-              ]
+              ],
+              "affected_question_ids": ["age1", "ecstat1"]
             },
             "person_2_working_situation": {
               "header": "",

--- a/spec/helpers/form_page_helper_spec.rb
+++ b/spec/helpers/form_page_helper_spec.rb
@@ -3,13 +3,26 @@ require "rails_helper"
 RSpec.describe FormPageHelper do
   describe "#action_href" do
     let(:lettings_log) { FactoryBot.create(:lettings_log) }
+    let(:sales_log) { FactoryBot.create(:sales_log) }
 
-    it "has an update answer link href helper" do
-      expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/#{lettings_log.id}/net-income?referrer=check_answers")
+    context "with a lettings log" do
+      it "has an update answer link href helper" do
+        expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/#{lettings_log.id}/net-income?referrer=check_answers")
+      end
+
+      it "returns a correct referrer in the url" do
+        expect(action_href(lettings_log, "retirement_value_check", "interruption_screen")).to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
+      end
     end
 
-    it "returns a correct referrer in the url" do
-      expect(action_href(lettings_log, "retirement_value_check", "interruption_screen")).to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
+    context "with a sales log" do
+      it "has an update answer link href helper" do
+        expect(action_href(sales_log, "buyer_1_age")).to eq("/sales-logs/#{sales_log.id}/buyer-1-age?referrer=check_answers")
+      end
+
+      it "returns a correct referrer in the url" do
+        expect(action_href(sales_log, "grant_value_check", "interruption_screen")).to eq("/sales-logs/#{sales_log.id}/grant-value-check?referrer=interruption_screen")
+      end
     end
   end
 end

--- a/spec/helpers/form_page_helper_spec.rb
+++ b/spec/helpers/form_page_helper_spec.rb
@@ -8,5 +8,9 @@ RSpec.describe FormPageHelper do
       lettings_log.id = 1
       expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/1/net-income?referrer=check_answers")
     end
+
+    it "returns a correct referrer in the url" do
+      expect(action_href(lettings_log, "retirement_value_check"), referrer: "interruption_screen").to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
+    end
   end
 end

--- a/spec/helpers/form_page_helper_spec.rb
+++ b/spec/helpers/form_page_helper_spec.rb
@@ -2,15 +2,14 @@ require "rails_helper"
 
 RSpec.describe FormPageHelper do
   describe "#action_href" do
-    let(:lettings_log) { FactoryBot.build(:lettings_log) }
+    let(:lettings_log) { FactoryBot.create(:lettings_log) }
 
     it "has an update answer link href helper" do
-      lettings_log.id = 1
-      expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/1/net-income?referrer=check_answers")
+      expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/#{lettings_log.id}/net-income?referrer=check_answers")
     end
 
     it "returns a correct referrer in the url" do
-      expect(action_href(lettings_log, "retirement_value_check"), referrer: "interruption_screen").to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
+      expect(action_href(lettings_log, "retirement_value_check", "interruption_screen")).to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
     end
   end
 end

--- a/spec/helpers/form_page_helper_spec.rb
+++ b/spec/helpers/form_page_helper_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe FormPageHelper do
+  describe "#action_href" do
+    let(:lettings_log) { FactoryBot.build(:lettings_log) }
+
+    it "has an update answer link href helper" do
+      lettings_log.id = 1
+      expect(action_href(lettings_log, "net_income")).to eq("/lettings-logs/1/net-income?referrer=check_answers")
+    end
+  end
+end

--- a/spec/helpers/interruption_screen_helper_spec.rb
+++ b/spec/helpers/interruption_screen_helper_spec.rb
@@ -241,4 +241,19 @@ RSpec.describe InterruptionScreenHelper do
       end
     end
   end
+
+  describe "soft_validation_affected_questions" do
+    let(:question) { lettings_log.form.get_question("retirement_value_check", lettings_log) }
+
+    it "returns a list of questions affected by the soft validation" do
+      expect(soft_validation_affected_questions(question, lettings_log).count).to eq(2)
+      expect(soft_validation_affected_questions(question, lettings_log).map(&:id)).to eq(%w[age1 ecstat1])
+    end
+  end
+
+  describe "interruption_action_href" do
+    it "returns a path to given question with interruption screen referrer" do
+      expect(interruption_action_href(lettings_log, "retirement_value_check")).to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
+    end
+  end
 end

--- a/spec/helpers/interruption_screen_helper_spec.rb
+++ b/spec/helpers/interruption_screen_helper_spec.rb
@@ -34,14 +34,9 @@ RSpec.describe InterruptionScreenHelper do
           "translation" => "soft_validations.net_income.hint_text",
           "arguments" => [
             {
-              "key" => "ecstat1",
-              "label" => true,
-              "i18n_template" => "ecstat1",
-            },
-            {
-              "key" => "earnings",
-              "label" => true,
-              "i18n_template" => "earnings",
+              "key" => "net_income_higher_or_lower_text",
+              "label" => false,
+              "i18n_template" => "net_income_higher_or_lower_text",
             },
           ],
         }
@@ -49,8 +44,7 @@ RSpec.describe InterruptionScreenHelper do
           .to eq(
             I18n.t(
               "soft_validations.net_income.hint_text",
-              ecstat1: lettings_log.form.get_question("ecstat1", lettings_log).answer_label(lettings_log).downcase,
-              earnings: lettings_log.form.get_question("earnings", lettings_log).answer_label(lettings_log),
+              net_income_higher_or_lower_text: "higher",
             ),
           )
       end

--- a/spec/helpers/interruption_screen_helper_spec.rb
+++ b/spec/helpers/interruption_screen_helper_spec.rb
@@ -250,10 +250,4 @@ RSpec.describe InterruptionScreenHelper do
       expect(soft_validation_affected_questions(question, lettings_log).map(&:id)).to eq(%w[age1 ecstat1])
     end
   end
-
-  describe "interruption_action_href" do
-    it "returns a path to given question with interruption screen referrer" do
-      expect(interruption_action_href(lettings_log, "retirement_value_check")).to eq("/lettings-logs/#{lettings_log.id}/retirement-value-check?referrer=interruption_screen")
-    end
-  end
 end

--- a/spec/models/form/lettings/pages/care_home_charges_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/care_home_charges_value_check_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Form::Lettings::Pages::CareHomeChargesValueCheck, type: :model do
   it "has the correct informative_text" do
     expect(page.informative_text).to eq("")
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[chcharge is_carehome])
+  end
 end

--- a/spec/models/form/lettings/pages/care_home_charges_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/care_home_charges_value_check_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Lettings::Pages::CareHomeChargesValueCheck, type: :model do
     expect(page.informative_text).to eq("")
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[chcharge is_carehome])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[chcharge is_carehome])
   end
 end

--- a/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Lettings::Pages::MaxRentValueCheck, type: :model do
   it "has the correct informative_text" do
     expect(page.informative_text).to eq({ "arguments" => [{ "arguments_for_key" => "soft_max_for_period", "i18n_template" => "soft_max_for_period", "key" => "field_formatted_as_currency" }], "translation" => "soft_validations.rent.max_hint_text" })
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
+  end
 end

--- a/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Lettings::Pages::MaxRentValueCheck, type: :model do
     expect(page.informative_text).to eq({ "arguments" => [{ "arguments_for_key" => "soft_max_for_period", "i18n_template" => "soft_max_for_period", "key" => "field_formatted_as_currency" }], "translation" => "soft_validations.rent.max_hint_text" })
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
   end
 end

--- a/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Form::Lettings::Pages::MinRentValueCheck, type: :model do
     })
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
   end
 end

--- a/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Form::Lettings::Pages::MinRentValueCheck, type: :model do
       ],
     })
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[brent startdate la beds rent_type needstype])
+  end
 end

--- a/spec/models/form/lettings/pages/net_income_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/net_income_value_check_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Form::Lettings::Pages::NetIncomeValueCheck, type: :model do
 
   it "has the correct informative_text" do
     expect(page.informative_text).to eq({
-      "arguments" => [{ "arguments_for_key" => "ecstat1", "i18n_template" => "ecstat1", "key" => "field_formatted_as_currency" }, { "arguments_for_key" => "earnings", "i18n_template" => "earnings", "key" => "field_formatted_as_currency" }],
+      "arguments" => [{ "label" => true, "i18n_template" => "ecstat1", "key" => "ecstat1" }, { "arguments_for_key" => "earnings", "i18n_template" => "earnings", "key" => "field_formatted_as_currency" }],
       "translation" => "soft_validations.net_income.hint_text",
     })
   end

--- a/spec/models/form/lettings/pages/net_income_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/net_income_value_check_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe Form::Lettings::Pages::NetIncomeValueCheck, type: :model do
   end
 
   it "has the correct title_text" do
-    expect(page.title_text).to eq({ "translation" => "soft_validations.net_income.title_text" })
+    expect(page.title_text).to eq({ "translation" => "soft_validations.net_income.title_text", "arguments" => [{ "i18n_template" => "incfreq", "key" => "incfreq", "label" => true }, { "arguments_for_key" => "earnings", "i18n_template" => "earnings", "key" => "field_formatted_as_currency" }] })
   end
 
   it "has the correct informative_text" do
     expect(page.informative_text).to eq({
-      "arguments" => [{ "label" => true, "i18n_template" => "ecstat1", "key" => "ecstat1" }, { "arguments_for_key" => "earnings", "i18n_template" => "earnings", "key" => "field_formatted_as_currency" }],
+      "arguments" => [{ "i18n_template" => "net_income_higher_or_lower_text", "key" => "net_income_higher_or_lower_text", "label" => false }],
       "translation" => "soft_validations.net_income.hint_text",
     })
   end

--- a/spec/models/form/lettings/pages/person_under_retirement_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/person_under_retirement_value_check_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Form::Lettings::Pages::PersonUnderRetirementValueCheck, type: :mo
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_2",
-            "label" => false,
+            "key" => "age2",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -48,21 +48,7 @@ RSpec.describe Form::Lettings::Pages::PersonUnderRetirementValueCheck, type: :mo
     end
 
     it "has the correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_2",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_2",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
   end
 
@@ -84,8 +70,8 @@ RSpec.describe Form::Lettings::Pages::PersonUnderRetirementValueCheck, type: :mo
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_3",
-            "label" => false,
+            "key" => "age3",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -93,21 +79,7 @@ RSpec.describe Form::Lettings::Pages::PersonUnderRetirementValueCheck, type: :mo
     end
 
     it "has the correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_3",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_3",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
   end
 end

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Form::Question, type: :model do
 
     it "has an update answer link href helper" do
       lettings_log.id = 1
-      expect(question.action_href(lettings_log, page.id)).to eq("/lettings-logs/1/net-income?referrer=check_answers")
+      expect(action_href(lettings_log, page.id)).to eq("/lettings-logs/1/net-income?referrer=check_answers")
     end
 
     context "when the question has an inferred answer" do

--- a/spec/models/form/question_spec.rb
+++ b/spec/models/form/question_spec.rb
@@ -257,11 +257,6 @@ RSpec.describe Form::Question, type: :model do
       expect(question.action_text(lettings_log)).to match(/Change/)
     end
 
-    it "has an update answer link href helper" do
-      lettings_log.id = 1
-      expect(action_href(lettings_log, page.id)).to eq("/lettings-logs/1/net-income?referrer=check_answers")
-    end
-
     context "when the question has an inferred answer" do
       let(:section_id) { "tenancy_and_property" }
       let(:subsection_id) { "property_information" }

--- a/spec/models/form/sales/pages/about_price_value_check_spec.rb
+++ b/spec/models/form/sales/pages/about_price_value_check_spec.rb
@@ -51,4 +51,8 @@ RSpec.describe Form::Sales::Pages::AboutPriceValueCheck, type: :model do
       ],
     })
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[value beds la])
+  end
 end

--- a/spec/models/form/sales/pages/about_price_value_check_spec.rb
+++ b/spec/models/form/sales/pages/about_price_value_check_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Form::Sales::Pages::AboutPriceValueCheck, type: :model do
     })
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[value beds la])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[value beds la])
   end
 end

--- a/spec/models/form/sales/pages/about_price_value_check_spec.rb
+++ b/spec/models/form/sales/pages/about_price_value_check_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Form::Sales::Pages::AboutPriceValueCheck, type: :model do
           "i18n_template" => "soft_min_or_soft_max",
         },
         {
-          "key" => "purchase_price_min_or_max_text",
-          "i18n_template" => "min_or_max",
+          "key" => "purchase_price_higher_or_lower_text",
+          "i18n_template" => "higher_or_lower",
         },
       ],
     })

--- a/spec/models/form/sales/pages/buyer1_income_value_check_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_income_value_check_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Sales::Pages::Buyer1IncomeValueCheck, type: :model do
     expect(page.interruption_screen?).to eq(true)
   end
 
-  it "is has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[ecstat1 income1])
+  it "is has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[ecstat1 income1])
   end
 end

--- a/spec/models/form/sales/pages/buyer1_income_value_check_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_income_value_check_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Sales::Pages::Buyer1IncomeValueCheck, type: :model do
   it "is interruption screen page" do
     expect(page.interruption_screen?).to eq(true)
   end
+
+  it "is has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[ecstat1 income1])
+  end
 end

--- a/spec/models/form/sales/pages/buyer_live_in_value_check_spec.rb
+++ b/spec/models/form/sales/pages/buyer_live_in_value_check_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Form::Sales::Pages::BuyerLiveInValueCheck, type: :model do
     })
   end
 
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[ownershipsch buy1livein])
+  end
+
   context "with buyer 2" do
     let(:person_index) { 2 }
 
@@ -59,6 +63,10 @@ RSpec.describe Form::Sales::Pages::BuyerLiveInValueCheck, type: :model do
         "translation" => "soft_validations.buyer2_livein_wrong_for_ownership_type.title_text",
         "arguments" => [{ "key" => "ownership_scheme", "label" => false, "i18n_template" => "ownership_scheme" }],
       })
+    end
+
+    it "has the correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[ownershipsch buy2livein])
     end
   end
 end

--- a/spec/models/form/sales/pages/buyer_live_in_value_check_spec.rb
+++ b/spec/models/form/sales/pages/buyer_live_in_value_check_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Form::Sales::Pages::BuyerLiveInValueCheck, type: :model do
     })
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[ownershipsch buy1livein])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[ownershipsch buy1livein])
   end
 
   context "with buyer 2" do
@@ -65,8 +65,8 @@ RSpec.describe Form::Sales::Pages::BuyerLiveInValueCheck, type: :model do
       })
     end
 
-    it "has the correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[ownershipsch buy2livein])
+    it "has the correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[ownershipsch buy2livein])
     end
   end
 end

--- a/spec/models/form/sales/pages/deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/deposit_value_check_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Sales::Pages::DepositValueCheck, type: :model do
     expect(page.interruption_screen?).to eq(true)
   end
 
-  it "is has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[savings deposit])
+  it "is has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[savings deposit])
   end
 end

--- a/spec/models/form/sales/pages/deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/deposit_value_check_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Sales::Pages::DepositValueCheck, type: :model do
   it "is interruption screen page" do
     expect(page.interruption_screen?).to eq(true)
   end
+
+  it "is has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[savings deposit])
+  end
 end

--- a/spec/models/form/sales/pages/discounted_sale_value_check_spec.rb
+++ b/spec/models/form/sales/pages/discounted_sale_value_check_spec.rb
@@ -49,4 +49,8 @@ RSpec.describe Form::Sales::Pages::DiscountedSaleValueCheck, type: :model do
       },
     ])
   end
+
+  it "has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[value deposit ownershipsch mortgage mortgageused discount grant type])
+  end
 end

--- a/spec/models/form/sales/pages/discounted_sale_value_check_spec.rb
+++ b/spec/models/form/sales/pages/discounted_sale_value_check_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Form::Sales::Pages::DiscountedSaleValueCheck, type: :model do
     ])
   end
 
-  it "has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[value deposit ownershipsch mortgage mortgageused discount grant type])
+  it "has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[value deposit ownershipsch mortgage mortgageused discount grant type])
   end
 end

--- a/spec/models/form/sales/pages/handover_date_check_spec.rb
+++ b/spec/models/form/sales/pages/handover_date_check_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Form::Sales::Pages::HandoverDateCheck, type: :model do
     expect(page.interruption_screen?).to eq(true)
   end
 
-  it "is has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[hodate saledate])
+  it "is has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[hodate saledate])
   end
 end

--- a/spec/models/form/sales/pages/handover_date_check_spec.rb
+++ b/spec/models/form/sales/pages/handover_date_check_spec.rb
@@ -44,4 +44,8 @@ RSpec.describe Form::Sales::Pages::HandoverDateCheck, type: :model do
   it "is interruption screen page" do
     expect(page.interruption_screen?).to eq(true)
   end
+
+  it "is has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[hodate saledate])
+  end
 end

--- a/spec/models/form/sales/pages/household_wheelchair_check_spec.rb
+++ b/spec/models/form/sales/pages/household_wheelchair_check_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Sales::Pages::HouseholdWheelchairCheck, type: :model do
   it "is interruption screen page" do
     expect(page.interruption_screen?).to eq(true)
   end
+
+  it "is has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[disabled wheel])
+  end
 end

--- a/spec/models/form/sales/pages/household_wheelchair_check_spec.rb
+++ b/spec/models/form/sales/pages/household_wheelchair_check_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Sales::Pages::HouseholdWheelchairCheck, type: :model do
     expect(page.interruption_screen?).to eq(true)
   end
 
-  it "is has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[disabled wheel])
+  it "is has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[disabled wheel])
   end
 end

--- a/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
+++ b/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Form::Sales::Pages::MonthlyChargesValueCheck, type: :model do
     expect(page.informative_text).to eq({})
   end
 
-  it "has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[type mscharge proptype])
+  it "has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[type mscharge proptype])
   end
 end

--- a/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
+++ b/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Pages::MonthlyChargesValueCheck, type: :model do
   it "has correct informative_text" do
     expect(page.informative_text).to eq({})
   end
+
+  it "has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[type mscharge proptype])
+  end
 end

--- a/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
+++ b/spec/models/form/sales/pages/monthly_charges_value_check_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Form::Sales::Pages::MonthlyChargesValueCheck, type: :model do
   it "has correct title_text" do
     expect(page.title_text).to eq({
       "translation" => "soft_validations.monthly_charges_over_soft_max.title_text",
-      "arguments" => [],
+      "arguments" => [{ "arguments_for_key" => "mscharge", "i18n_template" => "mscharge", "key" => "field_formatted_as_currency" }],
     })
   end
 
   it "has correct informative_text" do
-    expect(page.informative_text).to eq({})
+    expect(page.informative_text).to eq({ "arguments" => [], "translation" => "soft_validations.monthly_charges_over_soft_max.hint_text" })
   end
 
   it "has correct interruption_screen_question_ids" do

--- a/spec/models/form/sales/pages/mortgage_value_check_spec.rb
+++ b/spec/models/form/sales/pages/mortgage_value_check_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Form::Sales::Pages::MortgageValueCheck, type: :model do
     ])
   end
 
-  it "has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[mortgage inc1mort inc2mort jointpur income1 income2 inc1mort inc2mort])
+  it "has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[mortgage inc1mort inc2mort jointpur income1 income2 inc1mort inc2mort])
   end
 
   context "when checking buyer 2" do

--- a/spec/models/form/sales/pages/mortgage_value_check_spec.rb
+++ b/spec/models/form/sales/pages/mortgage_value_check_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Form::Sales::Pages::MortgageValueCheck, type: :model do
     ])
   end
 
+  it "has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[mortgage inc1mort inc2mort jointpur income1 income2 inc1mort inc2mort])
+  end
+
   context "when checking buyer 2" do
     let(:index) { 2 }
 

--- a/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
+++ b/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck, type: :m
   it "has the correct informative_text" do
     expect(page.informative_text).to eq({})
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[type jointpur age1 age2])
+  end
 end

--- a/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
+++ b/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck, type: :m
     expect(page.informative_text).to eq({})
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[type jointpur age1 age2])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[type jointpur age1 age2])
   end
 end

--- a/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
+++ b/spec/models/form/sales/pages/old_persons_shared_ownership_value_check_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Form::Sales::Pages::OldPersonsSharedOwnershipValueCheck, type: :m
 
   it "has the correct title_text" do
     expect(page.title_text).to eq({
-      "translation" => "soft_validations.old_persons_shared_ownership",
+      "translation" => "soft_validations.old_persons_shared_ownership.title_text",
       "arguments" => [],
     })
   end
 
   it "has the correct informative_text" do
-    expect(page.informative_text).to eq({})
+    expect(page.informative_text).to eq({ "arguments" => [], "translation" => "soft_validations.old_persons_shared_ownership.hint_text" })
   end
 
   it "has the correct interruption_screen_question_ids" do

--- a/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
+++ b/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Form::Sales::Pages::PercentageDiscountValueCheck, type: :model do
     ])
   end
 
-  it "has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[discount proptype])
+  it "has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[discount proptype])
   end
 end

--- a/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
+++ b/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
@@ -45,4 +45,8 @@ RSpec.describe Form::Sales::Pages::PercentageDiscountValueCheck, type: :model do
       },
     ])
   end
+
+  it "has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[discount proptype])
+  end
 end

--- a/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
+++ b/spec/models/form/sales/pages/percentage_discount_value_check_spec.rb
@@ -31,7 +31,10 @@ RSpec.describe Form::Sales::Pages::PercentageDiscountValueCheck, type: :model do
   end
 
   it "has the correct informative_text" do
-    expect(page.informative_text).to eq({})
+    expect(page.informative_text).to eq({
+      "translation" => "soft_validations.percentage_discount_value.hint_text",
+      "arguments" => [],
+    })
   end
 
   it "is interruption screen page" do

--- a/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
+++ b/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     expect(page.questions.map(&:id)).to eq(%w[student_not_child_value_check])
   end
 
-  it "has correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[relat2 exstat2 age2])
+  it "has correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[relat2 exstat2 age2])
   end
 
   context "with person 2" do
@@ -55,8 +55,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
       expect(page.depends_on).to eq([{ "person_2_student_not_child?" => true }])
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[relat2 exstat2 age2])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[relat2 exstat2 age2])
     end
   end
 
@@ -72,8 +72,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
       expect(page.depends_on).to eq([{ "person_3_student_not_child?" => true }])
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[relat3 exstat3 age3])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[relat3 exstat3 age3])
     end
   end
 
@@ -89,8 +89,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
       expect(page.depends_on).to eq([{ "person_4_student_not_child?" => true }])
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[relat4 exstat4 age4])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[relat4 exstat4 age4])
     end
   end
 
@@ -106,8 +106,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
       expect(page.depends_on).to eq([{ "person_5_student_not_child?" => true }])
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[relat5 exstat5 age5])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[relat5 exstat5 age5])
     end
   end
 
@@ -123,8 +123,8 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
       expect(page.depends_on).to eq([{ "person_6_student_not_child?" => true }])
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[relat6 exstat6 age6])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[relat6 exstat6 age6])
     end
   end
 end

--- a/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
+++ b/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     expect(page.questions.map(&:id)).to eq(%w[student_not_child_value_check])
   end
 
+  it "has correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[relat2 exstat2 age2])
+  end
+
   context "with person 2" do
     let(:person_index) { 2 }
     let(:page_id) { "person_2_student_not_child_value_check" }
@@ -49,6 +53,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
 
     it "has correct depends_on" do
       expect(page.depends_on).to eq([{ "person_2_student_not_child?" => true }])
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[relat2 exstat2 age2])
     end
   end
 
@@ -63,6 +71,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     it "has correct depends_on" do
       expect(page.depends_on).to eq([{ "person_3_student_not_child?" => true }])
     end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[relat3 exstat3 age3])
+    end
   end
 
   context "with person 4" do
@@ -75,6 +87,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
 
     it "has correct depends_on" do
       expect(page.depends_on).to eq([{ "person_4_student_not_child?" => true }])
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[relat4 exstat4 age4])
     end
   end
 
@@ -89,6 +105,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     it "has correct depends_on" do
       expect(page.depends_on).to eq([{ "person_5_student_not_child?" => true }])
     end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[relat5 exstat5 age5])
+    end
   end
 
   context "with person 6" do
@@ -101,6 +121,10 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
 
     it "has correct depends_on" do
       expect(page.depends_on).to eq([{ "person_6_student_not_child?" => true }])
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[relat6 exstat6 age6])
     end
   end
 end

--- a/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
+++ b/spec/models/form/sales/pages/person_student_not_child_value_check_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
   end
 
   it "has correct interruption_screen_question_ids" do
-    expect(page.interruption_screen_question_ids).to eq(%w[relat2 exstat2 age2])
+    expect(page.interruption_screen_question_ids).to eq(%w[relat2 ecstat2 age2])
   end
 
   context "with person 2" do
@@ -56,7 +56,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[relat2 exstat2 age2])
+      expect(page.interruption_screen_question_ids).to eq(%w[relat2 ecstat2 age2])
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[relat3 exstat3 age3])
+      expect(page.interruption_screen_question_ids).to eq(%w[relat3 ecstat3 age3])
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[relat4 exstat4 age4])
+      expect(page.interruption_screen_question_ids).to eq(%w[relat4 ecstat4 age4])
     end
   end
 
@@ -107,7 +107,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[relat5 exstat5 age5])
+      expect(page.interruption_screen_question_ids).to eq(%w[relat5 ecstat5 age5])
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe Form::Sales::Pages::PersonStudentNotChildValueCheck, type: :model
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[relat6 exstat6 age6])
+      expect(page.interruption_screen_question_ids).to eq(%w[relat6 ecstat6 age6])
     end
   end
 end

--- a/spec/models/form/sales/pages/retirement_value_check_spec.rb
+++ b/spec/models/form/sales/pages/retirement_value_check_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         ],
       })
     end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age1 exstat1 sex1])
+    end
   end
 
   context "with person 2" do
@@ -118,6 +122,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
           },
         ],
       })
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age2 exstat2 sex2])
     end
   end
 
@@ -167,6 +175,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         ],
       })
     end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age3 exstat3 sex3])
+    end
   end
 
   context "with person 4" do
@@ -214,6 +226,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
           },
         ],
       })
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age4 exstat4 sex4])
     end
   end
 
@@ -263,6 +279,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         ],
       })
     end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age5 exstat5 sex5])
+    end
   end
 
   context "with person 6" do
@@ -310,6 +330,10 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
           },
         ],
       })
+    end
+
+    it "has correct affected_question_ids" do
+      expect(page.affected_question_ids).to eq(%w[age6 exstat6 sex6])
     end
   end
 end

--- a/spec/models/form/sales/pages/retirement_value_check_spec.rb
+++ b/spec/models/form/sales/pages/retirement_value_check_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age1 exstat1 sex1])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age1 exstat1 sex1])
     end
   end
 
@@ -124,8 +124,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age2 exstat2 sex2])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age2 exstat2 sex2])
     end
   end
 
@@ -176,8 +176,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age3 exstat3 sex3])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age3 exstat3 sex3])
     end
   end
 
@@ -228,8 +228,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age4 exstat4 sex4])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age4 exstat4 sex4])
     end
   end
 
@@ -280,8 +280,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age5 exstat5 sex5])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age5 exstat5 sex5])
     end
   end
 
@@ -332,8 +332,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
       })
     end
 
-    it "has correct affected_question_ids" do
-      expect(page.affected_question_ids).to eq(%w[age6 exstat6 sex6])
+    it "has correct interruption_screen_question_ids" do
+      expect(page.interruption_screen_question_ids).to eq(%w[age6 exstat6 sex6])
     end
   end
 end

--- a/spec/models/form/sales/pages/retirement_value_check_spec.rb
+++ b/spec/models/form/sales/pages/retirement_value_check_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_1",
-            "label" => false,
+            "key" => "age1",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -55,25 +55,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_1",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_1",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age1 ecstat1 sex1])
+      expect(page.interruption_screen_question_ids).to eq(%w[age1 ecstat1])
     end
   end
 
@@ -98,8 +84,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_2",
-            "label" => false,
+            "key" => "age2",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -107,25 +93,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_2",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_2",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age2 ecstat2 sex2])
+      expect(page.interruption_screen_question_ids).to eq(%w[age2 ecstat2])
     end
   end
 
@@ -150,8 +122,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_3",
-            "label" => false,
+            "key" => "age3",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -159,25 +131,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_3",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_3",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age3 ecstat3 sex3])
+      expect(page.interruption_screen_question_ids).to eq(%w[age3 ecstat3])
     end
   end
 
@@ -202,8 +160,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_4",
-            "label" => false,
+            "key" => "age4",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -211,25 +169,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_4",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_4",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age4 ecstat4 sex4])
+      expect(page.interruption_screen_question_ids).to eq(%w[age4 ecstat4])
     end
   end
 
@@ -254,8 +198,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_5",
-            "label" => false,
+            "key" => "age5",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -263,25 +207,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_5",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_5",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age5 ecstat5 sex5])
+      expect(page.interruption_screen_question_ids).to eq(%w[age5 ecstat5])
     end
   end
 
@@ -306,8 +236,8 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
         "translation" => "soft_validations.retirement.min.title",
         "arguments" => [
           {
-            "key" => "retirement_age_for_person_6",
-            "label" => false,
+            "key" => "age6",
+            "label" => true,
             "i18n_template" => "age",
           },
         ],
@@ -315,25 +245,11 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct informative_text" do
-      expect(page.informative_text).to eq({
-        "translation" => "soft_validations.retirement.min.hint_text",
-        "arguments" => [
-          {
-            "key" => "plural_gender_for_person_6",
-            "label" => false,
-            "i18n_template" => "gender",
-          },
-          {
-            "key" => "retirement_age_for_person_6",
-            "label" => false,
-            "i18n_template" => "age",
-          },
-        ],
-      })
+      expect(page.informative_text).to eq({})
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age6 ecstat6 sex6])
+      expect(page.interruption_screen_question_ids).to eq(%w[age6 ecstat6])
     end
   end
 end

--- a/spec/models/form/sales/pages/retirement_value_check_spec.rb
+++ b/spec/models/form/sales/pages/retirement_value_check_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age1 exstat1 sex1])
+      expect(page.interruption_screen_question_ids).to eq(%w[age1 ecstat1 sex1])
     end
   end
 
@@ -125,7 +125,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age2 exstat2 sex2])
+      expect(page.interruption_screen_question_ids).to eq(%w[age2 ecstat2 sex2])
     end
   end
 
@@ -177,7 +177,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age3 exstat3 sex3])
+      expect(page.interruption_screen_question_ids).to eq(%w[age3 ecstat3 sex3])
     end
   end
 
@@ -229,7 +229,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age4 exstat4 sex4])
+      expect(page.interruption_screen_question_ids).to eq(%w[age4 ecstat4 sex4])
     end
   end
 
@@ -281,7 +281,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age5 exstat5 sex5])
+      expect(page.interruption_screen_question_ids).to eq(%w[age5 ecstat5 sex5])
     end
   end
 
@@ -333,7 +333,7 @@ RSpec.describe Form::Sales::Pages::RetirementValueCheck, type: :model do
     end
 
     it "has correct interruption_screen_question_ids" do
-      expect(page.interruption_screen_question_ids).to eq(%w[age6 exstat6 sex6])
+      expect(page.interruption_screen_question_ids).to eq(%w[age6 ecstat6 sex6])
     end
   end
 end

--- a/spec/models/form/sales/pages/savings_value_check_spec.rb
+++ b/spec/models/form/sales/pages/savings_value_check_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Sales::Pages::SavingsValueCheck, type: :model do
     expect(page.interruption_screen?).to eq(true)
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[savings])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[savings])
   end
 end

--- a/spec/models/form/sales/pages/savings_value_check_spec.rb
+++ b/spec/models/form/sales/pages/savings_value_check_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe Form::Sales::Pages::SavingsValueCheck, type: :model do
   it "is interruption screen page" do
     expect(page.interruption_screen?).to eq(true)
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[savings])
+  end
 end

--- a/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipDepositValueCheck, type: :mode
     expect(page.informative_text).to eq({})
   end
 
-  it "has the correct affected_question_ids" do
-    expect(page.affected_question_ids).to eq(%w[mortgage mortgageused cashdis type deposit value equity])
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[mortgage mortgageused cashdis type deposit value equity])
   end
 end

--- a/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipDepositValueCheck, type: :mode
   it "has the correct title_text" do
     expect(page.title_text).to eq({
       "translation" => "soft_validations.shared_ownership_deposit.title_text",
-      "arguments" => [{ "arguments_for_key" => "expected_shared_ownership_deposit_value", "i18n_template" => "expected_shared_ownership_deposit_value", "key" => "field_formatted_as_currency" }],
+      "arguments" => [{ "arguments_for_key" => "mortgage_deposit_and_discount_total", "i18n_template" => "mortgage_deposit_and_discount_total", "key" => "field_formatted_as_currency" }],
     })
   end
 

--- a/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipDepositValueCheck, type: :mode
   it "has the correct informative_text" do
     expect(page.informative_text).to eq({})
   end
+
+  it "has the correct affected_question_ids" do
+    expect(page.affected_question_ids).to eq(%w[mortgage mortgageused cashdis type deposit value equity])
+  end
 end

--- a/spec/models/form/sales/questions/household_wheelchair_check_spec.rb
+++ b/spec/models/form/sales/questions/household_wheelchair_check_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Form::Sales::Questions::HouseholdWheelchairCheck, type: :model do
   end
 
   it "has the correct header" do
-    expect(question.header).to eq("Are you sure? You said previously that somebody in household uses a wheelchair")
+    expect(question.header).to eq("You told us that someone in the household uses a wheelchair.")
   end
 
   it "has the correct check_answer_label" do

--- a/spec/models/validations/soft_validations_spec.rb
+++ b/spec/models/validations/soft_validations_spec.rb
@@ -84,25 +84,9 @@ RSpec.describe Validations::SoftValidations do
 
   describe "retirement soft validations" do
     context "when the tenant is retired but under the expected retirement age" do
-      context "when the tenant is female" do
-        it "shows the interruption screen" do
-          record.update!(age1: 43, sex1: "F", ecstat1: 5)
-          expect(record.person_1_retired_under_soft_min_age?).to be true
-        end
-      end
-
-      context "when the tenant is male" do
-        it "shows the interruption screen" do
-          record.update!(age1: 43, sex1: "M", ecstat1: 5)
-          expect(record.person_1_retired_under_soft_min_age?).to be true
-        end
-      end
-
-      context "when the tenant is non-binary" do
-        it "shows the interruption screen" do
-          record.update!(age1: 43, sex1: "X", ecstat1: 5)
-          expect(record.person_1_retired_under_soft_min_age?).to be true
-        end
+      it "shows the interruption screen" do
+        record.update!(age1: 43, ecstat1: 5)
+        expect(record.person_1_retired_under_soft_min_age?).to be true
       end
     end
 
@@ -130,25 +114,9 @@ RSpec.describe Validations::SoftValidations do
     end
 
     context "when the tenant prefers not to say what their economic status is but is under the expected retirement age" do
-      context "when the tenant is female" do
-        it "does not show the interruption screen" do
-          record.update!(age1: 43, sex1: "F", ecstat1: 10)
-          expect(record.person_1_retired_under_soft_min_age?).to be false
-        end
-      end
-
-      context "when the tenant is male" do
-        it "does not show the interruption screen" do
-          record.update!(age1: 43, sex1: "M", ecstat1: 10)
-          expect(record.person_1_retired_under_soft_min_age?).to be false
-        end
-      end
-
-      context "when the tenant is non-binary" do
-        it "does not show the interruption screen" do
-          record.update!(age1: 43, sex1: "X", ecstat1: 10)
-          expect(record.person_1_retired_under_soft_min_age?).to be false
-        end
+      it "does not show the interruption screen" do
+        record.update!(age1: 43, ecstat1: 10)
+        expect(record.person_1_retired_under_soft_min_age?).to be false
       end
     end
 

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -532,6 +532,33 @@ RSpec.describe FormController, type: :request do
             end
           end
         end
+
+        context "when the question was accessed from an interrution screen (soft validation)" do
+          let(:params) do
+            {
+              id: lettings_log.id,
+              lettings_log: {
+                page: page_id,
+                age1: 20,
+                interruption_page_id: "retirement_value_check",
+              },
+            }
+          end
+
+          before do
+            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}?referrer=interruption_screen", params:
+          end
+
+          it "redirects back to the soft validation page" do
+            expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/retirement-value-check")
+          end
+
+          it "displays a success banner" do
+            follow_redirect!
+            follow_redirect!
+            expect(response.body).to include("You have successfully updated lead tenant’s age")
+          end
+        end
       end
 
       context "with checkbox questions" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe FormController, type: :request do
           end
         end
 
-        context "when the question was accessed from an interrution screen (soft validation)" do
+        context "when the question was accessed from an interruption screen (soft validation)" do
           let(:params) do
             {
               id: lettings_log.id,
@@ -557,6 +557,29 @@ RSpec.describe FormController, type: :request do
             follow_redirect!
             follow_redirect!
             expect(response.body).to include("You have successfully updated lead tenant’s age")
+          end
+        end
+
+        context "when requesting a soft validation page for validation that isn't triggering" do
+          before do
+            get "/lettings-logs/#{lettings_log.id}/retirement-value-check", headers: headers.merge({ "HTTP_REFERER" => referrer })
+          end
+
+          context "when the referrer header has interruption_screen" do
+            let(:referrer) { "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}?referrer=interruption_screen" }
+
+            it "routes to the soft validation page" do
+              expect(response.body).to include("Make sure these answers are all correct")
+            end
+          end
+
+          context "when the referrer header does not have interruption screen" do
+            let(:referrer) { "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}" }
+
+            it "skips the soft validation page" do
+              follow_redirect!
+              expect(response.body).not_to include("Make sure these answers are all correct")
+            end
           end
         end
       end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe FormController, type: :request do
             let(:referrer) { "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}?referrer=interruption_screen" }
 
             it "routes to the soft validation page" do
-              expect(response.body).to include("Make sure these answers are all correct")
+              expect(response.body).to include("Make sure these answers are correct:")
             end
           end
 
@@ -578,7 +578,7 @@ RSpec.describe FormController, type: :request do
 
             it "skips the soft validation page" do
               follow_redirect!
-              expect(response.body).not_to include("Make sure these answers are all correct")
+              expect(response.body).not_to include("Make sure these answers are correct:")
             end
           end
         end


### PR DESCRIPTION
Update interruption screen design to display all the questions that affect the soft validation:
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/54268893/234795317-20d8af59-d4ff-4217-9ccd-7776cac30c80.png">

User can choose to confirm, skip or correct the values. If the values are changed the user is returned to the interruption screen and can change any other relevant values if needed.
<img width="1777" alt="image" src="https://user-images.githubusercontent.com/54268893/234795377-bdb42b6d-7e73-419b-b866-12744c2f1167.png">

We no longer display question headers, as we're no longer asking a question. Question headers would often be `Are you sure this is correct?` but some of them had more information in them, such as `Are you sure the property has been vacant for this long?`, messages such as these might need to be reworded. 
