### PR TITLE
Seed data coordinators as DPOs

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -600,9 +600,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_101144) do
     t.integer "discounted_sale_value_check"
     t.integer "student_not_child_value_check"
     t.integer "percentage_discount_value_check"
-    t.integer "combined_income_value_check"
     t.integer "buyer_livein_value_check"
     t.integer "status_cache", default: 0, null: false
+    t.integer "combined_income_value_check"
     t.datetime "discarded_at"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -600,9 +600,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_101144) do
     t.integer "discounted_sale_value_check"
     t.integer "student_not_child_value_check"
     t.integer "percentage_discount_value_check"
+    t.integer "combined_income_value_check"
     t.integer "buyer_livein_value_check"
     t.integer "status_cache", default: 0, null: false
-    t.integer "combined_income_value_check"
     t.datetime "discarded_at"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -175,6 +175,8 @@ unless Rails.env.test?
     ) do |user|
       user.password = "password"
       user.confirmed_at = Time.zone.now
+      user.is_dpo = true
+      create_data_protection_confirmation(user)
     end
 
     support_user = User.find_or_create_by!(
@@ -185,11 +187,10 @@ unless Rails.env.test?
     ) do |user|
       user.password = "password"
       user.confirmed_at = Time.zone.now
+      create_data_protection_confirmation(user)
     end
 
-    create_data_protection_confirmation(support_user)
-
-    pp "Seeded 3 dummy users"
+    pp "Seeded dummy users"
   end
 
   if (Rails.env.development? || Rails.env.review?) && SalesLog.count.zero?
@@ -318,7 +319,7 @@ unless Rails.env.test?
       units: 1,
       mobility_type: "W",
     )
-    pp "Seeded 3 dummy schemes"
+    pp "Seeded dummy schemes"
   end
 
   if LocalAuthority.count.zero?


### PR DESCRIPTION
This sets data coordinator as dpo in seeds so review apps don't have DSA banners displaying all the time.