### PR TITLE
CLDC-2386 Validate the correct template for the year

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -8,6 +8,7 @@ class BulkUpload::Lettings::Validator
   validate :validate_file_not_empty
   validate :validate_field_numbers_count
   validate :validate_max_columns_count_if_no_headers
+  validate :validate_correct_template
 
   def initialize(bulk_upload:, path:)
     @bulk_upload = bulk_upload
@@ -156,6 +157,12 @@ private
     return if halt_validations?
 
     errors.add(:base, :over_max_column_count) if csv_parser.too_many_columns?
+  end
+
+  def validate_correct_template
+    return if halt_validations?
+
+    errors.add(:base, :wrong_template) unless csv_parser.correct_template_for_year?
   end
 
   def halt_validations!

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -162,7 +162,7 @@ private
   def validate_correct_template
     return if halt_validations?
 
-    errors.add(:base, :wrong_template) unless csv_parser.correct_template_for_year?
+    errors.add(:base, :wrong_template) if csv_parser.wrong_template_for_year?
   end
 
   def halt_validations!

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -61,8 +61,8 @@ class BulkUpload::Lettings::Year2022::CsvParser
     max_columns_count > MAX_COLUMNS
   end
 
-  def correct_template_for_year?
-    true
+  def wrong_template_for_year?
+    false
   end
 
 private

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -61,6 +61,10 @@ class BulkUpload::Lettings::Year2022::CsvParser
     max_columns_count > MAX_COLUMNS
   end
 
+  def correct_template_for_year?
+    true
+  end
+
 private
 
   def default_field_numbers

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -5,6 +5,7 @@ class BulkUpload::Lettings::Year2023::CsvParser
 
   FIELDS = 134
   MAX_COLUMNS = 142
+  FORM_YEAR = 2023
 
   attr_reader :path
 
@@ -64,7 +65,7 @@ class BulkUpload::Lettings::Year2023::CsvParser
   end
 
   def correct_template_for_year?
-    collection_start_year_for_date(first_record_start_date) == 2023
+    collection_start_year_for_date(first_record_start_date) == FORM_YEAR
   rescue Date::Error
     true
   end

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -101,10 +101,6 @@ private
     @normalised_string
   end
 
