### PR TITLE
Multiple DPO ordering test fix

### DIFF
--- a/app/components/data_protection_confirmation_banner_component.rb
+++ b/app/components/data_protection_confirmation_banner_component.rb
@@ -22,7 +22,7 @@ class DataProtectionConfirmationBannerComponent < ViewComponent::Base
 
   def data_protection_officers_text
     if org_or_user_org.data_protection_officers.any?
-      "You can ask: #{org_or_user_org.data_protection_officers.map(&:name).join(', ')}"
+      "You can ask: #{org_or_user_org.data_protection_officers.map(&:name).sort_by(&:downcase).join(', ')}"
     end
   end
 

--- a/spec/components/data_protection_confirmation_banner_component_spec.rb
+++ b/spec/components/data_protection_confirmation_banner_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
           create(:user, organisation:, is_dpo: true, name: "Test McTest")
         end
 
-        it "returns the correct text" do
+        it "returns the correct list of names, in alphabetical order)" do
           expect(component.data_protection_officers_text).to eq("You can ask: Danny Rojas, Test McTest")
         end
       end


### PR DESCRIPTION
Sort dpo names in alphabetical order, which as a side-effect solves test failures caused by ordering not being fixed previously.