### PR TITLE
CLDC-2287 Bulk upload setup errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -455,7 +455,11 @@ private
       fields = field_mapping_for_errors[question_id.to_sym] || []
 
       fields.each do |field|
-        errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]))
+        if setup_question?(question)
+          errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]), category: :setup)
+        else
+          errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]))
+        end
       end
     end
   end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -472,7 +472,11 @@ private
       fields = field_mapping_for_errors[question_id.to_sym] || []
 
       fields.each do |field|
-        errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]))
+        if setup_question?(question)
+          errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]), category: :setup)
+        else
+          errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]))
+        end
       end
     end
   end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -624,9 +624,9 @@ private
     return if start_date.blank? || bulk_upload.form.blank?
 
     unless bulk_upload.form.valid_start_date_for_form?(start_date)
-      errors.add(:field_7, I18n.t("validations.date.outside_collection_window"))
-      errors.add(:field_8, I18n.t("validations.date.outside_collection_window"))
-      errors.add(:field_9, I18n.t("validations.date.outside_collection_window"))
+      errors.add(:field_7, I18n.t("validations.date.outside_collection_window"), category: :setup)
+      errors.add(:field_8, I18n.t("validations.date.outside_collection_window"), category: :setup)
+      errors.add(:field_9, I18n.t("validations.date.outside_collection_window"), category: :setup)
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -345,7 +345,7 @@ class BulkUpload::Lettings::Year2023::RowParser
   validates :field_72, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 7 must be a number or the letter R" }, allow_blank: true, on: :after_log
   validates :field_76, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 8 must be a number or the letter R" }, allow_blank: true, on: :after_log
 
-  validate :validate_needs_type_present
+  validate :validate_needs_type_present, on: :after_log
   validate :validate_data_types, on: :after_log
   validate :validate_relevant_collection_window, on: :after_log
   validate :validate_la_with_local_housing_referral, on: :after_log
@@ -537,7 +537,7 @@ private
 
   def validate_needs_type_present
     if field_4.blank?
-      errors.add(:field_4, I18n.t("validations.not_answered", question: "needs type"))
+      errors.add(:field_4, I18n.t("validations.not_answered", question: "needs type"), category: :setup)
     end
   end
 

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -941,9 +941,9 @@ private
     return if saledate.blank? || bulk_upload.form.blank?
 
     unless bulk_upload.form.valid_start_date_for_form?(saledate)
-      errors.add(:field_2, I18n.t("validations.date.outside_collection_window"))
-      errors.add(:field_3, I18n.t("validations.date.outside_collection_window"))
-      errors.add(:field_4, I18n.t("validations.date.outside_collection_window"))
+      errors.add(:field_2, I18n.t("validations.date.outside_collection_window"), category: :setup)
+      errors.add(:field_3, I18n.t("validations.date.outside_collection_window"), category: :setup)
+      errors.add(:field_4, I18n.t("validations.date.outside_collection_window"), category: :setup)
     end
   end
 

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
         error = BulkUploadError.find_by(row: "7", field: "field_96", category: "setup")
 
         expect(error.field).to eql("field_96")
-        expect(error.error).to eql("You must answer tenancy start date")
+        expect(error.error).to eql("You must answer tenancy start date (day)")
         expect(error.tenant_code).to eql("123")
         expect(error.property_ref).to be_nil
         expect(error.row).to eql("7")

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -949,6 +949,16 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       end
     end
 
+    describe "#field_134" do # renewal
+      context "when none possible option selected" do
+        let(:attributes) { setup_section_params.merge({ field_134: "101" }) }
+
+        it "adds a setup error" do
+          expect(parser.errors.where(:field_134, category: :setup).map(&:message)).to include("Enter a valid value for Is this letting a renewal?")
+        end
+      end
+    end
+
     describe "soft validations" do
       context "when soft validation is triggered" do
         let(:attributes) { setup_section_params.merge({ field_12: 22, field_35: 5 }) }

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
       it "has errors on setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_111 field_113 field_96 field_97 field_98])
+        expect(errors).to eql(%i[field_1 field_111 field_113 field_132 field_96 field_97 field_98])
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -717,8 +717,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         let(:attributes) { { bulk_upload:, field_5: "1", field_7: nil, field_8: nil, field_9: nil } }
 
         it "returns an error" do
-          parser.valid?
-
           expect(parser.errors[:field_7]).to be_present
           expect(parser.errors[:field_8]).to be_present
           expect(parser.errors[:field_9]).to be_present
@@ -729,8 +727,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         let(:attributes) { { bulk_upload:, field_9: "2022" } }
 
         it "returns an error" do
-          parser.valid?
-
           expect(parser.errors[:field_9]).to include("Tenancy start year must be 2 digits")
         end
       end
@@ -749,8 +745,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         let(:bulk_upload) { create(:bulk_upload, :lettings, user:, year: 2022) }
 
         it "does not return errors" do
-          parser.valid?
-
           expect(parser.errors[:field_7]).not_to be_present
           expect(parser.errors[:field_8]).not_to be_present
           expect(parser.errors[:field_9]).not_to be_present