-  def has_field_in_header?(field)
-    rows[rows.find_index { |row| row[0].match(/field number/i) }].any? { |cell| cell&.match?(/#{field}/i) }
-  end
-
   def first_record_start_date
     if with_headers?
       Date.new(row_parsers.first.field_98.to_i + 2000, row_parsers.first.field_97.to_i, row_parsers.first.field_96.to_i)

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -64,10 +64,10 @@ class BulkUpload::Lettings::Year2023::CsvParser
     max_columns_count > MAX_COLUMNS
   end
 
-  def correct_template_for_year?
-    collection_start_year_for_date(first_record_start_date) == FORM_YEAR
+  def wrong_template_for_year?
+    collection_start_year_for_date(first_record_start_date) != FORM_YEAR
   rescue Date::Error
-    true
+    false
   end
 
 private

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -137,7 +137,7 @@ private
   def validate_correct_template
     return if halt_validations?
 
-    errors.add(:base, :wrong_template) unless csv_parser.correct_template_for_year?
+    errors.add(:base, :wrong_template) if csv_parser.wrong_template_for_year?
   end
 
   def halt_validations!

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -5,6 +5,7 @@ class BulkUpload::Sales::Validator
 
   validate :validate_file_not_empty
   validate :validate_max_columns
+  validate :validate_correct_template
 
   def initialize(bulk_upload:, path:)
     @bulk_upload = bulk_upload
@@ -131,6 +132,12 @@ private
     column_count = rows.map(&:size).max
 
     errors.add(:base, :over_max_column_count) if column_count > csv_parser.class::MAX_COLUMNS
+  end
+
+  def validate_correct_template
+    return if halt_validations?
+
+    errors.add(:base, :wrong_template) unless csv_parser.correct_template_for_year?
   end
 
   def halt_validations!

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -43,8 +43,8 @@ class BulkUpload::Sales::Year2022::CsvParser
     cols[headers.find_index(field) + col_offset]
   end
 
-  def correct_template_for_year?
-    true
+  def wrong_template_for_year?
+    false
   end
 
 private

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -43,6 +43,10 @@ class BulkUpload::Sales::Year2022::CsvParser
     cols[headers.find_index(field) + col_offset]
   end
 
+  def correct_template_for_year?
+    true
+  end
+
 private
 
   def headers

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -49,10 +49,10 @@ class BulkUpload::Sales::Year2023::CsvParser
     cols[field_numbers.find_index(field) + col_offset]
   end
 
-  def correct_template_for_year?
-    collection_start_year_for_date(first_record_start_date) == FORM_YEAR
+  def wrong_template_for_year?
+    collection_start_year_for_date(first_record_start_date) != FORM_YEAR
   rescue Date::Error
-    true
+    false
   end
 
 private

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -49,15 +49,9 @@ class BulkUpload::Sales::Year2023::CsvParser
   end
 
   def correct_template_for_year?
-    if with_headers?
-      has_field_in_header?(135)
-    else
-      begin
-        collection_start_year_for_date(first_record_start_date) == 2023
-      rescue Date::Error
-        true
-      end
-    end
+    collection_start_year_for_date(first_record_start_date) == 2023
+  rescue Date::Error
+    true
   end
 
 private
@@ -107,6 +101,10 @@ private
   end
 
   def first_record_start_date
-    Date.new(rows.first[3].to_i + 2000, rows.first[2].to_i, rows.first[1].to_i)
+    if with_headers?
+      Date.new(row_parsers.first.field_4.to_i + 2000, row_parsers.first.field_3.to_i, row_parsers.first.field_2.to_i)
+    else
+      Date.new(rows.first[3].to_i + 2000, rows.first[2].to_i, rows.first[1].to_i)
+    end
   end
 end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -4,6 +4,7 @@ class BulkUpload::Sales::Year2023::CsvParser
   include CollectionTimeHelper
 
   MAX_COLUMNS = 142
+  FORM_YEAR = 2023
 
   attr_reader :path
 
@@ -49,7 +50,7 @@ class BulkUpload::Sales::Year2023::CsvParser
   end
 
   def correct_template_for_year?
-    collection_start_year_for_date(first_record_start_date) == 2023
+    collection_start_year_for_date(first_record_start_date) == FORM_YEAR
   rescue Date::Error
     true
   end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -96,10 +96,6 @@ private
     @normalised_string
   end
 
-  def has_field_in_header?(field)
-    rows[rows.find_index { |row| row[0].match(/field number/i) }].any? { |cell| cell&.match?(/#{field}/i) }
-  end
-
   def first_record_start_date
     if with_headers?
       Date.new(row_parsers.first.field_4.to_i + 2000, row_parsers.first.field_3.to_i, row_parsers.first.field_2.to_i)

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -46,6 +46,10 @@ class BulkUpload::Sales::Year2023::CsvParser
     cols[field_numbers.find_index(field) + col_offset]
   end
 
+  def correct_template_for_year?
+    !with_headers? || (with_headers? && has_field_in_header?(135))
+  end
+
 private
 
   def default_field_numbers
@@ -86,5 +90,9 @@ private
     @normalised_string.scrub!("")
 
     @normalised_string
+  end
+
+  def has_field_in_header?(field)
+    rows[rows.find_index { |row| row[0].match(/field number/i) }].any? { |cell| cell&.match?(/#{field}/i) }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
             base:
               wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template"
               over_max_column_count: "Too many columns, please ensure you have used the correct template"
+              wrong_template: "Incorrect fields, please ensure you have used the correct template"
         forms/bulk_upload_lettings/year:
           attributes:
             year:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,12 +50,13 @@ en:
             base:
               wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template"
               over_max_column_count: "Too many columns, please ensure you have used the correct template"
+              wrong_template: "Incorrect start dates, please ensure you have used the correct template"
         bulk_upload/sales/validator:
           attributes:
             base:
               wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template"
               over_max_column_count: "Too many columns, please ensure you have used the correct template"
-              wrong_template: "Incorrect fields, please ensure you have used the correct template"
+              wrong_template: "Incorrect sale dates, please ensure you have used the correct template"
         forms/bulk_upload_lettings/year:
           attributes:
             year:

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -191,6 +191,39 @@ RSpec.describe BulkUpload::Lettings::Validator do
           end
         end
       end
+
+      context "when uploading a 2022 template for 2023 bulk upload" do
+        let(:bulk_upload) { create(:bulk_upload, user:, year: 2023) }
+        let(:log) { build(:lettings_log, :completed, startdate: Time.zone.local(2022, 5, 6)) }
+
+        context "with no headers" do
+          before do
+            file.write(BulkUpload::LettingsLogToCsv.new(log:, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
+            file.close
+          end
+
+          it "is not valid" do
+            expect(validator).not_to be_valid
+          end
+        end
+
+        context "with headers" do
+          let(:seed) { rand }
+          let(:log_to_csv) { BulkUpload::LettingsLogToCsv.new(log:) }
+          let(:field_numbers) { log_to_csv.default_2022_field_numbers + %w[invalid_field_number] }
+          let(:field_values) { log_to_csv.to_2022_row + %w[value_for_invalid_field_number] }
+
+          before do
+            file.write(log_to_csv.custom_field_numbers_row(seed:, field_numbers:))
+            file.write(log_to_csv.to_custom_csv_row(seed:, field_values:))
+            file.rewind
+          end
+
+          it "is not valid" do
+            expect(validator).not_to be_valid
+          end
+        end
+      end
     end
   end
 

--- a/spec/services/bulk_upload/sales/validator_spec.rb
+++ b/spec/services/bulk_upload/sales/validator_spec.rb
@@ -27,7 +27,49 @@ RSpec.describe BulkUpload::Sales::Validator do
       end
     end
 
-    context "when incorrect headers"
+    context "when trying to upload 2022 data for 2023 bulk upload" do
+      let(:bulk_upload) { create(:bulk_upload, user:, year: 2023) }
+
+      context "with a valid csv" do
+        let(:path) { file_fixture("2022_23_sales_bulk_upload.csv") }
+
+        it "is not valid" do
+          expect(validator).not_to be_valid
+        end
+      end
+
+      context "with unix line endings" do
+        let(:fixture_path) { file_fixture("2022_23_sales_bulk_upload.csv") }
+        let(:file) { Tempfile.new }
+        let(:path) { file.path }
+
+        before do
+          string = File.read(fixture_path)
+          string.gsub!("\r\n", "\n")
+          file.write(string)
+          file.rewind
+        end
+
+        it "is not valid" do
+          expect(validator).not_to be_valid
+        end
+      end
+
+      context "without headers" do
+        let(:log) { build(:sales_log, :completed) }
+        let(:file) { Tempfile.new }
+        let(:path) { file.path }
+
+        before do
+          file.write(BulkUpload::SalesLogToCsv.new(log:, line_ending: "\r\n", col_offset: 0).to_2022_csv_row)
+          file.close
+        end
+
+        xit "is not valid" do
+          expect(validator).not_to be_valid
+        end
+      end
+    end
   end
 
   describe "#call" do

--- a/spec/services/bulk_upload/sales/validator_spec.rb
+++ b/spec/services/bulk_upload/sales/validator_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe BulkUpload::Sales::Validator do
           file.close
         end
 
-        xit "is not valid" do
+        it "is not valid" do
           expect(validator).not_to be_valid
         end
       end


### PR DESCRIPTION
When a 22/23 template is uploaded for a 23/24 bulk upload (23/24 selected in the form at `/bulk-upload-logs/year`) we attempt to create the logs, but all the questions are different and out of order.
Instead we should discard that file as it is using the wrong template.
We're doing it here by trying to construct the startdate/saledate from the first row and if it is not the same collection year as we're expecting, we send a failure email and don't create the logs.