### PR TITLE
CLDC-2421 explain why schemes without locations are incomplete

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -27,13 +27,13 @@ module LocationsHelper
     [
       { name: "Postcode", value: location.postcode, attribute: "postcode" },
       { name: "Location name", value: location.name, attribute: "name" },
+      { name: "Status", value: location.status, attribute: "status" },
       { name: "Local authority", value: formatted_local_authority_timeline(location, "name"), attribute: "local_authority" },
       { name: "Number of units", value: location.units, attribute: "units" },
       { name: "Most common unit", value: location.type_of_unit, attribute: "type_of_unit" },
       { name: "Mobility standards", value: location.mobility_type, attribute: "mobility_standards" },
       { name: "Location code", value: formatted_local_authority_timeline(location, "code"), attribute: "location_code" },
       { name: "Availability", value: location_availability(location), attribute: "availability" },
-      { name: "Status", value: location.status, attribute: "status" },
     ]
   end
 

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -3,6 +3,7 @@ module SchemesHelper
     base_attributes = [
       { name: "Scheme code", value: scheme.id_to_display },
       { name: "Name", value: scheme.service_name, edit: true },
+      { name: "Status", value: status_tag(scheme.status) },
       { name: "Confidential information", value: scheme.sensitive, edit: true },
       { name: "Type of scheme", value: scheme.scheme_type },
       { name: "Registered under Care Standards Act 2000", value: scheme.registered_under_care_act },
@@ -14,7 +15,6 @@ module SchemesHelper
       { name: "Level of support given", value: scheme.support_type },
       { name: "Intended length of stay", value: scheme.intended_stay },
       { name: "Availability", value: scheme_availability(scheme) },
-      { name: "Status", value: status_tag_from_resource(scheme) },
     ]
 
     if user.data_coordinator?

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -3,7 +3,7 @@ module SchemesHelper
     base_attributes = [
       { name: "Scheme code", value: scheme.id_to_display },
       { name: "Name", value: scheme.service_name, edit: true },
-      { name: "Status", value: status_tag(scheme.status) },
+      { name: "Status", value: status_tag_from_resource(scheme) },
       { name: "Confidential information", value: scheme.sensitive, edit: true },
       { name: "Type of scheme", value: scheme.scheme_type },
       { name: "Registered under Care Standards Act 2000", value: scheme.registered_under_care_act },

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -19,7 +19,12 @@
       <% display_scheme_attributes(@scheme, current_user).each do |attr| %>
         <%= summary_list.row do |row| %>
           <% row.key { attr[:name] } %>
-          <% row.value { details_html(attr) } %>
+          <% row.value do %>
+            <%= details_html(attr) %>
+            <% if attr[:name] == "Status" && @scheme.confirmed? && @scheme.locations.confirmed.none? %>
+              <span class="app-!-colour-muted">Add a location to complete this scheme</span>
+            <% end %>
+          <% end %>
           <% if SchemePolicy.new(current_user, @scheme).update? %>
             <% row.action(text: "Change", href: scheme_edit_name_path(scheme_id: @scheme.id)) if attr[:edit] %>
           <% end %>

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -140,13 +140,13 @@ RSpec.describe LocationsHelper do
       attributes = [
         { attribute: "postcode", name: "Postcode", value: location.postcode },
         { attribute: "name", name: "Location name", value: location.name },
+        { attribute: "status", name: "Status", value: :active },
         { attribute: "local_authority", name: "Local authority", value: location.location_admin_district },
         { attribute: "units", name: "Number of units", value: location.units },
         { attribute: "type_of_unit", name: "Most common unit", value: location.type_of_unit },
         { attribute: "mobility_standards", name: "Mobility standards", value: location.mobility_type },
         { attribute: "location_code", name: "Location code", value: location.location_code },
         { attribute: "availability", name: "Availability", value: "Active from 1 April 2022" },
-        { attribute: "status", name: "Status", value: :active },
       ]
 
       expect(display_location_attributes(location)).to eq(attributes)
@@ -162,13 +162,13 @@ RSpec.describe LocationsHelper do
         attributes = [
           { attribute: "postcode", name: "Postcode", value: location.postcode },
           { attribute: "name", name: "Location name", value: location.name },
+          { attribute: "status", name: "Status", value: :active },
           { attribute: "local_authority", name: "Local authority", value: "Eden (until 31 March 2023)\nCumberland (1 April 2023 - present)" },
           { attribute: "units", name: "Number of units", value: location.units },
           { attribute: "type_of_unit", name: "Most common unit", value: location.type_of_unit },
           { attribute: "mobility_standards", name: "Mobility standards", value: location.mobility_type },
           { attribute: "location_code", name: "Location code", value: "E07000030 (until 31 March 2023)\nE06000063 (1 April 2023 - present)" },
           { attribute: "availability", name: "Availability", value: "Active from 1 April 2022" },
-          { attribute: "status", name: "Status", value: :active },
         ]
 
         expect(display_location_attributes(location)).to eq(attributes)
@@ -185,13 +185,13 @@ RSpec.describe LocationsHelper do
         attributes = [
           { attribute: "postcode", name: "Postcode", value: location.postcode },
           { attribute: "name", name: "Location name", value: location.name },
+          { attribute: "status", name: "Status", value: :incomplete },
           { attribute: "local_authority", name: "Local authority", value: "" },
           { attribute: "units", name: "Number of units", value: location.units },
           { attribute: "type_of_unit", name: "Most common unit", value: location.type_of_unit },
           { attribute: "mobility_standards", name: "Mobility standards", value: location.mobility_type },
           { attribute: "location_code", name: "Location code", value: "" },
           { attribute: "availability", name: "Availability", value: "Active from 1 April 2022" },
-          { attribute: "status", name: "Status", value: :incomplete },
         ]
 
         expect(display_location_attributes(location)).to eq(attributes)

--- a/spec/helpers/schemes_helper_spec.rb
+++ b/spec/helpers/schemes_helper_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe SchemesHelper do
         attributes = [
           { name: "Scheme code", value: "S#{scheme.id}" },
           { name: "Name", value: "Test service_name", edit: true },
+          { name: "Status", value: status_tag(:incomplete) },
           { name: "Confidential information", value: "No", edit: true },
           { name: "Type of scheme", value: "Housing for older people" },
           { name: "Registered under Care Standards Act 2000", value: "Yes – registered care home providing personal care" },
@@ -126,7 +127,6 @@ RSpec.describe SchemesHelper do
           { name: "Level of support given", value: "High level" },
           { name: "Intended length of stay", value: "Permanent" },
           { name: "Availability", value: "Active from 1 April 2021" },
-          { name: "Status", value: status_tag(:incomplete) },
         ]
         expect(display_scheme_attributes(scheme, support_user)).to eq(attributes)
       end
@@ -135,6 +135,7 @@ RSpec.describe SchemesHelper do
         attributes = [
           { name: "Scheme code", value: "S#{scheme.id}" },
           { name: "Name", value: "Test service_name", edit: true },
+          { name: "Status", value: status_tag(:incomplete) },
           { name: "Confidential information", value: "No", edit: true },
           { name: "Type of scheme", value: "Housing for older people" },
           { name: "Registered under Care Standards Act 2000", value: "Yes – registered care home providing personal care" },
@@ -145,7 +146,6 @@ RSpec.describe SchemesHelper do
           { name: "Level of support given", value: "High level" },
           { name: "Intended length of stay", value: "Permanent" },
           { name: "Availability", value: "Active from 1 April 2021" },
-          { name: "Status", value: status_tag(:incomplete) },
         ]
         expect(display_scheme_attributes(scheme, coordinator_user)).to eq(attributes)
       end
@@ -160,6 +160,7 @@ RSpec.describe SchemesHelper do
         attributes = [
           { name: "Scheme code", value: "S#{scheme.id}" },
           { name: "Name", value: "Test service_name", edit: true },
+          { name: "Status", value: status_tag(:active) },
           { name: "Confidential information", value: "No", edit: true },
           { name: "Type of scheme", value: "Housing for older people" },
           { name: "Registered under Care Standards Act 2000", value: "Yes – registered care home providing personal care" },
@@ -171,7 +172,6 @@ RSpec.describe SchemesHelper do
           { name: "Level of support given", value: "High level" },
           { name: "Intended length of stay", value: "Permanent" },
           { name: "Availability", value: "Active from 1 April 2021" },
-          { name: "Status", value: status_tag(:active) },
         ]
         expect(display_scheme_attributes(scheme, support_user)).to eq(attributes)
       end
@@ -180,6 +180,7 @@ RSpec.describe SchemesHelper do
         attributes = [
           { name: "Scheme code", value: "S#{scheme.id}" },
           { name: "Name", value: "Test service_name", edit: true },
+          { name: "Status", value: status_tag(:active) },
           { name: "Confidential information", value: "No", edit: true },
           { name: "Type of scheme", value: "Housing for older people" },
           { name: "Registered under Care Standards Act 2000", value: "Yes – registered care home providing personal care" },
@@ -190,7 +191,6 @@ RSpec.describe SchemesHelper do
           { name: "Level of support given", value: "High level" },
           { name: "Intended length of stay", value: "Permanent" },
           { name: "Availability", value: "Active from 1 April 2021" },
-          { name: "Status", value: status_tag(:active) },
         ]
         expect(display_scheme_attributes(scheme, coordinator_user)).to eq(attributes)
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -364,6 +364,23 @@ RSpec.describe SchemesController, type: :request do
           expect(page).not_to have_content("Deactivate this scheme")
         end
       end
+
+      context "when the scheme has all details but no confirmed locations" do
+        it "shows the scheme as incomplete with text to explain" do
+          get scheme_path(specific_scheme)
+          expect(page).to have_content "Incomplete"
+          expect(page).to have_content "Add a location to complete this scheme"
+        end
+      end
+
+      context "when the scheme has all details and confirmed locations" do
+        it "shows the scheme as complete" do
+          create(:location, scheme: specific_scheme)
+          get scheme_path(specific_scheme)
+          expect(page).to have_content "Active"
+          expect(page).not_to have_content "Add a location to complete this scheme"
+        end
+      end
     end
 
     context "when signed in as a support user" do


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/CLDC-2421

   - amend ordering in scheme and location show pages to raise status towards top
   - implement a muted explanation text on schemes when they have complete details but no active locations to explain why they are incomplete
   - write tests to ensure this text is shown under the right conditions
