### PR TITLE
CLDC-2305 Bulk upload setup fields validations

### DIFF
--- a/app/models/bulk_upload_error.rb
+++ b/app/models/bulk_upload_error.rb
@@ -1,6 +1,7 @@
 class BulkUploadError < ApplicationRecord
   belongs_to :bulk_upload
 
+  scope :order_by_row, -> { order(row: :asc) }
   scope :order_by_cell, -> { order(Arel.sql("LPAD(cell, 10, '0')")) }
   scope :order_by_col, -> { order(Arel.sql("LPAD(col, 10, '0')")) }
 end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -966,9 +966,9 @@ private
 
       if setup_question?(question)
         fields.each do |field|
-          if errors[field].blank?
+          if errors[field].none?
             block_log_creation!
-            errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]), category: :setup)
+            errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field].downcase), category: :setup)
           end
         end
       else

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -292,7 +292,7 @@ class BulkUpload::Sales::Year2022::RowParser
 
   validates :field_76,
             presence: {
-              message: I18n.t("validations.not_answered", question: "shared ownership type"),
+              message: I18n.t("validations.not_answered", question: "discounted ownership type"),
             },
             if: :discounted_ownership?,
             on: :after_log
@@ -308,7 +308,7 @@ class BulkUpload::Sales::Year2022::RowParser
 
   validates :field_84,
             presence: {
-              message: I18n.t("validations.not_answered", question: "shared ownership type"),
+              message: I18n.t("validations.not_answered", question: "type of outright sale"),
             },
             if: :outright_sale?,
             on: :after_log

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -277,6 +277,7 @@ class BulkUpload::Sales::Year2022::RowParser
   validates :field_57,
             presence: {
               message: I18n.t("validations.not_answered", question: "shared ownership type"),
+              category: :setup,
             },
             if: :shared_ownership?,
             on: :after_log
@@ -293,6 +294,7 @@ class BulkUpload::Sales::Year2022::RowParser
   validates :field_76,
             presence: {
               message: I18n.t("validations.not_answered", question: "discounted ownership type"),
+              category: :setup,
             },
             if: :discounted_ownership?,
             on: :after_log
@@ -309,6 +311,7 @@ class BulkUpload::Sales::Year2022::RowParser
   validates :field_84,
             presence: {
               message: I18n.t("validations.not_answered", question: "type of outright sale"),
+              category: :setup,
             },
             if: :outright_sale?,
             on: :after_log

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -1163,7 +1163,7 @@ private
 
       if setup_question?(question)
         fields.each do |field|
-          if errors[field].blank?
+          if errors[field].none?
             block_log_creation!
             errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]), category: :setup)
           end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -463,6 +463,8 @@ class BulkUpload::Sales::Year2023::RowParser
   validate :validate_address_fields, on: :after_log
   validate :validate_if_log_already_exists, on: :after_log, if: -> { FeatureToggle.bulk_upload_duplicate_log_check_enabled? }
 
+  validate :validate_data_protection_answered, on: :after_log
+
   def self.question_for_field(field)
     QUESTIONS[field]
   end
@@ -529,6 +531,12 @@ class BulkUpload::Sales::Year2023::RowParser
   end
 
 private
+
+  def validate_data_protection_answered
+    unless field_29 == 1
+      errors.add(:field_29, I18n.t("validations.not_answered", question: QUESTIONS[:field_29].downcase), category: :setup)
+    end
+  end
 
   def prevtenbuy2
     case field_72

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -366,7 +366,7 @@ class BulkUpload::Sales::Year2023::RowParser
 
   validates :field_9,
             presence: {
-              message: I18n.t("validations.not_answered", question: "shared ownership type"),
+              message: I18n.t("validations.not_answered", question: "discounted ownership type"),
               category: :setup,
               if: :discounted_ownership?,
             },
@@ -382,7 +382,7 @@ class BulkUpload::Sales::Year2023::RowParser
 
   validates :field_10,
             presence: {
-              message: I18n.t("validations.not_answered", question: "shared ownership type"),
+              message: I18n.t("validations.not_answered", question: "type of ouright sale"),
               category: :setup,
               if: :outright_sale?,
             },

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -414,13 +414,21 @@ class BulkUpload::Sales::Year2023::RowParser
             on: :after_log
 
   validates :field_13,
