### PR TITLE
CLDC-1732 Provider and read only schemes

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -7,35 +7,7 @@ class LocationsController < ApplicationController
   before_action :find_scheme
   before_action :scheme_and_location_present, except: %i[create index]
 
-  before_action :authorize_read,
-                only: %i[
-                  show
-                  postcode
-                  local_authority
-                  name
-                  units
-                  type_of_unit
-                  mobility_standards
-                  availability
-                  check_answers
-                  confirm
-                ]
-
-  before_action :authorize_write,
-                only: %i[
-                  update_postcode
-                  update_local_authority
-                  update_name
-                  update_units
-                  update_type_of_unit
-                  update_mobility_standards
-                  update_availability
-                  new_deactivation
-                  deactivate_confirm
-                  deactivate
-                  new_reactivation
-                  reactivate
-                ]
+  before_action :authorize_user, except: %i[index create]
 
   def index
     authorize @scheme
@@ -240,12 +212,8 @@ class LocationsController < ApplicationController
 
 private
 
-  def authorize_read
-    authorize @location
-  end
-
-  def authorize_write
-    authorize @location
+  def authorize_user
+    authorize(@location || Location)
   end
 
   def scheme_and_location_present

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -12,7 +12,10 @@ module CheckAnswersHelper
   end
 
   def can_change_scheme_answer?(attribute_name, scheme)
+    return false unless current_user.support? || current_user.data_coordinator?
+
     editable_attributes = current_user.support? ? ["Name", "Confidential information", "Housing stock owned by"] : ["Name", "Confidential information"]
+
     !scheme.confirmed? || editable_attributes.include?(attribute_name)
   end
 

--- a/app/helpers/navigation_items_helper.rb
+++ b/app/helpers/navigation_items_helper.rb
@@ -24,6 +24,7 @@ module NavigationItemsHelper
       [
         NavigationItem.new("Lettings logs", lettings_logs_path, lettings_logs_current?(path)),
         NavigationItem.new("Sales logs", sales_logs_path, sales_logs_current?(path)),
+        (NavigationItem.new("Schemes", "/schemes", subnav_supported_housing_schemes_path?(path)) if current_user.organisation.holds_own_stock?),
         NavigationItem.new("Users", users_organisation_path(current_user.organisation), subnav_users_path?(path)),
         NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", subnav_details_path?(path)),
         NavigationItem.new("Stock owners", stock_owners_organisation_path(current_user.organisation), stock_owners_path?(path)),

--- a/app/helpers/navigation_items_helper.rb
+++ b/app/helpers/navigation_items_helper.rb
@@ -10,16 +10,6 @@ module NavigationItemsHelper
         NavigationItem.new("Sales logs", sales_logs_path, sales_logs_current?(path)),
         NavigationItem.new("Schemes", "/schemes", supported_housing_schemes_current?(path)),
       ].compact
