### PR TITLE
CLDC-2471 Add org id to about your org page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -107,10 +107,10 @@ class Organisation < ApplicationRecord
       { name: "Name", value: name, editable: true },
       { name: "Organisation ID", value: "ORG#{id}", editable: false },
       { name: "Address", value: address_string, editable: true },
-      { name: "Telephone_number", value: phone, editable: true },
+      { name: "Telephone number", value: phone, editable: true },
       { name: "Type of provider", value: display_provider_type, editable: false },
       { name: "Registration number", value: housing_registration_no || "", editable: false },
-      { name: "Rent_periods", value: rent_period_labels, editable: false, format: :bullet },
+      { name: "Rent periods", value: rent_period_labels, editable: false, format: :bullet },
       { name: "Owns housing stock", value: holds_own_stock ? "Yes" : "No", editable: false },
     ].compact
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -105,6 +105,7 @@ class Organisation < ApplicationRecord
   def display_organisation_attributes
     attrs = [
       { name: "Name", value: name, editable: true },
+      { name: "Organisation ID", value: "ORG#{id}", editable: false },
       { name: "Address", value: address_string, editable: true },
       { name: "Telephone_number", value: phone, editable: true },
       { name: "Type of provider", value: display_provider_type, editable: false },

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -17,7 +17,7 @@
       <% @organisation.display_organisation_attributes.each do |attr| %>
         <% if can_edit_org?(current_user) && attr[:editable] %>
           <%= summary_list.row do |row| %>
-            <% row.key { attr[:name].to_s.humanize } %>
+            <% row.key { attr[:name] } %>
             <% row.value { details_html(attr) } %>
             <% row.action(
               visually_hidden_text: attr[:name].to_s.humanize.downcase,
@@ -27,7 +27,7 @@
           <% end %>
         <% else %>
           <%= summary_list.row do |row| %>
-            <% row.key { attr[:name].to_s.humanize } %>
+            <% row.key { attr[:name] } %>
             <% row.value { details_html(attr) } %>
             <% row.action %>
           <% end %>

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Organisation, type: :model do
       it "does not include data protection agreement" do
         expect(organisation.display_organisation_attributes).to eq(
           [{ editable: true, name: "Name", value: "DLUHC" },
-           { name: "Organisation ID", value: "ORG#{organisation.id}", editable: false },
+           { editable: false, name: "Organisation ID", value: "ORG#{organisation.id}" },
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -246,10 +246,10 @@ RSpec.describe Organisation, type: :model do
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },
-           { editable: true, name: "Telephone_number", value: nil },
+           { editable: true, name: "Telephone number", value: nil },
            { editable: false, name: "Type of provider", value: "Local authority" },
            { editable: false, name: "Registration number", value: "1234" },
-           { editable: false, format: :bullet, name: "Rent_periods", value: %w[All] },
+           { editable: false, format: :bullet, name: "Rent periods", value: %w[All] },
            { editable: false, name: "Owns housing stock", value: "Yes" }],
         )
       end
@@ -267,10 +267,10 @@ RSpec.describe Organisation, type: :model do
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },
-           { editable: true, name: "Telephone_number", value: nil },
+           { editable: true, name: "Telephone number", value: nil },
            { editable: false, name: "Type of provider", value: "Local authority" },
            { editable: false, name: "Registration number", value: "1234" },
-           { editable: false, format: :bullet, name: "Rent_periods", value: %w[All] },
+           { editable: false, format: :bullet, name: "Rent periods", value: %w[All] },
            { editable: false, name: "Owns housing stock", value: "Yes" },
            { editable: false, name: "Data protection agreement", value: "Accepted" }],
         )

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Organisation, type: :model do
       it "includes data protection agreement" do
         expect(organisation.display_organisation_attributes).to eq(
           [{ editable: true, name: "Name", value: "DLUHC" },
-           { editable: false, name: "Organisation ID", value: "ORG#{organisation.id}"},
+           { editable: false, name: "Organisation ID", value: "ORG#{organisation.id}" },
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe Organisation, type: :model do
       it "does not include data protection agreement" do
         expect(organisation.display_organisation_attributes).to eq(
           [{ editable: true, name: "Name", value: "DLUHC" },
+           { name: "Organisation ID", value: "ORG#{organisation.id}", editable: false },
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },
@@ -262,6 +263,7 @@ RSpec.describe Organisation, type: :model do
       it "includes data protection agreement" do
         expect(organisation.display_organisation_attributes).to eq(
           [{ editable: true, name: "Name", value: "DLUHC" },
+           { editable: false, name: "Organisation ID", value: "ORG#{organisation.id}"},
            { editable: true,
              name: "Address",
              value: "2 Marsham Street\nLondon\nSW1P 4DF" },

--- a/spec/requests/delete_logs_controller_spec.rb
+++ b/spec/requests/delete_logs_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "DeleteLogs", type: :request do
     end
 
     before do
-      post delete_logs_confirmation_lettings_logs_path, params: params
+      post delete_logs_confirmation_lettings_logs_path, params:
     end
 
     it "requires delete logs form data to be provided" do
@@ -188,7 +188,7 @@ RSpec.describe "DeleteLogs", type: :request do
       end
 
       before do
-        post delete_logs_confirmation_lettings_logs_path, params: params
+        post delete_logs_confirmation_lettings_logs_path, params:
       end
 
       it "renders the list of logs table again" do
@@ -358,7 +358,7 @@ RSpec.describe "DeleteLogs", type: :request do
     end
 
     before do
-      post delete_logs_confirmation_sales_logs_path, params: params
+      post delete_logs_confirmation_sales_logs_path, params:
     end
 
     it "requires delete logs form data to be provided" do
@@ -428,7 +428,7 @@ RSpec.describe "DeleteLogs", type: :request do
       end
 
       before do
-        post delete_logs_confirmation_sales_logs_path, params: params
+        post delete_logs_confirmation_sales_logs_path, params:
       end
 
       it "renders the list of logs table again" do
@@ -602,7 +602,7 @@ RSpec.describe "DeleteLogs", type: :request do
       end
 
       before do
-        post delete_lettings_logs_confirmation_organisation_path(id: organisation), params: params
+        post delete_lettings_logs_confirmation_organisation_path(id: organisation), params:
       end
 
       it "requires delete logs form data to be provided" do
@@ -827,7 +827,7 @@ RSpec.describe "DeleteLogs", type: :request do
       end
 
       before do
-        post delete_sales_logs_confirmation_organisation_path(id: organisation), params: params
+        post delete_sales_logs_confirmation_organisation_path(id: organisation), params:
       end
 
       it "requires delete logs form data to be provided" do


### PR DESCRIPTION
This just adds the new CORE id (prepended with "ORG") to the about your org page.

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2471

looks like this: 
<img width="872" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/94526761/085d35ac-176d-4a5c-9c07-c8a1beb66633">
