### PR TITLE
Only loop through existing field mappings for errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -770,7 +770,7 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
-        field_mapping_for_errors[interruption_screen_question_id.to_sym].each do |field|
+        field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
           unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)
@@ -956,6 +956,7 @@ private
       mrcdate: %i[field_92 field_93 field_94],
 
       voiddate: %i[field_89 field_90 field_91],
+      is_carehome: %i[field_85],
     }
   end
 

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -515,7 +515,7 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
-        field_mapping_for_errors[interruption_screen_question_id.to_sym].each do |field|
+        field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
           unless errors.any? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -996,7 +996,7 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
-        field_mapping_for_errors[interruption_screen_question_id.to_sym].each do |field|
+        field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
           unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -1211,7 +1211,7 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
-        field_mapping_for_errors[interruption_screen_question_id.to_sym].each do |field|
+        field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
           unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)


### PR DESCRIPTION
We got this error on 2022 row parser.
```
undefined method `each' for nil:NilClass
field_mapping_for_errors[interruption_screen_question_id.to_sym].each do |field|
```
This PR adds the only missing interruption screen question id from 2022 form, but I've also added a check for nil before we look through those errors.