### PR TITLE
CLDC-1731 Allow data coordinators to view parent's schemes

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -227,7 +227,7 @@ private
 
   def authenticate_action!
     unless user_allowed_action?
-      render_not_found and return
+      render_not_found
     end
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,7 +4,7 @@ class LocationsController < ApplicationController
   before_action :authenticate_scope!
   before_action :find_location, except: %i[create index]
   before_action :find_scheme
-  before_action :authenticate_action!
+  before_action :authenticate_action!, only: %i[create update index new_deactivation deactivate_confirm deactivate postcode local_authority name units type_of_unit mobility_standards availability check_answers]
   before_action :scheme_and_location_present, except: %i[create index]
 
   include Modules::SearchFilter
@@ -21,6 +21,7 @@ class LocationsController < ApplicationController
   end
 
   def postcode; end
+  def update; end
 
   def update_postcode
     @location.postcode = location_params[:postcode]
@@ -225,13 +226,13 @@ private
   end
 
   def authenticate_action!
-    if %w[create update index new_deactivation deactivate_confirm deactivate postcode local_authority name units type_of_unit mobility_standards availability check_answers].include?(action_name) && !user_allowed_action?
+    unless user_allowed_action?
       render_not_found and return
     end
   end
 
   def user_allowed_action?
-    (current_user.organisation == @scheme&.owning_organisation) || (current_user.organisation.parent_organisations.any? { |org| org == @scheme&.owning_organisation }) || current_user.support?
+    current_user.support? || current_user.organisation == @scheme&.owning_organisation || current_user.organisation.parent_organisations.exists?(@scheme&.owning_organisation_id)
   end
 
   def location_params

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -225,9 +225,13 @@ private
   end
 
   def authenticate_action!
-    if %w[create update index new_deactivation deactivate_confirm deactivate postcode local_authority name units type_of_unit mobility_standards availability check_answers].include?(action_name) && !((current_user.organisation == @scheme&.owning_organisation) || current_user.support?)
+    if %w[create update index new_deactivation deactivate_confirm deactivate postcode local_authority name units type_of_unit mobility_standards availability check_answers].include?(action_name) && !user_allowed_action?
       render_not_found and return
     end
+  end
+
+  def user_allowed_action?
+    (current_user.organisation == @scheme&.owning_organisation) || (current_user.organisation.parent_organisations.any? { |org| org == @scheme&.owning_organisation }) || current_user.support?
   end
 
   def location_params

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -19,7 +19,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    all_schemes = Scheme.where(owning_organisation: @organisation).order_by_completion.order_by_service_name
+    all_schemes = Scheme.where(owning_organisation: [@organisation] + @organisation.parent_organisations).order_by_completion.order_by_service_name
 
     @pagy, @schemes = pagy(filtered_collection(all_schemes, search_term))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -265,9 +265,13 @@ private
   def authenticate_scope!
     head :unauthorized and return unless current_user.data_coordinator? || current_user.support?
 
-    if %w[show locations primary_client_group confirm_secondary_client_group secondary_client_group support details check_answers edit_name deactivate].include?(action_name) && !((current_user.organisation == @scheme&.owning_organisation) || current_user.support?)
+    if %w[show locations primary_client_group confirm_secondary_client_group secondary_client_group support details check_answers edit_name deactivate].include?(action_name) && !user_allowed_action?
       render_not_found and return
     end
+  end
+
+  def user_allowed_action?
+    (current_user.organisation == @scheme&.owning_organisation) || (current_user.organisation.parent_organisations.any? { |org| org == @scheme&.owning_organisation }) || current_user.support?
   end
 
   def redirect_if_scheme_confirmed

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -271,7 +271,7 @@ private
   end
 
   def user_allowed_action?
-    (current_user.organisation == @scheme&.owning_organisation) || (current_user.organisation.parent_organisations.any? { |org| org == @scheme&.owning_organisation }) || current_user.support?
+    current_user.support? || current_user.organisation == @scheme&.owning_organisation || current_user.organisation.parent_organisations.exists?(@scheme&.owning_organisation_id)
   end
 
   def redirect_if_scheme_confirmed

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -84,6 +84,10 @@ module LocationsHelper
     end
   end
 
+  def user_can_edit_scheme?(user, scheme)
+    user.support? || user.organisation == scheme.owning_organisation
+  end
+
 private
 
   ActivePeriod = Struct.new(:from, :to)

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -64,7 +64,9 @@
           <% end %>
         <% end %>
       <% end %>
