### PR TITLE
CLDC 2075: Hint details added to 3 question pages for year 2023

### DIFF
--- a/app/models/form/sales/pages/discounted_ownership_type.rb
+++ b/app/models/form/sales/pages/discounted_ownership_type.rb
@@ -15,6 +15,6 @@ class Form::Sales::Pages::DiscountedOwnershipType < ::Form::Page
   end
 
   def header
-    "Discounted ownership type" if form.start_date.year >= 2023
+    "Type of discounted ownership sale" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/discounted_ownership_type.rb
+++ b/app/models/form/sales/pages/discounted_ownership_type.rb
@@ -2,6 +2,7 @@ class Form::Sales::Pages::DiscountedOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "discounted_ownership_type"
+    @header = "Discounted ownership type"
     @depends_on = [{
       "ownershipsch" => 2,
     }]

--- a/app/models/form/sales/pages/discounted_ownership_type.rb
+++ b/app/models/form/sales/pages/discounted_ownership_type.rb
@@ -2,7 +2,7 @@ class Form::Sales::Pages::DiscountedOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "discounted_ownership_type"
-    @header = "Discounted ownership type"
+    @header = header
     @depends_on = [{
       "ownershipsch" => 2,
     }]
@@ -12,5 +12,9 @@ class Form::Sales::Pages::DiscountedOwnershipType < ::Form::Page
     @questions ||= [
       Form::Sales::Questions::DiscountedOwnershipType.new(nil, nil, self),
     ]
+  end
+
+  def header
+    "Discounted ownership type" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/outright_ownership_type.rb
+++ b/app/models/form/sales/pages/outright_ownership_type.rb
@@ -2,6 +2,7 @@ class Form::Sales::Pages::OutrightOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "outright_ownership_type"
+    @header = "Outright ownership type"
     @depends_on = [{
       "ownershipsch" => 3,
     }]

--- a/app/models/form/sales/pages/outright_ownership_type.rb
+++ b/app/models/form/sales/pages/outright_ownership_type.rb
@@ -2,7 +2,7 @@ class Form::Sales::Pages::OutrightOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "outright_ownership_type"
-    @header = "Outright ownership type"
+    @header = header
     @depends_on = [{
       "ownershipsch" => 3,
     }]
@@ -13,5 +13,9 @@ class Form::Sales::Pages::OutrightOwnershipType < ::Form::Page
       Form::Sales::Questions::OutrightOwnershipType.new(nil, nil, self),
       Form::Sales::Questions::OtherOwnershipType.new(nil, nil, self),
     ]
+  end
+
+  def header
+    "Outright ownership type" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/outright_ownership_type.rb
+++ b/app/models/form/sales/pages/outright_ownership_type.rb
@@ -16,6 +16,6 @@ class Form::Sales::Pages::OutrightOwnershipType < ::Form::Page
   end
 
   def header
-    "Outright ownership type" if form.start_date.year >= 2023
+    "Type of outright sale" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/shared_ownership_type.rb
+++ b/app/models/form/sales/pages/shared_ownership_type.rb
@@ -8,13 +8,13 @@ class Form::Sales::Pages::SharedOwnershipType < ::Form::Page
     }]
   end
 
-  def header
-    "Shared ownership type" if form.start_date.year >= 2023
-  end
-
   def questions
     @questions ||= [
-      Form::Sales::Questions::SharedOwnershipType.new(nil, nil, self),
+    Form::Sales::Questions::SharedOwnershipType.new(nil, nil, self),
     ]
+  end
+
+  def header
+    "Shared ownership type" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/shared_ownership_type.rb
+++ b/app/models/form/sales/pages/shared_ownership_type.rb
@@ -10,7 +10,7 @@ class Form::Sales::Pages::SharedOwnershipType < ::Form::Page
 
   def questions
     @questions ||= [
-    Form::Sales::Questions::SharedOwnershipType.new(nil, nil, self),
+      Form::Sales::Questions::SharedOwnershipType.new(nil, nil, self),
     ]
   end
 