-    elsif current_user.data_coordinator? && current_user.organisation.holds_own_stock?
-      [
-        NavigationItem.new("Lettings logs", lettings_logs_path, lettings_logs_current?(path)),
-        NavigationItem.new("Sales logs", sales_logs_path, sales_logs_current?(path)),
-        NavigationItem.new("Schemes", "/schemes", subnav_supported_housing_schemes_path?(path)),
-        NavigationItem.new("Users", users_organisation_path(current_user.organisation), subnav_users_path?(path)),
-        NavigationItem.new("About your organisation", "/organisations/#{current_user.organisation.id}", subnav_details_path?(path)),
-        NavigationItem.new("Stock owners", stock_owners_organisation_path(current_user.organisation), stock_owners_path?(path)),
-        NavigationItem.new("Managing agents", managing_agents_organisation_path(current_user.organisation), managing_agents_path?(path)),
-      ].compact
     else
       [
         NavigationItem.new("Lettings logs", lettings_logs_path, lettings_logs_current?(path)),

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -13,7 +13,11 @@ class LocationPolicy
   def create?
     return true if user.support?
 
-    user.data_coordinator? && user.organisation == scheme&.owning_organisation
+    if location == Location
+      user.data_coordinator?
+    else
+      user.data_coordinator? && user.organisation == scheme&.owning_organisation
+    end
   end
 
   def update?

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -62,7 +62,7 @@ class LocationPolicy
     define_method method_name do
       return true if user.support?
 
-      scheme&.owning_organisation == user.organisation
+      user.organisation.parent_organisations.exists?(scheme&.owning_organisation_id) || scheme&.owning_organisation == user.organisation
     end
   end
 

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,0 +1,70 @@
+class LocationPolicy
+  attr_reader :user, :location
+
+  def initialize(user, location)
+    @user = user
+    @location = location
+  end
+
+  def index?
+    true
+  end
+
+  def create?
+    return true if user.support?
+
+    user.data_coordinator? && user.organisation == scheme&.owning_organisation
+  end
+
+  def update?
+    return true if user.support?
+
+    user.data_coordinator? && scheme&.owning_organisation == user.organisation
+  end
+
+  %w[
+    update_postcode?
+    update_local_authority?
+    update_name?
+    update_units?
+    update_type_of_unit?
+    update_mobility_standards?
+    update_availability?
+    new_deactivation?
+    deactivate_confirm?
+    deactivate?
+    new_reactivation?
+    reactivate?
+    postcode?
+    local_authority?
+    name?
+    units?
+    type_of_unit?
+    mobility_standards?
+    availability?
+    confirm?
+  ].each do |method_name|
+    define_method method_name do
+      return true if user.support?
+
+      user.data_coordinator? && scheme&.owning_organisation == user.organisation
+    end
+  end
+
+  %w[
+    show?
+    check_answers?
+  ].each do |method_name|
+    define_method method_name do
+      return true if user.support?
+
+      scheme&.owning_organisation == user.organisation
+    end
+  end
+
+private
+
+  def scheme
+    location.scheme
+  end
+end

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -1,0 +1,59 @@
+class SchemePolicy
+  attr_reader :user, :scheme
+
+  def initialize(user, scheme)
+    @user = user
+    @scheme = scheme
+  end
+
+  def index?
+    return true if user.support?
+
+    if scheme == Scheme
+      true
+    else
+      scheme&.owning_organisation == user.organisation
+    end
+  end
+
+  def new?
+    user.data_coordinator? || user.support?
+  end
+
+  def create?
+    user.data_coordinator? || user.support?
+  end
+
+  def update?
+    user.data_coordinator? || user.support?
+  end
+
+  %w[
+    show?
+    check_answers?
+  ].each do |method_name|
+    define_method method_name do
+      return true if user.support?
+
+      scheme&.owning_organisation == user.organisation
+    end
+  end
+
+  %w[
+    edit_name?
+    primary_client_group?
+    confirm_secondary_client_group?
+    secondary_client_group?
+    new_deactivation?
+    deactivate?
+    details?
+    support?
+    deactivate_confirm?
+  ].each do |method_name|
+    define_method method_name do
+      return true if user.support?
+
+      user.data_coordinator? && scheme&.owning_organisation == user.organisation
+    end
+  end
+end

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -12,7 +12,7 @@ class SchemePolicy
     if scheme == Scheme
       true
     else
-      scheme&.owning_organisation == user.organisation
+      user.organisation.parent_organisations.exists?(scheme&.owning_organisation_id) || scheme&.owning_organisation == user.organisation
     end
   end
 
@@ -25,7 +25,9 @@ class SchemePolicy
   end
 
   def update?
-    user.data_coordinator? || user.support?
+    return true if user.support?
+
+    user.data_coordinator? && (scheme&.owning_organisation == user.organisation)
   end
 
   %w[
@@ -35,7 +37,7 @@ class SchemePolicy
     define_method method_name do
       return true if user.support?
 
-      scheme&.owning_organisation == user.organisation
+      user.organisation.parent_organisations.exists?(scheme&.owning_organisation_id) || scheme&.owning_organisation == user.organisation
     end
   end
 

--- a/app/views/locations/check_answers.html.erb
+++ b/app/views/locations/check_answers.html.erb
@@ -27,7 +27,10 @@
         <% end %>
     </div>
 </div>
-<div class="govuk-button-group">
-  <%= govuk_button_to "Save and return to locations", scheme_location_confirm_path(@scheme, @location, route: params[:route]), method: :patch %>
-  <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>
-</div>
+
+<% if LocationPolicy.new(current_user, Location).create? %>
+  <div class="govuk-button-group">
+    <%= govuk_button_to "Save and return to locations", scheme_location_confirm_path(@scheme, @location, route: params[:route]), method: :patch %>
+    <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>
+  </div>
+<% end %>

--- a/app/views/locations/check_answers.html.erb
+++ b/app/views/locations/check_answers.html.erb
@@ -15,20 +15,22 @@
 <%= render partial: "organisations/headings", locals: { main: "Check your answers", sub: "Add a location to #{@scheme.service_name}" } %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= govuk_summary_list do |summary_list| %>
-            <% display_location_attributes_for_check_answers(@location).each do |attr| %>
-                <%= summary_list.row do |row| %>
-                <% row.key { attr[:name] } %>
-                <% row.value { details_html(attr) } %>
-                <% row.action(text: action_text_helper(attr, @location), href: location_edit_path(@location, attr[:attribute])) %>
-                <% end %>
-            <% end %>
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_summary_list do |summary_list| %>
+      <% display_location_attributes_for_check_answers(@location).each do |attr| %>
+        <%= summary_list.row do |row| %>
+          <% row.key { attr[:name] } %>
+          <% row.value { details_html(attr) } %>
+          <% if LocationPolicy.new(current_user, @location).update? %>
+            <% row.action(text: action_text_helper(attr, @location), href: location_edit_path(@location, attr[:attribute])) %>
+          <% end %>
         <% end %>
-    </div>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
-<% if LocationPolicy.new(current_user, Location).create? %>
+<% if LocationPolicy.new(current_user, @location).create? %>
   <div class="govuk-button-group">
     <%= govuk_button_to "Save and return to locations", scheme_location_confirm_path(@scheme, @location, route: params[:route]), method: :patch %>
     <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -60,16 +60,16 @@
               <% row.cell(text: location.name) %>
               <% row.cell(text: location.id) %>
               <% row.cell(text: status_tag(location.status)) %>
-              <% end %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
-      <% if user_can_edit_scheme?(current_user, @scheme) %>
+
+      <% if LocationPolicy.new(current_user, Location).create? %>
         <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
       <% end %>
     </div>
   </div>
-
 <% else %>
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -65,7 +65,7 @@
         <% end %>
       <% end %>
 
-      <% if LocationPolicy.new(current_user, Location).create? %>
+      <% if LocationPolicy.new(current_user, @scheme.locations.new).create? %>
         <%= govuk_button_to "Add a location", scheme_locations_path(@scheme), method: "post", secondary: true %>
       <% end %>
     </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -10,17 +10,19 @@
 <%= render partial: "organisations/headings", locals: { main: @location.postcode, sub: @location.name } %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= govuk_summary_list do |summary_list| %>
-            <% display_location_attributes(@location).each do |attr| %>
-                <%= summary_list.row do |row| %>
-                <% row.key { attr[:name] } %>
-                <% row.value { attr[:attribute].eql?("status") ? status_tag(attr[:value]) : details_html(attr) } %>
-                <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" && user_can_edit_scheme?(current_user, @scheme) %>
-                <% end %>
-            <% end %>
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_summary_list do |summary_list| %>
+      <% display_location_attributes(@location).each do |attr| %>
+        <%= summary_list.row do |row| %>
+          <% row.key { attr[:name] } %>
+          <% row.value { attr[:attribute].eql?("status") ? status_tag(attr[:value]) : details_html(attr) } %>
+          <% if LocationPolicy.new(current_user, @location).update? %>
+            <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" %>
+          <% end %>
         <% end %>
-    </div>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <% if FeatureToggle.location_toggle_enabled? %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -26,7 +26,7 @@
 </div>
 
 <% if FeatureToggle.location_toggle_enabled? %>
-  <% if LocationPolicy.new(current_user, Location).deactivate? %>
+  <% if LocationPolicy.new(current_user, @location).deactivate? %>
     <%= toggle_location_link(@location) %>
   <% end %>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -22,6 +22,9 @@
         <% end %>
     </div>
 </div>
-<% if FeatureToggle.location_toggle_enabled? && user_can_edit_scheme?(current_user, @scheme) %>
+
+<% if FeatureToggle.location_toggle_enabled? %>
+  <% if LocationPolicy.new(current_user, Location).deactivate? %>
     <%= toggle_location_link(@location) %>
+  <% end %>
 <% end %>

--- a/app/views/organisations/schemes.html.erb
+++ b/app/views/organisations/schemes.html.erb
@@ -12,7 +12,9 @@
   <h2 class="govuk-visually-hidden">Supported housing schemes</h2>
 <% end %>
 
-<%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+<% if SchemePolicy.new(current_user, nil).create? %>
+  <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+<% end %>
 
 <%= govuk_details(
   classes: "govuk-!-width-two-thirds",

--- a/app/views/schemes/_scheme_summary_list_row.html.erb
+++ b/app/views/schemes/_scheme_summary_list_row.html.erb
@@ -14,9 +14,10 @@
             <%= details_html(attribute) %>
         </dd>
     <% end %>
+
     <% if can_change_scheme_answer?(attribute[:name], scheme) %>
-        <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="<%= change_link %>">Change</a>
-        </dd>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link" href="<%= change_link %>">Change</a>
+      </dd>
     <% end %>
 </div>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -12,17 +12,21 @@
           <% next if current_user.data_coordinator? && attr[:name] == ("owned by") %>
           <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: @scheme.confirmed? ? scheme_edit_name_path(@scheme) : scheme_details_path(@scheme, check_answers: true) } %>
         <% end %>
+
         <% @scheme.check_primary_client_attributes.each do |attr| %>
           <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_primary_client_group_path(@scheme, check_answers: true) } %>
         <% end %>
+
         <% @scheme.check_secondary_client_confirmation_attributes.each do |attr| %>
           <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_confirm_secondary_client_group_path(@scheme, check_answers: true) } %>
         <% end %>
