### PR TITLE
Reduce Sentry sample rate so that we don't hit our quota

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,24 @@
 Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.enabled_environments = %w[production staging review]
-  config.traces_sample_rate = 0.2
+
+  config.traces_sampler = lambda do |sampling_context|
+    transaction_context = sampling_context[:transaction_context]
+    op = transaction_context[:op]
+    transaction_name = transaction_context[:name]
+
+    case op
+    when /request/
+      case transaction_name
+      when /health/
+        0.0 # ignore healthcheck requests
+      else
+        0.01
+      end
+    when /sidekiq/
+      0.001
+    else
+      0.0 # We don't care about performance of other things
+    end
+  end
 end


### PR DESCRIPTION
- As we migrate more organisations onto the service we need to be more conservative.
- This PR removes tracing on health checks entirely, whilst lowering everything else from 0.2 to 0.01, or 0.001 in the case of Sidekiq.