--- a/app/models/form/sales/pages/shared_ownership_type.rb
+++ b/app/models/form/sales/pages/shared_ownership_type.rb
@@ -2,10 +2,14 @@ class Form::Sales::Pages::SharedOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "shared_ownership_type"
-    @header = "Shared Ownership"
+    @header = header
     @depends_on = [{
       "ownershipsch" => 1,
     }]
+  end
+
+  def header
+    "Shared ownership type" if form.start_date.year >= 2023
   end
 
   def questions

--- a/app/models/form/sales/pages/shared_ownership_type.rb
+++ b/app/models/form/sales/pages/shared_ownership_type.rb
@@ -15,6 +15,6 @@ class Form::Sales::Pages::SharedOwnershipType < ::Form::Page
   end
 
   def header
-    "Shared ownership type" if form.start_date.year >= 2023
+    "Type of shared ownership sale" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/pages/shared_ownership_type.rb
+++ b/app/models/form/sales/pages/shared_ownership_type.rb
@@ -2,6 +2,7 @@ class Form::Sales::Pages::SharedOwnershipType < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "shared_ownership_type"
+    @header = "Shared Ownership"
     @depends_on = [{
       "ownershipsch" => 1,
     }]

--- a/app/models/form/sales/questions/discounted_ownership_type.rb
+++ b/app/models/form/sales/questions/discounted_ownership_type.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::DiscountedOwnershipType < ::Form::Question
     @check_answer_label = "Type of discounted ownership sale"
     @header = "What is the type of discounted ownership sale?"
     @type = "radio"
-    @guidance_partial = "discounted_ownership_type_definitions"
+    @guidance_partial = guidance_partial
     @guidance_position = GuidancePosition::TOP
     @answer_options = ANSWER_OPTIONS
     @question_number = 5
@@ -20,4 +20,8 @@ class Form::Sales::Questions::DiscountedOwnershipType < ::Form::Question
     "21" => { "value" => "Social HomeBuy for outright purchase" },
     "22" => { "value" => "Any other equity loan scheme" },
   }.freeze
+
+  def guidance_partial
+    "discounted_ownership_type_definitions" if form.start_date.year >= 2023
+  end
 end

--- a/app/models/form/sales/questions/discounted_ownership_type.rb
+++ b/app/models/form/sales/questions/discounted_ownership_type.rb
@@ -5,6 +5,8 @@ class Form::Sales::Questions::DiscountedOwnershipType < ::Form::Question
     @check_answer_label = "Type of discounted ownership sale"
     @header = "What is the type of discounted ownership sale?"
     @type = "radio"
+    @guidance_partial = "discounted_ownership_type_definitions"
+    @guidance_position = GuidancePosition::TOP
     @answer_options = ANSWER_OPTIONS
     @question_number = 5
   end

--- a/app/models/form/sales/questions/outright_ownership_type.rb
+++ b/app/models/form/sales/questions/outright_ownership_type.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::OutrightOwnershipType < ::Form::Question
     @check_answer_label = "Type of outright sale"
     @header = "What is the type of outright sale?"
     @type = "radio"
-    @guidance_partial = "outright_sale_type_definitions"
+    @guidance_partial = guidance_partial
     @guidance_position = GuidancePosition::TOP
     @answer_options = ANSWER_OPTIONS
     @conditional_for = {
@@ -18,4 +18,8 @@ class Form::Sales::Questions::OutrightOwnershipType < ::Form::Question
     "10" => { "value" => "Outright" },
     "12" => { "value" => "Other sale" },
   }.freeze
+
+  def guidance_partial
+    "outright_sale_type_definitions" if form.start_date.year >= 2023
+  end
 end

--- a/app/models/form/sales/questions/outright_ownership_type.rb
+++ b/app/models/form/sales/questions/outright_ownership_type.rb
@@ -5,6 +5,8 @@ class Form::Sales::Questions::OutrightOwnershipType < ::Form::Question
     @check_answer_label = "Type of outright sale"
     @header = "What is the type of outright sale?"
     @type = "radio"
