### PR TITLE
CLDC-2386 check bulk upload template against date

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -150,13 +150,19 @@ private
   def validate_field_numbers_count
     return if halt_validations?
 
-    errors.add(:base, :wrong_field_numbers_count) unless csv_parser.correct_field_count?
+    unless csv_parser.correct_field_count?
+      errors.add(:base, :wrong_field_numbers_count)
+      halt_validations!
+    end
   end
 
   def validate_max_columns_count_if_no_headers
     return if halt_validations?
 
-    errors.add(:base, :over_max_column_count) if csv_parser.too_many_columns?
+    if csv_parser.too_many_columns?
+      errors.add(:base, :over_max_column_count)
+      halt_validations!
+    end
   end
 
   def validate_correct_template

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -3,6 +3,7 @@ require "csv"
 class BulkUpload::Lettings::Year2022::CsvParser
   FIELDS = 134
   MAX_COLUMNS = 135
+  FORM_YEAR = 2022
 
   attr_reader :path
 
@@ -62,10 +63,18 @@ class BulkUpload::Lettings::Year2022::CsvParser
   end
 
   def wrong_template_for_year?
-    false
+    !(first_record_start_date >= form.start_date && first_record_start_date <= form.end_date)
   end
 
 private
+
+  def form
+    @form ||= FormHandler.instance.lettings_form_for_start_year(FORM_YEAR)
+  end
+
+  def first_record_start_date
+    @first_record_start_date ||= row_parsers.first.startdate || Date.new
+  end
 
   def default_field_numbers
     ("field_1".."field_#{FIELDS}").to_a

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -461,6 +461,12 @@ class BulkUpload::Lettings::Year2022::RowParser
     end
   end
 
+  def startdate
+    Date.new(field_98 + 2000, field_97, field_96) if field_98.present? && field_97.present? && field_96.present?
+  rescue Date::Error
+    Date.new
+  end
+
 private
 
   def validate_declaration_acceptance
@@ -981,12 +987,6 @@ private
       voiddate: %i[field_89 field_90 field_91],
       is_carehome: %i[field_85],
     }
-  end
-
-  def startdate
-    Date.new(field_98 + 2000, field_97, field_96) if field_98.present? && field_97.present? && field_96.present?
-  rescue Date::Error
-    Date.new
   end
 
   def renttype

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -2,6 +2,7 @@ require "csv"
 
 class BulkUpload::Sales::Year2022::CsvParser
   MAX_COLUMNS = 126
+  FORM_YEAR = 2022
 
   attr_reader :path
 
@@ -44,10 +45,18 @@ class BulkUpload::Sales::Year2022::CsvParser
   end
 
   def wrong_template_for_year?
-    false
+    !(first_record_sale_date >= form.start_date && first_record_sale_date <= form.end_date)
   end
 
 private
+
+  def form
+    @form ||= FormHandler.instance.sales_form_for_start_year(FORM_YEAR)
+  end
+
+  def first_record_sale_date
+    @first_record_sale_date ||= row_parsers.first.saledate || Date.new
+  end
 
   def headers
     @headers ||= ("field_1".."field_125").to_a

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -453,6 +453,12 @@ class BulkUpload::Sales::Year2022::RowParser
     end
   end
 
+  def saledate
+    Date.new(field_4 + 2000, field_3, field_2) if field_2.present? && field_3.present? && field_4.present?
+  rescue Date::Error
+    Date.new
+  end
+
 private
 
   def validate_data_protection_answered
@@ -760,12 +766,6 @@ private
     else
       buyer_not_interviewed? ? 1 : nil
     end
-  end
-
-  def saledate
-    Date.new(field_4 + 2000, field_3, field_2) if field_2.present? && field_3.present? && field_4.present?
-  rescue Date::Error
-    Date.new
   end
 
   def hodate

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
         context "and doesn't have too many columns" do
           before do
-            file.write(("a" * 135).chars.join(","))
+            file.write(("a" * 95).chars.join(","))
+            file.write(",1,10,22,")
+            file.write(("a" * 37).chars.join(","))
             file.write("\n")
             file.rewind
           end

--- a/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
@@ -187,4 +187,32 @@ RSpec.describe BulkUpload::Lettings::Year2022::CsvParser do
       expect(service.row_parsers[0].field_12.to_i).to eq(35)
     end
   end
+
+  describe "#wrong_template_for_year?" do
+    context "when 23/24 file with 23/24 data" do
+      let(:log) { build(:lettings_log, :completed, startdate: Date.new(2023, 10, 1)) }
+
+      before do
+        file.write(BulkUpload::LettingsLogToCsv.new(log:, col_offset: 0).to_2023_csv_row)
+        file.rewind
+      end
+
+      it "returns true" do
+        expect(service).to be_wrong_template_for_year
+      end
+    end
+
+    context "when 22/23 file with 22/23 data" do
+      let(:log) { build(:lettings_log, :completed, startdate: Date.new(2022, 10, 1)) }
+
+      before do
+        file.write(BulkUpload::LettingsLogToCsv.new(log:, col_offset: 0).to_2022_csv_row)
+        file.rewind
+      end
+
+      it "returns false" do
+        expect(service).not_to be_wrong_template_for_year
+      end
+    end
+  end
 end

--- a/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
@@ -116,4 +116,35 @@ RSpec.describe BulkUpload::Sales::Year2022::CsvParser do
       expect(service.column_for_field("field_125")).to eql("DU")
     end
   end
+
+  describe "#wrong_template_for_year?" do
+    let(:file) { Tempfile.new }
+    let(:path) { file.path }
+
+    context "when 23/24 file with 23/24 data" do
+      let(:log) { build(:sales_log, :completed, saledate: Date.new(2023, 10, 1)) }
+
+      before do
+        file.write(BulkUpload::SalesLogToCsv.new(log:, col_offset: 0).to_2023_csv_row)
+        file.rewind
+      end
+
+      it "returns true" do
+        expect(service).to be_wrong_template_for_year
+      end
+    end
+
+    context "when 22/23 file with 22/23 data" do
+      let(:log) { build(:sales_log, :completed, saledate: Date.new(2022, 10, 1)) }
+
+      before do
+        file.write(BulkUpload::SalesLogToCsv.new(log:, col_offset: 0).to_2022_csv_row)
+        file.rewind
+      end
+
+      it "returns false" do
+        expect(service).not_to be_wrong_template_for_year
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

- https://digital.dclg.gov.uk/jira/browse/CLDC-2386

# Changes

- Selecting to upload for 22/23 then actually uploading 23/24 template with 23/24 data causes an error which is sent the user via email
- Implemented for both lettings and sales

# Screenshots

![Screenshot 2023-05-31 at 12 29 23](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/92580/5e317278-3a48-48d8-b84a-b1c95f519724)