+
         <% if @scheme.has_other_client_group == "Yes" %>
           <% @scheme.check_secondary_client_attributes.each do |attr| %>
             <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_secondary_client_group_path(@scheme, check_answers: true) } %>
           <% end %>
         <% end %>
+
         <% @scheme.check_support_attributes.each do |attr| %>
           <%= render partial: "scheme_summary_list_row", locals: { scheme: @scheme, attribute: attr, change_link: scheme_support_path(@scheme, check_answers: true) } %>
         <% end %>
@@ -32,5 +36,8 @@
   <%= f.hidden_field :page, value: "check-answers" %>
   <%= f.hidden_field :confirmed, value: "true" %>
   <% button_label = @scheme.confirmed? ? "Save" : "Create scheme" %>
-  <%= f.govuk_submit button_label %>
+
+  <% if SchemePolicy.new(current_user, @scheme).create? %>
+    <%= f.govuk_submit button_label %>
+  <% end %>
 <% end %>

--- a/app/views/schemes/index.html.erb
+++ b/app/views/schemes/index.html.erb
@@ -5,7 +5,9 @@
 
 <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Supported housing schemes", sub: nil } : { main: "Supported housing schemes", sub: current_user.organisation.name } %>
 
-<%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+<% if SchemePolicy.new(current_user, nil).create? %>
+  <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+<% end %>
 
 <%= render SearchComponent.new(current_user:, search_label: "Search by scheme name, code, postcode or location name", value: @searched) %>
 

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -22,7 +22,9 @@
           <%= summary_list.row do |row| %>
             <% row.key { attr[:name] } %>
             <% row.value { details_html(attr) } %>
-            <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] && user_can_edit_scheme?(current_user, @scheme) %>
+            <% if SchemePolicy.new(current_user, @scheme).update? %>
+              <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -35,7 +35,7 @@
 <% end %>
 
 <% if FeatureToggle.scheme_toggle_enabled? %>
-  <% if SchemePolicy.new(current_user, nil).deactivate? %>
+  <% if SchemePolicy.new(current_user, @scheme).deactivate? %>
     <%= toggle_scheme_link(@scheme) %>
   <% end %>
 <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -32,6 +32,8 @@
   </div>
 <% end %>
 
-<% if FeatureToggle.scheme_toggle_enabled? && user_can_edit_scheme?(current_user, @scheme) %>
-  <%= toggle_scheme_link(@scheme) %>
+<% if FeatureToggle.scheme_toggle_enabled? %>
+  <% if SchemePolicy.new(current_user, nil).deactivate? %>
+    <%= toggle_scheme_link(@scheme) %>
+  <% end %>
 <% end %>

--- a/spec/helpers/navigation_items_helper_spec.rb
+++ b/spec/helpers/navigation_items_helper_spec.rb
@@ -1,196 +1,331 @@
 require "rails_helper"
 
 RSpec.describe NavigationItemsHelper do
-  let(:current_user) { FactoryBot.create(:user, :data_coordinator) }
+  let(:current_user) { create(:user, :data_coordinator) }
 
   let(:users_path) { "/organisations/#{current_user.organisation.id}/users" }
   let(:organisation_path) { "/organisations/#{current_user.organisation.id}" }
 
-  describe "#primary items" do
-    context "when the sales log feature flag is enabled" do
-      context "when the user is a data coordinator" do
-        context "when the user is on the lettings logs page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", true),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/lettings-logs", current_user)).to eq(expected_navigation_items)
-          end
+  describe "#primary_items" do
+    context "when the user is a data coordinator" do
+      context "when the user is on the lettings logs page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", true),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
         end
 
-        context "when the user is on the sales logs page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", true),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/sales-logs", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the users page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", users_path, true),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items(users_path, current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on their organisation details page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, true),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("#{organisation_path}/details", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the account page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the individual user's page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", true),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/users/1", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the individual scheme's page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
-              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
-              NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
-              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-            ]
-          end
-
-          it "returns navigation items with Schemes item set as current" do
-            expect(primary_items("/schemes/1", current_user)).to eq(expected_navigation_items)
-          end
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/lettings-logs", current_user)).to eq(expected_navigation_items)
         end
       end
 