+    @guidance_partial = "outright_sale_type_definitions"
+    @guidance_position = GuidancePosition::TOP
     @answer_options = ANSWER_OPTIONS
     @conditional_for = {
       "othtype" => [12],

--- a/app/models/form/sales/questions/shared_ownership_type.rb
+++ b/app/models/form/sales/questions/shared_ownership_type.rb
@@ -5,7 +5,7 @@ class Form::Sales::Questions::SharedOwnershipType < ::Form::Question
     @check_answer_label = "Type of shared ownership sale"
     @header = "What is the type of shared ownership sale?"
     @hint_text = "A shared ownership sale is when the purchaser buys up to 75% of the property value and pays rent to the Private Registered Provider (PRP) on the remaining portion"
-    @guidance_partial = "shared_ownership_type_definitions"
+    @guidance_partial = guidance_partial
     @guidance_position = GuidancePosition::TOP
     @type = "radio"
     @answer_options = answer_options
@@ -35,5 +35,9 @@ class Form::Sales::Questions::SharedOwnershipType < ::Form::Question
         "30" => { "value" => "Shared Ownership - 2021 model lease" },
       }
     end
+  end
+
+  def guidance_partial
+    "shared_ownership_type_definitions" if form.start_date.year >= 2023
   end
 end

--- a/app/models/form/sales/questions/shared_ownership_type.rb
+++ b/app/models/form/sales/questions/shared_ownership_type.rb
@@ -5,6 +5,8 @@ class Form::Sales::Questions::SharedOwnershipType < ::Form::Question
     @check_answer_label = "Type of shared ownership sale"
     @header = "What is the type of shared ownership sale?"
     @hint_text = "A shared ownership sale is when the purchaser buys up to 75% of the property value and pays rent to the Private Registered Provider (PRP) on the remaining portion"
+    @guidance_partial = "shared_ownership_type_definitions"
+    @guidance_position = GuidancePosition::TOP
     @type = "radio"
     @answer_options = answer_options
     @question_number = 4

--- a/app/views/form/guidance/_discounted_ownership_type_definitions.erb
+++ b/app/views/form/guidance/_discounted_ownership_type_definitions.erb
@@ -1,0 +1,23 @@
+<%= govuk_details(summary_text: "Discounted ownership type definitions") do %>
+  <p class="govuk-body">
+    <b>Right to Acquire (RTA):</b>  a discounted sale of a property built or purchased after 31 March 1997 to tenants of a private registered provider.
+  </p>
+  <p class="govuk-body">
+    <b>Preserved Right to Buy (PRTB):</b>  a discounted sale of a property that used to be owned by a council to tenants of a private registered provider.
+  </p>
+  <p class="govuk-body">
+    <b>Voluntary Right to Buy (VRTB):</b>  a discounted sale to tenants in this PRP owned property, as part of a pilot scheme.
+  </p>
+  <p class="govuk-body">
+    <b>Right to Buy (RTB):</b>  a discounted sale to tenants in this council owned property.
+  </p>
+  <p class="govuk-body">
+    <b>Rent to Buy full ownership:</b> a sale on full ownership terms following a period of discounted rent.
+  </p>
+  <p class="govuk-body">
+    <b>Social HomeBuy for outright purchase:</b> a discounted sale to tenants of a private registered provider on full ownership terms.
+  </p>
+  <p class="govuk-body">
+    <b>Any other equity loan scheme:</b> any scheme, not covered elsewhere, in which a loan is used to purchase equity.
+  </p>
+<% end %>

--- a/app/views/form/guidance/_outright_sale_type_definitions.erb
+++ b/app/views/form/guidance/_outright_sale_type_definitions.erb
@@ -1,0 +1,8 @@
+<%= govuk_details(summary_text: "Outright sale type definitions") do %>
+  <p class="govuk-body">
+    <b>Outright sale:</b> the full purchase of a property, usually with a mortgage or cash.
+  </p>
+  <p class="govuk-body">
+    <b>Other sale:</b> any sale which does not fit the criteria of any of the remaining options.
+  </p>
+<% end %>

