### PR TITLE
CLDC-2365 Set managing org to owning org if there are no managing agents

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -104,7 +104,7 @@ private
 
       if current_user.support? && question.id == "owning_organisation_id" && @log.managing_organisation.blank?
         owning_organisation = Organisation.find(result["owning_organisation_id"])
-        if owning_organisation.present? && !owning_organisation.has_managing_agents?
+        if owning_organisation&.managing_agents&.empty?
           result["managing_organisation_id"] = owning_organisation.id
         end
       end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -101,6 +101,14 @@ private
       else
         result[question.id] = question_params
       end
+
+      if current_user.support? && question.id == "owning_organisation_id" && @log.managing_organisation.blank?
+        owning_organisation = Organisation.find(result["owning_organisation_id"])
+        if owning_organisation.present? && !owning_organisation.has_managing_agents?
+          result["managing_organisation_id"] = owning_organisation.id
+        end
+      end
+
       result
     end
   end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -135,6 +135,32 @@ RSpec.describe FormController, type: :request do
       end
     end
 
+    context "when owning organisation doesn't have any managing agents" do
+      let(:params) do
+        {
+          id: lettings_log.id,
+          lettings_log: {
+            page: "stock_owner",
+            owning_organisation_id: managing_organisation.id,
+          },
+        }
+      end
+
+      before do
+        lettings_log.update!(owning_organisation: nil, created_by: nil, managing_organisation: nil)
+        lettings_log.reload
+      end
+
+      it "sets managing organisation to owning organisation" do
+        post "/lettings-logs/#{lettings_log.id}/stock-owner", params: params
+        expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/created-by")
+        follow_redirect!
+        lettings_log.reload
+        expect(lettings_log.owning_organisation).to eq(managing_organisation)
+        expect(lettings_log.managing_organisation).to eq(managing_organisation)
+      end
+    end
+
     context "with valid managing organisation" do
       let(:params) do
         {


### PR DESCRIPTION
When a support user tries to create a log for an organisation without any managing orgs, managing org was not routed to but it was also not being inferred so the setup section would be impossible to complete.

It worked fine for data coordinators, because the managing organisation would get inferred in the `create` log request in `org_params`

This PR updates managing organisation when a support user updates the owning organisation, because we can't set it before we know the owning organisation.