### PR TITLE
CLDC-2459 Update end date for new logs creation

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -208,7 +208,7 @@ private
   def check_collection_period
     return unless @log
 
-    redirect_to lettings_log_path(@log) unless @log.collection_period_open?
+    redirect_to lettings_log_path(@log) unless @log.collection_period_open_for_editing?
   end
 
   CONFIRMATION_PAGE_IDS = %w[uprn_confirmation].freeze

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -46,7 +46,7 @@ class Form
       @submission_deadline = Time.zone.local(2023, 6, 9)
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]
     end
-    @edit_end_date = @new_logs_end_date
+    @edit_end_date = @new_logs_end_date + 2.months # it depends on the year and QA activities, but it would always be later than new logs end date
     @name = "#{start_date.year}_#{new_logs_end_date.year}_#{type}"
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,7 +6,7 @@ class Form
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
     if sales_or_start_year_after_2022?(type, start_year)
       @start_date = Time.zone.local(start_year, 4, 1)
-      @new_logs_end_date = Time.zone.local(start_year + 1, 12, 29)  # this is to be manually updated each year when we want to stop users from creating new logs
+      @new_logs_end_date = Time.zone.local(start_year + 1, 12, 31)  # this is to be manually updated each year when we want to stop users from creating new logs
       @submission_deadline = if start_year && start_year.to_i > 2022
                                Time.zone.local(start_year + 1, 6, 7)
                              else
@@ -39,7 +39,7 @@ class Form
       @pages = subsections.flat_map(&:pages)
       @questions = pages.flat_map(&:questions)
       @start_date = Time.iso8601(form_definition["start_date"])
-      @new_logs_end_date = Time.zone.local(@start_date.year + 1, 12, 29)
+      @new_logs_end_date = Time.zone.local(@start_date.year + 1, 12, 31)
       @submission_deadline = Time.zone.local(@start_date.year + 1, 6, 9)
       @edit_end_date = Time.zone.local(@start_date.year + 1, 12, 31)
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,11 +6,7 @@ class Form
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
     if sales_or_start_year_after_2022?(type, start_year)
       @start_date = Time.zone.local(start_year, 4, 1)
-      @new_logs_end_date = if start_year && start_year.to_i > 2022
-                             Time.zone.local(start_year + 1, 6, 9)
-                           else
-                             Time.zone.local(start_year + 1, 8, 7)
-                           end
+      @new_logs_end_date = Time.zone.local(start_year + 1, 12, 29)  # this is to be manually updated each year when we want to stop users from creating new logs
       @submission_deadline = if start_year && start_year.to_i > 2022
                                Time.zone.local(start_year + 1, 6, 7)
                              else
@@ -43,7 +39,7 @@ class Form
       @pages = subsections.flat_map(&:pages)
       @questions = pages.flat_map(&:questions)
       @start_date = Time.iso8601(form_definition["start_date"])
-      @new_logs_end_date = Time.iso8601(form_definition["end_date"])
+      @new_logs_end_date = Time.zone.local(@start_date.year + 1, 12, 29)
       @submission_deadline = Time.zone.local(@start_date.year + 1, 6, 9)
       @edit_end_date = Time.zone.local(@start_date.year + 1, 12, 31)
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -30,6 +30,7 @@ class Form
         "sections" => sections,
       }
       @unresolved_log_redirect_page_id = "tenancy_start_date" if type == "lettings"
+      @edit_end_date = Time.zone.local(start_year + 1, 12, 31) # this is to be manually updated each year when we want to stop users from editing logs
     else
       raise "No form definition file exists for given year".freeze unless File.exist?(form_path)
 
@@ -43,10 +44,10 @@ class Form
       @questions = pages.flat_map(&:questions)
       @start_date = Time.iso8601(form_definition["start_date"])
       @new_logs_end_date = Time.iso8601(form_definition["end_date"])
-      @submission_deadline = Time.zone.local(2023, 6, 9)
+      @submission_deadline = Time.zone.local(@start_date.year + 1, 6, 9)
+      @edit_end_date = Time.zone.local(@start_date.year + 1, 12, 31)
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]
     end
-    @edit_end_date = @new_logs_end_date + 2.months # it depends on the year and QA activities, but it would always be later than new logs end date
     @name = "#{start_date.year}_#{new_logs_end_date.year}_#{type}"
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,16 +1,16 @@
 class Form
   attr_reader :form_definition, :sections, :subsections, :pages, :questions,
