### PR TITLE
CLDC-2447 Bulk upload 23-24 lettings net income known bug

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1442,8 +1442,6 @@ private
     when 2
       1
     when 3
-      1
-    when 4
       2
     end
   end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1295,10 +1295,36 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
     end
 
     describe "#net_income_known" do
-      let(:attributes) { { bulk_upload:, field_51: "1" } }
+      context "when 1" do
+        let(:attributes) { { bulk_upload:, field_51: "1" } }
 
-      it "sets value from correct mapping" do
-        expect(parser.log.net_income_known).to eq(0)
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(0)
+        end
+      end
+
+      context "when 2" do
+        let(:attributes) { { bulk_upload:, field_51: "2" } }
+
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(1)
+        end
+      end
+
+      context "when 3" do
+        let(:attributes) { { bulk_upload:, field_51: "3" } }
+
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(1)
+        end
+      end
+
+      context "when 4" do
+        let(:attributes) { { bulk_upload:, field_51: "4" } }
+
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(2)
+        end
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1365,10 +1365,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#net_income_known" do
-      let(:attributes) { { bulk_upload:, field_120: "1" } }
+      context "when 1" do
+        let(:attributes) { { bulk_upload:, field_120: "1" } }
 
-      it "sets value from correct mapping" do
-        expect(parser.log.net_income_known).to eq(0)
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(0)
+        end
+      end
+
+      context "when 3" do
+        let(:attributes) { { bulk_upload:, field_120: "3" } }
+
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(2)
+        end
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1373,6 +1373,14 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
+      context "when 2" do
+        let(:attributes) { { bulk_upload:, field_120: "2" } }
+
+        it "sets value from correct mapping" do
+          expect(parser.log.net_income_known).to eq(1)
+        end
+      end
+
       context "when 3" do
         let(:attributes) { { bulk_upload:, field_120: "3" } }
 


### PR DESCRIPTION
ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2447

Another bug from value assignment being different in 23/24 parser but having just been copied from 22/23. I'll check with Jemma to see if I can check whether there are any other of these that we haven't caught. I came across one other by chance while working on a separate ticket, I don't think there's been a systematic check.