### PR TITLE
CLDC-2390 Extract town question to a separate row in CYA

### DIFF
--- a/app/models/form/lettings/questions/address_line1.rb
+++ b/app/models/form/lettings/questions/address_line1.rb
@@ -15,7 +15,6 @@ class Form::Lettings::Questions::AddressLine1 < ::Form::Question
       log.address_line1,
       log.address_line2,
       log.postcode_full,
-      log.town_or_city,
       log.county,
     ].select(&:present?).join("\n")
   end

--- a/app/models/form/lettings/questions/town_or_city.rb
+++ b/app/models/form/lettings/questions/town_or_city.rb
@@ -7,8 +7,4 @@ class Form::Lettings::Questions::TownOrCity < ::Form::Question
     @plain_label = true
     @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
-
-  def hidden_in_check_answers?(_log = nil, _current_user = nil)
-    true
-  end
 end

--- a/app/models/form/sales/questions/address_line1.rb
+++ b/app/models/form/sales/questions/address_line1.rb
@@ -15,7 +15,6 @@ class Form::Sales::Questions::AddressLine1 < ::Form::Question
       log.address_line1,
       log.address_line2,
       log.postcode_full,
-      log.town_or_city,
       log.county,
     ].select(&:present?).join("\n")
   end

--- a/app/models/form/sales/questions/town_or_city.rb
+++ b/app/models/form/sales/questions/town_or_city.rb
@@ -7,8 +7,4 @@ class Form::Sales::Questions::TownOrCity < ::Form::Question
     @plain_label = true
     @disable_clearing_if_not_routed_or_dynamic_answer_options = true
   end
-
-  def hidden_in_check_answers?(_log = nil, _current_user = nil)
-    true
-  end
 end

--- a/spec/models/form/lettings/questions/town_or_city_spec.rb
+++ b/spec/models/form/lettings/questions/town_or_city_spec.rb
@@ -42,8 +42,4 @@ RSpec.describe Form::Lettings::Questions::TownOrCity, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to be_nil
   end
-
-  it "has the correct hidden_in_check_answers" do
-    expect(question.hidden_in_check_answers?).to eq(true)
-  end
 end

--- a/spec/models/form/sales/questions/town_or_city_spec.rb
+++ b/spec/models/form/sales/questions/town_or_city_spec.rb
@@ -42,8 +42,4 @@ RSpec.describe Form::Sales::Questions::TownOrCity, type: :model do
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to be_nil
   end
-
-  it "has the correct hidden_in_check_answers" do
-    expect(question.hidden_in_check_answers?).to eq(true)
-  end
 end


### PR DESCRIPTION
Migrated logs don't always have all the address questions answered.
When some of the address fields are answered, but a mandatory field, such as town or city is not answered, the log is marked in progress, but there's no clear indication as to what question needs answering (because we display all the address answers on a single row in CYA).

This PR splits out town or city question in CYA, so it's clear to see when it's not answered.
<img width="942" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/84c00051-e148-40a6-982b-6898bead1576">

