### PR TITLE
CLDC-1800 Update provider relationships permissions

### DIFF
--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -65,8 +65,8 @@ class OrganisationRelationshipsController < ApplicationController
 
   def remove_stock_owner
     organisation_relationship = OrganisationRelationship.find_by!(
-      parent_organisation: organisation,
-      child_organisation: @target_organisation,
+      parent_organisation: @target_organisation,
+      child_organisation: organisation,
     )
     authorize organisation_relationship
   end
@@ -80,7 +80,13 @@ class OrganisationRelationshipsController < ApplicationController
     redirect_to stock_owners_organisation_path
   end
 
-  def remove_managing_agent; end
+  def remove_managing_agent
+    organisation_relationship = OrganisationRelationship.find_by!(
+      parent_organisation: organisation,
+      child_organisation: @target_organisation,
+    )
+    authorize organisation_relationship
+  end
 
   def delete_managing_agent
     OrganisationRelationship.find_by!(

--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -33,10 +33,12 @@ class OrganisationRelationshipsController < ApplicationController
 
   def add_stock_owner
     @organisation_relationship = organisation.parent_organisation_relationships.new
+    authorize @organisation_relationship
   end
 
   def add_managing_agent
     @organisation_relationship = organisation.child_organisation_relationships.new
+    authorize @organisation_relationship
   end
 
   def create_stock_owner

--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -53,6 +53,7 @@ class OrganisationRelationshipsController < ApplicationController
 
   def create_managing_agent
     @organisation_relationship = organisation.child_organisation_relationships.new(organisation_relationship_params)
+    authorize @organisation_relationship
     if @organisation_relationship.save
       flash[:notice] = "#{@organisation_relationship.child_organisation.name} is now one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} managing agents"
       redirect_to managing_agents_organisation_path

--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -41,6 +41,7 @@ class OrganisationRelationshipsController < ApplicationController
 
   def create_stock_owner
     @organisation_relationship = organisation.parent_organisation_relationships.new(organisation_relationship_params)
+    authorize @organisation_relationship
     if @organisation_relationship.save(context: :stock_owner)
       flash[:notice] = "#{@organisation_relationship.parent_organisation.name} is now one of #{current_user.data_coordinator? ? 'your' : "this organisation's"} stock owners"
       redirect_to stock_owners_organisation_path

--- a/app/controllers/organisation_relationships_controller.rb
+++ b/app/controllers/organisation_relationships_controller.rb
@@ -62,7 +62,13 @@ class OrganisationRelationshipsController < ApplicationController
     end
   end
 
-  def remove_stock_owner; end
+  def remove_stock_owner
+    organisation_relationship = OrganisationRelationship.find_by!(
+      parent_organisation: organisation,
+      child_organisation: @target_organisation,
+    )
+    authorize organisation_relationship
+  end
 
   def delete_stock_owner
     OrganisationRelationship.find_by!(

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -15,7 +15,7 @@ class OrganisationRelationshipPolicy
     remove_managing_agent?
   ].each do |method_name|
     define_method method_name do
-      return true unless user.data_provider?
+      !user.data_provider?
     end
   end
 end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -13,4 +13,8 @@ class OrganisationRelationshipPolicy
   def remove_stock_owner?
     return true unless user.data_provider?
   end
+
+  def create_managing_agent?
+    return true unless user.data_provider?
+  end
 end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -1,0 +1,12 @@
+class OrganisationRelationshipPolicy
+  attr_reader :user, :organisation_relationship
+
+  def initialize(user, organisation_relationship)
+    @user = user
+    @organisation_relationship = organisation_relationship
+  end
+
+  def create_stock_owner?
+    return true unless user.data_provider?
+  end
+end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -6,27 +6,16 @@ class OrganisationRelationshipPolicy
     @organisation_relationship = organisation_relationship
   end
 
-  def add_stock_owner?
-    return true unless user.data_provider?
-  end
-
-  def create_stock_owner?
-    return true unless user.data_provider?
-  end
-
-  def remove_stock_owner?
-    return true unless user.data_provider?
-  end
-
-  def add_managing_agent?
-    return true unless user.data_provider?
-  end
-
-  def create_managing_agent?
-    return true unless user.data_provider?
-  end
-
-  def remove_managing_agent?
-    return true unless user.data_provider?
+  %w[
+    add_stock_owner?
+    create_stock_owner?
+    remove_stock_owner?
+    add_managing_agent?
+    create_managing_agent?
+    remove_managing_agent?
+  ].each do |method_name|
+    define_method method_name do
+      return true unless user.data_provider?
+    end
   end
 end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -9,4 +9,8 @@ class OrganisationRelationshipPolicy
   def create_stock_owner?
     return true unless user.data_provider?
   end
+
+  def remove_stock_owner?
+    return true unless user.data_provider?
+  end
 end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -17,4 +17,8 @@ class OrganisationRelationshipPolicy
   def create_managing_agent?
     return true unless user.data_provider?
   end
+
+  def remove_managing_agent?
+    return true unless user.data_provider?
+  end
 end

--- a/app/policies/organisation_relationship_policy.rb
+++ b/app/policies/organisation_relationship_policy.rb
@@ -6,11 +6,19 @@ class OrganisationRelationshipPolicy
     @organisation_relationship = organisation_relationship
   end
 
+  def add_stock_owner?
+    return true unless user.data_provider?
+  end
+
   def create_stock_owner?
     return true unless user.data_provider?
   end
 
   def remove_stock_owner?
+    return true unless user.data_provider?
+  end
+
+  def add_managing_agent?
     return true unless user.data_provider?
   end
 

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -296,6 +296,27 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
       end
 
+      context "when directly adding a stock owner" do
+        let!(:stock_owner) { FactoryBot.create(:organisation) }
+        let(:params) do
+          {
+            "organisation_relationship": {
+              "parent_organisation_id": stock_owner.id,
+            },
+          }
+        end
+        let(:request) { post "/organisations/#{organisation.id}/stock-owners", headers:, params: }
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it "does not create a new organisation relationship" do
+          expect { request }.not_to change(OrganisationRelationship, :count)
+        end
+      end
+
       context "when accessing the managing agents tab" do
         context "with an organisation that the user belongs to" do
           let!(:managing_agent) { FactoryBot.create(:organisation) }

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
       context "when directly accessing the page to add a stock owner" do
         let(:request) { get "/organisations/#{organisation.id}/stock-owners/add", headers: }
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end
@@ -316,7 +316,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
         let(:request) { post "/organisations/#{organisation.id}/stock-owners", headers:, params: }
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end
@@ -334,7 +334,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           FactoryBot.create(:organisation_relationship, parent_organisation: stock_owner, child_organisation: organisation)
         end
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end
@@ -343,7 +343,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
       context "when directly accessing the page to add a managing agent" do
         let(:request) { get "/organisations/#{organisation.id}/managing-agents/add", headers: }
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end
@@ -360,7 +360,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
         let(:request) { post "/organisations/#{organisation.id}/managing-agents", headers:, params: }
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end
@@ -378,7 +378,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
         end
 
-        it "returns 401 from users page" do
+        it "returns 401" do
           request
           expect(response).to have_http_status(:unauthorized)
         end

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -318,20 +318,16 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
       end
 
       context "when directly removing a stock owner" do
-        let(:managing_agent) { FactoryBot.create(:organisation) }
-        let(:request) { get "/organisations/#{organisation.id}/stock-owners/remove?target_organisation_id=#{managing_agent.id}", headers: }
+        let(:stock_owner) { FactoryBot.create(:organisation) }
+        let(:request) { get "/organisations/#{organisation.id}/stock-owners/remove?target_organisation_id=#{stock_owner.id}", headers: }
 
         before do
-          FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+          FactoryBot.create(:organisation_relationship, parent_organisation: stock_owner, child_organisation: organisation)
         end
 
         it "returns 401 from users page" do
           request
           expect(response).to have_http_status(:unauthorized)
-        end
-
-        it "does not remove the organisation relationship" do
-          expect { request }.not_to change(OrganisationRelationship, :count)
         end
       end
 
@@ -353,6 +349,20 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
         it "does not create a new organisation relationship" do
           expect { request }.not_to change(OrganisationRelationship, :count)
+        end
+      end
+
+      context "when directly removing a managing agent" do
+        let(:managing_agent) { FactoryBot.create(:organisation) }
+        let(:request) { get "/organisations/#{organisation.id}/managing-agents/remove?target_organisation_id=#{managing_agent.id}", headers: }
+
+        before do
+          FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+        end
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -335,6 +335,27 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
       end
 
+      context "when directly adding a managing agent" do
+        let!(:managing_agent) { FactoryBot.create(:organisation) }
+        let(:params) do
+          {
+            "organisation_relationship": {
+              "child_organisation_id": managing_agent.id,
+            },
+          }
+        end
+        let(:request) { post "/organisations/#{organisation.id}/managing-agents", headers:, params: }
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it "does not create a new organisation relationship" do
+          expect { request }.not_to change(OrganisationRelationship, :count)
+        end
+      end
+
       context "when accessing the managing agents tab" do
         context "with an organisation that the user belongs to" do
           let!(:managing_agent) { FactoryBot.create(:organisation) }

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -317,6 +317,24 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
       end
 
+      context "when directly removing a stock owner" do
+        let(:managing_agent) { FactoryBot.create(:organisation) }
+        let(:request) { get "/organisations/#{organisation.id}/stock-owners/remove?target_organisation_id=#{managing_agent.id}", headers: }
+
+        before do
+          FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)
+        end
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it "does not remove the organisation relationship" do
+          expect { request }.not_to change(OrganisationRelationship, :count)
+        end
+      end
+
       context "when accessing the managing agents tab" do
         context "with an organisation that the user belongs to" do
           let!(:managing_agent) { FactoryBot.create(:organisation) }

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -296,6 +296,15 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
       end
 