-      context "when the user is a support user" do
-        let(:current_user) { FactoryBot.create(:user, :support) }
+      context "when the user is on the sales logs page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", true),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
 
-        context "when the user is on the lettings logs page" do
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/sales-logs", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the users page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, true),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items(users_path, current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on their organisation details page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", users_path, false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, true),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("#{organisation_path}/details", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the account page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the individual user's page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", true),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/users/1", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the individual scheme's page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+            NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+            NavigationItemsHelper::NavigationItem.new("About your organisation", organisation_path, false),
+            NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+            NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+          ]
+        end
+
+        it "returns navigation items with Schemes item set as current" do
+          expect(primary_items("/schemes/1", current_user)).to eq(expected_navigation_items)
+        end
+      end
+    end
+
+    context "when a data provider" do
+      let(:current_user) { create(:user, :data_provider) }
+
+      it "includes schemes" do
+        expect(primary_items("/", current_user)).to include(NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false))
+      end
+    end
+
+    context "when the user is a support user" do
+      let(:current_user) { create(:user, :support) }
+
+      context "when the user is on the lettings logs page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", true),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/lettings-logs", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the sales logs page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", true),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/sales-logs", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the users page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", true),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/users", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the account page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the Schemes page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/schemes", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the individual user's page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", true),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+          ]
+        end
+
+        it "returns navigation items with the users item set as current" do
+          expect(primary_items("/users/1", current_user)).to eq(expected_navigation_items)
+        end
+      end
+
+      context "when the user is on the individual scheme's page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+          ]
+        end
+
+        let(:expected_scheme_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", true),
+            NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", false),
+          ]
+        end
+
+        it "returns navigation items with Schemes item set as current" do
+          expect(primary_items("/schemes/1", current_user)).to eq(expected_navigation_items)
+          expect(scheme_items("/schemes/1", 1, "Locations")).to eq(expected_scheme_items)
+        end
+      end
+
+      context "when the user is on the scheme locations page" do
+        let(:expected_navigation_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+            NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
+            NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
+            NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+          ]
+        end
+
+        let(:expected_scheme_items) do
+          [
+            NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", false),
+            NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", true),
+          ]
+        end
+
+        it "returns navigation items with Schemes item set as current" do
+          expect(primary_items("/schemes/1/locations", current_user)).to eq(expected_navigation_items)
+          expect(scheme_items("/schemes/1/locations", 1, "Locations")).to eq(expected_scheme_items)
+        end
+      end
+
+      context "when the user is on the specific organisation's page" do
+        context "when the user is on organisation logs page" do
+          let(:required_sub_path) { "lettings-logs" }
           let(:expected_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
               NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", true),
+              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
               NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
               NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
             ]
           end
 
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/lettings-logs", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the sales logs page" do
-          let(:expected_navigation_items) do
+          let(:expected_secondary_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", true),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
+              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", true),
+              NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
+              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+              NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
+              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
             ]
           end
 
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/sales-logs", current_user)).to eq(expected_navigation_items)
+          it "returns navigation items with the logs item set as current" do
+            expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
+            expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
           end
         end
 
-        context "when the user is on the users page" do
+        context "when the user is on organisation users page" do
+          let(:required_sub_path) { "users" }
           let(:expected_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/users", true),
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-            ]
-          end
-
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/users", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the account page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
               NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
               NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
               NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
@@ -198,210 +333,81 @@ RSpec.describe NavigationItemsHelper do
             ]
           end
 
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/account", current_user)).to eq(expected_navigation_items)
-          end
-        end
-
-        context "when the user is on the Schemes page" do
-          let(:expected_navigation_items) do
+          let(:expected_secondary_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
+              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", true),
+              NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
+              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
             ]
           end
 
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/schemes", current_user)).to eq(expected_navigation_items)
+          it "returns navigation items with the logs item set as current" do
+            expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
+            expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
           end
         end
 
-        context "when the user is on the individual user's page" do
+        context "when the user is on organisation schemes page" do
+          let(:required_sub_path) { "schemes" }
           let(:expected_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/users", true),
+              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
+              NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
               NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
               NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
               NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
             ]
           end
 
-          it "returns navigation items with the users item set as current" do
-            expect(primary_items("/users/1", current_user)).to eq(expected_navigation_items)
+          let(:expected_secondary_navigation_items) do
+            [
+              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", true),
+              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+              NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
+              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
+            ]
+          end
+
+          it "returns navigation items with the schemes item set as current" do
+            expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
+            expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
           end
         end
 
-        context "when the user is on the individual scheme's page" do
+        context "when the user is on organisation details page" do
+          let(:required_sub_path) { "details" }
           let(:expected_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
+              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
               NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
               NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
               NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
+              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
             ]
           end
 
-          let(:expected_scheme_items) do
+          let(:expected_secondary_navigation_items) do
             [
-              NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", true),
-              NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", false),
+              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
+              NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
+              NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
+              NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", true),
+              NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
+              NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
             ]
           end
 
