### PR TITLE
CLDC 2328: Resend invitation button

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,9 @@ class UsersController < ApplicationController
   include Helpers::Email
   include Modules::SearchFilter
 
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: %i[resend_invite]
   before_action :find_resource, except: %i[new create]
-  before_action :authenticate_scope!, except: %i[new]
+  before_action :authenticate_scope!, except: %i[new resend_invite]
 
   def index
     redirect_to users_organisation_path(current_user.organisation) unless current_user.support?
@@ -27,6 +27,12 @@ class UsersController < ApplicationController
         end
       end
     end
+  end
+
+  def resend_invite
+    @user.send_confirmation_instructions
+    flash[:notice] = "Invitation sent"
+    render :show
   end
 
   def show; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,9 @@ class UsersController < ApplicationController
   include Helpers::Email
   include Modules::SearchFilter
 
-  before_action :authenticate_user!, except: %i[resend_invite]
+  before_action :authenticate_user!
   before_action :find_resource, except: %i[new create]
-  before_action :authenticate_scope!, except: %i[new resend_invite]
+  before_action :authenticate_scope!, except: %i[new]
 
   def index
     redirect_to users_organisation_path(current_user.organisation) unless current_user.support?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
 
   def resend_invite
     @user.send_confirmation_instructions
-    flash[:notice] = "Invitation sent"
+    flash[:notice] = "Invitation sent to #{@user.email}"
     render :show
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,11 +109,7 @@ class User < ApplicationRecord
   end
 
   def was_migrated_from_softwire?
-    let l = legacy_users
-    let y = old_user_id
-    let x = 1
     legacy_users.any? || old_user_id.present?
-
   end
 
   def send_confirmation_instructions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,11 @@ class User < ApplicationRecord
   end
 
   def was_migrated_from_softwire?
+    let l = legacy_users
+    let y = old_user_id
+    let x = 1
     legacy_users.any? || old_user_id.present?
+
   end
 
   def send_confirmation_instructions

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,17 +5,6 @@
     <h1 class="govuk-heading-l">
       <%= content_for(:title) %>
     </h1>
-    <p>
-      <% if current_user.can_toggle_active?(@user) %>
-        <% if @user.active? %>
-          <%= govuk_link_to "Deactivate user", "/users/#{@user.id}/deactivate" %>
-        <% else %>
-          <span class="app-!-colour-muted govuk-!-margin-right-2">
-            This user has been deactivated. <%= govuk_link_to "Reactivate user", "/users/#{@user.id}/reactivate" %>
-          </span>
-        <% end %>
-      <% end %>
-    </p>
 
     <h2 class="govuk-heading-m">
       Personal details
@@ -103,5 +92,30 @@
             end
           end %>
     <% end %>
+
+    <div class="govuk-button-group">
+      <p>
+        <% if current_user.can_toggle_active?(@user) %>
+          <% if @user.active? %>
+            <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
+          <% else %>
+            <span class="app-!-colour-muted govuk-!-margin-right-2">
+              This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>
+            </span>
+          <% end %>
+        <% end %>
+
+        <% if current_user.can_toggle_active?(@user) %>
+          <% if @user.active? %>
+            <%= govuk_button_link_to "Resend invite link", resend_invite_user_path(@user) %>
+          <% else %>
+            <span class="app-!-colour-muted govuk-!-margin-right-2">
+              This user has been deactivated. <%= govuk_link_to "Reactivate user", "/users/#{@user.id}/reactivate" %>
+            </span>
+          <% end %>
+        <% end %>
+      </p>
+    </div>
+
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -96,12 +96,14 @@
     <div class="govuk-button-group">
       <% if current_user.can_toggle_active?(@user) %>
         <% if @user.active? %>
+          <% if current_user.support? %>
+            <%= govuk_button_to "Resend invite link", resend_invite_user_path(@user) %>
+          <% end %>
           <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