-              :start_date, :end_date, :submission_deadline, :type, :name, :setup_definition,
+              :start_date, :new_logs_end_date, :submission_deadline, :type, :name, :setup_definition,
               :setup_sections, :form_sections, :unresolved_log_redirect_page_id, :edit_end_date
 
   def initialize(form_path, start_year = "", sections_in_form = [], type = "lettings")
     if sales_or_start_year_after_2022?(type, start_year)
       @start_date = Time.zone.local(start_year, 4, 1)
-      @end_date = if start_year && start_year.to_i > 2022
-                    Time.zone.local(start_year + 1, 6, 9)
-                  else
-                    Time.zone.local(start_year + 1, 8, 7)
-                  end
+      @new_logs_end_date = if start_year && start_year.to_i > 2022
+                             Time.zone.local(start_year + 1, 6, 9)
+                           else
+                             Time.zone.local(start_year + 1, 8, 7)
+                           end
       @submission_deadline = if start_year && start_year.to_i > 2022
                                Time.zone.local(start_year + 1, 6, 7)
                              else
@@ -26,7 +26,7 @@ class Form
       @form_definition = {
         "form_type" => type,
         "start_date" => start_date,
-        "end_date" => end_date,
+        "end_date" => new_logs_end_date,
         "sections" => sections,
       }
       @unresolved_log_redirect_page_id = "tenancy_start_date" if type == "lettings"
@@ -42,12 +42,12 @@ class Form
       @pages = subsections.flat_map(&:pages)
       @questions = pages.flat_map(&:questions)
       @start_date = Time.iso8601(form_definition["start_date"])
-      @end_date = Time.iso8601(form_definition["end_date"])
+      @new_logs_end_date = Time.iso8601(form_definition["end_date"])
       @submission_deadline = Time.zone.local(2023, 6, 9)
       @unresolved_log_redirect_page_id = form_definition["unresolved_log_redirect_page_id"]
     end
-    @edit_end_date = @end_date
-    @name = "#{start_date.year}_#{end_date.year}_#{type}"
+    @edit_end_date = @new_logs_end_date
+    @name = "#{start_date.year}_#{new_logs_end_date.year}_#{type}"
   end
 
   def get_subsection(id)
@@ -304,7 +304,7 @@ class Form
   end
 
   def valid_start_date_for_form?(start_date)
-    start_date >= self.start_date && start_date <= end_date
+    start_date >= self.start_date && start_date <= new_logs_end_date
   end
 
   def sales_or_start_year_after_2022?(type, start_year)

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -112,6 +112,11 @@ class FormHandler
     forms.count { |form| now.between?(form.start_date, form.new_logs_end_date) } > 1
   end
 
+  def lettings_in_edit_crossover_period?(now: Time.zone.now)
+    forms = lettings_forms.values
+    forms.count { |form| now.between?(form.start_date, form.edit_end_date) } > 1
+  end
+
   def sales_in_crossover_period?(now: Time.zone.now)
     forms = sales_forms.values
     forms.count { |form| now.between?(form.start_date, form.new_logs_end_date) } > 1

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -109,12 +109,12 @@ class FormHandler
 
   def lettings_in_crossover_period?(now: Time.zone.now)
     forms = lettings_forms.values
-    forms.count { |form| now.between?(form.start_date, form.end_date) } > 1
+    forms.count { |form| now.between?(form.start_date, form.new_logs_end_date) } > 1
   end
 
   def sales_in_crossover_period?(now: Time.zone.now)
     forms = sales_forms.values
-    forms.count { |form| now.between?(form.start_date, form.end_date) } > 1
+    forms.count { |form| now.between?(form.start_date, form.new_logs_end_date) } > 1
   end
 
   def use_fake_forms!(fake_forms = nil)

--- a/app/models/form_handler.rb
+++ b/app/models/form_handler.rb
@@ -122,6 +122,11 @@ class FormHandler
     forms.count { |form| now.between?(form.start_date, form.new_logs_end_date) } > 1
   end
 
+  def sales_in_edit_crossover_period?(now: Time.zone.now)
+    forms = sales_forms.values
+    forms.count { |form| now.between?(form.start_date, form.edit_end_date) } > 1
+  end
+
   def use_fake_forms!(fake_forms = nil)
     @directories = ["spec/fixtures/forms"]
     @forms = fake_forms || get_all_forms

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -97,6 +97,12 @@ class Log < ApplicationRecord
     form.new_logs_end_date > Time.zone.today
   end
 
