### PR TITLE
CLDC-2367 Add tenancy length validation to rent_type field

### DIFF
--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -31,6 +31,7 @@ module Validations::TenancyValidations
       next unless condition[:condition]
 
       record.errors.add :needstype, condition[:error]
+      record.errors.add :rent_type, condition[:error]
       record.errors.add :tenancylength, :tenancylength_invalid, message: condition[:error]
       record.errors.add :tenancy, condition[:error]
     end

--- a/app/models/validations/tenancy_validations.rb
+++ b/app/models/validations/tenancy_validations.rb
@@ -6,11 +6,7 @@ module Validations::TenancyValidations
   def validate_fixed_term_tenancy(record)
     is_present = record.tenancylength.present?
     is_in_range = record.tenancylength.to_i.between?(min_tenancy_length(record), 99)
-    conditions = [
-      {
-        condition: !(record.is_secure_tenancy? || record.is_assured_shorthold_tenancy?) && is_present,
-        error: I18n.t("validations.tenancy.length.fixed_term_not_required"),
-      },
+    rent_type_dependent_conditions = [
       {
         condition: (record.is_assured_shorthold_tenancy? && !is_in_range) && is_present,
         error: I18n.t(
@@ -19,19 +15,26 @@ module Validations::TenancyValidations
         ),
       },
       {
-        condition: record.is_secure_tenancy? && (!is_in_range && is_present),
+        condition: (record.is_secure_tenancy? && !is_in_range) && is_present,
         error: I18n.t(
           "validations.tenancy.length.secure",
           min_tenancy_length: min_tenancy_length(record),
         ),
       },
     ]
+    rent_type_independent_conditions = [
+      {
+        condition: !(record.is_secure_tenancy? || record.is_assured_shorthold_tenancy?) && is_present,
+        error: I18n.t("validations.tenancy.length.fixed_term_not_required"),
+      },
+    ]
+    conditions = rent_type_dependent_conditions + rent_type_independent_conditions
 
     conditions.each do |condition|
       next unless condition[:condition]
 
       record.errors.add :needstype, condition[:error]
-      record.errors.add :rent_type, condition[:error]
+      record.errors.add :rent_type, condition[:error] if rent_type_dependent_conditions.include?(condition)
       record.errors.add :tenancylength, :tenancylength_invalid, message: condition[:error]
       record.errors.add :tenancy, condition[:error]
     end

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Validations::TenancyValidations do
           record.tenancylength = 10
           tenancy_validator.validate_fixed_term_tenancy(record)
           expect(record.errors["needstype"]).to include(match(expected_error))
+          expect(record.errors["rent_type"]).not_to include(match(expected_error))
           expect(record.errors["tenancylength"]).to include(match(expected_error))
           expect(record.errors["tenancy"]).to include(match(expected_error))
         end
@@ -44,6 +45,7 @@ RSpec.describe Validations::TenancyValidations do
             record.tenancylength = 1
             tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["needstype"]).to include(match(expected_error))
+            expect(record.errors["rent_type"]).to include(match(expected_error))
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end
@@ -54,6 +56,7 @@ RSpec.describe Validations::TenancyValidations do
             record.tenancylength = 100
             tenancy_validator.validate_fixed_term_tenancy(record)
             expect(record.errors["needstype"]).to include(match(expected_error))
+            expect(record.errors["rent_type"]).to include(match(expected_error))
             expect(record.errors["tenancylength"]).to include(match(expected_error))
             expect(record.errors["tenancy"]).to include(match(expected_error))
           end


### PR DESCRIPTION
This is surplus to the ticket requirement, just a bug I found along the way. There was no work to implement the ticket ACs, they're already present on staging.


Here's the ticket anyway for completeness: https://digital.dclg.gov.uk/jira/browse/CLDC-2367