+            inclusion: {
+              in: [1, 2],
+              if: proc { outright_sale? && field_13.present? },
+              category: :setup,
+              question: QUESTIONS[:field_13].downcase,
+            },
+            on: :before_log
+
+  validates :field_13,
             presence: {
               message: I18n.t("validations.not_answered", question: "will the buyers live in the property"),
               category: :setup,
               if: :outright_sale?,
             },
             on: :after_log
-
 
   validates :field_14,
             presence: {

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -345,6 +345,7 @@ class BulkUpload::Sales::Year2023::RowParser
               in: [2, 30, 18, 16, 24, 28, 31, 32],
               if: proc { field_8.present? },
               category: :setup,
+              question: QUESTIONS[:field_8].downcase,
             },
             on: :before_log
 
@@ -361,6 +362,7 @@ class BulkUpload::Sales::Year2023::RowParser
               in: [8, 14, 27, 9, 29, 21, 22],
               if: proc { field_9.present? },
               category: :setup,
+              question: QUESTIONS[:field_9].downcase,
             },
             on: :before_log
 
@@ -377,6 +379,7 @@ class BulkUpload::Sales::Year2023::RowParser
               in: [10, 12],
               if: proc { field_10.present? },
               category: :setup,
+              question: QUESTIONS[:field_10].downcase,
             },
             on: :before_log
 

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -396,13 +396,14 @@ class BulkUpload::Sales::Year2023::RowParser
             },
             on: :after_log
 