+  def collection_period_open_for_editing?
+    return false if older_than_previous_collection_year?
+
+    form.edit_end_date > Time.zone.today
+  end
+
   def blank_invalid_non_setup_fields!
     setup_ids = form.setup_sections.flat_map(&:subsections).flat_map(&:questions).map(&:id)
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -94,7 +94,7 @@ class Log < ApplicationRecord
   def collection_period_open?
     return false if older_than_previous_collection_year?
 
-    form.end_date > Time.zone.today
+    form.new_logs_end_date > Time.zone.today
   end
 
   def blank_invalid_non_setup_fields!

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -5,7 +5,13 @@ module Validations::SetupValidations
   def validate_startdate_setup(record)
     return unless record.startdate && date_valid?("startdate", record)
 
-    unless record.startdate.between?(active_collection_start_date, current_collection_end_date)
+    first_collection_start_date = if record.startdate_was.present?
+                                    editable_collection_start_date
+                                  else
+                                    active_collection_start_date
+                                  end
+
+    unless record.startdate.between?(first_collection_start_date, current_collection_end_date)
       record.errors.add :startdate, startdate_validation_error_message
     end
   end
@@ -54,6 +60,14 @@ private
 
   def active_collection_start_date
     if FormHandler.instance.lettings_in_crossover_period?
+      previous_collection_start_date
+    else
+      current_collection_start_date
+    end
+  end
+
+  def editable_collection_start_date
+    if FormHandler.instance.lettings_in_edit_crossover_period?
       previous_collection_start_date
     else
       current_collection_start_date

--- a/app/services/bulk_upload/lettings/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/csv_parser.rb
@@ -63,7 +63,7 @@ class BulkUpload::Lettings::Year2022::CsvParser
   end
 
   def wrong_template_for_year?
-    !(first_record_start_date >= form.start_date && first_record_start_date <= form.end_date)
+    !(first_record_start_date >= form.start_date && first_record_start_date <= form.new_logs_end_date)
   end
 
 private

--- a/app/services/bulk_upload/sales/year2022/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2022/csv_parser.rb
@@ -45,7 +45,7 @@ class BulkUpload::Sales::Year2022::CsvParser
   end
 
   def wrong_template_for_year?
-    !(first_record_sale_date >= form.start_date && first_record_sale_date <= form.end_date)
+    !(first_record_sale_date >= form.start_date && first_record_sale_date <= form.new_logs_end_date)
   end
 
 private

--- a/app/views/form/_check_answers_summary_list.html.erb
+++ b/app/views/form/_check_answers_summary_list.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       <% end %>
 
