### PR TITLE
Update bundler 2.3.14 => 2.4.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,4 +509,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.14
+   2.4.12


### PR DESCRIPTION
# Context

- We have build warnings as part of our build process
```
**WARNING** Your Gemfile.lock was bundled with bundler 2.3.14, which is incompatible with the current bundler version (2.3.24).
**WARNING** Deleting "Bundled With" from the Gemfile.lock
```

# Changes

- Update bundler 2.3.14 => 2.4.12