### PR TITLE
CLDC-2348 Purchaser code bug fix

### DIFF
--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -23,7 +23,7 @@ class BulkUpload::Sales::Validator
         bulk_upload.bulk_upload_errors.create!(
           field: error.attribute,
           error: error.message,
-          purchaser_code: row_parser.field_1,
+          purchaser_code: row_parser.purchaser_code,
           row:,
           cell: "#{col}#{row}",
           col:,

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -344,6 +344,10 @@ class BulkUpload::Sales::Year2022::RowParser
       .exists?(duplicate_check_fields.index_with { |field| log.public_send(field) })
   end
 
+  def purchaser_code
+    field_1
+  end
+
 private
 
   def buyer_not_interviewed?
@@ -487,7 +491,7 @@ private
 
   def attributes_for_log
     attributes = {}
-    attributes["purchid"] = field_1
+    attributes["purchid"] = purchaser_code
     attributes["saledate"] = saledate
 
     attributes["noint"] = field_6

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -473,7 +473,11 @@ class BulkUpload::Sales::Year2023::RowParser
       .exists?(duplicate_check_fields.index_with { |field| log.public_send(field) })
   end
 
-private
+  def purchaser_code
+    field_6
+  end
+
+  private
 
   def prevtenbuy2
     case field_72
@@ -695,7 +699,7 @@ private
   def attributes_for_log
     attributes = {}
 
-    attributes["purchid"] = field_6
+    attributes["purchid"] = purchaser_code
     attributes["saledate"] = saledate
     attributes["noint"] = 2 if field_28 == 1
 

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -477,7 +477,7 @@ class BulkUpload::Sales::Year2023::RowParser
     field_6
   end
 
-  private
+private
 
   def prevtenbuy2
     case field_72

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -133,6 +133,25 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
     end
   end
 
+  describe "purchaser_code" do
+    before do
+      def purch_id_field
+        described_class::QUESTIONS.key("What is the purchaser code?").to_s
+      end
+    end
+
+    let(:attributes) do
+      {
+        bulk_upload:,
+        purch_id_field => "some purchaser code",
+      }
+    end
+
+    it "is linked to the correct field" do
+      expect(parser.purchaser_code).to eq("some purchaser code")
+    end
+  end
+
   describe "validations" do
     before do
       stub_request(:get, /api.postcodes.io/)

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -136,6 +136,25 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
     end
   end
 
+  describe "purchaser_code" do
+    before do
+      def purch_id_field
+        described_class::QUESTIONS.key("What is the purchaser code?").to_s
+      end
+    end
+
+    let(:attributes) do
+      {
+        bulk_upload:,
+        purch_id_field => "some purchaser code",
+      }
+    end
+
+    it "is linked to the correct field" do
+      expect(parser.purchaser_code).to eq("some purchaser code")
+    end
+  end
+
   describe "validations" do
     before do
       stub_request(:get, /api.postcodes.io/)


### PR DESCRIPTION
Purchaser code was being set to field_1, but in 23/24 it's field 6 so we assign it in the row_parsers instead.

Don't think this needs a test as the new row parsers will be made from the current ones, so the purchaser_code method should be present and updated in future years too.

Ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2348