### PR TITLE
CLDC-2359 Do not allow 32 as an option for 22/23 sale type

### DIFF
--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -1031,9 +1031,9 @@ private
   end
   
   def validate_shared_ownership_type
-    block_log_creation!
-
     if sale_type == 32
+      block_log_creation!
+
       errors.add(:field_8, I18n.t("validations.invalid_option", question: "shared ownership type"), category: :setup)
     end
   end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -287,6 +287,7 @@ class BulkUpload::Sales::Year2022::RowParser
   validate :validate_relevant_collection_window, on: :after_log
   validate :validate_incomplete_soft_validations, on: :after_log
   validate :validate_if_log_already_exists, on: :after_log, if: -> { FeatureToggle.bulk_upload_duplicate_log_check_enabled? }
+  validate :validate_shared_ownership_type, on: :after_log, if: :shared_ownership?
 
   def self.question_for_field(field)
     QUESTIONS[field]
@@ -1026,6 +1027,14 @@ private
   def validate_buyer1_economic_status
     if field_24 == 9
       errors.add(:field_24, "Buyer 1 cannot be a child under 16")
+    end
+  end
+  
+  def validate_shared_ownership_type
+    block_log_creation!
+
+    if sale_type == 32
+      errors.add(:field_8, I18n.t("validations.invalid_option", question: "shared ownership type"), category: :setup)
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -260,19 +260,19 @@ class BulkUpload::Sales::Year2022::RowParser
   attribute :field_124, :integer
   attribute :field_125, :integer
 
-  validates :field_2, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (day)") }, on: :after_log
-  validates :field_3, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (month)") }, on: :after_log
-  validates :field_4, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (year)") }, on: :after_log
+  validates :field_2, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (day)"), category: :setup }, on: :after_log
+  validates :field_3, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (month)"), category: :setup }, on: :after_log
+  validates :field_4, presence: { message: I18n.t("validations.not_answered", question: "sale completion date (year)"), category: :setup }, on: :after_log
   validates :field_4, format: { with: /\A\d{2}\z/, message: I18n.t("validations.setup.saledate.year_not_two_digits") }, on: :after_log
 
-  validates :field_113, presence: { message: I18n.t("validations.not_answered", question: "ownership type") }, on: :after_log
-  validates :field_57, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type") }, if: :shared_ownership?, on: :after_log
-  validates :field_76, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type") }, if: :discounted_ownership?, on: :after_log
-  validates :field_84, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type") }, if: :outright_sale?, on: :after_log
-  validates :field_115, presence: { message: I18n.t("validations.not_answered", question: "will the buyers live in the property") }, if: :outright_sale?, on: :after_log
-  validates :field_116, presence: { message: I18n.t("validations.not_answered", question: "joint purchase") }, if: :joint_purchase_asked?, on: :after_log
-  validates :field_114, presence: { message: I18n.t("validations.not_answered", question: "company buyer") }, if: :outright_sale?, on: :after_log
-  validates :field_109, presence: { message: I18n.t("validations.not_answered", question: "more than 2 buyers") }, if: :joint_purchase?, on: :after_log
+  validates :field_113, presence: { message: I18n.t("validations.not_answered", question: "ownership type"), category: :setup }, on: :after_log
+  validates :field_57, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type"), category: :setup }, if: :shared_ownership?, on: :after_log
+  validates :field_76, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type"), category: :setup }, if: :discounted_ownership?, on: :after_log
+  validates :field_84, presence: { message: I18n.t("validations.not_answered", question: "shared ownership type"), category: :setup }, if: :outright_sale?, on: :after_log
+  validates :field_115, presence: { message: I18n.t("validations.not_answered", question: "will the buyers live in the property"), category: :setup }, if: :outright_sale?, on: :after_log
+  validates :field_116, presence: { message: I18n.t("validations.not_answered", question: "joint purchase"), category: :setup }, if: :joint_purchase_asked?, on: :after_log
+  validates :field_114, presence: { message: I18n.t("validations.not_answered", question: "company buyer"), category: :setup }, if: :outright_sale?, on: :after_log
+  validates :field_109, presence: { message: I18n.t("validations.not_answered", question: "more than 2 buyers"), category: :setup }, if: :joint_purchase?, on: :after_log
 
   validate :validate_buyer1_economic_status, on: :before_log
   validate :validate_nulls, on: :after_log
@@ -941,13 +941,13 @@ private
 
       if setup_question?(question)
         fields.each do |field|
-          if errors[field].present?
+          unless errors.any? { |e| fields.include?(e.attribute) }
             errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase), category: :setup)
           end
         end
       else
         fields.each do |field|
-          if errors.none? { |e| fields.include?(e.attribute) }
+          unless errors.any? { |e| fields.include?(e.attribute) }
             errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase))
           end
         end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -1029,7 +1029,7 @@ private
       errors.add(:field_24, "Buyer 1 cannot be a child under 16")
     end
   end
-  
+
   def validate_shared_ownership_type
     if sale_type == 32
       block_log_creation!

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -1034,7 +1034,7 @@ private
     if sale_type == 32
       block_log_creation!
 
-      errors.add(:field_8, I18n.t("validations.invalid_option", question: "shared ownership type"), category: :setup)
+      errors.add(:field_57, I18n.t("validations.invalid_option", question: "shared ownership type"), category: :setup)
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -1163,7 +1163,8 @@ private
 
       if setup_question?(question)
         fields.each do |field|
-          if errors[field].present?
+          if errors[field].blank?
+            block_log_creation!
             errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]), category: :setup)
           end
         end

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -628,7 +628,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { valid_attributes.merge(field_113: 1, field_57: "32") }
 
         it "is not permitted as a setup error" do
-          expect(parser.errors.where(:field_8, category: :setup)).to be_present
+          expect(parser.errors.where(:field_57, category: :setup)).to be_present
         end
 
         it "blocks log creation" do

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_114 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_115 field_114 field_92])
       end
     end
 

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -622,6 +622,20 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         end
       end
     end
+
+    describe "shared ownership sale type" do
+      context "when 32 is selected for shared ownership type" do
+        let(:attributes) { valid_attributes.merge(field_113: 1, field_57: "32") }
+
+        it "is not permitted as a setup error" do
+          expect(parser.errors.where(:field_8, category: :setup)).to be_present
+        end
+
+        it "blocks log creation" do
+          expect(parser).to be_block_log_creation
+        end
+      end
+    end
   end
 
   describe "inferences" do

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -931,5 +931,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         expect(log["mscharge"]).to be_nil
       end
     end
+
+    describe "shared ownership sale type" do
+      context "when 32 is selected for shared ownership type" do
+        let(:attributes) { valid_attributes.merge(field_8: "32") }
+
+        it "sets the value correctly" do
+          log = parser.log
+          expect(log["type"]).to eq(32)
+        end
+      end
+    end
   end
 end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -938,7 +938,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
         it "sets the value correctly" do
           log = parser.log
-          expect(log["type"]).to eq(32)
+          expect(log.type).to eq(32)
         end
       end
     end


### PR DESCRIPTION
32 is a valid option for 23/24 shared ownership sale type, but it does not exist for 22/23. We want to prevent it from being saved with a setup error