-          it "returns navigation items with Schemes item set as current" do
-            expect(primary_items("/schemes/1", current_user)).to eq(expected_navigation_items)
-            expect(scheme_items("/schemes/1", 1, "Locations")).to eq(expected_scheme_items)
-          end
-        end
-
-        context "when the user is on the scheme locations page" do
-          let(:expected_navigation_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", false),
-              NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-              NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-              NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", true),
-            ]
-          end
-
-          let(:expected_scheme_items) do
-            [
-              NavigationItemsHelper::NavigationItem.new("Scheme", "/schemes/1", false),
-              NavigationItemsHelper::NavigationItem.new("Locations", "/schemes/1/locations", true),
-            ]
-          end
-
-          it "returns navigation items with Schemes item set as current" do
-            expect(primary_items("/schemes/1/locations", current_user)).to eq(expected_navigation_items)
-            expect(scheme_items("/schemes/1/locations", 1, "Locations")).to eq(expected_scheme_items)
-          end
-        end
-
-        context "when the user is on the specific organisation's page" do
-          context "when the user is on organisation logs page" do
-            let(:required_sub_path) { "lettings-logs" }
-            let(:expected_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
-                NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              ]
-            end
-
-            let(:expected_secondary_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", true),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
-                NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
-                NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
-                NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-                NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-              ]
-            end
-
-            it "returns navigation items with the logs item set as current" do
-              expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
-              expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
-            end
-          end
-
-          context "when the user is on organisation users page" do
-            let(:required_sub_path) { "users" }
-            let(:expected_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
-                NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              ]
-            end
-
-            let(:expected_secondary_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
-                NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", true),
-                NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
-                NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-                NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-              ]
-            end
-
-            it "returns navigation items with the logs item set as current" do
-              expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
-              expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
-            end
-          end
-
-          context "when the user is on organisation schemes page" do
-            let(:required_sub_path) { "schemes" }
-            let(:expected_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
-                NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              ]
-            end
-
-            let(:expected_secondary_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", true),
-                NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
-                NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", false),
-                NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-                NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-              ]
-            end
-
-            it "returns navigation items with the schemes item set as current" do
-              expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
-              expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
-            end
-          end
-
-          context "when the user is on organisation details page" do
-            let(:required_sub_path) { "details" }
-            let(:expected_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Organisations", "/organisations", true),
-                NavigationItemsHelper::NavigationItem.new("Users", "/users", false),
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/schemes", false),
-              ]
-            end
-
-            let(:expected_secondary_navigation_items) do
-              [
-                NavigationItemsHelper::NavigationItem.new("Lettings logs", "/organisations/#{current_user.organisation.id}/lettings-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Sales logs", "/organisations/#{current_user.organisation.id}/sales-logs", false),
-                NavigationItemsHelper::NavigationItem.new("Schemes", "/organisations/#{current_user.organisation.id}/schemes", false),
-                NavigationItemsHelper::NavigationItem.new("Users", "/organisations/#{current_user.organisation.id}/users", false),
-                NavigationItemsHelper::NavigationItem.new("About this organisation", "/organisations/#{current_user.organisation.id}", true),
-                NavigationItemsHelper::NavigationItem.new("Stock owners", "/organisations/#{current_user.organisation.id}/stock-owners", false),
-                NavigationItemsHelper::NavigationItem.new("Managing agents", "/organisations/#{current_user.organisation.id}/managing-agents", false),
-              ]
-            end
-
-            it "returns navigation items with the logs item set as current" do
-              expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
-              expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
-            end
+          it "returns navigation items with the logs item set as current" do
+            expect(primary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user)).to eq(expected_navigation_items)
+            expect(secondary_items("/organisations/#{current_user.organisation.id}/#{required_sub_path}", current_user.organisation.id)).to eq(expected_secondary_navigation_items)
           end
         end
       end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe LocationsController, type: :request do
   let(:page) { Capybara::Node::Simple.new(response.body) }
-  let(:user) { FactoryBot.create(:user, :support) }
-  let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+  let(:user) { create(:user, :support) }
+  let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
@@ -19,22 +19,21 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
 
       before do
         sign_in user
         get "/schemes/1/locations/create"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 404" do
+        expect(response).to be_not_found
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
 
       before do
         sign_in user
@@ -56,18 +55,18 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to add a new location to a scheme that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
+        let(:another_scheme) { create(:scheme) }
 
         it "displays the new page with an error message" do
           post scheme_locations_path(another_scheme)
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -90,11 +89,11 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to add a new location to a scheme that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
+        let(:another_scheme) { create(:scheme) }
 
         it "displays the new page with an error message" do
           post scheme_locations_path(another_scheme)
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
@@ -109,23 +108,23 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider user" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
 
       before do
         sign_in user
         get "/schemes/#{scheme.id}/locations"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 200" do
+        expect(response).to be_successful
       end
     end
 
     context "when signed in as a data coordinator user" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:locations) { FactoryBot.create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let!(:locations) { create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
 
       before do
         sign_in user
@@ -133,15 +132,15 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when coordinator attempts to see scheme belonging to a different organisation" do
-        let!(:another_scheme) { FactoryBot.create(:scheme) }
+        let(:another_scheme) { create(:scheme) }
 
         before do
-          FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2022, 4, 1))
+          create(:location, scheme:, startdate: Time.zone.local(2022, 4, 1))
         end
 
-        it "returns 404 not found" do
+        it "returns 401" do
           get "/schemes/#{another_scheme.id}/locations"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
 
@@ -177,7 +176,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when paginating over 20 results" do
-        let!(:locations) { FactoryBot.create_list(:location, 25, scheme:) }
+        let!(:locations) { create_list(:location, 25, scheme:) }
 
         context "when on the first page" do
           before do
@@ -275,9 +274,9 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme) }
-      let!(:locations) { FactoryBot.create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme) }
+      let!(:locations) { create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -318,7 +317,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when paginating over 20 results" do
-        let!(:locations) { FactoryBot.create_list(:location, 25, scheme:) }
+        let!(:locations) { create_list(:location, 25, scheme:) }
 
         context "when on the first page" do
           before do
@@ -401,23 +400,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/postcode"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/postcode"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -464,20 +464,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit postcode of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/postcode"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -543,23 +543,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/local-authority"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/local-authority"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -590,20 +591,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit local authority of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/local-authority"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -653,23 +654,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/name"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/name"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -699,20 +701,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit name of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/name"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -761,23 +763,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/units"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/units"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -807,20 +810,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit units of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/units"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -869,23 +872,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/type-of-unit"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/type-of-unit"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -915,20 +919,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit type_of_unit of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/type-of-unit"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -977,23 +981,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/mobility-standards"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/mobility-standards"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -1023,20 +1028,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit mobility_standards of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/mobility-standards"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1085,23 +1090,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/availability"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/availability"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 401" do
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
@@ -1161,20 +1167,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit startdate of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/availability"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1253,23 +1259,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1)) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1/check-answers"
+        get "/schemes/#{scheme.id}/locations/#{location.id}/check-answers"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 200" do
+        expect(response).to be_successful
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1)) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1)) }
 
       before do
         sign_in user
