### PR TITLE
CLDC-2370 Add missing bulk upload translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,11 @@ en:
             base:
               wrong_field_numbers_count: "incorrect number of fields, please ensure you have used the correct template"
               over_max_column_count: "too many columns, please ensure you have used the correct template"
+        bulk_upload/sales/validator:
+          attributes:
+            base:
+              wrong_field_numbers_count: "incorrect number of fields, please ensure you have used the correct template"
+              over_max_column_count: "too many columns, please ensure you have used the correct template"
         forms/bulk_upload_lettings/year:
           attributes:
             year:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,13 +44,13 @@ en:
         bulk_upload/lettings/validator:
           attributes:
             base:
-              wrong_field_numbers_count: "incorrect number of fields, please ensure you have used the correct template"
-              over_max_column_count: "too many columns, please ensure you have used the correct template"
+              wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template"
+              over_max_column_count: "Too many columns, please ensure you have used the correct template"
         bulk_upload/sales/validator:
           attributes:
             base:
-              wrong_field_numbers_count: "incorrect number of fields, please ensure you have used the correct template"
-              over_max_column_count: "too many columns, please ensure you have used the correct template"
+              wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template"
+              over_max_column_count: "Too many columns, please ensure you have used the correct template"
         forms/bulk_upload_lettings/year:
           attributes:
             year:

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["too many columns, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Too many columns, please ensure you have used the correct template"])
           end
         end
 
@@ -81,7 +81,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["incorrect number of fields, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template"])
           end
         end
 
@@ -99,7 +99,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["incorrect number of fields, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template"])
           end
         end
       end
@@ -118,7 +118,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["too many columns, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Too many columns, please ensure you have used the correct template"])
           end
         end
 
@@ -169,7 +169,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["incorrect number of fields, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template"])
           end
         end
 
@@ -187,7 +187,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
           it "is not valid" do
             expect(validator).not_to be_valid
-            expect(validator.errors["base"]).to eql(["incorrect number of fields, please ensure you have used the correct template"])
+            expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template"])
           end
         end
       end


### PR DESCRIPTION
There was some missing copy for sales that was causing a translation_missing error.

Here's the corrected message:
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/94526761/10690f77-dd26-4492-90c9-a1c0cf893b94)

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2370

