### PR TITLE
CLDC-2195 Back to button CTA

### DIFF
--- a/app/controllers/bulk_upload_lettings_results_controller.rb
+++ b/app/controllers/bulk_upload_lettings_results_controller.rb
@@ -10,7 +10,9 @@ class BulkUploadLettingsResultsController < ApplicationController
   end
 
   def resume
-    @bulk_upload = current_user.bulk_uploads.lettings.find(params[:id])
+    @bulk_upload = BulkUpload.lettings.find(params[:id])
+
+    authorize @bulk_upload
 
     if @bulk_upload.lettings_logs.in_progress.count.positive?
       set_bulk_upload_logs_filters

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -137,7 +137,11 @@ class Log < ApplicationRecord
   end
 
   def creation_method
-    bulk_upload_id ? "bulk upload" : "single log"
+    bulk_uploaded? ? "bulk upload" : "single log"
+  end
+
+  def bulk_uploaded?
+    bulk_upload_id.present?
   end
 
 private

--- a/app/policies/bulk_upload_policy.rb
+++ b/app/policies/bulk_upload_policy.rb
@@ -14,6 +14,10 @@ class BulkUploadPolicy
     owner? || same_org? || user.support?
   end
 
+  def resume?
+    owner? || same_org? || user.support?
+  end
+
 private
 
   def owner?

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -39,9 +39,15 @@
     <%= render "tasklist" %>
 
     <% if @log.completed? %>
-      <% if @log.lettings? %>
+      <% if @log.bulk_uploaded? %>
+        <% if @log.lettings? %>
+          <%= govuk_button_link_to "Back to uploaded logs", resume_bulk_upload_lettings_result_path(@log.bulk_upload) %>
+        <% else %>
+          <%= govuk_button_link_to "Back to uploaded logs", resume_bulk_upload_sales_result_path(@log.bulk_upload) %>
+        <% end %>
+      <% elsif @log.lettings? %>
         <%= govuk_button_link_to "Back to lettings logs", lettings_logs_path %>
-      <% else %>
+      <% elsif @log.sales? %>
         <%= govuk_button_link_to "Back to sales logs", sales_logs_path %>
       <% end %>
     <% end %>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -12,9 +12,11 @@
 
     <% if @log.status == "in_progress" %>
       <p class="govuk-body govuk-!-margin-bottom-7"><%= get_subsections_count(@log, :completed) %> of <%= get_subsections_count(@log) %> subsections completed.</p>
+
       <p class="govuk-body govuk-!-margin-bottom-2">
         <% next_incomplete_section = get_next_incomplete_section(@log) %>
       </p>
+
       <p>
         <% if next_incomplete_section.present? %>
           <a class="app-section-skip-link" href="#<%= next_incomplete_section.id.dasherize %>">
@@ -28,10 +30,20 @@
       <p class="govuk-body">
         <%= status_tag(@log.status) %>
       </p>
+
       <p class="govuk-body">
         <%= review_log_text(@log) %>
       </p>
     <% end %>
+
     <%= render "tasklist" %>
+
+    <% if @log.completed? %>
+      <% if @log.lettings? %>
+        <%= govuk_button_link_to "Back to lettings logs", lettings_logs_path %>
+      <% else %>
+        <%= govuk_button_link_to "Back to sales logs", sales_logs_path %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/spec/policies/bulk_upload_policy_spec.rb
+++ b/spec/policies/bulk_upload_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe BulkUploadPolicy do
   subject(:policy) { described_class }
 
-  permissions :summary?, :show? do
+  permissions :summary?, :show?, :resume? do
     it "grants access to owner" do
       user = build(:user)
       bulk_upload = build(:bulk_upload, user:)

--- a/spec/views/logs/edit.html.erb_spec.rb
+++ b/spec/views/logs/edit.html.erb_spec.rb
@@ -41,5 +41,31 @@ RSpec.describe "logs/edit.html.erb" do
         expect(fragment).to have_link(text: "Back to sales logs", href: "/sales-logs")
       end
     end
+
+    context "when lettings log is bulk uploaded" do
+      let(:bulk_upload) { create(:bulk_upload, :lettings) }
+      let(:log) { create(:lettings_log, :completed, bulk_upload:) }
+
+      it "has link 'Back to uploaded logs'" do
+        render
+
+        fragment = Capybara::Node::Simple.new(rendered)
+
+        expect(fragment).to have_link(text: "Back to uploaded logs", href: "/lettings-logs/bulk-upload-results/#{bulk_upload.id}/resume")
+      end
+    end
+
+    context "when sales log is bulk uploaded" do
+      let(:bulk_upload) { create(:bulk_upload, :sales) }
+      let(:log) { create(:sales_log, :completed, bulk_upload:) }
+
+      it "has link 'Back to uploaded logs'" do
+        render
+
+        fragment = Capybara::Node::Simple.new(rendered)
+
+        expect(fragment).to have_link(text: "Back to uploaded logs", href: "/sales-logs/bulk-upload-results/#{bulk_upload.id}/resume")
+      end
+    end
   end
 end

--- a/spec/views/logs/edit.html.erb_spec.rb
+++ b/spec/views/logs/edit.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "logs/edit.html.erb" do
+  before do
+    assign(:log, log)
+  end
+
+  context "when log is in progress" do
+    let(:log) { create(:lettings_log, :in_progress) }
+
+    it "there is no link back to log type root" do
+      render
+
+      fragment = Capybara::Node::Simple.new(rendered)
+
+      expect(fragment).not_to have_link(text: "Back to lettings logs", href: "/lettings-logs")
+    end
+  end
+
+  context "when log is completed" do
+    context "when showing a lettings log" do
+      let(:log) { create(:lettings_log, :completed) }
+
+      it "has link 'Back to lettings logs'" do
+        render
+
+        fragment = Capybara::Node::Simple.new(rendered)
+
+        expect(fragment).to have_link(text: "Back to lettings logs", href: "/lettings-logs")
+      end
+    end
+
+    context "when showing a sales log" do
+      let(:log) { create(:sales_log, :completed) }
+
+      it "has link 'Back to sales logs'" do
+        render
+
+        fragment = Capybara::Node::Simple.new(rendered)
+
+        expect(fragment).to have_link(text: "Back to sales logs", href: "/sales-logs")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2195
- to allow users to continue their journey after completing logs adding a CTA link on completed logs

# Changes

- when a completed bulk uploaded log shown link back to logs for that bulk upload
- if all those logs are completed interstitial is shown which links back to all logs 
- when a completed lettings or sales log show, link back to lettings or sales logs index

# Screenshots

![Screenshot 2023-05-10 at 13 34 32](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/92580/0eecbe4a-1ffd-4de8-8493-9754fd7de0b5)