@@ -1301,7 +1308,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         context "when location is not complete" do
-          let(:location) { FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1), postcode: nil) }
+          let(:location) { create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1), postcode: nil) }
 
           it "does not confirm location" do
             expect(Location.last.confirmed).to eq(false)
@@ -1316,20 +1323,20 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when trying to edit check_answers of location that belongs to another organisation" do
-        let(:another_scheme)  { FactoryBot.create(:scheme) }
-        let(:another_location)  { FactoryBot.create(:location, scheme: another_scheme) }
+        let(:another_scheme) { create(:scheme) }
+        let(:another_location) { create(:location, scheme: another_scheme) }
 
         it "displays the new page with an error message" do
           get "/schemes/#{another_scheme.id}/locations/#{another_location.id}/check-answers"
-          expect(response).to have_http_status(:not_found)
+          expect(response).to be_unauthorized
         end
       end
     end
 
     context "when signed in as a support user" do
-      let(:user) { FactoryBot.create(:user, :support) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1)) }
+      let(:user) { create(:user, :support) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1)) }
 
       before do
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -1362,7 +1369,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         context "when location is not complete" do
-          let(:location) { FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1), postcode: nil) }
+          let(:location) { create(:location, scheme:, startdate: Time.zone.local(2000, 1, 1), postcode: nil) }
 
           it "does not confirm location" do
             expect(Location.last.confirmed).to eq(false)
@@ -1395,25 +1402,26 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:, created_at: Time.zone.local(2022, 4, 1)) }
 
       before do
         sign_in user
-        patch "/schemes/1/locations/1/deactivate"
+        patch "/schemes/#{scheme.id}/locations/#{location.id}/deactivate"
       end
 
       it "returns 401 unauthorized" do
-        request
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:, created_at: Time.zone.local(2022, 4, 1)) }
+      let(:user) { create(:user, :data_coordinator) }
+      let!(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let!(:location) { create(:location, scheme:, created_at: Time.zone.local(2022, 4, 1)) }
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
-      let!(:lettings_log) { FactoryBot.create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
+      let!(:lettings_log) { create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
       let(:startdate) { Time.utc(2022, 10, 11) }
       let(:add_deactivations) { nil }
       let(:setup_locations) { nil }
@@ -1487,12 +1495,12 @@ RSpec.describe LocationsController, type: :request do
         let(:params) { { deactivation_date:, confirm: true, deactivation_date_type: "other" } }
         let(:mailer) { instance_double(LocationOrSchemeDeactivationMailer) }
 
-        let(:user_a) { FactoryBot.create(:user, email: "user_a@example.com") }
-        let(:user_b) { FactoryBot.create(:user, email: "user_b@example.com") }
+        let(:user_a) { create(:user, email: "user_a@example.com") }
+        let(:user_b) { create(:user, email: "user_b@example.com") }
 
         before do
-          FactoryBot.create_list(:lettings_log, 1, :sh, location:, scheme:, startdate:, created_by: user_a)
-          FactoryBot.create_list(:lettings_log, 3, :sh, location:, scheme:, startdate:, created_by: user_b)
+          create_list(:lettings_log, 1, :sh, location:, scheme:, startdate:, created_by: user_a)
+          create_list(:lettings_log, 3, :sh, location:, scheme:, startdate:, created_by: user_b)
 
           Timecop.freeze(Time.utc(2022, 10, 10))
           sign_in user
@@ -1615,7 +1623,7 @@ RSpec.describe LocationsController, type: :request do
       context "when deactivation date is during a deactivated period" do
         let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
         let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
-        let(:add_deactivations) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 5, 5), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
+        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 5, 5), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
 
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
@@ -1634,23 +1642,24 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        get "/schemes/1/locations/1"
+        get "/schemes/#{scheme.id}/locations/#{location.id}"
       end
 
-      it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+      it "returns 200" do
+        expect(response).to be_successful
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
       let(:add_deactivations) { location.location_deactivation_periods << location_deactivation_period }
 
       before do
@@ -1675,7 +1684,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with deactivated location" do
-        let(:location_deactivation_period) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 9), location:) }
+        let(:location_deactivation_period) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 9), location:) }
 
         it "renders reactivate this location" do
           expect(response).to have_http_status(:ok)
@@ -1684,7 +1693,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with location that's deactivating soon" do
-        let(:location_deactivation_period) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 12), location:) }
+        let(:location_deactivation_period) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 10, 12), location:) }
 
         it "does not render toggle location link" do
           expect(response).to have_http_status(:ok)
@@ -1694,7 +1703,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with location that's reactivating soon" do
-        let(:location_deactivation_period) { FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 4, 12), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
+        let(:location_deactivation_period) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 4, 12), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
 
         it "does not render toggle location link" do
           expect(response).to have_http_status(:ok)
@@ -1735,30 +1744,31 @@ RSpec.describe LocationsController, type: :request do
     end
 
     context "when signed in as a data provider" do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
 
       before do
         sign_in user
-        patch "/schemes/1/locations/1/reactivate"
+        patch "/schemes/#{scheme.id}/locations/#{location.id}/reactivate"
       end
 
       it "returns 401 unauthorized" do
-        request
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to be_unauthorized
       end
     end
 
     context "when signed in as a data coordinator" do
-      let(:user) { FactoryBot.create(:user, :data_coordinator) }
-      let!(:scheme) { FactoryBot.create(:scheme, owning_organisation: user.organisation) }
-      let!(:location) { FactoryBot.create(:location, scheme:) }
+      let(:user) { create(:user, :data_coordinator) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:location) { create(:location, scheme:) }
       let(:deactivation_date) { Time.zone.local(2022, 4, 1) }
       let(:startdate) { Time.utc(2022, 10, 11) }
 
       before do
         Timecop.freeze(Time.utc(2022, 10, 10))
         sign_in user
