### PR TITLE
CLDC-2360 Remove cannot delete warning

### DIFF
--- a/app/views/bulk_upload_lettings_resume/confirm.html.erb
+++ b/app/views/bulk_upload_lettings_resume/confirm.html.erb
@@ -9,10 +9,6 @@
 
     <p class="govuk-body"><%= pluralize_logs_and_errors_warning(@bulk_upload.logs.count, @bulk_upload.bulk_upload_errors.count) %> </p>
 
-    <%= govuk_warning_text(icon_fallback_text: "Danger") do %>
-      You can not delete logs once you create them
-    <% end %>
-
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_lettings_resume_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>
 

--- a/app/views/bulk_upload_lettings_soft_validations_check/confirm.html.erb
+++ b/app/views/bulk_upload_lettings_soft_validations_check/confirm.html.erb
@@ -9,10 +9,6 @@
 
     <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "unexpected answer") %> will be marked as correct.</p>
 
-    <%= govuk_warning_text(icon_fallback_text: "Danger") do %>
-      You can not delete logs once you create them
-    <% end %>
-
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_lettings_soft_validations_check_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>
 

--- a/app/views/bulk_upload_sales_resume/confirm.html.erb
+++ b/app/views/bulk_upload_sales_resume/confirm.html.erb
@@ -9,10 +9,6 @@
 
     <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload with <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> that still need to be fixed after upload.</p>
 
-    <%= govuk_warning_text(icon_fallback_text: "Danger") do %>
-      You can not delete logs once you create them
-    <% end %>
-
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_sales_resume_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>
 

--- a/app/views/bulk_upload_sales_soft_validations_check/confirm.html.erb
+++ b/app/views/bulk_upload_sales_soft_validations_check/confirm.html.erb
@@ -9,10 +9,6 @@
 
     <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "unexpected answer") %> will be marked as correct.</p>
 
-    <%= govuk_warning_text(icon_fallback_text: "Danger") do %>
-      You can not delete logs once you create them
-    <% end %>
-
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_sales_soft_validations_check_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>
 


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2360
- Remove the cannot delete logs copy as we can (soon) delete logs

# Changes

- Remove copy warning users they cannot delete logs after creation

# Review notes

- Do not merge until users can actually delete logs