### PR TITLE
CLDC-2383 Sidekiq graceful restart

### DIFF
--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -6,6 +6,8 @@ class BulkUpload::Processor
   end
 
   def call
+    destroy_any_existing_errors_from_prior_run
+
     download
 
     return send_failure_mail(errors: validator.errors.full_messages) if validator.invalid?
@@ -45,6 +47,10 @@ class BulkUpload::Processor
   end
 
 private
+
+  def destroy_any_existing_errors_from_prior_run
+    bulk_upload.bulk_upload_errors.destroy_all
+  end
 
   def send_how_to_fix_upload_mail
     BulkUploadMailer

--- a/config/cloud_foundry/review_manifest.yml
+++ b/config/cloud_foundry/review_manifest.yml
@@ -8,7 +8,7 @@ defaults: &defaults
       instances: 1
       memory: 1G
     - type: worker
-      command: bundle exec sidekiq
+      command: bundle exec sidekiq -t 3
       health-check-type: process
       instances: 1
   health-check-type: http

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -32,4 +32,8 @@ Sidekiq.configure_server do |config|
   config.on(:startup) do
     Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/sidekiq_cron_schedule.yml")
   end
+
+  config.on(:shutdown) do
+    Sidekiq::CLI.instance.launcher.quiet
+  end
 end

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ defaults: &defaults
       instances: 2
       memory: 1G
     - type: worker
-      command: bundle exec sidekiq
+      command: bundle exec sidekiq -t 3
       health-check-type: process
       instances: 2
   health-check-type: http
@@ -31,7 +31,7 @@ applications:
         instances: 4
         memory: 1G
       - type: worker
-        command: bundle exec sidekiq
+        command: bundle exec sidekiq -3
         health-check-type: process
         instances: 2
     env:

--- a/manifest.yml
+++ b/manifest.yml
@@ -31,7 +31,7 @@ applications:
         instances: 4
         memory: 1G
       - type: worker
-        command: bundle exec sidekiq -3
+        command: bundle exec sidekiq -t 3
         health-check-type: process
         instances: 2
     env:

--- a/spec/services/bulk_upload/processor_spec.rb
+++ b/spec/services/bulk_upload/processor_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe BulkUpload::Processor do
   let(:owning_org) { create(:organisation, old_visible_id: 123) }
 
   describe "#call" do
+    context "when errors exist from prior job run" do
+      let!(:existing_error) { create(:bulk_upload_error, bulk_upload:) }
+
+      it "destroys existing errors" do
+        processor.call
+
+        expect { existing_error.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context "when the bulk upload itself is not considered valid" do
       let(:mock_downloader) do
         instance_double(


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2383
- cloudfoundry sends shutdown signal to processes including sidekiq killing running jobs

# Changes

- lower sidekiq timeout from the default 25 seconds to 3 seconds. cloudfoundry only gives us 10 seconds before killing the process. 3 seconds should give some time to finish existing jobs
- when shutdown signal is given we tell sidekiq to shutdown quietly. this way jobs are cancelled and re-queued so they can be picked by the newly deployed worker
- for long running jobs ie bulk upload. we clear down existing errors generated before starting incase these are from a previous run. this to a degree will help with if the job if re-queued part way thru the process

# Notes

- for testing I was able to:
  - start a big upload
  - take note of the increasing count of errors
  - stop the box
  - start the box
  - take note of the error count starting again from zero then increasing again
- this show evidence on stopping, it does re-queue the job which is then picked up later by the worker again. and that the code to clear the errors to start again is also working as expected