### PR TITLE
CLDC-2377 Correctly set previous postcode known for bulk upload

### DIFF
--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -625,7 +625,7 @@ private
     attributes["prevten"] = buyer_not_interviewed? && field_39.blank? ? 0 : field_39
     attributes["prevloc"] = field_40
     attributes["previous_la_known"] = previous_la_known
-    attributes["ppcodenk"] = field_43
+    attributes["ppcodenk"] = previous_postcode_known
     attributes["ppostcode_full"] = ppostcode_full
 
     attributes["pregyrha"] = field_44
@@ -905,6 +905,12 @@ private
 
   def previous_la_known
     field_40.present? ? 1 : 0
+  end
+
+  def previous_postcode_known
+    return 1 if field_43.blank?
+
+    0 if field_43 == 1
   end
 
   def soctenant

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -819,7 +819,7 @@ private
     attributes["prevten"] = field_62
     attributes["prevloc"] = field_66
     attributes["previous_la_known"] = previous_la_known
-    attributes["ppcodenk"] = field_63
+    attributes["ppcodenk"] = previous_postcode_known
     attributes["ppostcode_full"] = ppostcode_full
 
     attributes["pregyrha"] = field_67
@@ -1105,6 +1105,12 @@ private
 
   def previous_la_known
     field_66.present? ? 1 : 0
+  end
+
+  def previous_postcode_known
+    return 1 if field_63 == 2
+
+    0 if field_63 == 1
   end
 
   def block_log_creation!

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -144,6 +144,34 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
     end
   end
 
+  describe "previous postcode known" do
+    context "when field_43 is 1" do
+      let(:attributes) do
+        {
+          bulk_upload:,
+          field_43: 1,
+        }
+      end
+
+      it "sets previous postcode known to yes" do
+        expect(parser.log.ppcodenk).to eq(0)
+      end
+    end
+
+    context "when field_43 is nil" do
+      let(:attributes) do
+        {
+          bulk_upload:,
+          field_43: nil,
+        }
+      end
+
+      it "sets previous postcode known to no" do
+        expect(parser.log.ppcodenk).to eq(1)
+      end
+    end
+  end
+
   describe "validations" do
     before do
       stub_request(:get, /api.postcodes.io/)

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -147,6 +147,34 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
     end
   end
 
+  describe "previous postcode known" do
+    context "when field_63 is 1" do
+      let(:attributes) do
+        {
+          bulk_upload:,
+          field_63: 1,
+        }
+      end
+
+      it "sets previous postcode known to yes" do
+        expect(parser.log.ppcodenk).to eq(0)
+      end
+    end
+
+    context "when field_63 is 2" do
+      let(:attributes) do
+        {
+          bulk_upload:,
+          field_63: 2,
+        }
+      end
+
+      it "sets previous postcode known to no" do
+        expect(parser.log.ppcodenk).to eq(1)
+      end
+    end
+  end
+
   describe "validations" do
     before do
       stub_request(:get, /api.postcodes.io/)


### PR DESCRIPTION
Values for previous postcode known incoming from bulk upload template are not a 1:1 mapping to our stored values. This PR maps those values correctly.
For 23/24:
- Code 2 in field 63 does not error, and the question is answered no
- Code 1 in field 63 does not error and the question is answered yes 

For 22/23:
- Null field 63 does not error, and the question is answered no
- Code 1 in field 63 does not error and the question is answered yes 