### PR TITLE
CLDC 2405: Show more information on the sales log info component

### DIFF
--- a/app/components/lettings_log_summary_component.html.erb
+++ b/app/components/lettings_log_summary_component.html.erb
@@ -3,11 +3,11 @@
     <div class="govuk-grid-column-one-half">
       <header class="app-log-summary__header">
         <h2 class="app-log-summary__title">
-          <%= govuk_link_to log.lettings? ? lettings_log_path(log) : sales_log_path(log) do %>
+          <%= govuk_link_to lettings_log_path(log) do %>
             <span class="govuk-visually-hidden">Log </span><%= log.id %>
           <% end %>
         </h2>
-        <% if log.lettings? && (log.tenancycode? or log.propcode?) %>
+        <% if log.tenancycode? or log.propcode? %>
           <dl class="app-metadata app-metadata--inline">
             <% if log.tenancycode? %>
               <div class="app-metadata__item">
@@ -23,39 +23,14 @@
             <% end %>
           </dl>
         <% end %>
-        <% if log.sales? %>
-          <dl class="app-metadata app-metadata--inline">
-            <% if log.purchaser_code %>
-              <div class="app-metadata__item">
-                <dt class="app-metadata__term">Purchaser</dt>
-                <dd class="app-metadata__definition"><%= log.purchaser_code %></dd>
-              </div>
-            <% end %>
-          </dl>
-        <% end %>
       </header>
-      <% if log.lettings? && (log.needstype? or log.startdate?) %>
+      <% if log.needstype? or log.startdate? %>
         <p class="govuk-body govuk-!-margin-bottom-2">
           <% if log.needstype? %>
             <%= log.is_general_needs? ? "General needs" : "Supported housing" %><br>
           <% end %>
           <% if log.startdate? %>
             Tenancy starts <time datetime="<%= log.startdate.iso8601 %>"><%= log.startdate.to_formatted_s(:govuk_date) %></time>
-          <% end %>
-        </p>
-      <% end %>
-      <% if log.sales? %>
-        <p class="govuk-body govuk-!-margin-bottom-2">
-          <% if log.ownership_scheme %>
-            <%= case log.ownership_scheme
-              when "shared ownership" then "Shared ownership"
-              when "discounted ownership" then "Discounted ownership"
-              when "outright sale" then "Outright or other sale"
-              end %>
-            <br>
-          <% end %>
-          <% if log.saledate %>
-            Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
           <% end %>
         </p>
       <% end %>
@@ -67,7 +42,7 @@
               <dd class="app-metadata__definition"><%= log.owning_organisation&.name %></dd>
             </div>
           <% end %>
-          <% if log.lettings? && log.managing_organisation %>
+          <% if log.managing_organisation %>
             <div class="app-metadata__item">
               <dt class="app-metadata__term">Managed by</dt>
               <dd class="app-metadata__definition"><%= log.managing_organisation&.name %></dd>

--- a/app/components/lettings_log_summary_component.rb
+++ b/app/components/lettings_log_summary_component.rb
@@ -1,0 +1,13 @@
+class LettingsLogSummaryComponent < ViewComponent::Base
+  attr_reader :current_user, :log
+
+  def initialize(current_user:, log:)
+    @current_user = current_user
+    @log = log
+    super
+  end
+
+  def log_status
+    helpers.status_tag(log.status)
+  end
+end

--- a/app/components/log_summary_component.html.erb
+++ b/app/components/log_summary_component.html.erb
@@ -23,8 +23,17 @@
             <% end %>
           </dl>
         <% end %>
+        <% if log.sales? %>
+          <dl class="app-metadata app-metadata--inline">
+            <% if log.purchaser_code %>
+              <div class="app-metadata__item">
+                <dt class="app-metadata__term">Purchaser</dt>
+                <dd class="app-metadata__definition"><%= log.purchaser_code %></dd>
+              </div>
+            <% end %>
+          </dl>
+        <% end %>
       </header>
-
       <% if log.lettings? && (log.needstype? or log.startdate?) %>
         <p class="govuk-body govuk-!-margin-bottom-2">
           <% if log.needstype? %>
@@ -35,17 +44,21 @@
           <% end %>
         </p>
       <% end %>