-      <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
+      <% if user_can_edit_scheme?(current_user, @scheme) %>
+        <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
+      <% end %>
     </div>
   </div>
 
@@ -118,7 +120,9 @@
       <% end %>
     <% end %>
   <% end %>
-  <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
+  <% if user_can_edit_scheme?(current_user, @scheme) %>
+    <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
+  <% end %>
 
 <% end %>
 

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -16,12 +16,12 @@
                 <%= summary_list.row do |row| %>
                 <% row.key { attr[:name] } %>
                 <% row.value { attr[:attribute].eql?("status") ? status_tag(attr[:value]) : details_html(attr) } %>
-                <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" %>
+                <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" && current_user.organisation == @scheme.owning_organisation %>
                 <% end %>
             <% end %>
         <% end %>
     </div>
 </div>
-<% if FeatureToggle.location_toggle_enabled? %>
+<% if FeatureToggle.location_toggle_enabled? && user_can_edit_scheme?(current_user, @scheme) %>
     <%= toggle_location_link(@location) %>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -16,7 +16,7 @@
                 <%= summary_list.row do |row| %>
                 <% row.key { attr[:name] } %>
                 <% row.value { attr[:attribute].eql?("status") ? status_tag(attr[:value]) : details_html(attr) } %>
-                <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" && current_user.organisation == @scheme.owning_organisation %>
+                <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" && user_can_edit_scheme?(current_user, @scheme) %>
                 <% end %>
             <% end %>
         <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -22,7 +22,7 @@
           <%= summary_list.row do |row| %>
             <% row.key { attr[:name] } %>
             <% row.value { details_html(attr) } %>
-            <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] %>
+            <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] && user_can_edit_scheme?(current_user, @scheme) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -32,6 +32,6 @@
   </div>
 <% end %>
 
-<% if FeatureToggle.scheme_toggle_enabled? %>
+<% if FeatureToggle.scheme_toggle_enabled? && user_can_edit_scheme?(current_user, @scheme) %>
   <%= toggle_scheme_link(@scheme) %>
 <% end %>

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -233,9 +233,6 @@ RSpec.describe SchemesController, type: :request do
         expect(page).to have_content(specific_scheme.id_to_display)
         expect(page).to have_content(specific_scheme.service_name)
         expect(page).to have_content(specific_scheme.sensitive)
-        expect(page).to have_content(specific_scheme.id_to_display)
-        expect(page).to have_content(specific_scheme.service_name)
-        expect(page).to have_content(specific_scheme.sensitive)
         expect(page).to have_content(specific_scheme.scheme_type)
         expect(page).to have_content(specific_scheme.registered_under_care_act)
         expect(page).to have_content(specific_scheme.primary_client_group)
@@ -304,6 +301,24 @@ RSpec.describe SchemesController, type: :request do
             expect(page).not_to have_link("Reactivate this scheme")
             expect(page).not_to have_link("Deactivate this scheme")
           end
+        end
+      end
+
+      context "when coordinator attempts to see scheme belonging to a parent organisation" do
+        let(:parent_organisation) { FactoryBot.create(:organisation) }
+        let!(:specific_scheme) { FactoryBot.create(:scheme, owning_organisation: parent_organisation) }
+
+        before do
+          create(:organisation_relationship, parent_organisation:, child_organisation: user.organisation)
+          get "/schemes/#{specific_scheme.id}"
+        end
+
+        it "shows the scheme" do
+          expect(page).to have_content(specific_scheme.id_to_display)
+        end
+
+        it "does not allow editing the scheme" do
+          expect(page).not_to have_link("Change")
         end
       end
     end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe SchemesController, type: :request do
         let!(:specific_scheme) { FactoryBot.create(:scheme, owning_organisation: parent_organisation) }
 
         before do
+          FactoryBot.create(:location, scheme: specific_scheme)
           create(:organisation_relationship, parent_organisation:, child_organisation: user.organisation)
           get "/schemes/#{specific_scheme.id}"
         end
@@ -349,6 +350,8 @@ RSpec.describe SchemesController, type: :request do
 
         it "does not allow editing the scheme" do
           expect(page).not_to have_link("Change")
+          expect(page).not_to have_content("Reactivate this scheme")
+          expect(page).not_to have_content("Deactivate this scheme")
         end
       end
     end


### PR DESCRIPTION
Display parent schemes for data coordinators:
Do not allow editing, deactivating schemes and locations or adding new locations to parent organisation scheme.