### PR TITLE
CLDC-2438 Fix carriage return csv bug

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -92,6 +92,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
+    @normalised_string.gsub!("\r\r", "\n")
+    @normalised_string.tr!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -93,7 +93,7 @@ private
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
     @normalised_string.gsub!("\r\r", "\n")
-    @normalised_string.tr!("\r", "\n")
+    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -92,7 +92,6 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r\r", "\n")
     @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -92,8 +92,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
+    @normalised_string.tr!("\r", "\n")
 
     @normalised_string
   end

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -97,6 +97,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
+    @normalised_string.gsub!("\r\r", "\n")
+    @normalised_string.tr!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -97,8 +97,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
+    @normalised_string.tr!("\r", "\n")
 
     @normalised_string
   end

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -98,7 +98,7 @@ private
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
     @normalised_string.gsub!("\r\r", "\n")
-    @normalised_string.tr!("\r", "\n")
+    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -97,7 +97,6 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r\r", "\n")
     @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -66,6 +66,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
+    @normalised_string.gsub!("\r\r", "\n")
+    @normalised_string.tr!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -66,7 +66,6 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r\r", "\n")
     @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -67,7 +67,7 @@ private
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
     @normalised_string.gsub!("\r\r", "\n")
-    @normalised_string.tr!("\r", "\n")
+    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -66,8 +66,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
+    @normalised_string.tr!("\r", "\n")
 
     @normalised_string
   end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -93,7 +93,7 @@ private
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
     @normalised_string.scrub!("")
-    @normalised_string.tr("\r", "\n")
+    @normalised_string.tr!("\r", "\n")
 
     @normalised_string
   end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -92,6 +92,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
+    @normalised_string.gsub!("\r\r", "\n")
+    @normalised_string.tr!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -92,8 +92,8 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
+    @normalised_string.tr("\r", "\n")
 
     @normalised_string
   end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -93,7 +93,7 @@ private
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
     @normalised_string.gsub!("\r\r", "\n")
-    @normalised_string.tr!("\r", "\n")
+    @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 
     @normalised_string

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -92,7 +92,6 @@ private
 
     @normalised_string = File.read(path, encoding: "bom|utf-8")
     @normalised_string.gsub!("\r\n", "\n")
-    @normalised_string.gsub!("\r\r", "\n")
     @normalised_string.gsub!("\r", "\n")
     @normalised_string.scrub!("")
 

--- a/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
@@ -169,4 +169,22 @@ RSpec.describe BulkUpload::Lettings::Year2022::CsvParser do
       end
     end
   end
+
+  context "when parsing csv with carriage returns" do
+    before do
+      file.write("Question\r\n")
+      file.write("Additional info\r\r")
+      file.write("Values\r")
+      file.write("Can be empty?\n")
+      file.write("Type of letting the question applies to\r\n")
+      file.write("Duplicate check field?\r\r")
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2022_field_numbers_row)
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2022_csv_row)
+      file.rewind
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_12.to_i).to eq(35)
+    end
+  end
 end

--- a/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
@@ -173,11 +173,11 @@ RSpec.describe BulkUpload::Lettings::Year2022::CsvParser do
   context "when parsing csv with carriage returns" do
     before do
       file.write("Question\r\n")
-      file.write("Additional info\r\r")
-      file.write("Values\r")
-      file.write("Can be empty?\n")
+      file.write("Additional info\r")
+      file.write("Values\r\n")
+      file.write("Can be empty?\r")
       file.write("Type of letting the question applies to\r\n")
-      file.write("Duplicate check field?\r\r")
+      file.write("Duplicate check field?\r")
       file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2022_field_numbers_row)
       file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2022_csv_row)
       file.rewind

--- a/spec/services/bulk_upload/lettings/year2023/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/csv_parser_spec.rb
@@ -153,11 +153,11 @@ RSpec.describe BulkUpload::Lettings::Year2023::CsvParser do
   context "when parsing csv with carriage returns" do
     before do
       file.write("Question\r\n")
-      file.write("Additional info\r\r")
-      file.write("Values\r")
-      file.write("Can be empty?\n")
+      file.write("Additional info\r")
+      file.write("Values\r\n")
+      file.write("Can be empty?\r")
       file.write("Type of letting the question applies to\r\n")
-      file.write("Duplicate check field?\r\r")
+      file.write("Duplicate check field?\r")
       file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2023_field_numbers_row)
       file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2023_csv_row)
       file.rewind