-
       <% if log.sales? %>
         <p class="govuk-body govuk-!-margin-bottom-2">
-        <%= case log.ownership_scheme %>
-          when 1 then "shared ownership"
-          <% when 2 then "discounted ownership"
-          <% when 3 then "outright sale" %>>  <% end %>
-        <% end %>
+          <% if log.ownership_scheme %>
+            <%= case log.ownership_scheme
+              when "shared ownership" then "Shared ownership"
+              when "discounted ownership" then "Discounted ownership"
+              when "outright sale" then "Outright or other sale"
+              end %>
+            <br>
+          <% end %>
+          <% if log.saledate %>
+            Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
+          <% end %>
         </p>
       <% end %>
-
       <% if current_user.support? || current_user.organisation.has_managing_agents? %>
         <dl class="app-metadata">
           <% if log.owning_organisation %>
@@ -63,7 +76,6 @@
         </dl>
       <% end %>
     </div>
-
     <footer class="govuk-grid-column-one-half app-log-summary__footer">
       <p class="govuk-body govuk-!-margin-bottom-2">
         <%= log_status %>

--- a/app/components/log_summary_component.html.erb
+++ b/app/components/log_summary_component.html.erb
@@ -36,6 +36,16 @@
         </p>
       <% end %>
 
+      <% if log.sales? %>
+        <p class="govuk-body govuk-!-margin-bottom-2">
+        <%= case log.ownership_scheme %>
+          when 1 then "shared ownership"
+          <% when 2 then "discounted ownership"
+          <% when 3 then "outright sale" %>>  <% end %>
+        <% end %>
+        </p>
+      <% end %>
+
       <% if current_user.support? || current_user.organisation.has_managing_agents? %>
         <dl class="app-metadata">
           <% if log.owning_organisation %>

--- a/app/components/sales_log_summary_component.html.erb
+++ b/app/components/sales_log_summary_component.html.erb
@@ -1,0 +1,55 @@
+<article class="app-log-summary">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <header class="app-log-summary__header">
+        <h2 class="app-log-summary__title">
+          <%= govuk_link_to sales_log_path(log) do %>
+          <span class="govuk-visually-hidden">Log </span><%= log.id %>
+          <% end %>
+        </h2>
+          <dl class="app-metadata app-metadata--inline">
+            <% if log.purchaser_code %>
+            <div class="app-metadata__item">
+              <dt class="app-metadata__term">Purchaser</dt>
+              <dd class="app-metadata__definition"><%= log.purchaser_code %></dd>
+            </div>
+            <% end %>
+          </dl>
+      </header>
+      <p class="govuk-body govuk-!-margin-bottom-2">
+        <% if log.ownership_scheme %>
+        <%= case log.ownership_scheme
+        when "shared ownership" then "Shared ownership"
+        when "discounted ownership" then "Discounted ownership"
+        when "outright sale" then "Outright or other sale"
+        end %>
+        <br>
+        <% end %>
+        <% if log.saledate %>
+        Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
+        <% end %>
+      </p>
+      <% if current_user.support? || current_user.organisation.has_managing_agents? %>
+      <dl class="app-metadata">
+        <% if log.owning_organisation %>
+        <div class="app-metadata__item">
+          <dt class="app-metadata__term">Owned by</dt>
+          <dd class="app-metadata__definition"><%= log.owning_organisation&.name %></dd>
+        </div>
+        <% end %>
+      </dl>
+      <% end %>
+    </div>
+    <footer class="govuk-grid-column-one-half app-log-summary__footer">
+      <p class="govuk-body govuk-!-margin-bottom-2">
+        <%= log_status %>
+      </p>
+      <p class="govuk-body">
+        Created <time datetime="<%= log.created_at.iso8601 %>"><%= log.created_at.to_formatted_s(:govuk_date) %></time>
+        <% if log.created_by %>
+        <span class="app-log-summary__footer--actor">by <%= log.created_by.name || log.created_by.email %></span>
+        <% end %>
+      </p>
+    </footer>
+  </div>
+</article>