-      <% if @log.collection_period_open? %>
+      <% if @log.collection_period_open_for_editing? %>
         <% row.action(
           text: question.action_text(@log),
           href: action_href(@log, question.page.id, referrer),

--- a/docs/adr/adr-019-form-end-dates.md
+++ b/docs/adr/adr-019-form-end-dates.md
@@ -13,5 +13,5 @@ Also, if incorrect data is found during QA process, data providers might be aske
 
 To accommodate the different end dates, we will now store 3 different dates on the form definition:
 - Submission deadline (submission_deadline) - this is the date displayed at the top of a completed log in lettings and sales - "You can review and make changes to this log until 9 June 2024.". Nothing happens on this date
-- New logs end date (end_date) - no new logs for that collection year can be submitted, but logs can be edited
+- New logs end date (new_logs_end_date) - no new logs for that collection year can be submitted, but logs can be edited
 - Edit and delete logs end date (edit_end_date) - logs can no longer be edited or deleted. Completed logs can still be viewed. Materials / references to the collection year are removed.

--- a/spec/features/bulk_upload_lettings_logs_spec.rb
+++ b/spec/features/bulk_upload_lettings_logs_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Bulk upload lettings log" do
 
   context "when not it crossover period" do
     it "shows journey with year option" do
-      Timecop.freeze(2023, 10, 1) do
+      Timecop.freeze(2024, 1, 1) do
         visit("/lettings-logs")
         expect(page).to have_link("Upload lettings logs in bulk")
         click_link("Upload lettings logs in bulk")
@@ -98,7 +98,7 @@ RSpec.describe "Bulk upload lettings log" do
 
   context "when the collection year isn't 22/23" do
     it "shows journey without the needstype" do
-      Timecop.freeze(2023, 10, 1) do
+      Timecop.freeze(2024, 1, 1) do
         visit("/lettings-logs")
         expect(page).to have_link("Upload lettings logs in bulk")
         click_link("Upload lettings logs in bulk")

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Accessible Autocomplete" do
   end
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/check_answers_page_lettings_logs_spec.rb
+++ b/spec/features/form/check_answers_page_lettings_logs_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Lettings Log Check Answers Page" do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
-    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/features/form/checkboxes_spec.rb
+++ b/spec/features/form/checkboxes_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Checkboxes" do
   end
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     RequestHelper.stub_http_requests
     sign_in user
   end

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Form Conditional Questions" do
 
   before do
     sign_in user
-    allow(sales_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(sales_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "Form Navigation" do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
-    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/features/form/page_routing_spec.rb
+++ b/spec/features/form/page_routing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Form Page Routing" do
   let(:validator) { lettings_log._validators[nil].first }
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/progressive_total_field_spec.rb
+++ b/spec/features/form/progressive_total_field_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Accessible Autocomplete" do
   end
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/saving_data_spec.rb
+++ b/spec/features/form/saving_data_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Form Saving Data" do
   end
 
   before do
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/tasklist_page_spec.rb
+++ b/spec/features/form/tasklist_page_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Task List" do
   before do
     Timecop.freeze(Time.zone.local(2021, 5, 1))
     setup_completed_log.update!(startdate: Time.zone.local(2021, 5, 1))
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
   end
 

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "validations" do
   let(:id) { lettings_log.id }
 
   before do
-    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
-    allow(lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     sign_in user
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe LocationsHelper do
     let(:location) { FactoryBot.create(:location, startdate: nil) }
 
     before do
-      Timecop.freeze(2022, 10, 10)
+      Timecop.freeze(2023, 10, 10)
     end
 
     after do
@@ -201,7 +201,7 @@ RSpec.describe LocationsHelper do
     context "when viewing availability" do
       context "with no deactivations" do
         it "displays current collection start date as availability date if created_at is later than collection start date" do
-          location.update!(startdate: nil, created_at: Time.zone.local(2023, 8, 16))
+          location.update!(startdate: nil, created_at: Time.zone.local(2024, 1, 16))
           availability_attribute = display_location_attributes(location).find { |x| x[:name] == "Availability" }[:value]
 
           expect(availability_attribute).to eq("Active from 1 April 2023")

--- a/spec/helpers/schemes_helper_spec.rb
+++ b/spec/helpers/schemes_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SchemesHelper do
     let(:scheme) { FactoryBot.create(:scheme, created_at: Time.zone.today) }
 
     before do
-      Timecop.freeze(2022, 10, 10)
+      Timecop.freeze(2023, 1, 10)
     end
 
     after do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Form, type: :model do
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
       expect(form.new_logs_end_date).to eq(Time.zone.parse("2023-08-07"))
-      expect(form.edit_end_date).to eq(Time.zone.parse("2023-08-07"))
+      expect(form.edit_end_date).to eq(Time.zone.parse("2023-10-07"))
       expect(form.submission_deadline).to eq(Time.zone.parse("2023-06-09"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -371,7 +371,9 @@ RSpec.describe Form, type: :model do
       expect(form.questions.count).to eq(13)
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
-      expect(form.end_date).to eq(Time.zone.parse("2023-08-07"))
+      expect(form.new_logs_end_date).to eq(Time.zone.parse("2023-08-07"))
+      expect(form.edit_end_date).to eq(Time.zone.parse("2023-08-07"))
+      expect(form.submission_deadline).to eq(Time.zone.parse("2023-06-09"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)
     end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Form, type: :model do
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
       expect(form.new_logs_end_date).to eq(Time.zone.parse("2023-08-07"))
-      expect(form.edit_end_date).to eq(Time.zone.parse("2023-10-07"))
+      expect(form.edit_end_date).to eq(Time.zone.parse("2023-12-31"))
       expect(form.submission_deadline).to eq(Time.zone.parse("2023-06-09"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe Form, type: :model do
       expect(form.questions.count).to eq(13)
       expect(form.questions.first.id).to eq("owning_organisation_id")
       expect(form.start_date).to eq(Time.zone.parse("2022-04-01"))
-      expect(form.new_logs_end_date).to eq(Time.zone.parse("2023-08-07"))
+      expect(form.new_logs_end_date).to eq(Time.zone.parse("2023-12-31"))
       expect(form.edit_end_date).to eq(Time.zone.parse("2023-12-31"))
       expect(form.submission_deadline).to eq(Time.zone.parse("2023-06-09"))
       expect(form.unresolved_log_redirect_page_id).to eq(nil)

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -3040,7 +3040,7 @@ RSpec.describe LettingsLog do
       let(:startdate) { nil }
 
       before do
-        allow(log).to receive_message_chain(:form, :end_date).and_return(Time.zone.now + 1.day)
+        allow(log).to receive_message_chain(:form, :new_logs_end_date).and_return(Time.zone.now + 1.day)
       end
 
       it "returns true" do
@@ -3052,7 +3052,7 @@ RSpec.describe LettingsLog do
       let(:startdate) { Time.zone.local(2020, 4, 1) }
 
       before do
-        allow(log).to receive_message_chain(:form, :end_date).and_return(Time.zone.now - 1.day)
+        allow(log).to receive_message_chain(:form, :new_logs_end_date).and_return(Time.zone.now - 1.day)
       end
 
       it "returns false" do

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -635,7 +635,7 @@ RSpec.describe SalesLog, type: :model do
       let(:saledate) { nil }
 
       before do
-        allow(log).to receive_message_chain(:form, :end_date).and_return(Time.zone.now + 1.day)
+        allow(log).to receive_message_chain(:form, :new_logs_end_date).and_return(Time.zone.now + 1.day)
       end
 
       it "returns true" do
@@ -647,7 +647,7 @@ RSpec.describe SalesLog, type: :model do
       let(:saledate) { Time.zone.local(2020, 4, 1) }
 
       before do
-        allow(log).to receive_message_chain(:form, :end_date).and_return(Time.zone.now - 1.day)
+        allow(log).to receive_message_chain(:form, :new_logs_end_date).and_return(Time.zone.now - 1.day)
       end
 
       it "returns false" do

--- a/spec/models/validations/sales/setup_validations_spec.rb
+++ b/spec/models/validations/sales/setup_validations_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Validations::Sales::SetupValidations do
         end
       end
 
-      context "when after the new logs end date but before edit end date for the previous period" do
+      context "when current time is after the new logs end date but before edit end date for the previous period" do
         let(:record) { build(:sales_log, saledate: Time.zone.local(2025, 4, 1)) }
 
         before do
@@ -120,7 +120,7 @@ RSpec.describe Validations::Sales::SetupValidations do
           expect(record.errors["saledate"]).to include(match "Enter a date within the 24/25 collection year, which is between 1st April 2024 and 31st March 2025")
         end
 
-        it "can edit already created logs logs for the previous collection year" do
+        it "can edit already created logs for the previous collection year" do
           record.saledate = Time.zone.local(2024, 1, 2)
           record.save!(validate: false)
           record.saledate = Time.zone.local(2024, 1, 1)
@@ -143,7 +143,7 @@ RSpec.describe Validations::Sales::SetupValidations do
           expect(record.errors["saledate"]).to include(match "Enter a date within the 24/25 collection year, which is between 1st April 2024 and 31st March 2025")
         end
 
-        it "cannot edit already created logs logs for the previous collection year" do
+        it "cannot edit already created logs for the previous collection year" do
           record.saledate = Time.zone.local(2024, 1, 2)
           record.save!(validate: false)
           record.saledate = Time.zone.local(2024, 1, 1)

--- a/spec/models/validations/sales/setup_validations_spec.rb
+++ b/spec/models/validations/sales/setup_validations_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Validations::Sales::SetupValidations do
         let(:record) { build(:sales_log, saledate: Time.zone.local(2025, 4, 1)) }
 
         before do
-          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 8, 8))
+          allow(Time).to receive(:now).and_return(Time.zone.local(2025, 1, 8))
         end
 
         it "cannot create new logs for the previous collection year" do
@@ -120,7 +120,7 @@ RSpec.describe Validations::Sales::SetupValidations do
           expect(record.errors["saledate"]).to include(match "Enter a date within the 24/25 collection year, which is between 1st April 2024 and 31st March 2025")
         end
 
-        it "can edit already created logs for the previous collection year" do
+        xit "can edit already created logs for the previous collection year" do
           record.saledate = Time.zone.local(2024, 1, 2)
           record.save!(validate: false)
           record.saledate = Time.zone.local(2024, 1, 1)

--- a/spec/models/validations/sales/setup_validations_spec.rb
+++ b/spec/models/validations/sales/setup_validations_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Validations::Sales::SetupValidations do
         let(:record) { build(:sales_log, saledate: Time.zone.local(2025, 4, 1)) }
 
         before do
-          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 12, 8))
+          allow(Time).to receive(:now).and_return(Time.zone.local(2025, 1, 8))
         end
 
         it "cannot create new logs for the previous collection year" do

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -85,6 +85,48 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
         end
       end
+
+      context "when after the new logs end date but before edit end date for the previous period" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.zone.local(2023, 8, 8))
+        end
+
+        it "cannot create new logs for the previous collection year" do
+          record.update!(startdate: nil)
+          record.startdate = Time.zone.local(2023, 1, 1)
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
+        end
+
+        it "can edit already created logs logs for the previous collection year" do
+          record.startdate = Time.zone.local(2023, 1, 2)
+          record.save!(validate: false)
+          record.startdate = Time.zone.local(2023, 1, 1)
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).not_to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
+        end
+      end
+
+      context "when after the new logs end date and after the edit end date for the previous period" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.zone.local(2023, 12, 8))
+        end
+
+        it "cannot create new logs for the previous collection year" do
+          record.update!(startdate: nil)
+          record.startdate = Time.zone.local(2023, 1, 1)
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
+        end
+
+        it "cannot edit already created logs logs for the previous collection year" do
+          record.startdate = Time.zone.local(2023, 1, 2)
+          record.save!(validate: false)
+          record.startdate = Time.zone.local(2023, 1, 1)
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
+        end
+      end
     end
   end
 

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
         end
 
-        it "can edit already created logs logs for the previous collection year" do
+        it "can edit already created logs for the previous collection year" do
           record.startdate = Time.zone.local(2023, 1, 2)
           record.save!(validate: false)
           record.startdate = Time.zone.local(2023, 1, 1)
@@ -119,7 +119,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
         end
 
-        it "cannot edit already created logs logs for the previous collection year" do
+        it "cannot edit already created logs for the previous collection year" do
           record.startdate = Time.zone.local(2023, 1, 2)
           record.save!(validate: false)
           record.startdate = Time.zone.local(2023, 1, 1)

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Validations::SetupValidations do
 
       context "when after the new logs end date but before edit end date for the previous period" do
         before do
-          allow(Time).to receive(:now).and_return(Time.zone.local(2023, 8, 8))
+          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 1, 8))
         end
 
         it "cannot create new logs for the previous collection year" do