--- a/app/views/form/guidance/_shared_ownership_type_definitions.erb
+++ b/app/views/form/guidance/_shared_ownership_type_definitions.erb
@@ -1,0 +1,26 @@
+<%= govuk_details(summary_text: "Shared ownership type definitions") do %>
+  <p class="govuk-body">
+    <b>Shared ownership:</b> Cannot be used for homes funded through the Affordable Homes Programme 2021 to 2026. Use the 2021 model lease for these properties.
+  </p>
+  <p class="govuk-body">
+    <b>Shared ownership 2021 model lease:</b> Homes bought using the  Affordable Homes Programme 2021 to 2026.
+  </p>
+  <p class="govuk-body">
+    <b>Older Persons Shared Ownership:</b> A type of shared ownership for those 55 years and over.
+  </p>
+  <p class="govuk-body">
+    <b>Social HomeBuy shared ownership purchase:</b> Tenants of private registered providers purchase their home at discount on Shared Ownership terms.
+  </p>
+  <p class="govuk-body">
+  <b>Home Ownership for people with Long-Term Disabilities (HOLD):</b> A shared ownership sale for those with long term disabilities.
+  </p>
+  <p class="govuk-body">
+    <b>Rent to Buy shared ownership:</b> A sale following a period of discounted rent.
+  </p>
+  <p class="govuk-body">
+    <b>Right to Shared Ownership:</b> A sale of a share of a rented home to a tenant using this scheme.
+  </p>
+  <p class="govuk-body">
+    <b>London Living Rent shared ownership:</b> A shared ownership sale following a period of discounted rent as part of the London Living Rent scheme.
+  </p>
+<% end %>

--- a/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Form::Sales::Pages::DiscountedOwnershipType, type: :model do
   end
 
   it "has the correct header" do
-    expect(page.header).to be_nil
+    expect(page.header).to eq("Discounted ownership type")
   end
 
   it "has the correct description" do

--- a/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
@@ -5,7 +5,26 @@ RSpec.describe Form::Sales::Pages::DiscountedOwnershipType, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection) }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date:)) }
+  let(:start_date) { Time.zone.today }
+
+  describe "headers" do
+    context "when form year is for 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "has the correct header" do
+        expect(page.header).to eq("Discounted ownership type")
+      end
+    end
+
+    context "when form year is for before 2023" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "does not have a page header" do
+        expect(page.header).to eq(nil)
+      end
+    end
+  end
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -17,10 +36,6 @@ RSpec.describe Form::Sales::Pages::DiscountedOwnershipType, type: :model do
 
   it "has the correct id" do
     expect(page.id).to eq("discounted_ownership_type")
-  end
-
-  it "has the correct header" do
-    expect(page.header).to eq("Discounted ownership type")
   end
 
   it "has the correct description" do

--- a/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Form::Sales::Pages::DiscountedOwnershipType, type: :model do
       let(:start_date) { Time.utc(2023, 2, 8) }
 
       it "has the correct header" do
-        expect(page.header).to eq("Discounted ownership type")
+        expect(page.header).to eq("Type of discounted ownership sale")
       end
     end
 

--- a/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/discounted_ownership_type_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe Form::Sales::Pages::DiscountedOwnershipType, type: :model do
   let(:start_date) { Time.zone.today }
 
   describe "headers" do
-    context "when form year is for 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
+    context "when form year is for 2023/24" do
+      let(:start_date) { Time.zone.local(2023, 4, 8) }
 
       it "has the correct header" do
         expect(page.header).to eq("Type of discounted ownership sale")
       end
     end
 
-    context "when form year is for before 2023" do
-      let(:start_date) { Time.utc(2022, 2, 8) }
+    context "when form year is for before 2023/24" do
+      let(:start_date) { Time.zone.local(2022, 2, 8) }
 
       it "does not have a page header" do
         expect(page.header).to eq(nil)