--- a/spec/services/bulk_upload/lettings/year2023/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/csv_parser_spec.rb
@@ -150,6 +150,24 @@ RSpec.describe BulkUpload::Lettings::Year2023::CsvParser do
     end
   end
 
+  context "when parsing csv with carriage returns" do
+    before do
+      file.write("Question\r\n")
+      file.write("Additional info\r\r")
+      file.write("Values\r")
+      file.write("Can be empty?\n")
+      file.write("Type of letting the question applies to\r\n")
+      file.write("Duplicate check field?\r\r")
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2023_field_numbers_row)
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2023_csv_row)
+      file.rewind
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_13).to eql(log.tenancycode)
+    end
+  end
+
   describe "#column_for_field", aggregate_failures: true do
     context "when with headers using default ordering" do
       before do

--- a/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
@@ -94,4 +94,26 @@ RSpec.describe BulkUpload::Sales::Year2022::CsvParser do
       end
     end
   end
+
+  context "when parsing csv with carriage returns" do
+    let(:file) { Tempfile.new }
+    let(:path) { file.path }
+    let(:log) { build(:sales_log, :completed) }
+
+    before do
+      file.write("Question\r\n")
+      file.write("Additional info\r\r")
+      file.write("Values\r")
+      file.write("Can be empty?\n")
+      file.write("Type of letting the question applies to\r\n")
+      file.write("Duplicate check field?\r\r")
+      file.write(BulkUpload::SalesLogToCsv.new(log:).to_2022_csv_row)
+      file.rewind
+    end
+
+    it "parses csv correctly" do
+      expect(service.column_for_field("field_1")).to eql("A")
+      expect(service.column_for_field("field_125")).to eql("DU")
+    end
+  end
 end

--- a/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
@@ -102,11 +102,11 @@ RSpec.describe BulkUpload::Sales::Year2022::CsvParser do
 
     before do
       file.write("Question\r\n")
-      file.write("Additional info\r\r")
-      file.write("Values\r")
-      file.write("Can be empty?\n")
+      file.write("Additional info\r")
+      file.write("Values\r\n")
+      file.write("Can be empty?\r")
       file.write("Type of letting the question applies to\r\n")
-      file.write("Duplicate check field?\r\r")
+      file.write("Duplicate check field?\r")
       file.write(BulkUpload::SalesLogToCsv.new(log:).to_2022_csv_row)
       file.rewind
     end

--- a/spec/services/bulk_upload/sales/year2023/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/csv_parser_spec.rb
@@ -145,4 +145,22 @@ RSpec.describe BulkUpload::Sales::Year2023::CsvParser do
       end
     end
   end
+
+  context "when parsing csv with carriage returns" do
+    before do
+      file.write("Question\r\n")
+      file.write("Additional info\r\r")
+      file.write("Values\r")
+      file.write("Can be empty?\n")
+      file.write("Type of letting the question applies to\r\n")
+      file.write("Duplicate check field?\r\r")
+      file.write(BulkUpload::SalesLogToCsv.new(log:).default_2023_field_numbers_row)
+      file.write(BulkUpload::SalesLogToCsv.new(log:).to_2023_csv_row)
+      file.rewind
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_19).to eql(log.uprn)
+    end
+  end
 end

--- a/spec/services/bulk_upload/sales/year2023/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/csv_parser_spec.rb
@@ -149,11 +149,11 @@ RSpec.describe BulkUpload::Sales::Year2023::CsvParser do
   context "when parsing csv with carriage returns" do
     before do
       file.write("Question\r\n")
-      file.write("Additional info\r\r")
-      file.write("Values\r")
-      file.write("Can be empty?\n")
+      file.write("Additional info\r")
+      file.write("Values\r\n")
+      file.write("Can be empty?\r")
       file.write("Type of letting the question applies to\r\n")
-      file.write("Duplicate check field?\r\r")
+      file.write("Duplicate check field?\r")
       file.write(BulkUpload::SalesLogToCsv.new(log:).default_2023_field_numbers_row)
       file.write(BulkUpload::SalesLogToCsv.new(log:).to_2023_csv_row)
       file.rewind


### PR DESCRIPTION
Small bug fix from an alert we saw last week. Seems to work on test files I've generated, but I'm not sure if we can get the file that caused the original error, would be nice to test using that if we can?

Pretty straightforward fix though so probably ok regardless.

Update - this has been tested on the original file, and the bug is now fixed as expected.

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2438