@@ -98,7 +98,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date within the 23/24 collection year, which is between 1st April 2023 and 31st March 2024")
         end
 
-        it "can edit already created logs for the previous collection year" do
+        xit "can edit already created logs for the previous collection year" do
           record.startdate = Time.zone.local(2023, 1, 2)
           record.save!(validate: false)
           record.startdate = Time.zone.local(2023, 1, 1)

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Validations::SetupValidations do
 
       context "when after the new logs end date and after the edit end date for the previous period" do
         before do
-          allow(Time).to receive(:now).and_return(Time.zone.local(2023, 12, 8))
+          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 1, 8))
         end
 
         it "cannot create new logs for the previous collection year" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FormController, type: :request do
 
   before do
     allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:edit_end_date).and_return(Time.zone.today + 2.months)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 
@@ -764,6 +765,7 @@ RSpec.describe FormController, type: :request do
             completed_lettings_log.update!(ecstat1: 1, earnings: 130, hhmemb: 1) # we're not routing to that page, so it gets cleared?
             allow(completed_lettings_log).to receive(:net_income_soft_validation_triggered?).and_return(true)
             allow(completed_lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+            allow(completed_lettings_log.form).to receive(:edit_end_date).and_return(Time.zone.today + 2.months)
             post "/lettings-logs/#{completed_lettings_log.id}/net-income-value-check", params: interrupt_params, headers: headers.merge({ "HTTP_REFERER" => referrer })
           end
 

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FormController, type: :request do
   let(:fake_2021_2022_form) { Form.new("spec/fixtures/forms/2021_2022.json") }
 
   before do
-    allow(fake_2021_2022_form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+    allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 
@@ -763,7 +763,7 @@ RSpec.describe FormController, type: :request do
           before do
             completed_lettings_log.update!(ecstat1: 1, earnings: 130, hhmemb: 1) # we're not routing to that page, so it gets cleared?
             allow(completed_lettings_log).to receive(:net_income_soft_validation_triggered?).and_return(true)
-            allow(completed_lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+            allow(completed_lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
             post "/lettings-logs/#{completed_lettings_log.id}/net-income-value-check", params: interrupt_params, headers: headers.merge({ "HTTP_REFERER" => referrer })
           end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -937,7 +937,7 @@ RSpec.describe LettingsLogsController, type: :request do
               completed_lettings_log.reload
 
               get "/lettings-logs/#{completed_lettings_log.id}", headers:, params: {}
-              expect(completed_lettings_log.form.new_logs_end_date).to eq(Time.zone.local(2023, 7, 1))
+              expect(completed_lettings_log.form.new_logs_end_date).to eq(Time.zone.local(2023, 12, 31))
               expect(completed_lettings_log.status).to eq("completed")
               expect(page).to have_link("review and make changes to this log", href: "/lettings-logs/#{completed_lettings_log.id}/review")
             end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -937,14 +937,14 @@ RSpec.describe LettingsLogsController, type: :request do
               completed_lettings_log.reload
 
               get "/lettings-logs/#{completed_lettings_log.id}", headers:, params: {}
-              expect(completed_lettings_log.form.end_date).to eq(Time.zone.local(2023, 7, 1))
+              expect(completed_lettings_log.form.new_logs_end_date).to eq(Time.zone.local(2023, 7, 1))
               expect(completed_lettings_log.status).to eq("completed")
               expect(page).to have_link("review and make changes to this log", href: "/lettings-logs/#{completed_lettings_log.id}/review")
             end
 
             xit "displays a closed collection window message for previous collection year logs" do
               get "/lettings-logs/#{completed_lettings_log.id}", headers:, params: {}
-              expect(completed_lettings_log.form.end_date).to eq(Time.zone.local(2022, 7, 1))
+              expect(completed_lettings_log.form.new_logs_end_date).to eq(Time.zone.local(2022, 7, 1))
               expect(completed_lettings_log.status).to eq("completed")
               expect(page).to have_content("This log is from the 2021/2022 collection window, which is now closed.")
             end
@@ -1198,7 +1198,7 @@ RSpec.describe LettingsLogsController, type: :request do
       let(:headers) { { "Accept" => "text/html" } }
 
       before do
-        allow(affected_lettings_log.form).to receive(:end_date).and_return(Time.zone.today + 1.day)
+        allow(affected_lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
       end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1095,6 +1095,24 @@ RSpec.describe LettingsLogsController, type: :request do
         expect(page).not_to have_link("Answer")
       end
 
+      context "when the edit end date is in the future" do
+        before do
+          Timecop.freeze(2022, 7, 5)
+        end
+
+        after do
+          Timecop.return
+        end
+
+        it "allows you to change the answers for previous collection year logs" do
+          get "/lettings-logs/#{completed_lettings_log.id}/setup/check-answers", headers: { "Accept" => "text/html" }, params: {}
+          expect(page).to have_link("Change")
+
+          get "/lettings-logs/#{completed_lettings_log.id}/income-and-benefits/check-answers", headers: { "Accept" => "text/html" }, params: {}
+          expect(page).to have_link("Change")
+        end
+      end
+
       it "does not let the user navigate to questions for previous collection year logs" do
         get "/lettings-logs/#{completed_lettings_log.id}/needs-type", headers: { "Accept" => "text/html" }, params: {}
         expect(response).to redirect_to("/lettings-logs/#{completed_lettings_log.id}")

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1111,6 +1111,11 @@ RSpec.describe LettingsLogsController, type: :request do
           get "/lettings-logs/#{completed_lettings_log.id}/income-and-benefits/check-answers", headers: { "Accept" => "text/html" }, params: {}
           expect(page).to have_link("Change")
         end
+
+        it "lets the user navigate to questions for previous collection year logs" do
+          get "/lettings-logs/#{completed_lettings_log.id}/needs-type", headers: { "Accept" => "text/html" }, params: {}
+          expect(response).to have_http_status(:ok)
+        end
       end
 
       it "does not let the user navigate to questions for previous collection year logs" do
@@ -1216,7 +1221,7 @@ RSpec.describe LettingsLogsController, type: :request do
       let(:headers) { { "Accept" => "text/html" } }
 
       before do
-        allow(affected_lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+        allow(affected_lettings_log.form).to receive(:edit_end_date).and_return(Time.zone.today + 1.day)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
       end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1401,7 +1401,7 @@ RSpec.describe LocationsController, type: :request do
       let(:setup_locations) { nil }
 
       before do
-        Timecop.freeze(Time.utc(2022, 10, 10))
+        Timecop.freeze(Time.utc(2023, 10, 10))
         sign_in user
         add_deactivations
         setup_locations
@@ -1608,7 +1608,7 @@ RSpec.describe LocationsController, type: :request do
         end
       end
 
-      context "when the date is entered is before the beginning of current collection window" do
+      context "when the date entered is before the beginning of current collection window" do
         let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "10", "deactivation_date(2i)": "4", "deactivation_date(1i)": "2020" } } }
 
         it "displays the new page with an error message" do
@@ -1656,9 +1656,9 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "when there is an earlier open deactivation" do
-        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
-        let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2023" } } }
-        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, location:) }
+        let(:deactivation_date) { Time.zone.local(2023, 10, 10) }
+        let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2024" } } }
+        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2024, 6, 5), reactivation_date: nil, location:) }
 
         it "redirects to the location page and updates the existing deactivation period" do
           follow_redirect!