-        FactoryBot.create(:location_deactivation_period, deactivation_date:, location:)
+        create(:location_deactivation_period, deactivation_date:, location:)
         location.save!
         patch "/schemes/#{scheme.id}/locations/#{location.id}/reactivate", params:
       end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1723,6 +1723,8 @@ RSpec.describe LocationsController, type: :request do
         end
 
         it "shows the location" do
+          get "/schemes/#{scheme.id}/locations/#{location.id}"
+
           expect(page).to have_content("Location name")
           expect(page).to have_content(location.name)
         end

--- a/spec/views/locations/check_answers.html.erb_spec.rb
+++ b/spec/views/locations/check_answers.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "locations/check_answers.html.erb" do
+  context "when a data provider" do
+    let(:user) { create(:user) }
+
+    let(:scheme) do
+      instance_double(
+        Scheme,
+        owning_organisation: user.organisation,
+        id: 1,
+        service_name: "some name",
+        id_to_display: "S1",
+        sensitive: false,
+        scheme_type: "some type",
+        registered_under_care_act: false,
+        arrangement_type: "some other type",
+        primary_client_group: false,
+        has_other_client_group: false,
+        secondary_client_group: false,
+        support_type: "some support type",
+        intended_stay: "some intended stay",
+        available_from: 1.week.ago,
+        scheme_deactivation_periods: [],
+        status: :active,
+      )
+    end
+
+    let(:location) do
+      instance_double(
+        Location,
+        name: "some location",
+        postcode: "EC1N 2TD",
+        linked_local_authorities: [],
+        units: "",
+        type_of_unit: "",
+        mobility_type: "",
+        available_from: 1.week.ago,
+        location_deactivation_periods: [],
+        status: :active,
+        active?: true,
+        scheme:,
+        startdate: 1.day.ago,
+      )
+    end
+
+    it "does not see create submission button" do
+      assign(:scheme, scheme)
+      assign(:location, location)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Save and return to locations")
+    end
+  end
+end

--- a/spec/views/locations/check_answers.html.erb_spec.rb
+++ b/spec/views/locations/check_answers.html.erb_spec.rb
@@ -54,5 +54,16 @@ RSpec.describe "locations/check_answers.html.erb" do
 
       expect(rendered).not_to have_content("Save and return to locations")
     end
+
+    it "does not see change answer links" do
+      assign(:scheme, scheme)
+      assign(:location, location)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Change")
+    end
   end
 end

--- a/spec/views/locations/index.html.erb_spec.rb
+++ b/spec/views/locations/index.html.erb_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "locations/index.html.erb" do
         available_from: 1.week.ago,
         scheme_deactivation_periods: [],
         status: :active,
+        locations: Location,
       )
     end
 

--- a/spec/views/locations/index.html.erb_spec.rb
+++ b/spec/views/locations/index.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "locations/index.html.erb" do
+  context "when a data provider" do
+    let(:user) { create(:user) }
+
+    let(:scheme) do
+      instance_double(
+        Scheme,
+        owning_organisation: user.organisation,
+        id: 1,
+        service_name: "some name",
+        id_to_display: "S1",
+        sensitive: false,
+        scheme_type: "some type",
+        registered_under_care_act: false,
+        arrangement_type: "some other type",
+        primary_client_group: false,
+        has_other_client_group: false,
+        secondary_client_group: false,
+        support_type: "some support type",
+        intended_stay: "some intended stay",
+        available_from: 1.week.ago,
+        scheme_deactivation_periods: [],
+        status: :active,
+      )
+    end
+
+    it "does not see add a location button" do
+      assign(:pagy, Pagy.new(count: 0, page: 1))
+      assign(:scheme, scheme)
+      assign(:locations, [])
+
+      allow(view).to receive(:current_user).and_return(user)
+      allow(SearchComponent).to receive(:new).and_return(inline: "")
+
+      render
+
+      expect(rendered).not_to have_content("Add a location")
+    end
+  end
+end

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -53,5 +53,16 @@ RSpec.describe "locations/show.html.erb" do
 
       expect(rendered).not_to have_content("Deactivate this location")
     end
+
+    it "does not see change answer links" do
+      assign(:scheme, scheme)
+      assign(:location, location)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Change")
+    end
   end
 end

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "locations/show.html.erb" do
+  context "when a data provider" do
+    let(:user) { create(:user) }
+
+    let(:scheme) do
+      instance_double(
+        Scheme,
+        owning_organisation: user.organisation,
+        id: 1,
+        service_name: "some name",
+        id_to_display: "S1",
+        sensitive: false,
+        scheme_type: "some type",
+        registered_under_care_act: false,
+        arrangement_type: "some other type",
+        primary_client_group: false,
+        has_other_client_group: false,
+        secondary_client_group: false,
+        support_type: "some support type",
+        intended_stay: "some intended stay",
+        available_from: 1.week.ago,
+        scheme_deactivation_periods: [],
+        status: :active,
+      )
+    end
+
+    let(:location) do
+      instance_double(
+        Location,
+        name: "some location",
+        postcode: "EC1N 2TD",
+        linked_local_authorities: [],
+        units: "",
+        type_of_unit: "",
+        mobility_type: "",
+        available_from: 1.week.ago,
+        location_deactivation_periods: [],
+        status: :active,
+        active?: true,
+        scheme:,
+      )
+    end
+
+    it "does not see add a location button" do
+      assign(:scheme, scheme)
+      assign(:location, location)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Deactivate this location")
+    end
+  end
+end

--- a/spec/views/organisations/schemes.html.erb_spec.rb
+++ b/spec/views/organisations/schemes.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "organisations/schemes.html.erb" do
+  context "when data provider" do
+    let(:user) { build(:user) }
+
+    it "does not render button to create schemes" do
+      assign(:organisation, user.organisation)
+      assign(:pagy, Pagy.new(count: 0, page: 1))
+      assign(:schemes, [])
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Create a new supported housing scheme")
+    end
+  end
+end

