### PR TITLE
CLDC-2455 Add soft validation on percentage owned

### DIFF
--- a/app/models/form/sales/pages/staircase_owned_value_check.rb
+++ b/app/models/form/sales/pages/staircase_owned_value_check.rb
@@ -1,0 +1,36 @@
+class Form::Sales::Pages::StaircaseOwnedValueCheck < ::Form::Page
+  def initialize(id, hsh, subsection, joint_purchase:)
+    super(id, hsh, subsection)
+    @joint_purchase = joint_purchase
+    @depends_on = [
+      {
+        "staircase_owned_out_of_soft_range?" => true,
+        "joint_purchase?" => joint_purchase,
+      },
+    ]
+    @title_text = {
+      "translation" => joint_purchase ? "soft_validations.staircase_owned.title_text.two" : "soft_validations.staircase_owned.title_text.one",
+      "arguments" => [
+        {
+          "key" => "stairowned",
+          "label" => true,
+          "i18n_template" => "stairowned",
+        },
+      ],
+    }
+    @informative_text = {
+      "translation" => "soft_validations.staircase_owned.hint_text",
+      "arguments" => [],
+    }
+  end
+
+  def questions
+    @questions ||= [
+      Form::Sales::Questions::StaircaseOwnedValueCheck.new(nil, nil, self),
+    ]
+  end
+
+  def interruption_screen_question_ids
+    %w[type stairowned]
+  end
+end

--- a/app/models/form/sales/questions/staircase_owned_value_check.rb
+++ b/app/models/form/sales/questions/staircase_owned_value_check.rb
@@ -1,0 +1,23 @@
+class Form::Sales::Questions::StaircaseOwnedValueCheck < ::Form::Question
+  def initialize(id, hsh, page)
+    super
+    @id = "stairowned_value_check"
+    @check_answer_label = "Percentage owned confirmation"
+    @header = "Are you sure?"
+    @type = "interruption_screen"
+    @answer_options = {
+      "0" => { "value" => "Yes" },
+      "1" => { "value" => "No" },
+    }
+    @hidden_in_check_answers = {
+      "depends_on" => [
+        {
+          "stairowned_value_check" => 0,
+        },
+        {
+          "stairowned_value_check" => 1,
+        },
+      ],
+    }
+  end
+end

--- a/app/models/form/sales/subsections/shared_ownership_scheme.rb
+++ b/app/models/form/sales/subsections/shared_ownership_scheme.rb
@@ -13,6 +13,8 @@ class Form::Sales::Subsections::SharedOwnershipScheme < ::Form::Subsection
       Form::Sales::Pages::AboutStaircase.new("about_staircasing_joint_purchase", nil, self, joint_purchase: true),
       Form::Sales::Pages::AboutStaircase.new("about_staircasing_not_joint_purchase", nil, self, joint_purchase: false),
       Form::Sales::Pages::StaircaseBoughtValueCheck.new(nil, nil, self),
+      Form::Sales::Pages::StaircaseOwnedValueCheck.new("staircase_owned_value_check_joint_purchase", nil, self, joint_purchase: true),
+      Form::Sales::Pages::StaircaseOwnedValueCheck.new("staircase_owned_value_check_not_joint_purchase", nil, self, joint_purchase: false),
       Form::Sales::Pages::Resale.new(nil, nil, self),
       Form::Sales::Pages::ExchangeDate.new(nil, nil, self),
       Form::Sales::Pages::HandoverDate.new(nil, nil, self),

--- a/app/models/validations/sales/financial_validations.rb
+++ b/app/models/validations/sales/financial_validations.rb
@@ -76,15 +76,6 @@ module Validations::Sales::FinancialValidations
     end
   end
 
-  def validate_percentage_owned_not_too_much_if_older_person(record)
-    return unless record.old_persons_shared_ownership? && record.stairowned
-
-    if record.stairowned > 75
-      record.errors.add :stairowned, I18n.t("validations.financial.staircasing.older_person_percentage_owned_maximum_75")
-      record.errors.add :type, I18n.t("validations.financial.staircasing.older_person_percentage_owned_maximum_75")
-    end
-  end
-
   def validate_equity_in_range_for_year_and_type(record)
     return unless record.type && record.equity && record.collection_start_year
 

--- a/app/models/validations/sales/soft_validations.rb
+++ b/app/models/validations/sales/soft_validations.rb
@@ -77,6 +77,12 @@ module Validations::Sales::SoftValidations
     !value.between?(sale_range.soft_min, sale_range.soft_max)
   end
 