+      context "when directly accessing the page to add a stock owner" do
+        let(:request) { get "/organisations/#{organisation.id}/stock-owners/add", headers: }
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
       context "when directly adding a stock owner" do
         let!(:stock_owner) { FactoryBot.create(:organisation) }
         let(:params) do
@@ -324,6 +333,15 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         before do
           FactoryBot.create(:organisation_relationship, parent_organisation: stock_owner, child_organisation: organisation)
         end
+
+        it "returns 401 from users page" do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "when directly accessing the page to add a managing agent" do
+        let(:request) { get "/organisations/#{organisation.id}/managing-agents/add", headers: }
 
         it "returns 401 from users page" do
           request
@@ -400,16 +418,6 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
           it "shows the pagination count" do
             expect(page).to have_content("1 total agents")
-          end
-        end
-
-        context "when adding a managing agent" do
-          before do
-            get "/organisations/#{organisation.id}/managing-agents/add", headers:, params: {}
-          end
-
-          it "has the correct header" do
-            expect(response.body).to include("What is the name of your managing agent?")
           end
         end
 

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
       end
 
       context "when directly accessing the page to add a stock owner" do
-        let(:request) { get "/organisations/#{organisation.id}/stock-owners/add", headers: }
+        let(:request) { get "/organisations/#{organisation.id}/stock-owners/add" }
 
         it "returns 401" do
           request
