### PR TITLE
CLDC-2420 Update deactivating soon label

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -149,7 +149,7 @@ class LocationsController < ApplicationController
   def show; end
 
   def new_deactivation
-    @location_deactivation_period = if @location.deactivates_in_more_than_6_months?
+    @location_deactivation_period = if @location.deactivates_in_a_long_time?
                                       @location.open_deactivation || LocationDeactivationPeriod.new
                                     else
                                       LocationDeactivationPeriod.new

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -27,7 +27,7 @@ class SchemesController < ApplicationController
   end
 
   def new_deactivation
-    @scheme_deactivation_period = if @scheme.deactivates_in_more_than_6_months?
+    @scheme_deactivation_period = if @scheme.deactivates_in_a_long_time?
                                     @scheme.open_deactivation || SchemeDeactivationPeriod.new
                                   else
                                     SchemeDeactivationPeriod.new

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -27,7 +27,11 @@ class SchemesController < ApplicationController
   end
 
   def new_deactivation
-    @scheme_deactivation_period = SchemeDeactivationPeriod.new
+    @scheme_deactivation_period = if @scheme.deactivates_in_more_than_6_months?
+                                    @scheme.open_deactivation || SchemeDeactivationPeriod.new
+                                  else
+                                    SchemeDeactivationPeriod.new
+                                  end
 
     if params[:scheme_deactivation_period].blank?
       render "toggle_active", locals: { action: "deactivate" }
@@ -54,7 +58,7 @@ class SchemesController < ApplicationController
   end
 
   def deactivate
-    if @scheme.scheme_deactivation_periods.create!(deactivation_date: params[:deactivation_date])
+    if @scheme.open_deactivation&.update!(deactivation_date: params[:deactivation_date]) || @scheme.scheme_deactivation_periods.create!(deactivation_date: params[:deactivation_date])
       logs = reset_location_and_scheme_for_logs!
 
       flash[:notice] = deactivate_success_notice

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -69,7 +69,7 @@ module LocationsHelper
   end
 
   def toggle_location_link(location)
-    return govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(location.scheme, location), warning: true if location.active? || location.deactivates_in_more_than_6_months?
+    return govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(location.scheme, location), warning: true if location.active? || location.deactivates_in_a_long_time?
     return govuk_button_link_to "Reactivate this location", scheme_location_new_reactivation_path(location.scheme, location) if location.deactivated?
   end
 

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -69,7 +69,7 @@ module LocationsHelper
   end
 
   def toggle_location_link(location)
-    return govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(location.scheme, location), warning: true if location.active?
+    return govuk_button_link_to "Deactivate this location", scheme_location_new_deactivation_path(location.scheme, location), warning: true if location.active? || location.deactivates_in_more_than_6_months?
     return govuk_button_link_to "Reactivate this location", scheme_location_new_reactivation_path(location.scheme, location) if location.deactivated?
   end
 

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -40,7 +40,7 @@ module SchemesHelper
   end
 
   def toggle_scheme_link(scheme)
-    return govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(scheme), warning: true if scheme.active? || scheme.deactivates_in_more_than_6_months?
+    return govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(scheme), warning: true if scheme.active? || scheme.deactivates_in_a_long_time?
     return govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(scheme) if scheme.deactivated?
   end
 

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -14,7 +14,7 @@ module SchemesHelper
       { name: "Level of support given", value: scheme.support_type },
       { name: "Intended length of stay", value: scheme.intended_stay },
       { name: "Availability", value: scheme_availability(scheme) },
-      { name: "Status", value: status_tag(scheme.status) },
+      { name: "Status", value: status_tag_from_resource(scheme) },
     ]
 
     if user.data_coordinator?

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -40,7 +40,7 @@ module SchemesHelper
   end
 
   def toggle_scheme_link(scheme)