-          <%= govuk_button_link_to "Resend invite link", resend_invite_user_path(@user) %>
         <% else %>
-          <span class="app-!-colour-muted govuk-!-margin-right-2">
-            This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>
-          </span>
+            <span class="app-!-colour-muted govuk-!-margin-right-2">
+              This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>
+            </span>
         <% end %>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -96,10 +96,10 @@
     <div class="govuk-button-group">
       <% if current_user.can_toggle_active?(@user) %>
         <% if @user.active? %>
-          <% if current_user.support? %>
-            <%= govuk_button_to "Resend invite link", resend_invite_user_path(@user) %>
-          <% end %>
           <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
+          <% if current_user.support? %>
+            <%= govuk_button_to "Resend invite link", resend_invite_user_path(@user), secondary: true %>
+          <% end %>
         <% else %>
             <span class="app-!-colour-muted govuk-!-margin-right-2">
               This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -94,27 +94,16 @@
     <% end %>
 
     <div class="govuk-button-group">
-      <p>
-        <% if current_user.can_toggle_active?(@user) %>
-          <% if @user.active? %>
-            <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
-          <% else %>
-            <span class="app-!-colour-muted govuk-!-margin-right-2">
-              This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>
-            </span>
-          <% end %>
+      <% if current_user.can_toggle_active?(@user) %>
+        <% if @user.active? %>
+          <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
+          <%= govuk_button_link_to "Resend invite link", resend_invite_user_path(@user) %>
+        <% else %>
+          <span class="app-!-colour-muted govuk-!-margin-right-2">
+            This user has been deactivated. <%= govuk_button_link_to "Reactivate user", reactivate_user_path(@user) %>
+          </span>
         <% end %>
-
-        <% if current_user.can_toggle_active?(@user) %>
-          <% if @user.active? %>
-            <%= govuk_button_link_to "Resend invite link", resend_invite_user_path(@user) %>
-          <% else %>
-            <span class="app-!-colour-muted govuk-!-margin-right-2">
-              This user has been deactivated. <%= govuk_link_to "Reactivate user", "/users/#{@user.id}/reactivate" %>
-            </span>
-          <% end %>
-        <% end %>
-      </p>
+      <% end %>
     </div>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
     member do
       get "deactivate", to: "users#deactivate"
       get "reactivate", to: "users#reactivate"
+      get "resend-invite", to: "users#resend_invite"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
     member do
       get "deactivate", to: "users#deactivate"
       get "reactivate", to: "users#reactivate"
-      get "resend-invite", to: "users#resend_invite"
+      post "resend-invite", to: "users#resend_invite"
     end
   end
 

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -452,7 +452,6 @@ RSpec.describe "User Features" do
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       end
     end
-
   end
 
   context "when signed in as support" do
@@ -730,6 +729,5 @@ RSpec.describe "User Features" do
         end
       end
     end
-
   end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe UsersController, type: :request do
         expect(response).to redirect_to("/account/sign-in")
       end
     end
+
+    describe "#resend_invite" do
+      it "does not allow resending activation emails" do
+        get "/users/#{user.id}/deactivate", headers: headers, params: {}
+        expect(response).to redirect_to("/account/sign-in")
+      end
+    end
   end
 
   context "when user is signed in as a data provider" do
@@ -123,6 +130,10 @@ RSpec.describe UsersController, type: :request do
           expect(page).not_to have_link("Deactivate user", href: "/users/#{user.id}/deactivate")
         end
 
+        it "does not allow resending invitation emails" do
+          expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+        end
+
         context "when user is deactivated" do
           before do
             user.update!(active: false)
@@ -131,6 +142,10 @@ RSpec.describe UsersController, type: :request do
 
           it "does not allow reactivating the user" do
             expect(page).not_to have_link("Reactivate user", href: "/users/#{user.id}/reactivate")
+          end
+
+          it "does not allow resending invitation emails" do
+            expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
           end
         end
       end