-  validates :field_13,
-            presence: {
-              message: I18n.t("validations.not_answered", question: "will the buyers live in the property"),
+  validates :field_12,
+            inclusion: {
+              in: [1, 2],
+              if: proc { outright_sale? && field_12.present? },
               category: :setup,
-              if: :outright_sale?,
+              question: QUESTIONS[:field_12].downcase,
             },
-            on: :after_log
+            on: :before_log
 
   validates :field_12,
             presence: {
@@ -411,6 +412,15 @@ class BulkUpload::Sales::Year2023::RowParser
               if: :outright_sale?,
             },
             on: :after_log
+
+  validates :field_13,
+            presence: {
+              message: I18n.t("validations.not_answered", question: "will the buyers live in the property"),
+              category: :setup,
+              if: :outright_sale?,
+            },
+            on: :after_log
+
 
   validates :field_14,
             presence: {

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -388,6 +388,14 @@ class BulkUpload::Sales::Year2023::RowParser
             },
             on: :after_log
 
+  validates :field_11,
+            presence: {
+              message: I18n.t("validations.not_answered", question: "type of outright sale"),
+              category: :setup,
+              if: proc { field_10 == 12 },
+            },
+            on: :after_log
+
   validates :field_13,
             presence: {
               message: I18n.t("validations.not_answered", question: "will the buyers live in the property"),

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -341,6 +341,14 @@ class BulkUpload::Sales::Year2023::RowParser
             on: :after_log
 
   validates :field_8,
+            inclusion: {
+              in: [2, 30, 18, 16, 24, 28, 31, 32],
+              if: proc { field_8.present? },
+              category: :setup,
+            },
+            on: :before_log
+
+  validates :field_8,
             presence: {
               message: I18n.t("validations.not_answered", question: "shared ownership type"),
               category: :setup,
@@ -349,12 +357,28 @@ class BulkUpload::Sales::Year2023::RowParser
             on: :after_log
 
   validates :field_9,
+            inclusion: {
+              in: [8, 14, 27, 9, 29, 21, 22],
+              if: proc { field_9.present? },
+              category: :setup,
+            },
+            on: :before_log
+
+  validates :field_9,
             presence: {
               message: I18n.t("validations.not_answered", question: "shared ownership type"),
               category: :setup,
               if: :discounted_ownership?,
             },
             on: :after_log
+
+  validates :field_10,
+            inclusion: {
+              in: [10, 12],
+              if: proc { field_10.present? },
+              category: :setup,
+            },
+            on: :before_log
 
   validates :field_10,
             presence: {
@@ -1155,6 +1179,8 @@ private
   def validate_valid_radio_option
     log.attributes.each do |question_id, _v|
       question = log.form.get_question(question_id, log)
+
+      next if question_id == "type"
 
       next unless question&.type == "radio"
       next if log[question_id].blank? || question.answer_options.key?(log[question_id].to_s) || !question.page.routed_to?(log, nil)

--- a/app/views/bulk_upload_lettings_results/show.html.erb
+++ b/app/views/bulk_upload_lettings_results/show.html.erb
@@ -13,7 +13,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% @bulk_upload.bulk_upload_errors.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
+    <% @bulk_upload.bulk_upload_errors.order_by_row.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
       <%= render BulkUploadErrorRowComponent.new(bulk_upload_errors: errors_for_row) %>
     <% end %>
   </div>

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <% c.with_tab(label: "Full error report") do %>
-      <% @bulk_upload.bulk_upload_errors.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
+      <% @bulk_upload.bulk_upload_errors.order_by_row.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
         <%= render BulkUploadErrorRowComponent.new(bulk_upload_errors: errors_for_row) %>
       <% end %>
     <% end %>

--- a/app/views/bulk_upload_sales_results/show.html.erb
+++ b/app/views/bulk_upload_sales_results/show.html.erb
@@ -13,7 +13,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% @bulk_upload.bulk_upload_errors.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
+    <% @bulk_upload.bulk_upload_errors.order_by_row.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
       <%= render BulkUploadErrorRowComponent.new(bulk_upload_errors: errors_for_row) %>
     <% end %>
   </div>

--- a/app/views/bulk_upload_sales_results/summary.html.erb
+++ b/app/views/bulk_upload_sales_results/summary.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <% c.with_tab(label: "Full error report") do %>
-      <% @bulk_upload.bulk_upload_errors.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
+      <% @bulk_upload.bulk_upload_errors.order_by_row.order_by_cell.group_by(&:row).each do |_row, errors_for_row| %>
         <%= render BulkUploadErrorRowComponent.new(bulk_upload_errors: errors_for_row) %>
       <% end %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
   activemodel:
     errors:
       models:
+        bulk_upload/sales/year2023/row_parser:
+          inclusion: Enter a valid value for %{question}
         bulk_upload/lettings/validator:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
   activemodel:
     errors:
       models:
+        bulk_upload/sales/year2022/row_parser:
+          inclusion: Enter a valid value for %{question}
         bulk_upload/sales/year2023/row_parser:
           inclusion: Enter a valid value for %{question}
         bulk_upload/lettings/validator:

--- a/spec/services/bulk_upload/sales/validator_spec.rb
+++ b/spec/services/bulk_upload/sales/validator_spec.rb
@@ -173,51 +173,5 @@ RSpec.describe BulkUpload::Sales::Validator do
         expect(validator).not_to be_create_logs
       end
     end
-
-    context "when a column has error rate below absolute threshold" do
-      context "when a column is over 60% error threshold" do
-        let(:log_1) { build(:sales_log, :completed, created_by: user) }
-        let(:log_2) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-        let(:log_3) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-        let(:log_4) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-        let(:log_5) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-
-        before do
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.close
-        end
-
-        it "returns true" do
-          validator.call
-          expect(validator).to be_create_logs
-        end
-      end
-
-      context "when a column is under 60% error threshold" do
-        let(:log_1) { build(:sales_log, :completed, created_by: user) }
-        let(:log_2) { build(:sales_log, :completed, created_by: user) }
-        let(:log_3) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-        let(:log_4) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-        let(:log_5) { build(:sales_log, :in_progress, created_by: user, saledate: Time.zone.local(2022, 5, 1)) }
-
-        before do
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_1, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_2, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_3, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_4, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.write(BulkUpload::SalesLogToCsv.new(log: log_5, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
-          file.close
-        end
-
-        it "returns true" do
-          validator.call
-          expect(validator).to be_create_logs
-        end
-      end
-    end
   end
 end

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -212,9 +212,9 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
 
       it "has errors on correct setup fields" do
-        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_57 field_116 field_92 field_112])
+        expect(errors).to eql(%i[field_112 field_116 field_2 field_3 field_4 field_57 field_92])
       end
     end
 
@@ -246,9 +246,9 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
 
       it "has errors on correct setup fields" do
-        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_76 field_116 field_92 field_112])
+        expect(errors).to eql(%i[field_112 field_116 field_2 field_3 field_4 field_76 field_92])
       end
     end
 
@@ -282,8 +282,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_115 field_114 field_92])
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_114 field_92 field_112])
+        expect(errors).to eql(%i[field_112 field_114 field_115 field_2 field_3 field_4 field_84 field_92])
       end
     end
 