-    return govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(scheme), warning: true if scheme.active?
+    return govuk_button_link_to "Deactivate this scheme", scheme_new_deactivation_path(scheme), warning: true if scheme.active? || scheme.deactivates_in_more_than_6_months?
     return govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(scheme) if scheme.deactivated?
   end
 

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -27,13 +27,17 @@ module TagHelper
     deactivated: "grey",
   }.freeze
 
-  def status_tag(resource, classes = [])
-    display_status = resource.status
-    display_status = :active if resource.deactivates_in_more_than_6_months?
+  def status_tag(status, classes = [])
     govuk_tag(
       classes:,
-      colour: COLOUR[display_status.to_sym],
-      text: TEXT[display_status.to_sym],
+      colour: COLOUR[status.to_sym],
+      text: TEXT[status.to_sym],
     )
+  end
+
+  def status_tag_from_resource(resource, classes = [])
+    status = resource.status
+    status = :active if resource.deactivates_in_more_than_6_months?
+    status_tag(status, classes)
   end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -37,7 +37,7 @@ module TagHelper
 
   def status_tag_from_resource(resource, classes = [])
     status = resource.status
-    status = :active if resource.deactivates_in_more_than_6_months?
+    status = :active if resource.deactivates_in_a_long_time?
     status_tag(status, classes)
   end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -27,11 +27,13 @@ module TagHelper
     deactivated: "grey",
   }.freeze
 
-  def status_tag(status, classes = [])
+  def status_tag(resource, classes = [])
+    display_status = resource.status
+    display_status = :active if resource.deactivates_in_more_than_6_months?
     govuk_tag(
       classes:,
-      colour: COLOUR[status.to_sym],
-      text: TEXT[status.to_sym],
+      colour: COLOUR[display_status.to_sym],
+      text: TEXT[display_status.to_sym],
     )
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -108,8 +108,8 @@ class Location < ApplicationRecord
     status == :reactivating_soon
   end
 
-  def deactivates_in_more_than_6_months?
-    status == :deactivating_soon && open_deactivation.present? && open_deactivation.deactivation_date > 6.months.from_now
+  def deactivates_in_a_long_time?
+    status_at(6.months.from_now) == :deactivating_soon
   end
 
   def validate_postcode

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -108,6 +108,10 @@ class Location < ApplicationRecord
     status == :reactivating_soon
   end
 
+  def deactivates_in_more_than_6_months?
+    status == :deactivating_soon && open_deactivation.present? && open_deactivation.deactivation_date > 6.months.from_now
+  end
+
   def validate_postcode
     if !postcode&.match(POSTCODE_REGEXP)
       error_message = I18n.t("validations.postcode")

--- a/app/models/location_deactivation_period.rb
+++ b/app/models/location_deactivation_period.rb
@@ -4,7 +4,7 @@ class LocationDeactivationPeriodValidator < ActiveModel::Validator
   def validate(record)
     location = record.location
     recent_deactivation = location.location_deactivation_periods.deactivations_without_reactivation.first
-    if recent_deactivation.present?
+    if recent_deactivation.present? && recent_deactivation.deactivation_date <= 6.months.from_now
       validate_reactivation(record, recent_deactivation, location)
     else
       validate_deactivation(record, location)

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -242,4 +242,8 @@ class Scheme < ApplicationRecord
   def deactivated?
     status == :deactivated
   end
+
+  def deactivates_in_more_than_6_months?
+    status == :deactivating_soon && open_deactivation.present? && open_deactivation.deactivation_date > 6.months.from_now
+  end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -243,7 +243,7 @@ class Scheme < ApplicationRecord
     status == :deactivated
   end
 
-  def deactivates_in_more_than_6_months?
-    status == :deactivating_soon && open_deactivation.present? && open_deactivation.deactivation_date > 6.months.from_now
+  def deactivates_in_a_long_time?
+    status_at(6.months.from_now) == :deactivating_soon
   end
 end

--- a/app/models/scheme_deactivation_period.rb
+++ b/app/models/scheme_deactivation_period.rb
@@ -4,7 +4,7 @@ class SchemeDeactivationPeriodValidator < ActiveModel::Validator
   def validate(record)
     scheme = record.scheme
     recent_deactivation = scheme.scheme_deactivation_periods.deactivations_without_reactivation.first
