### PR TITLE
Fix N+1 query in scheme answer options page

### DIFF
--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -30,10 +30,10 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     organisation = lettings_log.owning_organisation || lettings_log.created_by&.organisation
     schemes = if organisation
-                Scheme.select(:id).where(owning_organisation_id: organisation.id,
-                                         confirmed: true)
+                Scheme.includes(:locations).select(:id).where(owning_organisation_id: organisation.id,
+                                                              confirmed: true)
               else
-                Scheme.select(:id).where(confirmed: true)
+                Scheme.includes(:locations).select(:id).where(confirmed: true)
               end
     filtered_scheme_ids = schemes.joins(:locations).merge(Location.where("startdate <= ? or startdate IS NULL",
                                                                          Time.zone.today)).map(&:id)


### PR DESCRIPTION
- We were alerted to an N+1 query in the scheme selection page via Sentry
- This PR eagerly loads a related scheme's locations so that we're not loading them individually, which is slow.

Sentry: https://dluhc-core.sentry.io/issues/4111826569/?project=6196323&referrer=slack