@@ -311,7 +310,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge(field_57: "100", field_113: "1") }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_57, category: :setup).map(&:message)).to eql(["Enter a valid value for what is the type of shared ownership sale?"])
+          expect(parser.errors.where(:field_57, category: :setup).map(&:message)).to include("Enter a valid value for what is the type of shared ownership sale?")
         end
       end
     end
@@ -498,7 +497,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_109: "100", field_116: "1" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_109, category: :setup).map(&:message)).to eql(["Enter a valid value for are there more than two joint purchasers of this property?"])
+          expect(parser.errors.where(:field_109, category: :setup).map(&:message)).to include("Enter a valid value for are there more than two joint purchasers of this property?")
         end
       end
     end
@@ -518,7 +517,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_113: "100" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_113, category: :setup).map(&:message)).to eql(["Enter a valid value for was this purchase made through an ownership scheme?"])
+          expect(parser.errors.where(:field_113, category: :setup).map(&:message)).to include("Enter a valid value for was this purchase made through an ownership scheme?")
         end
       end
     end
@@ -528,7 +527,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_114: "100", field_113: "3" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_114, category: :setup).map(&:message)).to eql(["Enter a valid value for is the buyer a company?"])
+          expect(parser.errors.where(:field_114, category: :setup).map(&:message)).to include("Enter a valid value for is the buyer a company?")
         end
       end
     end
@@ -538,7 +537,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_115: "100", field_113: "3", field_114: "2" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_115, category: :setup).map(&:message)).to eql(["Enter a valid value for will the buyers live in the property?"])
+          expect(parser.errors.where(:field_115, category: :setup).map(&:message)).to include("Enter a valid value for will the buyers live in the property?")
         end
       end
     end
@@ -548,7 +547,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_116: "100" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_116, category: :setup).map(&:message)).to eql(["Enter a valid value for is this a joint purchase?"])
+          expect(parser.errors.where(:field_116, category: :setup).map(&:message)).to include("Enter a valid value for is this a joint purchase?")
         end
       end
     end
@@ -729,10 +728,6 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
 
         it "is not permitted as a setup error" do
           expect(parser.errors.where(:field_57, category: :setup)).to be_present
-        end
-
-        it "blocks log creation" do
-          expect(parser).to be_block_log_creation
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -451,6 +451,16 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
     end
 
+    describe "#field_113" do # purchase made thru ownership scheme?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_113: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_113, category: :setup).map(&:message)).to eql(["Enter a valid value for was this purchase made through an ownership scheme?"])
+        end
+      end
+    end
+
     describe "#field_117" do
       context "when not a possible value" do
         let(:attributes) { valid_attributes.merge({ field_117: "3" }) }

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -477,11 +477,9 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         let(:attributes) { setup_section_params.merge({ field_2: nil, field_3: nil, field_4: nil }) }
 
         it "returns them as setup errors" do
-          setup_errors = parser.errors.select { |e| e.options[:category] == :setup }
-
-          expect(setup_errors.find { |e| e.attribute == :field_2 }).to be_present
-          expect(setup_errors.find { |e| e.attribute == :field_3 }).to be_present
-          expect(setup_errors.find { |e| e.attribute == :field_4 }).to be_present
+          expect(parser.errors.where(:field_2, category: :setup)).to be_present
+          expect(parser.errors.where(:field_3, category: :setup)).to be_present
+          expect(parser.errors.where(:field_4, category: :setup)).to be_present
         end
       end
 

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -304,6 +304,16 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
     end
 
+    describe "#field_57" do # type of shared ownership scheme
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_57: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_57, category: :setup).map(&:message)).to eql(["Enter a valid value for what is the type of shared ownership sale?"])
+        end
+      end
+    end
+
     describe "#field_92" do # owning org
       context "when no data given" do
         let(:attributes) { { bulk_upload:, field_92: "" } }

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_113 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_113 field_92 field_112])
       end
     end
 