@@ -314,7 +314,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
             },
           }
         end
-        let(:request) { post "/organisations/#{organisation.id}/stock-owners", headers:, params: }
+        let(:request) { post "/organisations/#{organisation.id}/stock-owners", params: }
 
         it "returns 401" do
           request
@@ -328,7 +328,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
       context "when directly removing a stock owner" do
         let(:stock_owner) { FactoryBot.create(:organisation) }
-        let(:request) { get "/organisations/#{organisation.id}/stock-owners/remove?target_organisation_id=#{stock_owner.id}", headers: }
+        let(:request) { get "/organisations/#{organisation.id}/stock-owners/remove?target_organisation_id=#{stock_owner.id}" }
 
         before do
           FactoryBot.create(:organisation_relationship, parent_organisation: stock_owner, child_organisation: organisation)
@@ -341,7 +341,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
       end
 
       context "when directly accessing the page to add a managing agent" do
-        let(:request) { get "/organisations/#{organisation.id}/managing-agents/add", headers: }
+        let(:request) { get "/organisations/#{organisation.id}/managing-agents/add" }
 
         it "returns 401" do
           request
@@ -358,7 +358,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
             },
           }
         end
-        let(:request) { post "/organisations/#{organisation.id}/managing-agents", headers:, params: }
+        let(:request) { post "/organisations/#{organisation.id}/managing-agents", params: }
 
         it "returns 401" do
           request
@@ -372,7 +372,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
       context "when directly removing a managing agent" do
         let(:managing_agent) { FactoryBot.create(:organisation) }
-        let(:request) { get "/organisations/#{organisation.id}/managing-agents/remove?target_organisation_id=#{managing_agent.id}", headers: }
+        let(:request) { get "/organisations/#{organisation.id}/managing-agents/remove?target_organisation_id=#{managing_agent.id}" }
 
         before do
           FactoryBot.create(:organisation_relationship, parent_organisation: organisation, child_organisation: managing_agent)


### PR DESCRIPTION
Data providers should not be able to:
- remove housing providers from organisation relationships
- add new housing providers to organisation relationships
- remove managing agents from organisation relationships (CLDC-1799)
- add new managing agents to organisation relationships (CLDC-1799)