### PR TITLE
CLDC-2288 ensure derived answers cleared when renewal changed from yes to no

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -37,7 +37,7 @@ module DerivedVariables::LettingsLogVariables
   end
 
   def set_derived_fields!
-    clear_inapplicable_derived_values
+    clear_inapplicable_derived_values!
     set_encoded_derived_values!(DEPENDENCIES)
 
     if rsnvac.present?
@@ -130,7 +130,7 @@ private
     },
   ].freeze
 
-  def clear_inapplicable_derived_values
+  def clear_inapplicable_derived_values!
     reset_invalidated_derived_values!(DEPENDENCIES)
     if (startdate_changed? || renewal_changed?) && (renewal_was == 1 && startdate_was&.between?(Time.zone.local(2021, 4, 1), Time.zone.local(2022, 3, 31)))
       self.underoccupation_benefitcap = nil

--- a/app/models/derived_variables/shared_logic.rb
+++ b/app/models/derived_variables/shared_logic.rb
@@ -1,5 +1,5 @@
 module DerivedVariables::SharedLogic
-  private
+private
 
   def reset_invalidated_derived_values!(dependencies)
     dependencies.each do |dependency|

--- a/app/models/derived_variables/shared_logic.rb
+++ b/app/models/derived_variables/shared_logic.rb
@@ -1,0 +1,27 @@
+module DerivedVariables::SharedLogic
+  private
+
+  def reset_invalidated_derived_values!(dependencies)
+    dependencies.each do |dependency|
+      any_conditions_changed = dependency[:conditions].any? { |attribute, _value| send("#{attribute}_changed?") }
+      next unless any_conditions_changed
+
+      previously_in_derived_state = dependency[:conditions].all? { |attribute, value| send("#{attribute}_was") == value }
+      next unless previously_in_derived_state
+
+      dependency[:derived_values].each do |derived_attribute, _derived_value|
+        Rails.logger.debug("Cleared derived #{derived_attribute} value")
+        send("#{derived_attribute}=", nil)
+      end
+    end
+  end
+
+  def set_encoded_derived_values!(dependencies)
+    dependencies.each do |dependency|
+      derivation_applies = dependency[:conditions].all? { |attribute, value| send(attribute) == value }
+      if derivation_applies
+        dependency[:derived_values].each { |attribute, value| send("#{attribute}=", value) }
+      end
+    end
+  end
+end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -531,7 +531,6 @@ class LettingsLog < Log
 
 private
 
-  # show in diff
   def reset_derived_questions
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
@@ -549,7 +548,6 @@ private
       end
     end
   end
-  # show in diff
 
   def reset_invalid_unresolved_log_fields!
     return unless unresolved?

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -531,24 +531,6 @@ class LettingsLog < Log
 
 private
 
-  def reset_derived_questions
-    dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
-                            referral: [{ key: :renewal, value: 0 }],
-                            rsnvac: [{ key: :renewal, value: 0 }],
-                            underoccupation_benefitcap: [{ key: :renewal, value: 0 }],
-                            wchair: [{ key: :needstype, value: 1 }],
-                            location_id: [{ key: :needstype, value: 1 }] }
-
-    dependent_questions.each do |dependent, conditions|
-      condition_key = conditions.first[:key]
-      condition_value = conditions.first[:value]
-      if public_send("#{condition_key}_changed?") && condition_value == public_send(condition_key) && !public_send("#{dependent}_changed?")
-        Rails.logger.debug("Cleared derived #{dependent} value")
-        self[dependent] = nil
-      end
-    end
-  end
-
   def reset_invalid_unresolved_log_fields!
     return unless unresolved?
 
@@ -581,7 +563,6 @@ private
 
     reset_invalid_unresolved_log_fields!
     reset_scheme
-    reset_derived_questions
   end
 
   def dynamically_not_required

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -531,6 +531,7 @@ class LettingsLog < Log
 
 private
 
+  # show in diff
   def reset_derived_questions
     dependent_questions = { waityear: [{ key: :renewal, value: 0 }],
                             referral: [{ key: :renewal, value: 0 }],
@@ -548,6 +549,7 @@ private
       end
     end
   end
+  # show in diff
 
   def reset_invalid_unresolved_log_fields!
     return unless unresolved?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,7 +539,7 @@ en:
       in_soft_max_range:
         message: "Net income is higher than expected based on the lead tenant’s working situation. Are you sure this is correct?"
     income:
-      under_soft_min_for_economic_status: 
+      under_soft_min_for_economic_status:
         title_text: "You told us income was %{income}."
         hint_text: "This is less than we would expect for someone in this working situation."
     rent:
@@ -571,10 +571,10 @@ en:
       hint_text: "This is higher than we would expect."
     shared_ownership_deposit:
       title_text: "You told us that the mortgage, deposit and discount add up to %{mortgage_deposit_and_discount_total}"
-    old_persons_shared_ownership: 
+    old_persons_shared_ownership:
       title_text: "You told us the buyer is using the Older Persons Shared Ownership scheme."
       hint_text: "At least one buyer must be aged 65 years and over to use this scheme."
-    staircase_bought_seems_high: 
+    staircase_bought_seems_high:
       title_text: "You told us that %{percentage}% was bought in this staircasing transaction."
       hint_text: "Most staircasing transactions are less than 50%"
     monthly_charges_over_soft_max:

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1578,7 +1578,8 @@ RSpec.describe LettingsLog do
       it "clears underoccupation_benefitcap if log is no longer in 2021/22" do
         lettings_log.update!(renewal: 1)
         expect(lettings_log.underoccupation_benefitcap).to be 2
-        lettings_log.update!(startdate: Time.zone.now)
+        Timecop.return
+        lettings_log.update!(startdate: Time.zone.local(2023, 1, 1))
         expect(lettings_log.underoccupation_benefitcap).to be nil
       end
 
@@ -1591,7 +1592,6 @@ RSpec.describe LettingsLog do
 
           it "correctly derives prevten" do
             expect(lettings_log.prevten).to be 32
-
           end
 
           it "clears prevten if the log is marked as supported housing" do
@@ -1613,7 +1613,6 @@ RSpec.describe LettingsLog do
 
           it "correctly derives prevten" do
             expect(lettings_log.prevten).to be 30
-
           end
 
           it "clears prevten if the log is marked as supported housing" do

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1574,7 +1574,6 @@ RSpec.describe LettingsLog do
         expect { lettings_log.update!(renewal: 0) }.to change(lettings_log, :rsnvac).from(14).to nil
       end
 
-      # should have extra tests for whether it is derived when voiddate, mrcdate etc set and reset
       it "derives vacdays as 0 if log is renewal" do
         expect { lettings_log.update!(renewal: 1) }.to change(lettings_log, :vacdays).to 0
       end


### PR DESCRIPTION
[JIRA TICKET](https://digital.dclg.gov.uk/jira/browse/CLDC-2288)

Building on work in 2163, I have extracted logic around deriving variables into its own module, for both logs to use.

I have added and updated a large number of tests around deriving lettings log variables and moved code about clearing derived values into the LettingsLogVariables module