@@ -1667,14 +1667,13 @@ RSpec.describe LocationsController, type: :request do
           expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
           location.reload
           expect(location.location_deactivation_periods.count).to eq(1)
-          expect(location.location_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2023, 9, 8))
+          expect(location.location_deactivation_periods.first.deactivation_date).to eq(Time.zone.local(2024, 9, 8))
         end
       end
 
       context "when there is a later open deactivation" do
-        let(:deactivation_date) { Time.zone.local(2022, 10, 10) }
         let(:params) { { location_deactivation_period: { deactivation_date_type: "other", "deactivation_date(3i)": "8", "deactivation_date(2i)": "9", "deactivation_date(1i)": "2022" } } }
-        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2023, 6, 5), reactivation_date: nil, location:) }
+        let(:add_deactivations) { create(:location_deactivation_period, deactivation_date: Time.zone.local(2024, 6, 5), reactivation_date: nil, location:) }
 
         it "redirects to the confirmation page" do
           follow_redirect!
@@ -1833,7 +1832,7 @@ RSpec.describe LocationsController, type: :request do
       let(:startdate) { Time.utc(2022, 9, 11) }
 
       before do
-        Timecop.freeze(Time.utc(2022, 9, 10))
+        Timecop.freeze(Time.utc(2023, 1, 10))
         sign_in user
         create(:location_deactivation_period, deactivation_date:, location:)
         location.save!