@@ -183,6 +198,10 @@ RSpec.describe UsersController, type: :request do
 
             it "does not allow reactivating the user" do
               expect(page).not_to have_link("Reactivate user", href: "/users/#{other_user.id}/reactivate")
+            end
+
+            it "does not allow resending invitation emails" do
+              expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
             end
           end
         end
@@ -499,6 +518,10 @@ RSpec.describe UsersController, type: :request do
           it "does not allow reactivating the user" do
             expect(page).not_to have_link("Reactivate user", href: "/users/#{user.id}/reactivate")
           end
+
+          it "does not allow resending invitation emails" do
+            expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+          end
         end
       end
 
@@ -530,6 +553,10 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Deactivate user", href: "/users/#{other_user.id}/deactivate")
           end
 
+          it "allows you to resend invitation emails" do
+            expect(page).to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+          end
+
           context "when user is deactivated" do
             before do
               other_user.update!(active: false)
@@ -542,6 +569,10 @@ RSpec.describe UsersController, type: :request do
 
             it "allows reactivating the user" do
               expect(page).to have_link("Reactivate user", href: "/users/#{other_user.id}/reactivate")
+            end
+
+            it "does not allow you to resend invitation emails" do
+              expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
             end
           end
         end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe UsersController, type: :request do
 
     describe "#resend_invite" do
       it "does not allow resending activation emails" do
-        get "/users/#{user.id}/deactivate", headers: headers, params: {}
-        expect(response).to redirect_to("/account/sign-in")
+        get deactivate_user_path(user.id), headers: headers, params: {}
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
@@ -131,7 +131,7 @@ RSpec.describe UsersController, type: :request do
         end
 
         it "does not allow resending invitation emails" do
-          expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+          expect(page).not_to have_button("Resend invite link")
         end
 
         context "when user is deactivated" do
@@ -201,7 +201,7 @@ RSpec.describe UsersController, type: :request do
             end
 
             it "does not allow resending invitation emails" do
-              expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+              expect(page).not_to have_button("Resend invite link")
             end
           end
         end
@@ -520,7 +520,7 @@ RSpec.describe UsersController, type: :request do
           end
 
           it "does not allow resending invitation emails" do
-            expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+            expect(page).not_to have_button("Resend invite link")
           end
         end
       end
@@ -553,8 +553,8 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Deactivate user", href: "/users/#{other_user.id}/deactivate")
           end
 
-          it "allows you to resend invitation emails" do
-            expect(page).to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+          it "does not allow you to resend invitation emails" do
+            expect(page).not_to have_button("Resend invite link")
           end
 
           context "when user is deactivated" do
@@ -572,7 +572,7 @@ RSpec.describe UsersController, type: :request do
             end
 
             it "does not allow you to resend invitation emails" do
-              expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+              expect(page).not_to have_button("Resend invite link")
             end
           end
         end
@@ -1202,6 +1202,10 @@ RSpec.describe UsersController, type: :request do
 
           it "allows deactivating the user" do
             expect(page).to have_link("Deactivate user", href: "/users/#{other_user.id}/deactivate")
+          end
+
+          it "allows you to resend invitation emails" do
+            expect(page).to have_button("Resend invite link")
           end
 
           context "when user is deactivated" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe UsersController, type: :request do
           end
 
           it "does not allow resending invitation emails" do
-            expect(page).not_to have_link("Resend invite link", href: "/users/#{other_user.id}/resend-invite")
+            expect(page).not_to have_link("Resend invite link")
           end
         end
       end


### PR DESCRIPTION
### **Change**
This ticket is concerned with moving the existing 'deactivate'/'reactivate' buttons to the bottom of the page as well as adding a button to resend invitations to new users who's details have not been confirmed via email.

### **Old design :**
![Old](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/29e39d72-2c43-4ab0-bc0a-623cf2e4c48e)

### **New design :**
![New](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/2722a9e6-3145-480e-a7dc-bf4f2b8dba27)



