### PR TITLE
CLDC-2437 Fix interruption screen routing bug

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -46,7 +46,7 @@ class FormController < ApplicationController
   end
 
   def show_page
-    if request.params["referrer"] == "interruption_screen"
+    if request.params["referrer"] == "interruption_screen" && request.headers["HTTP_REFERER"].present?
       @interruption_page_id = URI.parse(request.headers["HTTP_REFERER"]).path.split("/").last.underscore
       @interruption_page_referrer_type = referrer_from_query
     end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -582,6 +582,31 @@ RSpec.describe FormController, type: :request do
             end
           end
         end
+
+        context "when requesting a soft validation page without a http referrer header" do
+          before do
+            get "/lettings-logs/#{lettings_log.id}/#{page_path}?referrer=interruption_screen", headers:
+          end
+
+          context "when the page is routed to" do
+            let(:page_path) { page_id.dasherize }
+
+            it "directs to the question page" do
+              expect(response.body).to include("What is the tenant’s age?")
+              expect(response.body).to include("Skip for now")
+            end
+          end
+
+          context "when the page is not routed to" do
+            let(:page_path) { "person-2-working-situation" }
+
+            it "redirects to the log page" do
+              follow_redirect!
+              expect(response.body).to include("Before you start")
+              expect(response.body).not_to include("Skip for now")
+            end
+          end
+        end
       end
 
       context "with checkbox questions" do


### PR DESCRIPTION
There was an `InvalidURIError` on sentry when navigating to `/sales-logs/:x/purchase-price-outright-sale?referrer=interruption_screen` it was getting hit on this line:
`@interruption_page_id = URI.parse(request.headers["HTTP_REFERER"]).path.split("/").last.underscore`

It was possible to reproduce it by directly navigating to the URL, and it was being caused by `HTTP_REFERER` header being empty.

Only setting `@interruption_page_id` if `HTTP_REFERER` is provided seems to fix this error.