--- a/app/components/sales_log_summary_component.html.erb
+++ b/app/components/sales_log_summary_component.html.erb
@@ -4,40 +4,35 @@
       <header class="app-log-summary__header">
         <h2 class="app-log-summary__title">
           <%= govuk_link_to sales_log_path(log) do %>
-          <span class="govuk-visually-hidden">Log </span><%= log.id %>
+            <span class="govuk-visually-hidden">Log </span><%= log.id %>
           <% end %>
         </h2>
           <dl class="app-metadata app-metadata--inline">
             <% if log.purchaser_code %>
-            <div class="app-metadata__item">
-              <dt class="app-metadata__term">Purchaser</dt>
-              <dd class="app-metadata__definition"><%= log.purchaser_code %></dd>
-            </div>
+              <div class="app-metadata__item">
+                <dt class="app-metadata__term">Purchaser</dt>
+                <dd class="app-metadata__definition"><%= log.purchaser_code %></dd>
+              </div>
             <% end %>
           </dl>
       </header>
       <p class="govuk-body govuk-!-margin-bottom-2">
         <% if log.ownership_scheme %>
-        <%= case log.ownership_scheme
-        when "shared ownership" then "Shared ownership"
-        when "discounted ownership" then "Discounted ownership"
-        when "outright sale" then "Outright or other sale"
-        end %>
-        <br>
+          <%= log.ownership_scheme(uppercase: true) %><br>
         <% end %>
         <% if log.saledate %>
-        Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
+          Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
         <% end %>
       </p>
       <% if current_user.support? || current_user.organisation.has_managing_agents? %>
-      <dl class="app-metadata">
-        <% if log.owning_organisation %>
-        <div class="app-metadata__item">
-          <dt class="app-metadata__term">Owned by</dt>
-          <dd class="app-metadata__definition"><%= log.owning_organisation&.name %></dd>
-        </div>
-        <% end %>
-      </dl>
+        <dl class="app-metadata">
+          <% if log.owning_organisation %>
+            <div class="app-metadata__item">
+              <dt class="app-metadata__term">Owned by</dt>
+              <dd class="app-metadata__definition"><%= log.owning_organisation&.name %></dd>
+            </div>
+          <% end %>
+        </dl>
       <% end %>
     </div>
     <footer class="govuk-grid-column-one-half app-log-summary__footer">
@@ -47,7 +42,7 @@
       <p class="govuk-body">
         Created <time datetime="<%= log.created_at.iso8601 %>"><%= log.created_at.to_formatted_s(:govuk_date) %></time>
         <% if log.created_by %>
-        <span class="app-log-summary__footer--actor">by <%= log.created_by.name || log.created_by.email %></span>
+          <span class="app-log-summary__footer--actor">by <%= log.created_by.name || log.created_by.email %></span>
         <% end %>
       </p>
     </footer>

--- a/app/components/sales_log_summary_component.rb
+++ b/app/components/sales_log_summary_component.rb
@@ -1,4 +1,4 @@
-class LogSummaryComponent < ViewComponent::Base
+class SalesLogSummaryComponent < ViewComponent::Base
   attr_reader :current_user, :log
 
   def initialize(current_user:, log:)

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -384,12 +384,12 @@ class SalesLog < Log
   end
 
   def ownership_scheme(uppercase: false)
-    owner_scheme = case ownershipsch
+    ownership_scheme = case ownershipsch
                    when 1 then "shared ownership"
                    when 2 then "discounted ownership"
                    when 3 then "outright or other sale"
                    end
-    uppercase ? owner_scheme.capitalize : owner_scheme
+    uppercase ? ownership_scheme.capitalize : ownership_scheme
   end
 
   def combined_income

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -383,12 +383,13 @@ class SalesLog < Log
     beds.nil? ? nil : [beds, LaSaleRange::MAX_BEDS].min
   end
 
-  def ownership_scheme
-    case ownershipsch
-    when 1 then "shared ownership"
-    when 2 then "discounted ownership"
-    when 3 then "outright sale"
-    end
+  def ownership_scheme(uppercase: false)
+    owner_scheme = case ownershipsch
+                   when 1 then "shared ownership"
+                   when 2 then "discounted ownership"
+                   when 3 then "outright or other sale"
+                   end
+    uppercase ? owner_scheme.capitalize : owner_scheme
   end
 
   def combined_income

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -61,6 +61,10 @@ class SalesLog < Log
     attribute_names
   end
 
