### PR TITLE
CLDC-2393 Ensure bulk upload answers are red

### DIFF
--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -46,10 +46,22 @@ private
   end
 
   def get_answer_label(question, lettings_log)
-    question.answer_label(lettings_log, current_user).presence || "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe
+    question.answer_label(lettings_log, current_user).presence || unanswered_value(log: lettings_log)
   end
 
   def get_question_label(question)
     [question.question_number_string, question.check_answer_label.to_s.presence || question.header.to_s].compact.join(" - ")
+  end
+
+  def unanswered_value(log:)
+    if bulk_uploaded?(log:)
+      "<span class=\"app-!-colour-red\">You still need to answer this question</span>".html_safe
+    else
+      "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe
+    end
+  end
+
+  def bulk_uploaded?(log:)
+    log.bulk_upload
   end
 end

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -2,13 +2,16 @@
   <% questions.each do |question| %>
     <% summary_list.row do |row| %>
       <% row.key { get_question_label(question) } %>
+
       <% row.value do %>
-          <%= simple_format(
-            get_answer_label(question, @log),
-            wrapper_tag: "span",
-            class: "govuk-!-margin-right-4",
-          ) %>
+        <%= simple_format(
+          get_answer_label(question, @log),
+          wrapper_tag: "span",
+          class: "govuk-!-margin-right-4",
+        ) %>
+
         <% extra_value = question.get_extra_check_answer_value(@log) %>
+
         <% if extra_value && question.answer_label(@log, current_user).present? %>
           <%= simple_format(
             extra_value,
@@ -16,10 +19,12 @@
             class: "govuk-!-font-weight-regular app-!-colour-muted",
           ) %>
         <% end %>
+
         <% question.get_inferred_answers(@log).each do |inferred_answer| %>
           <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
         <% end %>
       <% end %>
+
       <% if @log.collection_period_open? %>
         <% row.action(
           text: question.action_text(@log),

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe CheckAnswersHelper do
       Singleton.__init__(FormHandler)
       example.run
     end
-    Timecop.return
-    Singleton.__init__(FormHandler)
   end
 
   describe "display_answered_questions_summary" do
@@ -34,6 +32,18 @@ RSpec.describe CheckAnswersHelper do
           .to match(/You answered all the questions./)
         expect(display_answered_questions_summary(subsection, lettings_log, current_user))
           .not_to match(/href/)
+      end
+    end
+  end
+
+  describe "#get_answer_label" do
+    context "when unanswered and bulk upload" do
+      let(:question) { log.form.questions.sample }
+      let(:bulk_upload) { build(:bulk_upload, :sales) }
+      let(:log) { build(:sales_log, bulk_upload:) }
+
+      it "is red" do
+        expect(get_answer_label(question, log)).to include("red")
       end
     end
   end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2393
- Ensure missing answers are highlighted red for bulk upload

# Changes

- There seem to be 2 ways of presenting answers, 1 via view component the other via a partial
- Fixed the partial pathway where the bug was present