+  def staircase_owned_out_of_soft_range?
+    return unless type && stairowned
+
+    type == 24 && stairowned.between?(76, 100)
+  end
+
   def shared_ownership_deposit_invalid?
     return unless mortgage || mortgageused == 2 || mortgageused == 3
     return unless cashdis || !is_type_discount?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,7 +390,6 @@ en:
       cash_discount_invalid: "Cash discount must be £0 - £999,999"
       staircasing:
         percentage_bought_must_be_greater_than_percentage_owned: "Total percentage buyer now owns must be more than percentage bought in this transaction"
-        older_person_percentage_owned_maximum_75: "Percentage cannot be above 75% under Older Person's Shared Ownership"
         percentage_bought_must_be_at_least_threshold: "The minimum increase in equity while staircasing is %{threshold}%"
       monthly_leasehold_charges:
         not_zero: "Monthly leasehold charges cannot be £0 if the property has monthly charges"
@@ -600,6 +599,12 @@ en:
     purchase_price:
       title_text: "You told us the purchase price is %{value}"
       hint_text: "This is %{higher_or_lower} than we would expect"
+    staircase_owned:
+      title_text:
+        one: "You told us that the buyer now owns %{stairowned} of the property"
+        two: "You told us that the buyers now own %{stairowned} of the property"
+      hint_text: "The maximum percentage that can be owned under the Older Persons Shared Ownership scheme is 75%, unless the property was funded outside the Affordable Homes Programme.
+Make sure these answers are correct."
     retirement:
       min:
         title: "You told us this person is aged %{age} years and retired."

--- a/db/migrate/20230621142422_add_stairowned_value_check_to_sales_logs.rb
+++ b/db/migrate/20230621142422_add_stairowned_value_check_to_sales_logs.rb
@@ -1,0 +1,5 @@
+class AddStairownedValueCheckToSalesLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sales_logs, :stairowned_value_check, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_09_101144) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_21_142422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -604,6 +604,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_101144) do
     t.integer "status_cache", default: 0, null: false
     t.integer "combined_income_value_check"
     t.datetime "discarded_at"
+    t.integer "stairowned_value_check"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -600,9 +600,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_142422) do
     t.integer "discounted_sale_value_check"
     t.integer "student_not_child_value_check"
     t.integer "percentage_discount_value_check"
+    t.integer "combined_income_value_check"
     t.integer "buyer_livein_value_check"
     t.integer "status_cache", default: 0, null: false
-    t.integer "combined_income_value_check"
     t.datetime "discarded_at"
     t.integer "stairowned_value_check"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"

--- a/spec/models/form/sales/pages/staircase_owned_value_check_spec.rb
+++ b/spec/models/form/sales/pages/staircase_owned_value_check_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Form::Sales::Pages::StaircaseOwnedValueCheck, type: :model do
+  subject(:page) { described_class.new(page_id, page_definition, subsection, joint_purchase:) }
+
+  let(:page_id) { "an_id" }
+  let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:joint_purchase) { false }
+
+  it "has correct subsection" do
+    expect(page.subsection).to eq(subsection)
+  end
+
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(%w[stairowned_value_check])
+  end
+
+  it "has the correct id" do
+    expect(page.id).to eq("an_id")
+  end
+
+  it "has the correct header" do
+    expect(page.header).to be_nil
+  end
+
+  it "has correct depends_on" do
+    expect(page.depends_on).to eq([{
+      "staircase_owned_out_of_soft_range?" => true,
+      "joint_purchase?" => joint_purchase,
+    }])
+  end
+
+  it "is interruption screen page" do
+    expect(page.interruption_screen?).to eq(true)
+  end
+
+  it "has the correct informative_text" do
+    expect(page.informative_text).to eq({
+      "translation" => "soft_validations.staircase_owned.hint_text",
+      "arguments" => [],
+    })
+  end
+
+  it "has the correct interruption_screen_question_ids" do
+    expect(page.interruption_screen_question_ids).to eq(%w[type stairowned])
+  end
+
+  context "when not a joint purchase" do
+    it "has the correct title_text" do
+      expect(page.title_text).to eq({
+        "translation" => "soft_validations.staircase_owned.title_text.one",
+        "arguments" => [
+          {
+            "key" => "stairowned",
+            "label" => true,
+            "i18n_template" => "stairowned",
+          },
+        ],
+      })
+    end
+  end
+
+  context "when a joint purchase" do
+    let(:joint_purchase) { true }
+
+    it "has the correct title_text" do
+      expect(page.title_text).to eq({
+        "translation" => "soft_validations.staircase_owned.title_text.two",
+        "arguments" => [
+          {
+            "key" => "stairowned",
+            "label" => true,
+            "i18n_template" => "stairowned",
+          },
+        ],
+      })
+    end
+  end
+end