+  def purchaser_code
+    purchid
+  end
+
   def form_name
     return unless saledate
 

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -385,10 +385,10 @@ class SalesLog < Log
 
   def ownership_scheme(uppercase: false)
     ownership_scheme = case ownershipsch
-                   when 1 then "shared ownership"
-                   when 2 then "discounted ownership"
-                   when 3 then "outright or other sale"
-                   end
+                       when 1 then "shared ownership"
+                       when 2 then "discounted ownership"
+                       when 3 then "outright or other sale"
+                       end
     uppercase ? ownership_scheme.capitalize : ownership_scheme
   end
 

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -17,5 +17,9 @@
 </div>
 </h2>
 <% logs.map do |log| %>
-  <%= render(LogSummaryComponent.new(current_user:, log:)) %>
+  <% if log.sales? %>
+    <%= render(SalesLogSummaryComponent.new(current_user:, log:)) %>
+    <% else %>
+    <%= render(LettingsLogSummaryComponent.new(current_user:, log:)) %>
+  <% end %>
 <% end %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -18,8 +18,8 @@
 </h2>
 <% logs.map do |log| %>
   <% if log.sales? %>
-    <%= render(SalesLogSummaryComponent.new(current_user:, log:)) %>
+    <%= render SalesLogSummaryComponent.new(current_user:, log:) %>
     <% else %>
-    <%= render(LettingsLogSummaryComponent.new(current_user:, log:)) %>
+    <%= render LettingsLogSummaryComponent.new(current_user:, log:) %>
   <% end %>
 <% end %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -11,7 +11,6 @@
 </div>
 <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
   <% if logs&.any? && (display_delete_logs?(@current_user, searched, filter_type) || in_organisations_tab?) %>
-  <%# remove @ on current user %>
     <%= govuk_link_to "Delete logs", delete_logs_path, class: "app-!-colour-red" %>
   <% end %>
 </div>

--- a/spec/components/lettings_log_summary_component_spec.rb
+++ b/spec/components/lettings_log_summary_component_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe LettingsLogSummaryComponent, type: :component do
   let(:propcode) { "P3647" }
   let(:tenancycode) { "T62863" }
   let(:lettings_log) { FactoryBot.create(:lettings_log, needstype: 1, tenancycode:, propcode:, startdate: Time.zone.today) }
-  let(:sales_log) { FactoryBot.create(:sales_log) }
 
   context "when rendering lettings log for a support user" do
-    it "show the log summary with organisational relationships" do
+    it "shows the log summary with organisational relationships" do
       result = render_inline(described_class.new(current_user: support_user, log: lettings_log))
 
       expect(result).to have_link(lettings_log.id.to_s)
@@ -25,26 +24,8 @@ RSpec.describe LettingsLogSummaryComponent, type: :component do
   end
 
   context "when rendering lettings log for a data coordinator user" do
-    it "show the log summary" do
+    it "does not show the user who the log is owned and managed by" do
       result = render_inline(described_class.new(current_user: coordinator_user, log: lettings_log))
-
-      expect(result).not_to have_content("Owned by")
-      expect(result).not_to have_content("Managed by")
-    end
-  end
-
-  context "when rendering sales log for a support user" do
-    it "show the log summary with organisational relationships" do
-      result = render_inline(described_class.new(current_user: support_user, log: sales_log))
-
-      expect(result).to have_content("Owned by\n              DLUHC")
-      expect(result).not_to have_content("Managed by")
-    end
-  end
-
-  context "when rendering sales log for a data coordinator user" do
-    it "show the log summary" do
-      result = render_inline(described_class.new(current_user: coordinator_user, log: sales_log))
 
       expect(result).not_to have_content("Owned by")
       expect(result).not_to have_content("Managed by")

--- a/spec/components/lettings_log_summary_component_spec.rb
+++ b/spec/components/lettings_log_summary_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe LogSummaryComponent, type: :component do
+RSpec.describe LettingsLogSummaryComponent, type: :component do
   let(:support_user) { FactoryBot.create(:user, :support) }
   let(:coordinator_user) { FactoryBot.create(:user) }
   let(:propcode) { "P3647" }

