### PR TITLE
CLDC-2352 Infer uprn_known in 23/24 sales bulk upload

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -155,7 +155,6 @@ class Log < ApplicationRecord
       self.town_or_city = nil
       self.postcode_full = nil
       self.county = nil
-      process_postcode_changes!
     end
   end
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -155,6 +155,7 @@ class Log < ApplicationRecord
       self.town_or_city = nil
       self.postcode_full = nil
       self.county = nil
+      process_postcode_changes!
     end
   end
 

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -816,6 +816,7 @@ private
     attributes["mortgageused"] = mortgageused
 
     attributes["uprn"] = field_19
+    attributes["uprn_known"] = field_19.present? ? 1 : 0
     attributes["address_line1"] = field_20
     attributes["address_line2"] = field_21
     attributes["town_or_city"] = field_22

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -597,6 +597,25 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#uprn_known" do
+      context "when uprn known" do
+        let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }
+
+        it "is correctly set" do
+          expect(parser.log.uprn_known).to be(1)
+        end
+      end
+
+      context "when uprn not known" do
+        let(:attributes) { setup_section_params.merge({ field_19: nil }) }
+
+        it "is correctly set" do
+          expect(parser.log.uprn_known).to be(0)
+        end
+      end
+
+    end
+
     describe "#address_line1" do
       let(:attributes) { setup_section_params.merge({ field_20: "some street" }) }
 

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -613,7 +613,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           expect(parser.log.uprn_known).to be(0)
         end
       end
-
     end
 
     describe "#address_line1" do


### PR DESCRIPTION
Infers `uprn_known` depending on whether uprn was given in the bulk upload form or not. Note: invalid uprns still clear uprn_known later on when logs are uploaded which is the correct behaviour in my 

Here's the fixed behaviour, `uprn_known` is "Not known" and the address is populated:
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/94526761/82243ad8-3c33-4334-adae-11b2ee06fd00)


ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2352