### PR TITLE
CLDC-2082 Add merge orgs new phone number page

### DIFF
--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -9,6 +9,7 @@ class MergeRequestsController < ApplicationController
     new_organisation_name
     new_organisation_address
     new_organisation_telephone_number
+    new_organisation_type
     merge_date
   ]
   before_action :authenticate_user!
@@ -19,6 +20,7 @@ class MergeRequestsController < ApplicationController
   def new_organisation_name; end
   def new_organisation_address; end
   def new_organisation_telephone_number; end
+  def new_organisation_type; end
   def merge_date; end
 
   def create
@@ -83,6 +85,8 @@ private
       new_organisation_address_merge_request_path(@merge_request)
     when "new_organisation_address"
       new_organisation_telephone_number_merge_request_path(@merge_request)
+    when "new_organisation_telephone_number"
+      new_organisation_type_merge_request_path(@merge_request)
     end
   end
 
@@ -115,6 +119,7 @@ private
       :new_organisation_address_line1,
       :new_organisation_address_line2,
       :new_organisation_postcode,
+      :new_organisation_telephone_number
     )
 
     if merge_params[:requesting_organisation_id].present? && (current_user.data_coordinator? || current_user.data_provider?)

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -119,7 +119,7 @@ private
       :new_organisation_address_line1,
       :new_organisation_address_line2,
       :new_organisation_postcode,
-      :new_organisation_telephone_number
+      :new_organisation_telephone_number,
     )
 
     if merge_params[:requesting_organisation_id].present? && (current_user.data_coordinator? || current_user.data_provider?)

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -155,6 +155,8 @@ private
       end
     when "new_organisation_name"
       @merge_request.errors.add(:new_organisation_name, :blank) if merge_request_params[:new_organisation_name].blank?
+    when "new_organisation_telephone_number"
+      @merge_request.errors.add(:new_organisation_telephone_number, :blank) if merge_request_params[:new_organisation_telephone_number].blank?
     end
   end
 

--- a/app/views/merge_requests/new_organisation_telephone_number.html.erb
+++ b/app/views/merge_requests/new_organisation_telephone_number.html.erb
@@ -14,7 +14,6 @@
       <%= f.hidden_field :page, value: "new_organisation_telephone_number" %>
       <div class="govuk-button-group">
         <%= f.govuk_submit %>
-        <%= govuk_link_to("Skip for now", new_organisation_type_merge_request_path(@merge_request)) %>
       </div>
     </div>
   </div>

--- a/app/views/merge_requests/new_organisation_telephone_number.html.erb
+++ b/app/views/merge_requests/new_organisation_telephone_number.html.erb
@@ -3,3 +3,19 @@
   <% content_for :title, title %>
   <%= govuk_back_link href: new_organisation_address_merge_request_path(@merge_request) %>
 <% end %>
+
+<%= form_with model: @merge_request, url: merge_request_path, method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h2 class="govuk-heading-l">What is <%= @merge_request.new_organisation_name.possessive %> telephone number?</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= f.govuk_text_field :new_organisation_telephone_number, label: nil, width: "two-thirds" %>
+      <%= f.hidden_field :page, value: "new_organisation_telephone_number" %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit %>
+        <%= govuk_link_to("Skip for now", new_organisation_type_merge_request_path(@merge_request)) %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/merge_requests/new_organisation_type.html.erb
+++ b/app/views/merge_requests/new_organisation_type.html.erb
@@ -1,0 +1,5 @@
+<% content_for :before_content do %>
+  <% title = "New organisation type" %>
+  <% content_for :title, title %>
+  <%= govuk_back_link href: new_organisation_telephone_number_merge_request_path(@merge_request) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,8 @@ en:
             new_organisation_name:
               blank: "Enter an organisation name"
               invalid: "An organisation with this name already exists"
-
+            new_organisation_telephone_number:
+              blank: "Enter a valid telephone number"
 
 
   validations:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
       get "new-organisation-name"
       get "new-organisation-address"
       get "new-organisation-telephone-number"
+      get "new-organisation-type"
       get "merge-date"
     end
   end

--- a/db/migrate/20230505105327_add_new_organisation_telephone_number_to_merge_request.rb
+++ b/db/migrate/20230505105327_add_new_organisation_telephone_number_to_merge_request.rb
@@ -1,0 +1,5 @@
+class AddNewOrganisationTelephoneNumberToMergeRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merge_requests, :new_organisation_telephone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_04_111352) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_05_105327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -375,6 +375,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_04_111352) do
     t.string "new_organisation_address_line1"
     t.string "new_organisation_address_line2"
     t.string "new_organisation_postcode"
+    t.string "new_organisation_telephone_number"
   end
 
   create_table "organisation_relationships", force: :cascade do |t|

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe MergeRequestsController, type: :request do
         end
       end
 
-      describe "#new_organsation_name" do
+      describe "#new_organisation_name" do
         let(:merge_request) { MergeRequest.create!(requesting_organisation: organisation, new_absorbing_organisation: true) }
 
         context "when viewing the new organisation name page" do
@@ -554,7 +554,7 @@ RSpec.describe MergeRequestsController, type: :request do
         end
       end
 
-      describe "#new_organsation_address" do
+      describe "#new_organisation_address" do
         let(:merge_request) { MergeRequest.create!(requesting_organisation: organisation, new_organisation_name: "New name", new_absorbing_organisation: true) }
 
         context "when viewing the new organisation name page" do
@@ -594,19 +594,19 @@ RSpec.describe MergeRequestsController, type: :request do
             expect(response).to redirect_to(new_organisation_telephone_number_merge_request_path(merge_request))
           end
 
