### PR TITLE
CLDC-2492 add creation method field to logs

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -178,14 +178,6 @@ class Log < ApplicationRecord
     end
   end
 
-  def creation_method_code
-    bulk_uploaded? ? 2 : 1
-  end
-
-  def creation_method_label
-    bulk_uploaded? ? "bulk upload" : "single log"
-  end
-
   def bulk_uploaded?
     bulk_upload_id.present?
   end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -20,6 +20,12 @@ class Log < ApplicationRecord
   enum status: STATUS
   enum status_cache: STATUS, _prefix: true
 
+  CREATION_METHOD = {
+    "single log" => 1,
+    "bulk upload" => 2,
+  }.freeze
+  enum creation_method: CREATION_METHOD
+
   scope :visible, -> { where(status: %w[not_started in_progress completed]) }
   scope :exportable, -> { where(status: %w[not_started in_progress completed deleted]) }
 

--- a/app/services/bulk_upload/lettings/log_creator.rb
+++ b/app/services/bulk_upload/lettings/log_creator.rb
@@ -14,6 +14,7 @@ class BulkUpload::Lettings::LogCreator
 
       row_parser.log.blank_invalid_non_setup_fields!
       row_parser.log.bulk_upload = bulk_upload
+      row_parser.log.creation_method = "bulk upload"
       row_parser.log.skip_update_status = true
       row_parser.log.status = "pending"
       row_parser.log.status_cache = row_parser.log.calculate_status

--- a/app/services/bulk_upload/sales/log_creator.rb
+++ b/app/services/bulk_upload/sales/log_creator.rb
@@ -14,6 +14,7 @@ class BulkUpload::Sales::LogCreator
 
       row_parser.log.blank_invalid_non_setup_fields!
       row_parser.log.bulk_upload = bulk_upload
+      row_parser.log.creation_method = "bulk upload"
       row_parser.log.skip_update_status = true
       row_parser.log.status = "pending"
       row_parser.log.status_cache = row_parser.log.calculate_status

--- a/app/services/csv/lettings_log_csv_service.rb
+++ b/app/services/csv/lettings_log_csv_service.rb
@@ -108,8 +108,8 @@ module Csv
         codes: %i[scheme id_to_display],
       },
       creation_method: {
-        labels: %i[creation_method_label],
-        codes: %i[creation_method_code],
+        labels: %i[creation_method],
+        codes: %i[creation_method_before_type_cast],
       },
       is_dpo: {
         labels: %i[created_by is_dpo?],

--- a/app/services/csv/sales_log_csv_service.rb
+++ b/app/services/csv/sales_log_csv_service.rb
@@ -43,8 +43,8 @@ module Csv
         codes: %i[owning_organisation name],
       },
       creation_method: {
-        labels: %i[creation_method_label],
-        codes: %i[creation_method_code],
+        labels: %i[creation_method],
+        codes: %i[creation_method_before_type_cast],
       },
     }.freeze
 

--- a/db/migrate/20230629124739_add_creation_method_to_lettings_logs.rb
+++ b/db/migrate/20230629124739_add_creation_method_to_lettings_logs.rb
@@ -1,0 +1,5 @@
+class AddCreationMethodToLettingsLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lettings_logs, :creation_method, :integer, default: 1
+  end
+end

--- a/db/migrate/20230629125541_add_creation_method_to_sales_logs.rb
+++ b/db/migrate/20230629125541_add_creation_method_to_sales_logs.rb
@@ -1,0 +1,5 @@
+class AddCreationMethodToSalesLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sales_logs, :creation_method, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_142422) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_29_125541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -290,6 +290,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_142422) do
     t.integer "carehome_charges_value_check"
     t.integer "status_cache", default: 0, null: false
     t.datetime "discarded_at"
+    t.integer "creation_method", default: 1
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"
@@ -600,11 +601,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_142422) do
     t.integer "discounted_sale_value_check"
     t.integer "student_not_child_value_check"
     t.integer "percentage_discount_value_check"
-    t.integer "combined_income_value_check"
     t.integer "buyer_livein_value_check"
     t.integer "status_cache", default: 0, null: false
+    t.integer "combined_income_value_check"
     t.datetime "discarded_at"
     t.integer "stairowned_value_check"
+    t.integer "creation_method", default: 1
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true

--- a/spec/services/bulk_upload/lettings/log_creator_spec.rb
+++ b/spec/services/bulk_upload/lettings/log_creator_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe BulkUpload::Lettings::LogCreator do
         expect(log.bulk_upload).to eql(bulk_upload)
         expect(bulk_upload.lettings_logs).to include(log)
       end
+
+      it "sets the creation method" do
+        service.call
+
+        expect(LettingsLog.last.creation_method).to eq "bulk upload"
+      end
     end
 
     context "when a valid csv with several blank rows" do

--- a/spec/services/bulk_upload/sales/log_creator_spec.rb
+++ b/spec/services/bulk_upload/sales/log_creator_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe BulkUpload::Sales::LogCreator do
         Singleton.__init__(FormHandler)
         example.run
       end
-      Timecop.return
-      Singleton.__init__(FormHandler)
     end
 
     context "when a valid csv with new log" do
@@ -35,6 +33,12 @@ RSpec.describe BulkUpload::Sales::LogCreator do
         log = SalesLog.last
         expect(log.bulk_upload).to eql(bulk_upload)
         expect(bulk_upload.sales_logs).to include(log)
+      end
+
+      it "sets the creation method" do
+        service.call
+
+        expect(SalesLog.last.creation_method).to eq "bulk upload"
       end
     end
 


### PR DESCRIPTION
Add fields to the log models
define the associated enum
update csv services to retrieve data direct from the log and remove deprecated methods from the log
ensure bulk uploaded logs have creation method set correctly