--- a/spec/views/schemes/check_answers.html.erb_spec.rb
+++ b/spec/views/schemes/check_answers.html.erb_spec.rb
@@ -1,38 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "schemes/check_answers.html.erb" do
-  let(:user) { build(:user) }
-
-  let(:scheme) do
-    instance_double(
-      Scheme,
-      owning_organisation: user.organisation,
-      id: 1,
-      service_name: "some name",
-      id_to_display: "S1",
-      sensitive: false,
-      scheme_type: "some type",
-      registered_under_care_act: false,
-      arrangement_type: "some other type",
-      primary_client_group: false,
-      has_other_client_group: false,
-      secondary_client_group: false,
-      support_type: "some support type",
-      intended_stay: "some intended stay",
-      available_from: 1.week.ago,
-      scheme_deactivation_periods: [],
-      status: :active,
-      to_model: Scheme.new,
-      check_details_attributes: [],
-      check_primary_client_attributes: [
-        { name: "Primary client group", value: "foo", id: "primary_client_group" },
-      ],
-      check_secondary_client_confirmation_attributes: [],
-      check_support_attributes: [],
-      confirmed?: false,
-      errors: ActiveModel::Errors.new(Scheme.new),
-    )
-  end
+  let(:organisation) { create(:organisation, holds_own_stock: true) }
+  let(:user) { build(:user, organisation:) }
+  let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
 
   context "when a data provider" do
     it "does not render change links" do

--- a/spec/views/schemes/check_answers.html.erb_spec.rb
+++ b/spec/views/schemes/check_answers.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "schemes/check_answers.html.erb" do
+  let(:user) { build(:user) }
+
+  let(:scheme) do
+    instance_double(
+      Scheme,
+      owning_organisation: user.organisation,
+      id: 1,
+      service_name: "some name",
+      id_to_display: "S1",
+      sensitive: false,
+      scheme_type: "some type",
+      registered_under_care_act: false,
+      arrangement_type: "some other type",
+      primary_client_group: false,
+      has_other_client_group: false,
+      secondary_client_group: false,
+      support_type: "some support type",
+      intended_stay: "some intended stay",
+      available_from: 1.week.ago,
+      scheme_deactivation_periods: [],
+      status: :active,
+      to_model: Scheme.new,
+      check_details_attributes: [],
+      check_primary_client_attributes: [
+        { name: "Primary client group", value: "foo", id: "primary_client_group" },
+      ],
+      check_secondary_client_confirmation_attributes: [],
+      check_support_attributes: [],
+      confirmed?: false,
+      errors: ActiveModel::Errors.new(Scheme.new),
+    )
+  end
+
+  context "when a data provider" do
+    it "does not render change links" do
+      assign(:scheme, scheme)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Change")
+    end
+
+    it "does not render submit button" do
+      assign(:scheme, scheme)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Create scheme")
+    end
+  end
+end

--- a/spec/views/schemes/index.html.erb_spec.rb
+++ b/spec/views/schemes/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "schemes/index.html.erb" do
+  context "when data provider" do
+    let(:user) { build(:user) }
+
+    it "does not render button to create schemes" do
+      assign(:pagy, Pagy.new(count: 0, page: 1))
+      assign(:schemes, [])
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Create a new supported housing scheme")
+    end
+  end
+end

--- a/spec/views/schemes/show.html.erb_spec.rb
+++ b/spec/views/schemes/show.html.erb_spec.rb
@@ -1,34 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "schemes/show.html.erb" do
-  before do
-    allow(FeatureToggle).to receive(:scheme_toggle_enabled?).and_return(true)
-  end
-
   context "when data provider" do
-    let(:user) { build(:user) }
-
-    let(:scheme) do
-      instance_double(
-        Scheme,
-        owning_organisation: user.organisation,
-        id: 1,
-        service_name: "some name",
-        id_to_display: "S1",
-        sensitive: false,
-        scheme_type: "some type",
-        registered_under_care_act: false,
-        arrangement_type: "some other type",
-        primary_client_group: false,
-        has_other_client_group: false,
-        secondary_client_group: false,
-        support_type: "some support type",
-        intended_stay: "some intended stay",
-        available_from: 1.week.ago,
-        scheme_deactivation_periods: [],
-        status: :active,
-      )
-    end
+    let(:organisation) { create(:organisation, holds_own_stock: true) }
+    let(:user) { build(:user, organisation:) }
+    let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
 
     it "does not render button to deactivate schemes" do
       assign(:scheme, scheme)

--- a/spec/views/schemes/show.html.erb_spec.rb
+++ b/spec/views/schemes/show.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "schemes/show.html.erb" do
+  before do
+    allow(FeatureToggle).to receive(:scheme_toggle_enabled?).and_return(true)
+  end
+
+  context "when data provider" do
+    let(:user) { build(:user) }
+
+    let(:scheme) do
+      instance_double(
+        Scheme,
+        owning_organisation: user.organisation,
+        id: 1,
+        service_name: "some name",
+        id_to_display: "S1",
+        sensitive: false,
+        scheme_type: "some type",
+        registered_under_care_act: false,
+        arrangement_type: "some other type",
+        primary_client_group: false,
+        has_other_client_group: false,
+        secondary_client_group: false,
+        support_type: "some support type",
+        intended_stay: "some intended stay",
+        available_from: 1.week.ago,
+        scheme_deactivation_periods: [],
+        status: :active,
+      )
+    end
+
+    it "does not render button to deactivate schemes" do
+      assign(:scheme, scheme)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Deactivate this scheme")
+    end
+  end
+end

--- a/spec/views/schemes/show.html.erb_spec.rb
+++ b/spec/views/schemes/show.html.erb_spec.rb
@@ -39,5 +39,15 @@ RSpec.describe "schemes/show.html.erb" do
 
       expect(rendered).not_to have_content("Deactivate this scheme")
     end
+
+    it "does not see change answer links" do
+      assign(:scheme, scheme)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).not_to have_content("Change")
+    end
   end
 end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1732
- data providers are given read-only able access to schemes and locations 

# Changes

- introduce `pundit` policies to schemes and locations. the old scope mechanism has been removed
- apply policies at view level so hide write access based functionality from data providers