### PR TITLE
Check links instead of content in some tests

### DIFF
--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1138,14 +1138,14 @@ RSpec.describe LettingsLogsController, type: :request do
       it "only displays affected logs" do
         get "/lettings-logs/update-logs", headers:, params: {}
         expect(page).to have_content("You need to update 3 logs")
-        expect(page).to have_content(affected_lettings_logs.first.id)
-        expect(page).not_to have_content(non_affected_lettings_logs.first.id)
+        expect(page).to have_link("Update now", href: "/lettings-logs/#{affected_lettings_logs.first.id}/tenancy-start-date")
+        expect(page).not_to have_link("Update now", href: "/lettings-logs/#{non_affected_lettings_logs.first.id}/tenancy-start-date")
       end
 
       it "only displays the logs created by the user" do
         get "/lettings-logs/update-logs", headers:, params: {}
-        expect(page).to have_content(affected_lettings_logs.second.id)
-        expect(page).not_to have_content(other_user_affected_lettings_log.id)
+        expect(page).to have_link("Update now", href: "/lettings-logs/#{affected_lettings_logs.second.id}/tenancy-start-date")
+        expect(page).not_to have_link("Update now", href: "/lettings-logs/#{other_user_affected_lettings_log.id}/tenancy-start-date")
         expect(page).to have_content("You need to update 3 logs")
       end
 


### PR DESCRIPTION
Checking for IDs in the content is quite flaky, because a lot of the time it would succeed in finding that ID number on the page, but not as the ID we actually expect. Checking for links that point to the logs with those specific IDs is more accurate and should reduce flakiness