### PR TITLE
CLDC-2361 Extract bulk upload filter from session

### DIFF
--- a/app/controllers/lettings_logs_controller.rb
+++ b/app/controllers/lettings_logs_controller.rb
@@ -118,7 +118,7 @@ private
   end
 
   def redirect_if_bulk_upload_resolved
-    if @bulk_upload && @bulk_upload.lettings? && @bulk_upload.lettings_logs.in_progress.count.zero?
+    if @bulk_upload&.lettings? && @bulk_upload.lettings_logs.in_progress.count.zero?
       redirect_to resume_bulk_upload_lettings_result_path(@bulk_upload)
     end
   end

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -70,7 +70,7 @@ private
   end
 
   def redirect_if_bulk_upload_resolved
-    if @bulk_upload && @bulk_upload.sales? && @bulk_upload.sales_logs.in_progress.count.zero?
+    if @bulk_upload&.sales? && @bulk_upload.sales_logs.in_progress.count.zero?
       redirect_to resume_bulk_upload_sales_result_path(@bulk_upload)
     end
   end

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -3,6 +3,9 @@ class SalesLogsController < LogsController
   before_action :set_session_filters, if: :current_user, only: %i[index email_csv download_csv]
   before_action :authenticate_scope!, only: %i[download_csv email_csv]
 
+  before_action :extract_bulk_upload_from_session_filters, only: [:index]
+  before_action :redirect_if_bulk_upload_resolved, only: [:index]
+
   def create
     super { SalesLog.new(log_params) }
   end
@@ -60,6 +63,17 @@ class SalesLogsController < LogsController
   end
 
 private
+
+  def extract_bulk_upload_from_session_filters
+    filter_service = FilterService.new(current_user:, session:)
+    @bulk_upload = filter_service.bulk_upload
+  end
+
+  def redirect_if_bulk_upload_resolved
+    if @bulk_upload && @bulk_upload.sales? && @bulk_upload.sales_logs.in_progress.count.zero?
+      redirect_to resume_bulk_upload_sales_result_path(@bulk_upload)
+    end
+  end
 
   def authenticate_scope!
     head :unauthorized and return if codes_only_export? && !current_user.support?

--- a/spec/controllers/sales_logs_controller_spec.rb
+++ b/spec/controllers/sales_logs_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe SalesLogsController do
+  let(:bulk_upload) { create(:bulk_upload, :sales) }
+
+  before do
+    sign_in bulk_upload.user
+  end
+
+  describe "#index" do
+    context "when a sales bulk upload has been resolved" do
+      it "redirects to resume_bulk_upload_sales_result_path" do
+        session[:logs_filters] = { bulk_upload_id: [bulk_upload.id.to_s] }.to_json
+
+        get :index
+
+        expect(response).to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}/resume")
+      end
+    end
+
+    context "when a resolved lettings bulk upload filter applied" do
+      let(:bulk_upload) { create(:bulk_upload, :lettings) }
+
+      it "does not redirect to resume" do
+        session[:logs_filters] = { bulk_upload_id: [bulk_upload.id.to_s] }.to_json
+
+        get :index
+
+        expect(response).not_to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}/resume")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2361
- When fixing inline for sales bulk uploads users need to be able to show only logs related to the bulk upload therefore have the bulk upload filter applied

# Changes

- After a sales bulk upload the session is set with bulk upload filter
- When viewing sales log ensure we extract this apply as a filter

# Issues

- The current implementation is globally shared between lettings and sales therefore there are issues when switching between the 2 areas
- There is a backlog ticket to refactor the filter and recommend fixing this issue then