### PR TITLE
CLDC-1753 Blank autocomplete selects null option

### DIFF
--- a/app/frontend/controllers/accessible_autocomplete_controller.js
+++ b/app/frontend/controllers/accessible_autocomplete_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
   connect () {
     const selectEl = this.element
     const selectOptions = Array.from(selectEl.options).filter(function (option, index, arr) { return option.value !== '' })
+    const nullOption = Array.from(selectEl.options).find(function (option, index, arr) { return option.value === '' })
     const options = selectOptions.map((o) => enhanceOption(o))
 
     const matches = /^(\w+)\[(\w+)\]$/.exec(selectEl.name)
@@ -29,7 +30,12 @@ export default class extends Controller {
           selectOptions,
           (option) => (option.textContent || option.innerText) === val
         )[0]
-        if (selectedOption) selectedOption.selected = true
+
+        if (selectedOption) {
+          selectedOption.selected = true
+        } else {
+          nullOption.selected = true
+        }
       }
     })
   }


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-1753
- Selecting the null option for autocomplete does not actually select anything therefore resends the original value set in the form which mismatches with what the user actually selected 

# Changes

- If no matching value is found we select the null option

# Demo

## Before fix
![automplete-no-select](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/92580/b2518dd7-82eb-49cd-aebc-b72c2d0e9756)

## After fix
![blank-autocomplete](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/92580/f17e929f-432e-4405-a4cc-b43a3f0c4200)