@@ -1882,13 +1881,13 @@ RSpec.describe LocationsController, type: :request do
       end
 
       context "with other future date" do
-        let(:params) { { location_deactivation_period: { reactivation_date_type: "other", "reactivation_date(3i)": "14", "reactivation_date(2i)": "12", "reactivation_date(1i)": "2022" } } }
+        let(:params) { { location_deactivation_period: { reactivation_date_type: "other", "reactivation_date(3i)": "14", "reactivation_date(2i)": "12", "reactivation_date(1i)": "2023" } } }
 
         it "redirects to the location page and displays a success banner" do
           expect(response).to redirect_to("/schemes/#{scheme.id}/locations/#{location.id}")
           follow_redirect!
           expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
-          expect(page).to have_content("#{location.name} will reactivate on 14 December 2022")
+          expect(page).to have_content("#{location.name} will reactivate on 14 December 2023")
         end
       end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1893,7 +1893,7 @@ RSpec.describe SchemesController, type: :request do
       let(:setup_schemes) { nil }
 
       before do
-        Timecop.freeze(Time.utc(2022, 10, 10))
+        Timecop.freeze(Time.utc(2023, 10, 10))
         sign_in user
         setup_schemes
         patch "/schemes/#{scheme.id}/new-deactivation", params:

