### PR TITLE
CLDC 2454: add answer option to q90 depending on q78

### DIFF
--- a/app/models/form/sales/questions/mortgageused.rb
+++ b/app/models/form/sales/questions/mortgageused.rb
@@ -17,8 +17,8 @@ class Form::Sales::Questions::Mortgageused < ::Form::Question
   }.freeze
 
   def displayed_answer_options(log, _user = nil)
-    if log.stairowned == 100 &&
-        ANSWER_OPTIONS
+    if log.stairowned == 100
+      ANSWER_OPTIONS
     else
       {
         "1" => { "value" => "Yes" },

--- a/app/models/form/sales/questions/mortgageused.rb
+++ b/app/models/form/sales/questions/mortgageused.rb
@@ -18,7 +18,7 @@ class Form::Sales::Questions::Mortgageused < ::Form::Question
 
   def displayed_answer_options(log, _user = nil)
     if log.stairowned == 100 &&
-      ANSWER_OPTIONS
+        ANSWER_OPTIONS
     else
       {
         "1" => { "value" => "Yes" },

--- a/app/models/form/sales/questions/mortgageused.rb
+++ b/app/models/form/sales/questions/mortgageused.rb
@@ -23,6 +23,10 @@ class Form::Sales::Questions::Mortgageused < ::Form::Question
     }
   end
 
+  def answer_options(_log, _user = null)
+    log.stairowned == 100
+  end
+
   def question_number
     case @ownershipsch
     when 1

--- a/app/models/form/sales/questions/mortgageused.rb
+++ b/app/models/form/sales/questions/mortgageused.rb
@@ -16,15 +16,15 @@ class Form::Sales::Questions::Mortgageused < ::Form::Question
     "3" => { "value" => "Don’t know" },
   }.freeze
 
-  def displayed_answer_options(_log, _user = nil)
-    {
-      "1" => { "value" => "Yes" },
-      "2" => { "value" => "No" },
-    }
-  end
-
-  def answer_options(_log, _user = null)
-    log.stairowned == 100
+  def displayed_answer_options(log, _user = nil)
+    if log.stairowned == 100 &&
+      ANSWER_OPTIONS
+    else
+      {
+        "1" => { "value" => "Yes" },
+        "2" => { "value" => "No" },
+      }
+    end
   end
 
   def question_number

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -50,7 +50,7 @@ module Validations::Sales::SaleInformationValidations
   def validate_discounted_ownership_value(record)
     return unless record.saledate && collection_start_year_for_date(record.saledate) >= 2024
     return unless record.value && record.deposit && record.ownershipsch
-    return unless record.mortgage || record.mortgageused == 2
+    return unless record.mortgage || record.mortgageused == 2 || record.mortgageused == 3
     return unless record.discount || record.grant || record.type == 29
 
     if record.mortgage_deposit_and_grant_total != record.value_with_discount && record.discounted_ownership_sale?

--- a/app/models/validations/sales/soft_validations.rb
+++ b/app/models/validations/sales/soft_validations.rb
@@ -135,7 +135,7 @@ module Validations::Sales::SoftValidations
   def discounted_ownership_value_invalid?
     return unless saledate && collection_start_year <= 2023
     return unless value && deposit && ownershipsch
-    return unless mortgage || mortgageused == 2
+    return unless mortgage || mortgageused == 2 || mortgageused == 3
     return unless discount || grant || type == 29
 
     mortgage_deposit_and_grant_total != value_with_discount && discounted_ownership_sale?

--- a/spec/models/form/sales/questions/mortgageused_spec.rb
+++ b/spec/models/form/sales/questions/mortgageused_spec.rb
@@ -50,22 +50,24 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
 
   context "staircase owned percentage is 100%" do
     let(:log) { build(:sales_log, stairowned: 100) }
+
     it "show's the don't know option" do
       expect(question.displayed_answer_options(log)).to eq({
-         "1" => { "value" => "Yes" },
-         "2" => { "value" => "No" },
-         "3" => { "value" => "Don’t know" }
+        "1" => { "value" => "Yes" },
+        "2" => { "value" => "No" },
+        "3" => { "value" => "Don’t know" },
       })
     end
   end
 
   context "staircase owned percentage is less than 100%" do
     let(:log) { build(:sales_log, stairowned: 99) }
+
     it "show's the don't know option" do
       expect(question.displayed_answer_options(log)).to eq({
-       "1" => { "value" => "Yes" },
-       "2" => { "value" => "No" },
-     })
+        "1" => { "value" => "Yes" },
+        "2" => { "value" => "No" },
+      })
     end
   end
 end

--- a/spec/models/form/sales/questions/mortgageused_spec.rb
+++ b/spec/models/form/sales/questions/mortgageused_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
     expect(question.hint_text).to be_nil
   end
 
-  context "staircase owned percentage is 100%" do
+  context "when staircase owned percentage is 100%" do
     let(:log) { build(:sales_log, stairowned: 100) }
 
     it "show's the don't know option" do
@@ -60,7 +60,7 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
     end
   end
 
-  context "staircase owned percentage is less than 100%" do
+  context "when staircase owned percentage is less than 100%" do
     let(:log) { build(:sales_log, stairowned: 99) }
 
     it "show's the don't know option" do

--- a/spec/models/form/sales/questions/mortgageused_spec.rb
+++ b/spec/models/form/sales/questions/mortgageused_spec.rb
@@ -48,10 +48,24 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
     expect(question.hint_text).to be_nil
   end
 
-  it "has the correct displayed_answer_options" do
-    expect(question.displayed_answer_options(log)).to eq({
-      "1" => { "value" => "Yes" },
-      "2" => { "value" => "No" },
-    })
+  context "staircase owned percentage is 100%" do
+    let(:log) { build(:sales_log, stairowned: 100) }
+    it "show's the don't know option" do
+      expect(question.displayed_answer_options(log)).to eq({
+         "1" => { "value" => "Yes" },
+         "2" => { "value" => "No" },
+         "3" => { "value" => "Don’t know" }
+      })
+    end
+  end
+
+  context "staircase owned percentage is less than 100%" do
+    let(:log) { build(:sales_log, stairowned: 99) }
+    it "show's the don't know option" do
+      expect(question.displayed_answer_options(log)).to eq({
+       "1" => { "value" => "Yes" },
+       "2" => { "value" => "No" },
+     })
+    end
   end
 end


### PR DESCRIPTION
This ticket ( https://digital.dclg.gov.uk/jira/browse/CLDC-2454 ) is concerned with adding the option 'don't know' to Q90 - 'Was a mortgage used for the purchase of this property?' if the answer to Q78 - 'What percentage of the property does the buyer now own in total?' is 100%.

This is achieved by looking at the value of the current log and showing different answers depending on the answer to Q78.