@@ -214,7 +214,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_57 field_116 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_57 field_116 field_92 field_112])
       end
     end
 
@@ -232,7 +232,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_109 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_109 field_92 field_112])
       end
     end
 
@@ -248,7 +248,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_76 field_116 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_76 field_116 field_92 field_112])
       end
     end
 
@@ -266,7 +266,7 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_109 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_109 field_92 field_112])
       end
     end
 
@@ -280,9 +280,10 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
 
       it "has errors on correct setup fields" do
-        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
         expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_115 field_114 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_84 field_114 field_92 field_112])
       end
     end
 
@@ -291,25 +292,56 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         {
           bulk_upload:,
           field_1: "test id",
-          field_113: "3",
           field_84: "12",
+          field_85: "other sale type",
+          field_113: "3",
           field_114: "2",
         }
       end
 
       it "has errors on correct setup fields" do
-        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute)
+        errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_2 field_3 field_4 field_115 field_116 field_92])
+        expect(errors).to eql(%i[field_2 field_3 field_4 field_115 field_116 field_92 field_112].sort)
       end
     end
 
     describe "#field_57" do # type of shared ownership scheme
       context "when an invalid option" do
-        let(:attributes) { setup_section_params.merge({ field_57: "100" }) }
+        let(:attributes) { setup_section_params.merge(field_57: "100", field_113: "1") }
 
         it "returns setup error" do
           expect(parser.errors.where(:field_57, category: :setup).map(&:message)).to eql(["Enter a valid value for what is the type of shared ownership sale?"])
+        end
+      end
+    end
+
+    describe "#field_76" do # type of discounted ownership scheme
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_76: "100", field_113: "2" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_76, category: :setup).map(&:message)).to eql(["Enter a valid value for what is the type of discounted ownership sale?"])
+        end
+      end
+    end
+
+    describe "#field_84" do # type of outright sale
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_84: "100", field_113: "3" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_84, category: :setup).map(&:message)).to eql(["Enter a valid value for what is the type of outright sale?"])
+        end
+      end
+    end
+
+    describe "#field_85" do # type of other outright sale
+      context "when cant be blank" do
+        let(:attributes) { setup_section_params.merge({ field_85: nil, field_84: "12" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_85, category: :setup).map(&:message)).to eql(["You must answer type of outright sale"])
         end
       end
     end
@@ -461,12 +493,62 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
     end
 
+    describe "#field_109" do # more that 2 joint purchasers?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_109: "100", field_116: "1" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_109, category: :setup).map(&:message)).to eql(["Enter a valid value for are there more than two joint purchasers of this property?"])
+        end
+      end
+    end
+
+    describe "#field_112" do # data protection
+      context "when not accepted" do
+        let(:attributes) { setup_section_params.merge(field_112: nil) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_112, category: :setup).map(&:message)).to eql(["You must answer data protection question"])
+        end
+      end
+    end
+
     describe "#field_113" do # purchase made thru ownership scheme?
       context "when an invalid option" do
         let(:attributes) { setup_section_params.merge({ field_113: "100" }) }
 
         it "returns setup error" do
           expect(parser.errors.where(:field_113, category: :setup).map(&:message)).to eql(["Enter a valid value for was this purchase made through an ownership scheme?"])
+        end
+      end
+    end
+
+    describe "#field_114" do # is buyer a company?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_114: "100", field_113: "3" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_114, category: :setup).map(&:message)).to eql(["Enter a valid value for is the buyer a company?"])
+        end
+      end
+    end
+
+    describe "#field_115" do # will buyers live in property?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_115: "100", field_113: "3", field_114: "2" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_115, category: :setup).map(&:message)).to eql(["Enter a valid value for will the buyers live in the property?"])
+        end
+      end
+    end
+
+    describe "#field_116" do # joint purchase?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_116: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_116, category: :setup).map(&:message)).to eql(["Enter a valid value for is this a joint purchase?"])
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -575,6 +575,36 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_8" do # type for shared ownership sale
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_8: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_8, category: :setup)).to be_present
+        end
+      end
+    end
+
+    describe "#field_9" do # type for discounted sale
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_9: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_9, category: :setup)).to be_present
+        end
+      end
+    end
+
+    describe "#field_10" do # type for outright sale
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_10: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_10, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_19" do # UPRN
       context "when UPRN known and lookup found" do
         let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_3 field_4 field_5 field_7])
