### PR TITLE
CLDC-2379 Stop soft validations being applied to fields that are not routed to in bulk upload

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -793,8 +793,10 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
+        next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
+
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)
           end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -538,8 +538,10 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
+        next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
+
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          unless errors.any? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)
           end

--- a/app/services/bulk_upload/sales/year2022/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/row_parser.rb
@@ -1110,8 +1110,10 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
+        next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
+
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)
           end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -1285,8 +1285,10 @@ private
       next if question.completed?(log)
 
       question.page.interruption_screen_question_ids.each do |interruption_screen_question_id|
+        next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
+
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          unless errors.any? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(". ")
             errors.add(field, message: error_message, category: :soft_validation)
           end

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -990,11 +990,23 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
         end
       end
 
+      context "when a soft validation is triggered that relates both to fields that are and are not routed to" do
+        let(:attributes) { setup_section_params.merge({ field_47: "1", field_20: "M", field_21: "M" }) }
+
+        it "adds errors to fields that are routed to" do
+          expect(parser.errors.where(:field_20, category: :soft_validation)).to be_present
+          expect(parser.errors.where(:field_21, category: :soft_validation)).to be_present
+        end
+
+        it "does not add errors to fields that are not routed to" do
+          expect(parser.errors.where(:field_22, category: :soft_validation)).not_to be_present
+          expect(parser.errors.where(:field_23, category: :soft_validation)).not_to be_present
+        end
+      end
+
       context "when soft validation is triggered and the mappings for errors are not defined" do
         let(:attributes) { setup_section_params.merge({ field_12: 22, field_35: 5 }) }
-        # rubocop:disable RSpec/AnyInstance
-        let(:mock_interruption_ids) { allow_any_instance_of(Form::Page).to receive(:interruption_screen_question_ids).and_return(%w[fake_question_id]) }
-        # rubocop:enable RSpec/AnyInstance
+        let(:mock_interruption_ids) { allow_any_instance_of(Form::Page).to receive(:interruption_screen_question_ids).and_return(%w[fake_question_id]) } # rubocop:disable RSpec/AnyInstance
 
         it "does not crash" do
           expect(parser.errors).to be_present

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -49,8 +49,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     FormHandler.instance.use_real_forms!
 
     example.run
-
-    FormHandler.instance.use_fake_forms!
   end
 
   describe "#blank_row?" do
@@ -1016,6 +1014,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "populates with correct error message" do
           expect(parser.errors.where(:field_46, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
           expect(parser.errors.where(:field_50, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
+        end
+      end
+
+      context "when a soft validation is triggered that relates both to fields that are and are not routed to" do
+        let(:attributes) { setup_section_params.merge({ field_82: "1", field_47: "M", field_53: "M", field_57: "M" }) }
+
+        it "adds errors to fields that are routed to" do
+          expect(parser.errors.where(:field_53, category: :soft_validation)).to be_present
+          expect(parser.errors.where(:field_57, category: :soft_validation)).to be_present
+        end
+
+        it "does not add errors to fields that are not routed to" do
+          expect(parser.errors.where(:field_61, category: :soft_validation)).not_to be_present
+          expect(parser.errors.where(:field_65, category: :soft_validation)).not_to be_present
         end
       end
 

--- a/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/row_parser_spec.rb
@@ -112,8 +112,6 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
       Singleton.__init__(FormHandler)
       example.run
     end
-    Timecop.return
-    Singleton.__init__(FormHandler)
   end
 
   describe "#blank_row?" do
@@ -721,6 +719,19 @@ RSpec.describe BulkUpload::Sales::Year2022::RowParser do
         it "populates with correct error message" do
           expect(parser.errors.where(:field_7, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
           expect(parser.errors.where(:field_24, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
+        end
+      end
+
+      context "when a soft validation is triggered that relates both to fields that are and are not routed to" do
+        let(:attributes) { valid_attributes.merge({ field_123: "2" }) }
+
+        it "adds errors to fields that are routed to" do
+          expect(parser.errors.where(:field_123, category: :soft_validation)).to be_present
+        end
+
+        it "does not add errors to fields that are not routed to" do
+          expect(parser.errors.where(:field_73, category: :soft_validation)).not_to be_present
+          expect(parser.errors.where(:field_70, category: :soft_validation)).not_to be_present
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -115,8 +115,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       Singleton.__init__(FormHandler)
       example.run
     end
-    Timecop.return
-    Singleton.__init__(FormHandler)
   end
 
   describe "#blank_row?" do
@@ -869,6 +867,18 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         it "populates with correct error message" do
           expect(parser.errors.where(:field_30, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
           expect(parser.errors.where(:field_30, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
+        end
+      end
+
+      context "when a soft validation is triggered that relates both to fields that are and are not routed to" do
+        let(:attributes) { valid_attributes.merge({ field_103: "300000" }) }
+
+        it "adds errors to fields that are routed to" do
+          expect(parser.errors.where(:field_103, category: :soft_validation)).to be_present
+        end
+
+        it "does not add errors to fields that are not routed to" do
+          expect(parser.errors.where(:field_112, category: :soft_validation)).not_to be_present
         end
       end
     end


### PR DESCRIPTION
As in the screenshots in the [JIRA ticket](https://digital.dclg.gov.uk/jira/browse/CLDC-2379), we have currently been adding soft validations to every field that they could possibly affect in bulk upload.

This PR ensures that soft validations are only added to bulk upload fields that relate to questions in the form that would be routed to