### PR TITLE
Fix uprn tests wip

### DIFF
--- a/spec/shared/shared_log_examples.rb
+++ b/spec/shared/shared_log_examples.rb
@@ -57,6 +57,7 @@ RSpec.shared_examples "shared log examples" do |log_type|
           uprn_confirmed: 1,
           uprn_known: 1,
           county: "county",
+          postcode_full: nil,
         )
       end
 
@@ -80,7 +81,6 @@ RSpec.shared_examples "shared log examples" do |log_type|
         .and change(log, :postcode_full).from(nil).to("POSTCODE")
         .and change(log, :uprn_confirmed).from(1).to(nil)
         .and change(log, :county).from("county").to(nil)
-        .and change(log, :uprn_known).from(nil).to(1)
       end
     end
 

--- a/spec/shared/shared_log_examples.rb
+++ b/spec/shared/shared_log_examples.rb
@@ -55,6 +55,7 @@ RSpec.shared_examples "shared log examples" do |log_type|
           log_type,
           uprn: "123456789",
           uprn_confirmed: 1,
+          uprn_known: 1,
           county: "county",
         )
       end
@@ -92,7 +93,7 @@ RSpec.shared_examples "shared log examples" do |log_type|
     end
 
     context "when service errors" do
-      let(:log) { create(log_type, uprn: "123456789", uprn_confirmed: 1) }
+      let(:log) { build(log_type, :in_progress, uprn_known: 1, uprn: "123456789", uprn_confirmed: 1) }
       let(:error_message) { "error" }
 
       it "adds error to log" do


### PR DESCRIPTION
Clearing invalidated dependent fields in a recent PR meant we had to rewrite these tests to pass.