### PR TITLE
Remove chart.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "accessible-autocomplete": "^2.0.3",
     "babel-loader": "^8.2.3",
     "babel-plugin-macros": "^3.1.0",
-    "chart.js": "^3.6.0",
     "copy-webpack-plugin": "^10.2.4",
     "core-js": "^3.21.1",
     "css-loader": "^6.7.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = {
           path.resolve(__dirname, 'node_modules/@hotwired/stimulus'),
           path.resolve(__dirname, 'node_modules/@stimulus/polyfills'),
           path.resolve(__dirname, 'node_modules/@rails/actioncable'),
-          path.resolve(__dirname, 'node_modules/chartjs'),
           path.resolve(__dirname, 'app/frontend')
         ],
         use: ['babel-loader']

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,11 +1964,6 @@ character-parser@^2.2.0:
   dependencies:
     is-regex "^1.0.3"
 
-chart.js@^3.6.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
-  integrity sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==
-
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"


### PR DESCRIPTION
# Context

- Removing dependencies that are not used

# Changes

- Remove chart.js which appears to be part of activeadmin and chartkick which seemed to have been removed