@@ -762,19 +756,16 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           Timecop.freeze(Date.new(2022, 4, 2)) do
             example.run
           end
-          Timecop.return
         end
 
         let(:attributes) { { bulk_upload:, field_7: "1", field_8: "1", field_9: "22" } }
 
         let(:bulk_upload) { create(:bulk_upload, :lettings, user:, year: 2022) }
 
-        it "returns errors" do
-          parser.valid?
-
-          expect(parser.errors[:field_7]).to be_present
-          expect(parser.errors[:field_8]).to be_present
-          expect(parser.errors[:field_9]).to be_present
+        it "returns setup errors" do
+          expect(parser.errors.where(:field_7, category: :setup)).to be_present
+          expect(parser.errors.where(:field_8, category: :setup)).to be_present
+          expect(parser.errors.where(:field_9, category: :setup)).to be_present
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -903,6 +903,14 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(parser.errors.where(:field_6, category: :setup).map(&:message)).to eql(["You must answer property renewal"])
         end
       end
+
+      context "when none possible option selected" do
+        let(:attributes) { setup_section_params.merge({ field_6: "101" }) }
+
+        it "adds a setup error" do
+          expect(parser.errors.where(:field_6, category: :setup).map(&:message)).to include("Enter a valid value for Is this letting a renewal?")
+        end
+      end
     end
 
     describe "#field_18" do # UPRN

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -501,8 +501,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when matching scheme cannot be found" do
         let(:attributes) { { bulk_upload:, field_5: "1", field_16: "123" } }
 
-        it "returns an error" do
-          expect(parser.errors[:field_16]).to be_present
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_16, category: :setup)).to be_present
         end
       end
 
@@ -510,8 +510,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         let(:other_scheme) { create(:scheme, :with_old_visible_id) }
         let(:attributes) { { bulk_upload:, field_5: "1", field_16: other_scheme.old_visible_id, field_1: owning_org.old_visible_id } }
 
-        it "returns an error" do
-          expect(parser.errors[:field_16]).to include("This management group code does not belong to your organisation, or any of your stock owners / managing agents")
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_16, category: :setup).map(&:message)).to include("This management group code does not belong to your organisation, or any of your stock owners / managing agents")
         end
       end
 
@@ -547,8 +547,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           }
         end
 
-        it "returns an error" do
-          expect(parser.errors[:field_17]).to be_present
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_17, category: :setup)).to be_present
         end
       end
 
@@ -581,8 +581,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           }
         end
 
-        it "returns an error" do
-          expect(parser.errors[:field_17]).to be_present
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_17, category: :setup)).to be_present
         end
       end
     end
@@ -784,9 +784,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         let(:attributes) { { bulk_upload:, field_1: "", field_4: 1 } }
 
         it "is not permitted as setup error" do
-          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
-
-          expect(setup_errors.find { |e| e.attribute == :field_1 }.message).to eql("The owning organisation code is incorrect")
+          expect(parser.errors.where(:field_1, category: :setup).map(&:message)).to eql(["You must answer owning organisation"])
         end
 
         it "blocks log creation" do
@@ -887,16 +885,12 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       end
     end
 
-    describe "#field_4" do
+    describe "#field_4" do # needs type
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_4: nil, field_13: "123" } }
 
         it "is reported as a setup error" do
-          errors = parser.errors.select { |e| e.options[:category] == :setup }
-          error = errors.find { |e| e.attribute == :field_4 }
-
-          expect(error).to be_present
-          expect(error.type).to eql("You must answer needs type")
+          expect(parser.errors.where(:field_4, category: :setup).map(&:message)).to eql(["You must answer needs type"])
         end
       end
     end
@@ -905,8 +899,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       context "when blank" do
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_6: "" } }
 
-        it "has errors on the field" do
-          expect(parser.errors[:field_6]).to include("You must answer property renewal")
+        it "has setup errors on the field" do
+          expect(parser.errors.where(:field_6, category: :setup).map(&:message)).to eql(["You must answer property renewal"])
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -506,17 +506,16 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
           Timecop.freeze(Date.new(2022, 4, 2)) do
             example.run
           end
-          Timecop.return
         end
 
         let(:attributes) { setup_section_params.merge({ field_2: "1", field_3: "1", field_4: "22" }) }
 
         let(:bulk_upload) { create(:bulk_upload, :sales, user:, year: 2022) }
 
-        it "returns errors" do
-          expect(parser.errors[:field_2]).to be_present
-          expect(parser.errors[:field_3]).to be_present
-          expect(parser.errors[:field_4]).to be_present
+        it "returns setup errors" do
+          expect(parser.errors.where(:field_2, category: :setup)).to be_present
+          expect(parser.errors.where(:field_3, category: :setup)).to be_present
+          expect(parser.errors.where(:field_4, category: :setup)).to be_present
         end
       end
     end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2287
- bulk upload errors on setup fields are not being categorised as setup errors

# Changes

- ensure errors on setup field are categorised as `setup` errors
- ordering of validations tweaked, so `validate_nulls` is further down the execution order. this is so any existing validation run first and `validate_nulls` only adds errors if there aren't any existing errors on a field
- removed old 16/60% tests are no longer required due to introduction of `how to fix` journey