+        expect(errors).to eql(%i[field_1 field_29 field_3 field_4 field_5 field_7])
       end
     end
 
@@ -254,7 +254,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_14 field_3 field_4 field_5 field_8])
+        expect(errors).to eql(%i[field_1 field_14 field_29 field_3 field_4 field_5 field_8])
       end
     end
 
@@ -272,7 +272,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_15 field_3 field_4 field_5])
+        expect(errors).to eql(%i[field_1 field_15 field_29 field_3 field_4 field_5])
       end
     end
 
@@ -288,7 +288,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_14 field_3 field_4 field_5 field_9])
+        expect(errors).to eql(%i[field_1 field_14 field_29 field_3 field_4 field_5 field_9])
       end
     end
 
@@ -306,7 +306,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_3 field_4 field_5 field_7])
+        expect(errors).to eql(%i[field_1 field_29 field_3 field_4 field_5 field_7])
       end
     end
 
@@ -322,7 +322,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_10 field_12 field_13 field_3 field_4 field_5])
+        expect(errors).to eql(%i[field_1 field_10 field_12 field_13 field_29 field_3 field_4 field_5])
       end
     end
 
@@ -340,7 +340,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_11 field_13 field_14 field_3 field_4 field_5])
+        expect(errors).to eql(%i[field_1 field_11 field_13 field_14 field_29 field_3 field_4 field_5])
       end
     end
 
@@ -726,6 +726,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           it "cannot be blank" do
             expect(parser.errors[data[:field]]).to be_present
           end
+        end
+      end
+    end
+
+    describe "#field_29" do # data protection
+      let(:attributes) { setup_section_params.merge({ field_29: nil }) }
+
+      context "when not answered" do
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_29, category: :setup)).to be_present
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -625,6 +625,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_15" do # more than 2 joint buyers?
+      context "when invalid option and must be answered" do
+        let(:attributes) { setup_section_params.merge({ field_14: "1", field_15: "100" }) }
+
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_15, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_19" do # UPRN
       context "when UPRN known and lookup found" do
         let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -626,6 +626,17 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_13" do # will buyers live in the property?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_7: "3", field_13: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_13).map(&:message)).to eql(["Enter a valid value for will the buyers live in the property?"])