-    if recent_deactivation.present?
+    if recent_deactivation.present? && recent_deactivation.deactivation_date <= 6.months.from_now
       validate_reactivation(record, recent_deactivation, scheme)
     else
       validate_deactivation(record, scheme)

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -47,6 +47,7 @@ class SchemePolicy
     confirm_secondary_client_group?
     secondary_client_group?
     new_deactivation?
+    new_reactivation?
     deactivate?
     details?
     support?

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -49,6 +49,7 @@ class SchemePolicy
     new_deactivation?
     new_reactivation?
     deactivate?
+    reactivate?
     details?
     support?
     deactivate_confirm?

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -54,7 +54,7 @@
                                                                              end), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
             <% row.cell(text: location.name) %>
             <% row.cell(text: location.id) %>
-            <% row.cell(text: status_tag(location.status)) %>
+            <% row.cell(text: status_tag(location)) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -54,7 +54,7 @@
                                                                              end), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
             <% row.cell(text: location.name) %>
             <% row.cell(text: location.id) %>
-            <% row.cell(text: status_tag(location)) %>
+            <% row.cell(text: status_tag_from_resource(location)) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -15,7 +15,7 @@
       <% display_location_attributes(@location).each do |attr| %>
         <%= summary_list.row do |row| %>
           <% row.key { attr[:name] } %>
-          <% row.value { attr[:attribute].eql?("status") ? status_tag(attr[:value]) : details_html(attr) } %>
+          <% row.value { attr[:attribute].eql?("status") ? status_tag(@location) : details_html(attr) } %>
           <% if LocationPolicy.new(current_user, @location).update? %>
             <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" %>
           <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -15,7 +15,7 @@
       <% display_location_attributes(@location).each do |attr| %>
         <%= summary_list.row do |row| %>
           <% row.key { attr[:name] } %>
-          <% row.value { attr[:attribute].eql?("status") ? status_tag(@location) : details_html(attr) } %>
+          <% row.value { attr[:attribute].eql?("status") ? status_tag_from_resource(@location) : details_html(attr) } %>
           <% if LocationPolicy.new(current_user, @location).update? %>
             <% row.action(text: "Change", href: scheme_location_name_path(@scheme, @location, referrer: "details")) if attr[:attribute] == "name" %>
           <% end %>

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -17,7 +17,7 @@
           <% row.cell(text: simple_format(scheme_cell(scheme), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
           <% row.cell(text: scheme.id_to_display) %>
           <% row.cell(text: scheme.locations&.count) %>
-          <% row.cell(text: status_tag(scheme)) %>
+          <% row.cell(text: status_tag_from_resource(scheme)) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -17,7 +17,7 @@
           <% row.cell(text: simple_format(scheme_cell(scheme), { class: "govuk-!-font-weight-bold" }, wrapper_tag: "div")) %>
           <% row.cell(text: scheme.id_to_display) %>
           <% row.cell(text: scheme.locations&.count) %>
-          <% row.cell(text: status_tag(scheme.status)) %>
+          <% row.cell(text: status_tag(scheme)) %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
-      xcontext "when deactivation date is during a deactivated period" do
+      context "when deactivation date is during a deactivated period" do
         let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
         let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
         let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 5, 5), reactivation_date: Time.zone.local(2022, 10, 12), location:) }

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1538,6 +1538,37 @@ RSpec.describe LocationsController, type: :request do
             expect(lettings_log.unresolved).to eq(nil)
           end
         end
