### PR TITLE
CLDC-2230 Do not display the looping link in the review page

### DIFF
--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -12,7 +12,7 @@
       <%= content_for(:title) %>
     </h1>
     <p class="govuk-body">
-      <%= review_log_text(@log) %>
+      You can review and make changes to this log until <%= @log.form.end_date.to_formatted_s(:govuk_date) %>.
     </p>
     <% @log.form.sections.map do |section| %>
       <h2 class="govuk-heading-m"><%= section.label %></h2>


### PR DESCRIPTION
If you click on the "review and make changes to this log" text on the top of a completed (sales or lettings) log and get to the "review a log page" there is the same text on the top of the page, but the hyperlink links to itself
On the "review a log" page we keep the text but remove the hyperlink