--- a/spec/models/form/sales/pages/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/outright_ownership_type_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
   end
 
   describe "headers" do
-    context "when the form year is 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
+    context "when the form year is 2023/24" do
+      let(:start_date) { Time.zone.local(2023, 4, 8) }
 
       it "has the correct header" do
         expect(page.header).to eq("Type of outright sale")
       end
     end
 
-    context "when the form is before the year 2023" do
-      let(:start_date) { Time.utc(2022, 2, 8) }
+    context "when the form is before the year 2023/24" do
+      let(:start_date) { Time.zone.local(2022, 4, 8) }
 
       it "does not have a page header" do
         expect(page.header).to eq(nil)

--- a/spec/models/form/sales/pages/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/outright_ownership_type_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection) }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date:)) }
+  let(:start_date) { Time.zone.today }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -19,10 +20,6 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
     expect(page.id).to eq("outright_ownership_type")
   end
 
-  it "has the correct header" do
-    expect(page.header).to eq("Outright ownership type")
-  end
-
   it "has the correct description" do
     expect(page.description).to be_nil
   end
@@ -31,5 +28,23 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
     expect(page.depends_on).to eq([{
       "ownershipsch" => 3,
     }])
+  end
+
+  describe "headers" do
+    context "when the form year is 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "has the correct header" do
+        expect(page.header).to eq("Outright ownership type")
+      end
+    end
+
+    context "when the form is before the year 2023" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "does not have a page header" do
+        expect(page.header).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/models/form/sales/pages/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/outright_ownership_type_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
       let(:start_date) { Time.utc(2023, 2, 8) }
 
       it "has the correct header" do
-        expect(page.header).to eq("Outright ownership type")
+        expect(page.header).to eq("Type of outright sale")
       end
     end
 

--- a/spec/models/form/sales/pages/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/outright_ownership_type_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Form::Sales::Pages::OutrightOwnershipType, type: :model do
   end
 
   it "has the correct header" do
-    expect(page.header).to be_nil
+    expect(page.header).to eq("Outright ownership type")
   end
 
   it "has the correct description" do

--- a/spec/models/form/sales/pages/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_type_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
       let(:start_date) { Time.utc(2023, 2, 8) }
 
       it "has the correct header" do
-        expect(page.header).to eq("Shared ownership type")
+        expect(page.header).to eq("Type of shared ownership sale")
       end
     end
 

--- a/spec/models/form/sales/pages/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_type_spec.rb
@@ -1,14 +1,30 @@
-require "rails_helper"
+require "rails_hel\per"
 
 RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date:)) }
   let(:start_date) { Time.utc(2022, 4, 1) }
-  let(:form) { instance_double(Form, start_date:) }
-  let(:subsection) { instance_double(Form::Subsection, form:) }
 
+  describe "headers" do
+    context "when 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "has the correct header" do
+        expect(page.header).to eq("Shared ownership type")
+      end
+    end
+
+    context "when before 2023" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "has the correct header" do
+        expect(page.header).to eq(nil)
+      end
+    end
+  end
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
   end
@@ -19,10 +35,6 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
 
   it "has the correct id" do
     expect(page.id).to eq("shared_ownership_type")
-  end
-
-  it "has the correct header" do
-    expect(page.header).to eq("Shared Ownership")
   end
 
   it "has the correct description" do

--- a/spec/models/form/sales/pages/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_type_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
       end
     end
   end
+
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
   end

--- a/spec/models/form/sales/pages/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_type_spec.rb
@@ -1,4 +1,4 @@
-require "rails_hel\per"
+require "rails_helper"
 
 RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
@@ -9,16 +9,16 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
   let(:start_date) { Time.utc(2022, 4, 1) }
 
   describe "headers" do