+
+        context "and there already is a deactivation period" do
+          let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, location:) }
+
+          before do
+            patch "/schemes/#{scheme.id}/locations/#{location.id}/deactivate", params:
+          end
+
+          it "updates existing location with valid deactivation date and renders location page" do
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+            location.reload
+            expect(location.location_deactivation_periods.count).to eq(1)
+            expect(location.location_deactivation_periods.first.deactivation_date).to eq(deactivation_date)
+          end
+
+          it "clears the location and scheme answers" do
+            expect(lettings_log.location).to eq(location)
+            expect(lettings_log.scheme).to eq(scheme)
+            lettings_log.reload
+            expect(lettings_log.location).to eq(nil)
+            expect(lettings_log.scheme).to eq(nil)
+          end
+
+          it "marks log as needing attention" do
+            expect(lettings_log.unresolved).to eq(nil)
+            lettings_log.reload
+            expect(lettings_log.unresolved).to eq(true)
+          end
+        end
       end
 
       context "when the date is not selected" do
@@ -1594,7 +1625,7 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
-      context "when deactivation date is during a deactivated period" do
+      xcontext "when deactivation date is during a deactivated period" do
         let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
         let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
         let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 5, 5), reactivation_date: Time.zone.local(2022, 10, 12), location:) }
@@ -1602,6 +1633,34 @@ RSpec.describe LocationsController, type: :request do
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.location.deactivation.during_deactivated_period"))
+        end
+      end
+
+      context "when there is an earlier open deactivation" do
+        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
+        let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2023" } } }
+        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, location:) }
+
+        it "redirects to the location page and updates the existing deactivation period" do
+          follow_redirect!
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+          location.reload
+          expect(location.location_deactivation_periods.count).to eq(1)
+          expect(location.location_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2023, 9, 8))
+        end
+      end
+
+      context "when there is a later open deactivation" do
+        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
+        let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
+        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, location:) }
+
+        it "redirects to the confirmation page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_content("This change will affect 1 logs")
         end
       end
     end
@@ -1752,10 +1811,10 @@ RSpec.describe LocationsController, type: :request do
       let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
       let(:location) { create(:location, scheme:) }
       let(:deactivation_date) { Time.zone.local(2022, 4, 1) }
-      let(:startdate) { Time.utc(2022, 10, 11) }
+      let(:startdate) { Time.utc(2022, 9, 11) }
 
       before do
-        Timecop.freeze(Time.utc(2022, 10, 10))
+        Timecop.freeze(Time.utc(2022, 9, 10))
         sign_in user
         create(:location_deactivation_period, deactivation_date:, location:)
         location.save!
@@ -1786,7 +1845,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with other date" do
-        let(:params) { { location_deactivation_period: { reactivation_date_type: "other", "reactivation_date(3i)": "10", "reactivation_date(2i)": "10", "reactivation_date(1i)": "2022" } } }
+        let(:params) { { location_deactivation_period: { reactivation_date_type: "other", "reactivation_date(3i)": "10", "reactivation_date(2i)": "9", "reactivation_date(1i)": "2022" } } }
 
         it "redirects to the location page and displays a success banner" do
           expect(response).to redirect_to("/schemes/#{scheme.id}/locations/#{location.id}")
@@ -1799,7 +1858,7 @@ RSpec.describe LocationsController, type: :request do
           follow_redirect!
           location.reload
           expect(location.location_deactivation_periods.count).to eq(1)
-          expect(location.location_deactivation_periods.first.reactivation_date).to eq(Time.zone.local(2022, 10, 10))
+          expect(location.location_deactivation_periods.first.reactivation_date).to eq(Time.zone.local(2022, 9, 10))
         end
       end
 

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1673,6 +1673,19 @@ RSpec.describe LocationsController, type: :request do
           expect(response).to have_http_status(:ok)
           expect(page).not_to have_link("Reactivate this location")
           expect(page).not_to have_link("Deactivate this location")
+          expect(page).to have_content("Deactivating soon")
+        end
+      end
+
+      context "with location that's deactivating in more than 6 months" do
+        let(:location_deactivation_period) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 12), location:) }
+
+        it "does render toggle location link" do
+          expect(response).to have_http_status(:ok)
+          expect(page).not_to have_link("Reactivate this location")
+          expect(page).to have_link("Deactivate this location")
+          expect(response.body).not_to include("<strong class=\"govuk-tag govuk-tag--yellow\">Deactivating soon</strong>")
+          expect(response.body).to include("<strong class=\"govuk-tag govuk-tag--green\">Active</strong>")
         end
       end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -2001,6 +2001,38 @@ RSpec.describe SchemesController, type: :request do
           end
         end
 