--- a/spec/components/sales_log_summary_component_spec.rb
+++ b/spec/components/sales_log_summary_component_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe SalesLogSummaryComponent, type: :component do
+  let(:support_user) { FactoryBot.create(:user, :support) }
+  let(:coordinator_user) { FactoryBot.create(:user) }
+  let(:purchid) { "62863" }
+  let(:ownershipsch) { "0" }
+  let(:saledate) {  Time.zone.today }
+  let(:sales_log) { FactoryBot.create(:sales_log, ownershipsch:, purchid:, saledate:) }
+
+  context "when rendering sales log for a support user" do
+    it "shows the log summary with organisational relationships" do
+      result = render_inline(described_class.new(current_user: support_user, log: sales_log))
+
+      expect(result).to have_content("Owned by\n              DLUHC")
+      expect(result).not_to have_content("Managed by")
+    end
+  end
+
+  context "when rendering sales log for a data coordinator user" do
+    it "does not show the user who the log is owned and managed by" do
+      result = render_inline(described_class.new(current_user: coordinator_user, log: sales_log))
+
+      expect(result).not_to have_content("Owned by")
+      expect(result).not_to have_content("Managed by")
+    end
+  end
+
+  describe "what is shown in regards to sale completion" do
+    context "when a sale is completed" do
+      let(:saledate) { Time.zone.today }
+
+      it "shows the sale completion date" do
+        result = render_inline(described_class.new(current_user: coordinator_user, log: sales_log))
+
+        expect(result).to have_content("Sale completed")
+      end
+    end
+
+    context "when a sale is completed and a purchaser id is provided" do
+      let(:purchid) { "62863" }
+      let(:saledate) { Time.zone.today }
+
+      it "shows the purchaser id" do
+        result = render_inline(described_class.new(current_user: coordinator_user, log: sales_log))
+
+        expect(result).to have_content(purchid)
+      end
+    end
+
+    context "when the sale is not completed" do
+      let(:saledate) {  nil }
+
+      it "does not show a sale completed date" do
+        result = render_inline(described_class.new(current_user: coordinator_user, log: sales_log))
+
+        expect(result).not_to have_content("Sale completed")
+      end
+    end
+  end
+
+  describe "what is shown dependant on ownership type" do
+    context "when the ownership scheme is shared ownership" do
+      let(:ownershipsch) { "1" }
+
+      it "displayed the correct ownership type" do
+        result = render_inline(described_class.new(current_user: support_user, log: sales_log))
+
+        expect(result).to have_content("Shared ownership")
+        expect(result).not_to have_content("Discounted ownership")
+        expect(result).not_to have_content("Outright or other sale")
+      end
+    end
+
+    context "when the ownership scheme is discounted ownership" do
+      let(:ownershipsch) { "2" }
+
+      it "displayed the correct ownership type" do
+        result = render_inline(described_class.new(current_user: support_user, log: sales_log))
+
+        expect(result).not_to have_content("Shared ownership")
+        expect(result).to have_content("Discounted ownership")
+        expect(result).not_to have_content("Outright or other sale")
+      end
+    end
+
+    context "when the ownership scheme is outright or other sale" do
+      let(:ownershipsch) { "3" }
+
+      it "displayed the correct ownership type" do
+        result = render_inline(described_class.new(current_user: support_user, log: sales_log))
+
+        expect(result).not_to have_content("Shared ownership")
+        expect(result).not_to have_content("Discounted ownership")
+        expect(result).to have_content("Outright or other sale")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ticket - https://digital.dclg.gov.uk/jira/browse/CLDC-2405 is concerned with exposing the purchaser id, the sale type and the sale completion date to users viewing the list of sales logs in a similar way to how the data is presented on the lettings log list.

To implement this I split the log summary component into a sales and lettings log as the single component was starting to show lots of clearly different behaviour based on if the log was sales or lettings.

It was suggested to me that an alternative approach would have been move internal logic up a level and have the component decoupled from a log type and simply receive 'heading 1' 'sub heading text' etc (as I believe the original component was intended).

If a third log type is introduced in the future then that would how I would be the way I would change this component.