--- a/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/csv_parser_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe BulkUpload::Lettings::Year2022::CsvParser do
 
   describe "#wrong_template_for_year?" do
     context "when 23/24 file with 23/24 data" do
-      let(:log) { build(:lettings_log, :completed, startdate: Date.new(2023, 10, 1)) }
+      let(:log) { build(:lettings_log, :completed, startdate: Date.new(2024, 1, 1)) }
 
       before do
         file.write(BulkUpload::LettingsLogToCsv.new(log:, col_offset: 0).to_2023_csv_row)

--- a/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2022/csv_parser_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe BulkUpload::Sales::Year2022::CsvParser do
     let(:path) { file.path }
 
     context "when 23/24 file with 23/24 data" do
-      let(:log) { build(:sales_log, :completed, saledate: Date.new(2023, 10, 1)) }
+      let(:log) { build(:sales_log, :completed, saledate: Date.new(2024, 1, 1)) }
 
       before do
         file.write(BulkUpload::SalesLogToCsv.new(log:, col_offset: 0).to_2023_csv_row)


### PR DESCRIPTION
This builds on top of [CLDC-2451-collection-year-dates](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/tree/CLDC-2451-collection-year-dates)

* Rename `end_date` to `new_logs_end_date`
* Update `edit_end_date` to be at the end of the year. It would have to be manually updated every year when we're ready to close editing for the collection period
* Instead of `lettings/sales_in_edit_crossover_period?` use `lettings/sales_in_edit_crossover_period?` to determine if a log can still be edited
* Use `record.saledate_was` to determine if it's a new log, if it is `nil` only allow a log to be created until `new_logs_end_date` if `record.saledate_was` has a value, allow it to be updated until `edit_logs_end_date`
* Bulk upload is still using `new_logs_end_date` to determine whether it's in crossover period