### PR TITLE
CLDC-2350 Set uprn confirmed

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -41,7 +41,7 @@ class Log < ApplicationRecord
   }
   scope :created_by, ->(user) { where(created_by: user) }
 
-  attr_accessor :skip_update_status
+  attr_accessor :skip_update_status, :skip_update_uprn_confirmed
 
   def process_uprn_change!
     if uprn.present?
@@ -53,7 +53,7 @@ class Log < ApplicationRecord
       presenter = UprnDataPresenter.new(service.result)
 
       self.uprn_known = 1
-      self.uprn_confirmed = nil
+      self.uprn_confirmed = nil unless skip_update_uprn_confirmed
       self.address_line1 = presenter.address_line1
       self.address_line2 = presenter.address_line2
       self.town_or_city = presenter.town_or_city

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1153,6 +1153,8 @@ private
     attributes["first_time_property_let_as_social_housing"] = first_time_property_let_as_social_housing
 
     attributes["uprn_known"] = field_18.present? ? 1 : 0
+    attributes["uprn_confirmed"] = 1 if field_18.present?
+    attributes["skip_update_uprn_confirmed"] = true
     attributes["uprn"] = field_18
     attributes["address_line1"] = field_19
     attributes["address_line2"] = field_20

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -824,6 +824,8 @@ private
 
     attributes["uprn"] = field_19
     attributes["uprn_known"] = field_19.present? ? 1 : 0
+    attributes["uprn_confirmed"] = 1 if field_19.present?
+    attributes["skip_update_uprn_confirmed"] = true
     attributes["address_line1"] = field_20
     attributes["address_line2"] = field_21
     attributes["town_or_city"] = field_22

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1077,6 +1077,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         it "sets to 1" do
           expect(parser.log.uprn_known).to be(1)
+          expect(parser.log.uprn_confirmed).to be(1)
         end
       end
 

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -539,6 +539,12 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         it "is valid" do
           expect(parser.errors[:field_19]).to be_blank
         end
+
+        it "sets UPRN and UPRN known" do
+          expect(parser.log.uprn).to eq("100023336956")
+          expect(parser.log.uprn_known).to eq(1)
+          expect(parser.log.uprn_confirmed).to eq(1)
+        end
       end
 
       context "when UPRN not known but address known" do


### PR DESCRIPTION
We want UPRN confirmed to be set to yes whenever we bulk upload a log. That means not reseting it to nil when processing the UPRN changes.