-    context "when 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
+    context "when form is after the year 2023/24" do
+      let(:start_date) { Time.zone.local(2023, 4, 8) }
 
       it "has the correct header" do
         expect(page.header).to eq("Type of shared ownership sale")
       end
     end
 
-    context "when before 2023" do
-      let(:start_date) { Time.utc(2022, 2, 8) }
+    context "when form is before the year 2023/24" do
+      let(:start_date) { Time.zone.local(2022, 2, 8) }
 
       it "has the correct header" do
         expect(page.header).to eq(nil)

--- a/spec/models/form/sales/pages/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_type_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipType, type: :model do
   end
 
   it "has the correct header" do
-    expect(page.header).to be_nil
+    expect(page.header).to eq("Shared Ownership")
   end
 
   it "has the correct description" do

--- a/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page) }
+  let(:page) { instance_double(Form::Page, subsection:) }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date:)) }
+  let(:start_date) { Time.zone.today }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -41,5 +43,28 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
       "21" => { "value" => "Social HomeBuy for outright purchase" },
       "22" => { "value" => "Any other equity loan scheme" },
     })
+  end
+
+  describe "partial guidance" do
+    context "when the form is for 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "shows shows correct guidance_partial" do
+        expect(question.guidance_partial).to eq("discounted_ownership_type_definitions")
+      end
+
+      it "is at the top" do
+        expect(question.top_guidance?).to eq(true)
+        expect(question.bottom_guidance?).to eq(false)
+      end
+    end
+
+    context "when the form is for before 2023" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "does not show a guidance_partial" do
+        expect(question.guidance_partial).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
   end
 
   describe "partial guidance" do
-    context "when the form is for 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
+    context "when the form is for 2023/24" do
+      let(:start_date) { Time.zone.local(2023, 4, 8) }
 
       it "shows shows correct guidance_partial" do
         expect(question.guidance_partial).to eq("discounted_ownership_type_definitions")
@@ -59,8 +59,8 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
       end
     end
 
-    context "when the form is for before 2023" do
-      let(:start_date) { Time.utc(2022, 2, 8) }
+    context "when the form is for before 2023/24" do
+      let(:start_date) { Time.zone.local(2022, 4, 8) }
 
       it "does not show a guidance_partial" do
         expect(question.guidance_partial).to eq(nil)

--- a/spec/models/form/sales/questions/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/outright_ownership_type_spec.rb
@@ -64,10 +64,8 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
       let(:start_date) { Time.utc(2022, 2, 8) }
 
       it "does not display a guidance partial" do
-        expect(question.guidance_partial).to eq(nil);
+        expect(question.guidance_partial).to eq(nil)
       end
     end
   end
-
-
 end

--- a/spec/models/form/sales/questions/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/outright_ownership_type_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
   end
 
   describe "partial guidance" do
-    context "when the form is for year 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
+    context "when the form is for year 2023/24" do
+      let(:start_date) { Time.zone.local(2023, 4, 8) }
 
       it "has the correct guidance_partial" do
         expect(question.guidance_partial).to eq("outright_sale_type_definitions")
@@ -60,8 +60,8 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
       end
     end
 
-    context "when the form is for before year 2023" do
-      let(:start_date) { Time.utc(2022, 2, 8) }
+    context "when the form is for before year 2023/24" do
+      let(:start_date) { Time.zone.local(2022, 4, 8) }
 
       it "does not display a guidance partial" do
         expect(question.guidance_partial).to eq(nil)

--- a/spec/models/form/sales/questions/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/outright_ownership_type_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page) }
+  let(:page) { instance_double(Form::Page, subsection:) }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date:)) }
+  let(:start_date) { Time.zone.today }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -13,10 +15,6 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
 
   it "has the correct id" do
     expect(question.id).to eq("type")
-  end
-
-  it "has the correct header" do
-    expect(question.header).to eq("What is the type of outright sale?")
   end
 
   it "has the correct check_answer_label" do
@@ -43,4 +41,33 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
       "othtype" => [12],
     })
   end
