### PR TITLE
CLDC-2444 production bug logs uneditable

### DIFF
--- a/app/helpers/tasklist_helper.rb
+++ b/app/helpers/tasklist_helper.rb
@@ -31,9 +31,9 @@ module TasklistHelper
 
   def review_log_text(log)
     if log.collection_period_open?
-      link = log.sales? ? review_sales_log_path(id: log, sales_log: true) : review_lettings_log_path(log)
+      path = log.sales? ? review_sales_log_path(id: log, sales_log: true) : review_lettings_log_path(log)
 
-      "You can #{govuk_link_to 'review and make changes to this log', link} until #{log.form.end_date.to_formatted_s(:govuk_date)}.".html_safe
+      "You can #{govuk_link_to 'review and make changes to this log', path} until #{log.form.display_end_date.to_formatted_s(:govuk_date)}.".html_safe
     else
       start_year = log.startdate ? collection_start_year_for_date(log.startdate) : log.form.start_date.year
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,6 +1,6 @@
 class Form
   attr_reader :form_definition, :sections, :subsections, :pages, :questions,
-              :start_date, :end_date, :type, :name, :setup_definition,
+              :start_date, :end_date, :display_end_date, :type, :name, :setup_definition,
               :setup_sections, :form_sections, :unresolved_log_redirect_page_id
 
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
@@ -9,7 +9,7 @@ class Form
       @end_date = if start_year && start_year.to_i > 2022
                     Time.zone.local(start_year + 1, 6, 9)
                   else
-                    Time.zone.local(start_year + 1, 6, 7)
+                    Time.zone.local(start_year + 1, 8, 7)
                   end
       @setup_sections = type == "sales" ? [Form::Sales::Sections::Setup.new(nil, nil, self)] : [Form::Lettings::Sections::Setup.new(nil, nil, self)]
       @form_sections = sections_in_form.map { |sec| sec.new(nil, nil, self) }
@@ -40,6 +40,7 @@ class Form
       @end_date = Time.iso8601(form_definition["end_date"])
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]
     end
+    @display_end_date = start_year == 2022 ? Time.zone.local(2023, 6, 9) : @end_date
     @name = "#{start_date.year}_#{end_date.year}_#{type}"
   end
 

--- a/app/views/form/review.html.erb
+++ b/app/views/form/review.html.erb
@@ -12,7 +12,7 @@
       <%= content_for(:title) %>
     </h1>
     <p class="govuk-body">
-      You can review and make changes to this log until <%= @log.form.end_date.to_formatted_s(:govuk_date) %>.
+      You can review and make changes to this log until <%= @log.form.display_end_date.to_formatted_s(:govuk_date) %>.
     </p>
     <% @log.form.sections.map do |section| %>
       <h2 class="govuk-heading-m"><%= section.label %></h2>

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -1,7 +1,7 @@
 {
   "form_type": "lettings",
   "start_date": "2022-04-01T00:00:00.000+01:00",
-  "end_date": "2023-06-09T00:00:00.000+01:00",
+  "end_date": "2023-08-09T00:00:00.000+01:00",
   "unresolved_log_redirect_page_id": "tenancy_start_date",
   "sections": {
     "tenancy_and_property": {

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe TasklistHelper do
 
         it "returns relevant text" do
           expect(review_log_text(sales_log)).to eq(
-            "You can #{govuk_link_to 'review and make changes to this log', review_sales_log_path(id: sales_log, sales_log: true)} until 7 June 2023.".html_safe,
+            "You can #{govuk_link_to 'review and make changes to this log', review_sales_log_path(id: sales_log, sales_log: true)} until 9 June 2023.".html_safe,
           )
         end
       end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Form, type: :model do
       expect(form.questions.count).to eq(13)
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
-      expect(form.end_date).to eq(Time.zone.parse("2023-06-07"))
+      expect(form.end_date).to eq(Time.zone.parse("2023-08-07"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)
     end
 


### PR DESCRIPTION
push back end date of forms to allow them to continue to be edited for now. Adjust the copy about the date until when logs can be edited to keep it consistent with how things have been up until now

https://digital.dclg.gov.uk/jira/browse/CLDC-2444