### PR TITLE
CLDC 1507: Explain rent types details added to rent type question page

### DIFF
--- a/app/models/form/lettings/pages/rent_type.rb
+++ b/app/models/form/lettings/pages/rent_type.rb
@@ -2,6 +2,7 @@ class Form::Lettings::Pages::RentType < ::Form::Page
   def initialize(_id, hsh, subsection)
     super("rent_type", hsh, subsection)
     @derived = true
+    @header = "Rent Type"
   end
 
   def questions

--- a/app/models/form/lettings/questions/rent_type.rb
+++ b/app/models/form/lettings/questions/rent_type.rb
@@ -5,6 +5,8 @@ class Form::Lettings::Questions::RentType < ::Form::Question
     @check_answer_label = "Rent type"
     @header = "What is the rent type?"
     @type = "radio"
+    @guidance_partial = "rent_type_definitions"
+    @guidance_position = GuidancePosition::TOP
     @answer_options = ANSWER_OPTIONS
     @conditional_for = { "irproduct_other" => [5] }
     @question_number = 6

--- a/app/views/form/guidance/_rent_type_definitions.erb
+++ b/app/views/form/guidance/_rent_type_definitions.erb
@@ -1,21 +1,21 @@
 <%= govuk_details(summary_text: "Rent type definitions") do %>
   <p class="govuk-body">
-    <b>Affordable Rent:</b> where up to 80% of market rent can be charged. A new supply agreement is signed with Homes England or the Greater London Authority (GLA). 
+    <b>Affordable Rent:</b> where up to 80% of market rent can be charged. A new supply agreement is signed with Homes England or the Greater London Authority (GLA).
   </p>
   <p class="govuk-body">
-    <b>London Affordable Rent:</b> a tenure of affordable housing available in London by the GLA. It is an affordable rent which must be set in accordance with the Regulator of Social Housing’s Affordable Rent guidance. The landlord of these homes must be registered with the Regulator of Social Housing. These are a type of Affordable Rent lettings.   
+    <b>London Affordable Rent:</b> a tenure of affordable housing available in London by the GLA. It is an affordable rent which must be set in accordance with the Regulator of Social Housing’s Affordable Rent guidance. The landlord of these homes must be registered with the Regulator of Social Housing. These are a type of Affordable Rent lettings.
   </p>
   <p class="govuk-body">
-    <b>London Living Rent:</b> a tenure of affordable housing available in London by the GLA. It was introduced in Affordable Homes Programme 2016 to 2021. These are a type of Intermediate Rent lettings. 
+    <b>London Living Rent:</b> a tenure of affordable housing available in London by the GLA. It was introduced in Affordable Homes Programme 2016 to 2021. These are a type of Intermediate Rent lettings.
   </p>
   <p class="govuk-body">
     <b>Rent to Buy: </b> a discount of up to 20% market rent is charged for a single rental period for a minimum of 5 years. After that period, the tenant is offered first chance to purchase the property (either shared ownership or outright) at full market value. These are a type of Intermediate Rent lettings.
   </p>
   <p class="govuk-body">
-    <b>  Social Rent:</b> where target rents are determined through the national rent regime. This is sometimes also known as 'formula rent'.
+    <b>Social Rent:</b> where target rents are determined through the national rent regime. This is sometimes also known as 'formula rent'.
   </p>
 
   <p class="govuk-body">
-    <b>  Other intermediate rent:</b> any other specific scheme where up to 80% of market rent can be charged. This includes schemes with reduced rent so tenants can save towards a house purchasing deposit and schemes with an in-built future opportunity to buy the property being rented.
+    <b>Other intermediate rent:</b> any other specific scheme where up to 80% of market rent can be charged. This includes schemes with reduced rent so tenants can save towards a house purchasing deposit and schemes with an in-built future opportunity to buy the property being rented.
   </p>
 <% end %>

--- a/app/views/form/guidance/_rent_type_definitions.erb
+++ b/app/views/form/guidance/_rent_type_definitions.erb
@@ -1,0 +1,21 @@
+<%= govuk_details(summary_text: "Rent type definitions") do %>
+  <p class="govuk-body">
+    <b>Affordable Rent:</b> where up to 80% of market rent can be charged. A new supply agreement is signed with Homes England or the Greater London Authority (GLA). 
+  </p>
+  <p class="govuk-body">
+    <b>London Affordable Rent:</b> a tenure of affordable housing available in London by the GLA. It is an affordable rent which must be set in accordance with the Regulator of Social Housing’s Affordable Rent guidance. The landlord of these homes must be registered with the Regulator of Social Housing. These are a type of Affordable Rent lettings.   
+  </p>
+  <p class="govuk-body">
+    <b>London Living Rent:</b> a tenure of affordable housing available in London by the GLA. It was introduced in Affordable Homes Programme 2016 to 2021. These are a type of Intermediate Rent lettings. 
+  </p>
+  <p class="govuk-body">
+    <b>Rent to Buy: </b> a discount of up to 20% market rent is charged for a single rental period for a minimum of 5 years. After that period, the tenant is offered first chance to purchase the property (either shared ownership or outright) at full market value. These are a type of Intermediate Rent lettings.
+  </p>
+  <p class="govuk-body">
+    <b>  Social Rent:</b> where target rents are determined through the national rent regime. This is sometimes also known as 'formula rent'.
+  </p>
+
+  <p class="govuk-body">
+    <b>  Other intermediate rent:</b> any other specific scheme where up to 80% of market rent can be charged. This includes schemes with reduced rent so tenants can save towards a house purchasing deposit and schemes with an in-built future opportunity to buy the property being rented.
+  </p>
+<% end %>

--- a/spec/models/form/lettings/pages/rent_type_spec.rb
+++ b/spec/models/form/lettings/pages/rent_type_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Form::Lettings::Pages::RentType, type: :model do
   end
 
   it "has the correct header" do
-    expect(page.header).to be_nil
+    expect(page.header).to eq("Rent Type")
   end
 
   it "has the correct description" do

--- a/spec/models/form/lettings/questions/rent_type_spec.rb
+++ b/spec/models/form/lettings/questions/rent_type_spec.rb
@@ -49,4 +49,8 @@ RSpec.describe Form::Lettings::Questions::RentType, type: :model do
   it "is not marked as derived" do
     expect(question.derived?).to be false
   end
+
+  it "has the guidance partial" do
+    expect(question.guidance_partial).to eq("rent_type_definitions")
+  end
 end


### PR DESCRIPTION
This ticket is concerned with adding a details component to the 'Rent Type' question page.

**Before:**
![image-2023-02-23-17-44-51-166](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/3ab18617-ee98-4780-84e9-fe08b0f5d9ba)

**After:**
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/6b3addfe-b1c4-4a3e-a678-b1c601877303)

**After expanded:**
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/741fbaa1-9619-4714-9f16-23048f158539)