+
+  it "has the correct header" do
+    expect(question.header).to eq("What is the type of outright sale?")
+  end
+
+  describe "partial guidance" do
+    context "when the form is for year 2023" do
+      let(:start_date) { Time.utc(2023, 2, 8) }
+
+      it "has the correct guidance_partial" do
+        expect(question.guidance_partial).to eq("outright_sale_type_definitions")
+      end
+
+      it "is at the top" do
+        expect(question.top_guidance?).to eq(true)
+        expect(question.bottom_guidance?).to eq(false)
+      end
+    end
+
+    context "when the form is for before year 2023" do
+      let(:start_date) { Time.utc(2022, 2, 8) }
+
+      it "does not display a guidance partial" do
+        expect(question.guidance_partial).to eq(nil);
+      end
+    end
+  end
+
+
 end

--- a/spec/models/form/sales/questions/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/shared_ownership_type_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
 
   context "when form start date is 2022/23" do
     let(:start_date) { Time.zone.local(2022, 4, 1) }
+
     it "has the correct answer_options" do
       expect(question.answer_options).to eq({
         "2" => { "value" => "Shared Ownership" },

--- a/spec/models/form/sales/questions/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/shared_ownership_type_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
         "30" => { "value" => "Shared Ownership - 2021 model lease" },
       })
     end
+
+    it "does not show a guidance_partial" do
+      expect(question.guidance_partial).to eq(nil)
+    end
   end
 
   context "when form start date is 2023" do
@@ -66,6 +70,10 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
         "31" => { "value" => "Right to Shared Ownership (RtSO)" },
         "32" => { "value" => "London Living Rent — Shared Ownership" },
       })
+    end
+
+    it "shows shows correct guidance_partial" do
+      expect(question.guidance_partial).to eq("shared_ownership_type_definitions")
     end
   end
 end

--- a/spec/models/form/sales/questions/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/shared_ownership_type_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:start_date) { Time.utc(2022, 4, 1) }
+  let(:start_date) { Time.zone.local(2022, 4, 1) }
   let(:form) { instance_double(Form, start_date:) }
   let(:subsection) { instance_double(Form::Subsection, form:) }
   let(:page) { instance_double(Form::Page, subsection:) }
@@ -38,7 +38,8 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
     expect(question.hint_text).to eq("A shared ownership sale is when the purchaser buys up to 75% of the property value and pays rent to the Private Registered Provider (PRP) on the remaining portion")
   end
 
-  context "when form start date is 2022" do
+  context "when form start date is 2022/23" do
+    let(:start_date) { Time.zone.local(2022, 4, 1) }
     it "has the correct answer_options" do
       expect(question.answer_options).to eq({
         "2" => { "value" => "Shared Ownership" },
@@ -56,8 +57,8 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
     end
   end
 
-  context "when form start date is 2023" do
-    let(:start_date) { Time.utc(2023, 4, 2) }
+  context "when form start date is 2023/24" do
+    let(:start_date) { Time.zone.local(2023, 4, 2) }
 
     it "has the correct answer_options" do
       expect(question.answer_options).to eq({

--- a/spec/models/form/sales/subsections/setup_spec.rb
+++ b/spec/models/form/sales/subsections/setup_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Subsections::Setup, type: :model do
 
   let(:subsection_id) { nil }
   let(:subsection_definition) { nil }
-  let(:section) { instance_double(Form::Sales::Sections::Setup) }
+  let(:section) { instance_double(Form::Sales::Sections::Setup, form: instance_double(Form, start_date:)) }
+  let(:start_date) { Time.utc(2022, 4, 1) }
 
   it "has correct section" do
     expect(setup.section).to eq(section)


### PR DESCRIPTION
This ticket is concerned with adding an additional details component to three questions each with unique content.
These details components are only to appear when the year of the form is 2023/2024.

**Before :** - and still for years before that are not 2023/24
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/f70f6de1-34e3-4cb3-a504-def984db75bc)

**After : **  
![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/a2c596b2-476d-4262-b71e-8751cc6bbee3)