+          expect(parser.errors.where(:field_13, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_14" do # joint purchase
       context "when an invalid option" do
         let(:attributes) { setup_section_params.merge({ field_14: "100" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -565,6 +565,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_7" do # ownership scheme
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_7: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_7, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_19" do # UPRN
       context "when UPRN known and lookup found" do
         let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -615,6 +615,17 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_12" do # buyer a company?
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_7: "3", field_12: "100" }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_12).map(&:message)).to eql(["Enter a valid value for is the buyer a company?"])
+          expect(parser.errors.where(:field_12, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_14" do # joint purchase
       context "when an invalid option" do
         let(:attributes) { setup_section_params.merge({ field_14: "100" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -615,6 +615,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#field_14" do # joint purchase
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_14: "100" }) }
+
+        it "returns a setup error" do
+          expect(parser.errors.where(:field_14, category: :setup)).to be_present
+        end
+      end
+    end
+
     describe "#field_19" do # UPRN
       context "when UPRN known and lookup found" do
         let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         let(:attributes) { setup_section_params.merge({ field_7: "3", field_12: "100" }) }
 
         it "returns setup error" do
-          expect(parser.errors.where(:field_12).map(&:message)).to eql(["Enter a valid value for is the buyer a company?"])
+          expect(parser.errors.where(:field_12).map(&:message)).to include("Enter a valid value for is the buyer a company?")
           expect(parser.errors.where(:field_12, category: :setup)).to be_present
         end
       end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       it "has errors on correct setup fields" do
         errors = parser.errors.select { |e| e.options[:category] == :setup }.map(&:attribute).sort
 
-        expect(errors).to eql(%i[field_1 field_13 field_14 field_3 field_4 field_5])
+        expect(errors).to eql(%i[field_1 field_11 field_13 field_14 field_3 field_4 field_5])
       end
     end
 
@@ -601,6 +601,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
         it "returns setup error" do
           expect(parser.errors.where(:field_10, category: :setup)).to be_present
+        end
+      end
+    end
+
+    describe "#field_11" do # type of other outright sale
+      context "when an invalid option" do
+        let(:attributes) { setup_section_params.merge({ field_10: "12", field_11: nil }) }
+
+        it "returns setup error" do
+          expect(parser.errors.where(:field_11, category: :setup)).to be_present
         end
       end
     end

--- a/spec/views/bulk_upload_lettings_results/show.html.erb_spec.rb
+++ b/spec/views/bulk_upload_lettings_results/show.html.erb_spec.rb
@@ -3,18 +3,37 @@ require "rails_helper"
 RSpec.describe "bulk_upload_lettings_results/show.html.erb" do
   let(:bulk_upload) { create(:bulk_upload, :lettings) }
 
-  before do
-    create(:bulk_upload_error, bulk_upload:, cell: "AA100", row: "100", col: "AA")
-    create(:bulk_upload_error, bulk_upload:, cell: "Z100", row: "100", col: "Z")
+  context "when mutiple rows in wrong order" do
+    before do
+      create(:bulk_upload_error, bulk_upload:, cell: "C14", row: "14", col: "C")
+      create(:bulk_upload_error, bulk_upload:, cell: "D10", row: "10", col: "D")
+    end
+
+    it "renders errors order by row" do
+      assign(:bulk_upload, bulk_upload)
+
+      render
+
+      fragment = Capybara::Node::Simple.new(rendered)
+
+      expect(fragment.find_css(".x-govuk-summary-card__title strong").map(&:inner_text)).to eql(["Row 10", "Row 14"])
+    end
   end
 
-  it "renders errors ordered by cell" do
-    assign(:bulk_upload, bulk_upload)
+  context "when 1 row with 2 errors" do
+    before do
+      create(:bulk_upload_error, bulk_upload:, cell: "AA100", row: "100", col: "AA")
+      create(:bulk_upload_error, bulk_upload:, cell: "Z100", row: "100", col: "Z")
+    end
 
-    render
+    it "renders errors ordered by cell" do
+      assign(:bulk_upload, bulk_upload)
 
-    fragment = Capybara::Node::Simple.new(rendered)
+      render
 
-    expect(fragment.find_css("table tbody th").map(&:inner_text)).to eql(%w[Z100 AA100])
+      fragment = Capybara::Node::Simple.new(rendered)
+
+      expect(fragment.find_css("table tbody th").map(&:inner_text)).to eql(%w[Z100 AA100])
+    end
   end
 end

--- a/spec/views/bulk_upload_sales_results/show.html.erb_spec.rb
+++ b/spec/views/bulk_upload_sales_results/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "bulk_upload_lettings_results/summary.html.erb" do
-  let(:bulk_upload) { create(:bulk_upload, :lettings) }
+RSpec.describe "bulk_upload_sales_results/show.html.erb" do
+  let(:bulk_upload) { create(:bulk_upload, :sales) }
 
   context "when mutiple rows in wrong order" do
     before do

--- a/spec/views/bulk_upload_sales_results/summary.html.erb_spec.rb
+++ b/spec/views/bulk_upload_sales_results/summary.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "bulk_upload_lettings_results/summary.html.erb" do
-  let(:bulk_upload) { create(:bulk_upload, :lettings) }
+RSpec.describe "bulk_upload_sales_results/summary.html.erb" do
+  let(:bulk_upload) { create(:bulk_upload, :sales) }
 
   context "when mutiple rows in wrong order" do
     before do


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2305
- This is rework to add missing validations for sales setup fields for bulk upload

# Changes

- There is code that clears log fields if they are not a valid option. in order to generate errors for these we check certain fields for content prior to `log.valid?` being called. Unfortunately there does not appear to be an easy way to access to valid options therefore these values have been hard coded
- Privacy notice must be accepted other considered a setup error
- The `type` question can actually be one of three questions with the same identifier. these are excluded as part of `validate_valid_radio_option` and instead validated with a different mechanism. The rationale being that `log.valid?` will clear data before we get there
- Remove tests associated to upload threshold which are no longer required