### PR TITLE
Update more validations upon import

### DIFF
--- a/app/models/validations/local_authority_validations.rb
+++ b/app/models/validations/local_authority_validations.rb
@@ -3,7 +3,7 @@ module Validations::LocalAuthorityValidations
     postcode = record.ppostcode_full
     if record.previous_postcode_known? && (postcode.blank? || !postcode.match(POSTCODE_REGEXP))
       error_message = I18n.t("validations.postcode")
-      record.errors.add :ppostcode_full, error_message
+      record.errors.add :ppostcode_full, :wrong_format, message: error_message
     end
   end
 end

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -20,7 +20,7 @@ module Validations::Sales::FinancialValidations
     if record.london_property? && record.income2 > 90_000
       relevant_fields.each { |field| record.errors.add field, :over_hard_max_for_london, message: I18n.t("validations.financial.income.over_hard_max_for_london") }
     elsif record.property_not_in_london? && record.income2 > 80_000
-      relevant_fields.each { |field| record.errors.add field, I18n.t("validations.financial.income.over_hard_max_for_outside_london") }
+      relevant_fields.each { |field| record.errors.add field, :over_hard_max_for_outside_london, message: I18n.t("validations.financial.income.over_hard_max_for_outside_london") }
     end
   end
 

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -467,11 +467,11 @@ module Imports
     def previous_postcode_known(xml_doc, previous_postcode, prevloc)
       previous_postcode_known = string_or_nil(xml_doc, "Q12bnot")
       if previous_postcode_known == "Temporary_or_Unknown" || (previous_postcode.nil? && prevloc.present?)
-        0
+        0 # not known
       elsif previous_postcode.nil?
         nil
       else
-        1
+        1 # known
       end
     end
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -231,6 +231,7 @@ module Imports
         %i[equity under_min] => %w[equity],
         %i[mscharge under_min] => %w[mscharge has_mscharge],
         %i[mortgage cannot_be_0] => %w[mortgage],
+        %i[frombeds outside_the_range] => %w[frombeds],
       }
 
       errors.each do |(error, fields)|

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -225,6 +225,7 @@ module Imports
         %i[exdate over_a_year_from_saledate] => %w[exdate],
         %i[income1 over_hard_max_for_outside_london] => %w[income1],
         %i[income1 over_hard_max_for_london] => %w[income1],
+        %i[income2 over_hard_max_for_outside_london] => %w[income2],
         %i[income2 over_hard_max_for_london] => %w[income2],
         %i[equity over_max] => %w[equity],
         %i[equity under_min] => %w[equity],

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -229,6 +229,7 @@ module Imports
         %i[income2 over_hard_max_for_london] => %w[income2],
         %i[equity over_max] => %w[equity],
         %i[equity under_min] => %w[equity],
+        %i[mscharge under_min] => %w[mscharge has_mscharge],
         %i[mortgage cannot_be_0] => %w[mortgage],
       }
 

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -249,6 +249,12 @@ module Imports
         attributes.delete("postcode_full")
         attributes["pcodenk"] = attributes["la"].present? ? 1 : nil
         save_sales_log(attributes, previous_status)
+      elsif sales_log.errors.of_kind?(:ppostcode_full, :wrong_format)
+        @logger.warn("Log #{sales_log.old_id}: Removing previous postcode as the postcode is invalid")
+        @logs_overridden << sales_log.old_id
+        attributes.delete("ppostcode_full")
+        attributes["ppcodenk"] = attributes["prevloc"].present? ? 1 : nil
+        save_sales_log(attributes, previous_status)
       elsif sales_log.errors.of_kind?(:uprn, :uprn_error)
         @logger.warn("Log #{sales_log.old_id}: Setting uprn_known to no with error: #{sales_log.errors[:uprn].join(', ')}")
         @logs_overridden << sales_log.old_id

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -595,6 +595,33 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "and it has a record with previous postcode in invalid format" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      before do
+        sales_log_xml.at_xpath("//xmlns:Q7Postcode").content = "L3132AF"
+        sales_log_xml.at_xpath("//xmlns:Q7ONSLACode").content = "E07000223"
+      end
+
+      it "intercepts the relevant validation error" do
+        expect(logger).to receive(:warn).with(/Log shared_ownership_sales_log: Removing previous postcode as the postcode is invalid/)
+        expect { sales_log_service.send(:create_log, sales_log_xml) }
+          .not_to raise_error
+      end
+
+      it "clears out the invalid answers and sets correct prevloc" do
+        allow(logger).to receive(:warn)
+
+        sales_log_service.send(:create_log, sales_log_xml)
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+
+        expect(sales_log).not_to be_nil
+        expect(sales_log.ppostcode_full).to be_nil
+        expect(sales_log.ppcodenk).to eq(1) # not known
+        expect(sales_log.prevloc).to eq("E07000223") # not known
+      end
+    end
+
     context "and setup field has validation error in incomplete log" do
       let(:sales_log_id) { "shared_ownership_sales_log" }
 


### PR DESCRIPTION
- Clear invalid previous postcode on sales loss
- Add an error to clear when income2 is above threshold for non London locations
- Remove mscharge and frombeds if they're out of the range