### PR TITLE
CLDC-2382 Fix bulk upload frequency of household rent and charges bug

### DIFF
--- a/app/models/form/lettings/pages/rent_period.rb
+++ b/app/models/form/lettings/pages/rent_period.rb
@@ -2,7 +2,7 @@ class Form::Lettings::Pages::RentPeriod < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "rent_period"
-    @depends_on = [{ "household_charge" => 0 }, { "household_charge" => nil }]
+    @depends_on = [{ "needstype" => 1 }, { "needstype" => 2, "household_charge" => 0 }, { "needstype" => 2, "household_charge" => nil }]
   end
 
   def questions

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -7481,9 +7481,14 @@
               },
               "depends_on": [
                 {
+                  "needstype": 1
+                },
+                {
+                  "needstype": 2,
                   "household_charge": 0
                 },
                 {
+                  "needstype": 2,
                   "household_charge": null
                 }
               ]


### PR DESCRIPTION
The issue described in the ticket was caused by the `period` question not being routed to because the user had erroneously answered the `household_charges` field in a general needs bulk upload (`household_charges` is only for supported housing). Hence `period` was being cleared when it shouldn't have been.

The user doesn't need to wait for this fix, they can just remove their answer to `household_charges` and the bulk upload will complete successfully.

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2382