### PR TITLE
Clear scheme if it has no confirmed locations

### DIFF
--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -24,7 +24,7 @@ module Validations::SetupValidations
     return unless record.scheme
 
     unless record.scheme.locations.confirmed.any?
-      record.errors.add :scheme_id, I18n.t("validations.scheme.no_completed_locations")
+      record.errors.add :scheme_id, :no_completed_locations, message: I18n.t("validations.scheme.no_completed_locations")
     end
   end
 

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -328,6 +328,7 @@ module Imports
         %i[layear renewal_just_moved] => %w[layear],
         %i[voiddate after_mrcdate] => %w[voiddate mrcdate majorrepairs],
         %i[tshortfall more_than_rent] => %w[tshortfall tshortfall_known],
+        %i[scheme_id no_completed_locations] => %w[scheme_id location_id],
       }
 
       (2..8).each do |person|


### PR DESCRIPTION
When importing the logs some of the schemes selected have no confirmed locations, we want to clear those scheme and location ids to be able to import the rest of the data