### PR TITLE
CLDC-2449 production recursion error on finding url for next incomplete section

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -127,7 +127,7 @@ class Form
     if log.status == "completed"
       return first_question_in_last_subsection(subsection_ids)
     elsif log.calculate_status == "completed"
-      log.update(status: "completed")
+      log.update!(status: "completed")
       return first_question_in_last_subsection(subsection_ids)
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -126,6 +126,9 @@ class Form
 
     if log.status == "completed"
       return first_question_in_last_subsection(subsection_ids)
+    elsif log.calculate_status == "completed"
+      log.update(status: "completed")
+      return first_question_in_last_subsection(subsection_ids)
     end
 
     next_subsection = next_subsection(subsection, log, subsection_ids)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -124,10 +124,7 @@ class Form
   def next_incomplete_section_redirect_path(subsection, log)
     subsection_ids = subsections.map(&:id)
 
-    if log.status == "completed"
-      return first_question_in_last_subsection(subsection_ids)
-    elsif log.calculate_status == "completed"
-      log.update!(status: "completed")
+    if log.status == "completed" || log.calculate_status == "completed" # if a log's status in in progress but then fields are made optional, all its subsections are complete, resulting in a stack error
       return first_question_in_last_subsection(subsection_ids)
     end
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -139,9 +139,9 @@ class Log < ApplicationRecord
   def calculate_status
     return "deleted" if discarded_at.present?
 
-    if all_fields_completed? && errors.empty?
+    if all_subsections_completed? && errors.empty?
       "completed"
-    elsif all_fields_nil?
+    elsif all_subsections_unstarted?
       "not_started"
     else
       "in_progress"
@@ -210,11 +210,11 @@ private
     self.status = calculate_status
   end
 
-  def all_fields_completed?
+  def all_subsections_completed?
     form.subsections.all? { |subsection| subsection.complete?(self) || subsection.not_displayed_in_tasklist?(self) }
   end
 
-  def all_fields_nil?
+  def all_subsections_unstarted?
     not_started_statuses = %i[not_started cannot_start_yet]
     form.subsections.all? { |subsection| not_started_statuses.include? subsection.status(self) }
   end

--- a/spec/factories/lettings_log.rb
+++ b/spec/factories/lettings_log.rb
@@ -146,6 +146,8 @@ FactoryBot.define do
       joint { 3 }
       address_line1 { "fake address" }
       town_or_city { "London" }
+      ppcodenk { 0 }
+      tshortfall_known { 1 }
     end
     trait :export do
       tenancycode { "987654" }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Form, type: :model do
         FormHandler.instance.use_real_forms!
       end
 
-      it "should not raise a Stack Error" do
+      it "does not raise a Stack Error" do
         expect { form.next_incomplete_section_redirect_path(subsection, lettings_log) }.not_to raise_error
       end
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -205,10 +205,9 @@ RSpec.describe Form, type: :model do
       let(:lettings_log) { build(:lettings_log, :completed, status: "in_progress") }
       let(:subsection) { form.get_subsection("setup") }
 
-      around do |example|
+      before do
+        Timecop.return
         FormHandler.instance.use_real_forms!
-
-        example.run
       end
 
       it "should not raise a Stack Error" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -190,8 +190,6 @@ RSpec.describe Form, type: :model do
         FormHandler.instance.use_real_forms!
 
         example.run
-
-        FormHandler.instance.use_fake_forms!
       end
 
       it "finds the path to the section after" do
@@ -200,6 +198,21 @@ RSpec.describe Form, type: :model do
         lettings_log.needstype = 2
         lettings_log.postcode_known = 0
         expect(form.next_incomplete_section_redirect_path(subsection, lettings_log)).to eq("joint")
+      end
+    end
+
+    context "when a log has status in progress but all subsections are complete" do
+      let(:lettings_log) { build(:lettings_log, :completed, status: "in_progress") }
+      let(:subsection) { form.get_subsection("setup") }
+
+      around do |example|
+        FormHandler.instance.use_real_forms!
+
+        example.run
+      end
+
+      it "should not raise a Stack Error" do
+        expect { form.next_incomplete_section_redirect_path(subsection, lettings_log) }.not_to raise_error
       end
     end
   end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -5,4 +5,27 @@ RSpec.describe Log, type: :model do
     expect(SalesLog).to be < described_class
     expect(LettingsLog).to be < described_class
   end
+
+  describe "#calculate_status" do
+    it "returns the correct status for a completed sales log" do
+      complete_sales_log = create(:sales_log, :completed, status: nil)
+      expect(complete_sales_log.calculate_status).to eq "completed"
+    end
+
+    it "returns the correct status for an in progress sales log" do
+      in_progress_sales_log = create(:sales_log, :in_progress, status: nil)
+      expect(in_progress_sales_log.calculate_status).to eq "in_progress"
+    end
+
+    it "returns the correct status for a completed lettings log" do
+      complete_lettings_log = create(:lettings_log, :completed, status: nil)
+      binding.pry
+      expect(complete_lettings_log.calculate_status).to eq "completed"
+    end
+
+    it "returns the correct status for an in progress lettings log" do
+      in_progress_lettings_log = create(:lettings_log, :in_progress, status: nil)
+      expect(in_progress_lettings_log.calculate_status).to eq "in_progress"
+    end
+  end
 end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Log, type: :model do
 
     it "returns the correct status for a completed lettings log" do
       complete_lettings_log = create(:lettings_log, :completed, status: nil)
-      binding.pry
       expect(complete_lettings_log.calculate_status).to eq "completed"
     end
 


### PR DESCRIPTION
small fix in the method where the error was occurring.
amend lettings log factory to ensure that completed trait really is completed
tests for :calculate_status that also implicitly test the factory traits

We may also iterate over production data with the following (this does not need to be done at the same time as this work is deployed)

```
logs_with_incorrect_status = []
LettingsLog.find_each { |log|  logs_with_incorrect_status << log if log.status == "in_progress" && log.form.subsections.all? { |ss| ss.complete?(log) } }
logs_with_incorrect_status.each { |log| log.update!(status: "completed") }
```