+        context "and there already is a deactivation period" do
+          let(:add_deactivations) { create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, scheme:) }
+
+          before do
+            create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, scheme:)
+            patch "/schemes/#{scheme.id}/deactivate", params:
+          end
+
+          it "updates existing scheme with valid deactivation date and renders scheme page" do
+            follow_redirect!
+            follow_redirect!
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+            scheme.reload
+            expect(scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivation_date)
+          end
+
+          it "clears the scheme and scheme answers" do
+            expect(lettings_log.scheme).to eq(scheme)
+            lettings_log.reload
+            expect(lettings_log.scheme).to eq(nil)
+            expect(lettings_log.scheme).to eq(nil)
+          end
+
+          it "marks log as needing attention" do
+            expect(lettings_log.unresolved).to eq(nil)
+            lettings_log.reload
+            expect(lettings_log.unresolved).to eq(true)
+          end
+        end
+
         context "and the users need to be notified" do
           it "sends E-mails to the creators of affected logs with counts" do
             expect {
@@ -2061,6 +2093,35 @@ RSpec.describe SchemesController, type: :request do
         it "displays page with an error message" do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(page).to have_content(I18n.t("validations.scheme.toggle_date.invalid"))
+        end
+      end
+
+      context "when there is an earlier open deactivation" do
+        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
+        let(:params) { { scheme_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2023" } } }
+        let(:add_deactivations) { create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, scheme:) }
+
+        it "redirects to the scheme page and updates the existing deactivation period" do
+          follow_redirect!
+          follow_redirect!
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+          scheme.reload
+          expect(scheme.scheme_deactivation_periods.count).to eq(1)
+          expect(scheme.scheme_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2023, 9, 8))
+        end
+      end
+
+      context "when there is a later open deactivation" do
+        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
+        let(:params) { { scheme_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
+        let(:add_deactivations) { create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, scheme:) }
+
+        it "redirects to the confirmation page" do
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_content("This change will affect 1 logs")
         end
       end
     end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -330,6 +330,18 @@ RSpec.describe SchemesController, type: :request do
             expect(page).not_to have_link("Deactivate this scheme")
           end
         end
+
+        context "with scheme that's deactivating in more than 6 months" do
+          let(:scheme_deactivation_period) { create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2023, 5, 12), scheme:) }
+
+          it "does not render toggle scheme link" do
+            expect(response).to have_http_status(:ok)
+            expect(page).not_to have_link("Reactivate this scheme")
+            expect(page).to have_link("Deactivate this scheme")
+            expect(response.body).not_to include("<strong class=\"govuk-tag govuk-tag--yellow\">Deactivating soon</strong>")
+            expect(response.body).to include("<strong class=\"govuk-tag govuk-tag--green\">Active</strong>")
+          end
+        end
       end
 
       context "when coordinator attempts to see scheme belonging to a parent organisation" do

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "locations/show.html.erb" do
         status: :active,
         active?: true,
         scheme:,
+        deactivates_in_more_than_6_months?: false,
       )
     end
 

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "locations/show.html.erb" do
         status: :active,
         active?: true,
         scheme:,
-        deactivates_in_more_than_6_months?: false,
+        deactivates_in_a_long_time?: false,
       )
     end
 


### PR DESCRIPTION
All schemes and locations with an end date have a "deactivating soon" label this appears no matter what the end date is: e.g. if the end date is way in the future, this still appears.

Now we only show "Deactivating soon" label if the deactivation is happening in 6 months or less. If the deactivation is in more than 6 months the label for location or scheme is "Active".
This change only happens on the display layer and the underlying statuses are still the same.

The user can also deactivate a scheme or location that is deactivating_soon but appears as "Active". If this happens we update the open deactivation instead of creating a new one.

All the availability information is staying the same.
