### PR TITLE
CLDC-2313 add bulk upload validation buyer 1 cannot be child

### DIFF
--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -274,6 +274,7 @@ class BulkUpload::Sales::Year2022::RowParser
   validates :field_114, presence: { message: I18n.t("validations.not_answered", question: "company buyer") }, if: :outright_sale?, on: :after_log
   validates :field_109, presence: { message: I18n.t("validations.not_answered", question: "more than 2 buyers") }, if: :joint_purchase?, on: :after_log
 
+  validate :validate_buyer1_economic_status, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -946,7 +947,7 @@ private
         end
       else
         fields.each do |field|
-          unless errors.any? { |e| fields.include?(e.attribute) }
+          if errors.none? { |e| fields.include?(e.attribute) }
             errors.add(field, I18n.t("validations.not_answered", question: question.check_answer_label&.downcase))
           end
         end
@@ -971,7 +972,7 @@ private
         end
       else
         fields.each do |field|
-          unless errors.any? { |e| fields.include?(e.attribute) }
+          if errors.none? { |e| fields.include?(e.attribute) }
             errors.add(field, I18n.t("validations.invalid_option", question: QUESTIONS[field]))
           end
         end
@@ -1019,6 +1020,12 @@ private
       errors.add(:field_13, error_message) # Buyer 1 gender
       errors.add(:field_24, error_message) # Buyer 1 working situation
       errors.add(:field_1, error_message) # Purchaser code
+    end
+  end
+
+  def validate_buyer1_economic_status
+    if field_24 == 9
+      errors.add(:field_24, "Buyer 1 cannot be a child under 16")
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -813,7 +813,7 @@ private
   end
 
   def owning_organisation
-    Organisation.find_by_id_on_multiple_fields(field_92)
+    @owning_organisation ||= Organisation.find_by_id_on_multiple_fields(field_92)
   end
 
   def created_by

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -396,6 +396,7 @@ class BulkUpload::Sales::Year2023::RowParser
             },
             on: :after_log
 
+  validate :validate_buyer1_economic_status, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -1031,7 +1032,7 @@ private
   end
 
   def owning_organisation
-    Organisation.find_by_id_on_multiple_fields(field_1)
+    @owning_organisation ||= Organisation.find_by_id_on_multiple_fields(field_1)
   end
 
   def created_by
@@ -1229,6 +1230,12 @@ private
           end
         end
       end
+    end
+  end
+
+  def validate_buyer1_economic_status
+    if field_35 == 9
+      errors.add(:field_35, "Buyer 1 cannot be a child under 16")
     end
   end
 end

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -622,8 +622,6 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         end
       end
     end
-
-
   end
 
   describe "inferences" do

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -107,14 +107,6 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
     }
   end
 
-  # around do |example|
-  #   FormHandler.instance.use_real_forms!
-
-  #   example.run
-
-  #   FormHandler.instance.use_fake_forms!
-  # end
-
   describe "#blank_row?" do
     context "when a new object" do
       it "returns true" do

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
     }
   end
 
-  around do |example|
-    FormHandler.instance.use_real_forms!
+  # around do |example|
+  #   FormHandler.instance.use_real_forms!
 
-    example.run
+  #   example.run
 
-    FormHandler.instance.use_fake_forms!
-  end
+  #   FormHandler.instance.use_fake_forms!
+  # end
 
   describe "#blank_row?" do
     context "when a new object" do
@@ -469,6 +469,17 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       end
     end
 
+    describe "field_24" do # ecstat1
+      context "when buyer 1 is marked as a child" do
+        let(:attributes) { valid_attributes.merge({ field_24: 9 }) }
+
+        it "a custom validation is applied" do
+          validation_message = "Buyer 1 cannot be a child under 16"
+          expect(parser.errors[:field_24]).to include validation_message
+        end
+      end
+    end
+
     describe "fields 2, 3, 4 => saledate" do
       context "when all of these fields are blank" do
         let(:attributes) { setup_section_params.merge({ field_2: nil, field_3: nil, field_4: nil }) }
@@ -619,6 +630,8 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         end
       end
     end
+
+
   end
 
   describe "inferences" do

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -110,14 +110,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
     }
   end
 
-  around do |example|
-    FormHandler.instance.use_real_forms!
-
-    example.run
-
-    FormHandler.instance.use_fake_forms!
-  end
-
   describe "#blank_row?" do
     context "when a new object" do
       it "returns true" do
@@ -690,6 +682,17 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           it "sets ##{age} to nil" do
             expect(parser.log.public_send(age)).to be_nil
           end
+        end
+      end
+    end
+
+    describe "field_35" do # ecstat1
+      context "when buyer 1 is marked as a child" do
+        let(:attributes) { valid_attributes.merge({ field_35: "9" }) }
+
+        it "a custom validation is applied" do
+          validation_message = "Buyer 1 cannot be a child under 16"
+          expect(parser.errors[:field_35]).to include validation_message
         end
       end
     end


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2313

9 (child under 16) is an option for all ecstat questions except ecstat 1, so rather than displaying the standard provide valid value validation we display a particular validation for buyer 1.
Further notes on particular code choices in line in diff