### PR TITLE
CLDC-2364 Display guidance text on net income question

### DIFF
--- a/app/models/form/lettings/questions/earnings.rb
+++ b/app/models/form/lettings/questions/earnings.rb
@@ -9,6 +9,7 @@ class Form::Lettings::Questions::Earnings < ::Form::Question
     @check_answers_card_number = 0
     @min = 0
     @guidance_partial = "what_counts_as_income"
+    @guidance_position = GuidancePosition::TOP
     @hint_text = ""
     @step = 0.01
     @prefix = "£"

--- a/app/models/form/lettings/questions/net_income_known.rb
+++ b/app/models/form/lettings/questions/net_income_known.rb
@@ -7,6 +7,7 @@ class Form::Lettings::Questions::NetIncomeKnown < ::Form::Question
     @type = "radio"
     @check_answers_card_number = 0
     @guidance_partial = "what_counts_as_income"
+    @guidance_position = GuidancePosition::TOP
     @hint_text = ""
     @answer_options = ANSWER_OPTIONS
     @question_number = 86

--- a/spec/models/form/lettings/questions/net_income_known_spec.rb
+++ b/spec/models/form/lettings/questions/net_income_known_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe Form::Lettings::Questions::NetIncomeKnown do
       expect(question.type).to eql("radio")
     end
   end
+
+  describe "#partial guidance" do
+    it "is at the top" do
+      expect(question.top_guidance?).to eq(true)
+      expect(question.bottom_guidance?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
`guidance_position` was not set on the net income question, which meant that both `top_guidance?` and `bottom_guidance?` resulted in false and the guidance was not displayed on the question at all.