--- a/spec/models/form/sales/questions/staircase_owned_value_check_spec.rb
+++ b/spec/models/form/sales/questions/staircase_owned_value_check_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Form::Sales::Questions::StaircaseOwnedValueCheck, type: :model do
+  subject(:question) { described_class.new(question_id, question_definition, page) }
+
+  let(:question_id) { nil }
+  let(:question_definition) { nil }
+  let(:page) { instance_double(Form::Page) }
+
+  it "has correct page" do
+    expect(question.page).to eq(page)
+  end
+
+  it "has the correct id" do
+    expect(question.id).to eq("stairowned_value_check")
+  end
+
+  it "has the correct header" do
+    expect(question.header).to eq("Are you sure?")
+  end
+
+  it "has the correct check_answer_label" do
+    expect(question.check_answer_label).to eq("Percentage owned confirmation")
+  end
+
+  it "has the correct type" do
+    expect(question.type).to eq("interruption_screen")
+  end
+
+  it "is not marked as derived" do
+    expect(question.derived?).to be false
+  end
+
+  it "has the correct hint" do
+    expect(question.hint_text).to be_nil
+  end
+
+  it "has a correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(nil)
+  end
+
+  it "has the correct answer_options" do
+    expect(question.answer_options).to eq({
+      "0" => { "value" => "Yes" },
+      "1" => { "value" => "No" },
+    })
+  end
+
+  it "has the correct hidden_in_check_answers" do
+    expect(question.hidden_in_check_answers).to eq({
+      "depends_on" => [
+        {
+          "stairowned_value_check" => 0,
+        },
+        {
+          "stairowned_value_check" => 1,
+        },
+      ],
+    })
+  end
+end

--- a/spec/models/form/sales/subsections/shared_ownership_scheme_spec.rb
+++ b/spec/models/form/sales/subsections/shared_ownership_scheme_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipScheme, type: :model do
         about_staircasing_joint_purchase
         about_staircasing_not_joint_purchase
         staircase_bought_value_check
+        staircase_owned_value_check_joint_purchase
+        staircase_owned_value_check_not_joint_purchase
         resale
         exchange_contracts
         handover_date

--- a/spec/models/validations/sales/financial_validations_spec.rb
+++ b/spec/models/validations/sales/financial_validations_spec.rb
@@ -214,36 +214,6 @@ RSpec.describe Validations::Sales::FinancialValidations do
     end
   end
 
-  describe "#validate_percentage_owned_not_too_much_if_older_person" do
-    let(:record) { FactoryBot.create(:sales_log) }
-
-    context "when log type is not older persons shared ownership" do
-      it "does not add an error when percentage owned after staircasing transaction exceeds 75%" do
-        record.type = 2
-        record.stairowned = 80
-        financial_validator.validate_percentage_owned_not_too_much_if_older_person(record)
-        expect(record.errors).to be_empty
-      end
-    end
-
-    context "when log type is older persons shared ownership" do
-      it "does not add an error when percentage owned after staircasing transaction is less than 75%" do
-        record.type = 24
-        record.stairowned = 50
-        financial_validator.validate_percentage_owned_not_too_much_if_older_person(record)
-        expect(record.errors).to be_empty
-      end
-
-      it "adds an error when percentage owned after staircasing transaction exceeds 75%" do
-        record.type = 24
-        record.stairowned = 90
-        financial_validator.validate_percentage_owned_not_too_much_if_older_person(record)
-        expect(record.errors["stairowned"]).to include(match I18n.t("validations.financial.staircasing.older_person_percentage_owned_maximum_75"))
-        expect(record.errors["type"]).to include(match I18n.t("validations.financial.staircasing.older_person_percentage_owned_maximum_75"))
-      end
-    end
-  end
-
   describe "#validate_child_income" do
     let(:record) { FactoryBot.create(:sales_log) }
 


### PR DESCRIPTION
This adds a soft validation when percentage owned is 76-100% if type is Older Persons Shared Ownership. This used to be hard but it can be valid in some cases as explained in the en.yml.

ticket: https://digital.dclg.gov.uk/jira/browse/CLDC-2455