### PR TITLE
CLDC-2380 Correctly set hhregres and hhregresstill

### DIFF
--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -702,7 +702,7 @@ private
       owning_organisation_id: %i[field_1],
       created_by: %i[field_2],
       hhregres: %i[field_73],
-      hhregresstill: %i[field_73],
+      hhregresstill: %i[field_74],
       armedforcesspouse: %i[field_75],
 
       mortgagelender: %i[field_107 field_121 field_130],
@@ -868,8 +868,8 @@ private
 
     attributes["owning_organisation"] = owning_organisation
     attributes["created_by"] = created_by || bulk_upload.user
-    attributes["hhregres"] = hhregres
-    attributes["hhregresstill"] = hhregresstill
+    attributes["hhregres"] = field_73
+    attributes["hhregresstill"] = field_74
     attributes["armedforcesspouse"] = field_75
 
     attributes["mortgagelender"] = mortgagelender
@@ -911,8 +911,6 @@ private
 
     attributes["buy2living"] = field_71
     attributes["prevtenbuy2"] = prevtenbuy2
-
-    attributes["hhregresstill"] = field_74
 
     attributes["prevshared"] = field_85
 
@@ -1086,21 +1084,6 @@ private
 
   def created_by
     @created_by ||= User.find_by(email: field_2)
-  end
-
-  def hhregres
-    case field_73
-    when 3 then 3
-    when 4, 5, 6 then 1
-    when 7 then 7
-    when 8 then 8
-    end
-  end
-
-  def hhregresstill
-    return unless hhregres == 1
-
-    field_73
   end
 
   def previous_la_known

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -936,6 +936,14 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
+    describe "#hhregres" do
+      let(:attributes) { setup_section_params.merge({ field_73: "1" }) }
+
+      it "is correctly set" do
+        expect(parser.log.hhregres).to be(1)
+      end
+    end
+
     describe "#hhregresstill" do
       let(:attributes) { setup_section_params.merge({ field_74: "4" }) }
 


### PR DESCRIPTION
Hhregres mapping changed in 23/24 but wasn't updated.
It maps 1:1 to the template, this PR reflects that.
Also update the error message mapping for hhregresstill (field_74) it was set to field_73, because in 22/23 template we did not have a separate question for hhregresstill and were deriving it from hhregress.