-          it "updates new organisation address line 1 to correct addess line" do
+          it "updates new organisation address line 1 to correct address line" do
             expect { request }.to change {
               merge_request.reload.new_organisation_address_line1
             }.from(nil).to("first address line")
           end
 
-          it "updates new organisation address line 2 to correct addess line" do
+          it "updates new organisation address line 2 to correct address line" do
             expect { request }.to change {
               merge_request.reload.new_organisation_address_line2
             }.from(nil).to("second address line")
           end
 
-          it "updates new organisation postcode to correct addess line" do
+          it "updates new organisation postcode to correct address line" do
             expect { request }.to change {
               merge_request.reload.new_organisation_postcode
             }.from(nil).to("new postcode")
@@ -630,6 +630,91 @@ RSpec.describe MergeRequestsController, type: :request do
           it "does not throw an error" do
             request
             expect(response).to redirect_to(new_organisation_telephone_number_merge_request_path(merge_request))
+          end
+        end
+      end
+
+      describe "#new_organisation_telephone_number" do
+        let(:merge_request) { MergeRequest.create!(requesting_organisation: organisation, new_organisation_name: "New name", new_absorbing_organisation: true) }
+
+        context "when viewing the new organisation telephone number page" do
+          before do
+            get "/merge-request/#{merge_request.id}/new-organisation-telephone-number", headers:
+          end
+
+          it "displays the correct question" do
+            expect(page).to have_content("What is New name’s telephone number?")
+          end
+
+          it "has the correct back button" do
+            expect(page).to have_link("Back", href: new_organisation_address_merge_request_path(merge_request))
+          end
+
+          it "has a skip link" do
+            expect(page).to have_link("Skip for now", href: new_organisation_type_merge_request_path(merge_request))
+          end
+        end
+
+        context "when updating the new organisation telephone number" do
+          let(:params) do
+            { merge_request: { new_organisation_telephone_number: "1234", page: "new_organisation_telephone_number" } }
+          end
+
+          let(:request) do
+            patch "/merge-request/#{merge_request.id}", headers:, params:
+          end
+
+          it "redirects to new organisation type path" do
+            request
+            expect(response).to redirect_to(new_organisation_type_merge_request_path(merge_request))
+          end
+
+          it "updates new organisation name to the correct telephone number" do
+            expect { request }.to change {
+              merge_request.reload.new_organisation_telephone_number
+            }.from(nil).to("1234")
+          end
+        end
+
+        context "when the new organisation telephone number is not answered" do
+          let(:params) do
+            { merge_request: { new_organisation_telephone_number: nil, page: "new_organisation_telephone_number" } }
+          end
+
+          let(:request) do
+            patch "/merge-request/#{merge_request.id}", headers:, params:
+          end
+
+          it "renders the error" do
+            request
+            expect(page).to have_content("Enter a telephone number")
+          end
+
+          it "does not update the organisation name" do
+            expect { request }.not_to(change { merge_request.reload.attributes })
+          end
+        end
+
+        context "when the new organisation telephone number already exists" do
+          before do
+            create(:organisation, phone: "1234")
+          end
+
+          let(:params) do
+            { merge_request: { new_organisation_telephone_number: "1234", page: "new_organisation_telephone_number" } }
+          end
+
+          let(:request) do
+            patch "/merge-request/#{merge_request.id}", headers:, params:
+          end
+
+          it "renders the error" do
+            request
+            expect(page).to have_content("An organisation with this telephone number already exists")
+          end
+
+          it "does not update the organisation name" do
+            expect { request }.not_to(change { merge_request.reload.attributes })
           end
         end
       end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -687,33 +687,10 @@ RSpec.describe MergeRequestsController, type: :request do
 
           it "renders the error" do
             request
-            expect(page).to have_content("Enter a telephone number")
+            expect(page).to have_content("Enter a valid telephone number")
           end
 
-          it "does not update the organisation name" do
-            expect { request }.not_to(change { merge_request.reload.attributes })
-          end
-        end
-
-        context "when the new organisation telephone number already exists" do
-          before do
-            create(:organisation, phone: "1234")
-          end
-
-          let(:params) do
-            { merge_request: { new_organisation_telephone_number: "1234", page: "new_organisation_telephone_number" } }
-          end
-
-          let(:request) do
-            patch "/merge-request/#{merge_request.id}", headers:, params:
-          end
-
-          it "renders the error" do
-            request
-            expect(page).to have_content("An organisation with this telephone number already exists")
-          end
-
-          it "does not update the organisation name" do
+          it "does not update the organisation telephone number" do
             expect { request }.not_to(change { merge_request.reload.attributes })
           end
         end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -649,10 +649,6 @@ RSpec.describe MergeRequestsController, type: :request do
           it "has the correct back button" do
             expect(page).to have_link("Back", href: new_organisation_address_merge_request_path(merge_request))
           end
-
-          it "has a skip link" do
-            expect(page).to have_link("Skip for now", href: new_organisation_type_merge_request_path(merge_request))
-          end
         end
 
         context "when updating the new organisation telephone number" do


### PR DESCRIPTION
ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2082

Adds new organisation telephone number page in the merge organisation path if organisations are merging into a new one.

Kept this separate from the similar behaviour for existing orgs for better separation of concerns.
Also added dummy page for the upcoming organisation type ticket (can't see this in JIRA but assume it's coming soon).

new page:

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/94526761/236478266-ded201e9-2b92-44c4-9b60-1aca624fc6ee.png">


