### PR TITLE
CLDC-1770 Activating soon locations validations

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -258,7 +258,7 @@ private
 
   def reset_scheme_location!
     self.location = nil
-    if scheme && scheme.locations.active.size == 1
+    if scheme && scheme.locations.active_in_2_weeks.size == 1
       self.location = scheme.locations.first
     end
   end

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -32,7 +32,7 @@ module DerivedVariables::LettingsLogVariables
   def scheme_has_multiple_locations?
     return false unless scheme
 
-    @scheme_locations_count ||= scheme.locations.active.size
+    @scheme_locations_count ||= scheme.locations.active_in_2_weeks.size
     @scheme_locations_count > 1
   end
 

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -19,8 +19,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
     answer_opts = {}
     return answer_opts unless ActiveRecord::Base.connected?
 
-    Location.select(:id, :postcode, :name).where("startdate <= ? or startdate IS NULL",
-                                                 Time.zone.today).each_with_object(answer_opts) do |location, hsh|
+    Location.started_in_2_weeks.select(:id, :postcode, :name).each_with_object(answer_opts) do |location, hsh|
       hsh[location.id.to_s] = { "value" => location.postcode, "hint" => location.name }
       hsh
     end
@@ -29,7 +28,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     return {} unless lettings_log.scheme
 
-    scheme_location_ids = lettings_log.scheme.locations.confirmed.pluck(:id)
+    scheme_location_ids = lettings_log.scheme.locations.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
   end
 

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -28,7 +28,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     return {} unless lettings_log.scheme
 
-    scheme_location_ids = lettings_log.scheme.locations.pluck(:id)
+    scheme_location_ids = lettings_log.scheme.locations.confirmed.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
   end
 

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -35,8 +35,7 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
               else
                 Scheme.includes(:locations).select(:id).where(confirmed: true)
               end
-    filtered_scheme_ids = schemes.joins(:locations).merge(Location.where("startdate <= ? or startdate IS NULL",
-                                                                         Time.zone.today)).map(&:id)
+    filtered_scheme_ids = schemes.joins(:locations).merge(Location.started_in_2_weeks).map(&:id)
     answer_options.select do |k, _v|
       filtered_scheme_ids.include?(k.to_i) || k.blank?
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -23,6 +23,8 @@ class Location < ApplicationRecord
   scope :search_by, ->(param) { search_by_name(param).or(search_by_postcode(param)) }
   scope :started, -> { where("startdate <= ?", Time.zone.today).or(where(startdate: nil)) }
   scope :active, -> { where(confirmed: true).and(started) }
+  scope :started_in_2_weeks, -> { where("startdate <= ?", Time.zone.today + 2.weeks).or(where(startdate: nil)) }
+  scope :active_in_2_weeks, -> { where(confirmed: true).and(started_in_2_weeks) }
   scope :confirmed, -> { where(confirmed: true) }
   scope :unconfirmed, -> { where.not(confirmed: true) }
 

--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -54,8 +54,8 @@ module Validations::DateValidations
       record.errors.add :startdate, I18n.t("validations.setup.startdate.ten_years_after_mrc_date")
     end
 
-    location_during_startdate_validation(record, :startdate)
-    scheme_during_startdate_validation(record, :startdate)
+    location_during_startdate_validation(record)
+    scheme_during_startdate_validation(record)
   end
 
 private

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -23,7 +23,7 @@ module Validations::SetupValidations
   end
 
   def validate_location(record)
-    location_during_startdate_validation(record, :location_id)
+    location_during_startdate_validation(record)
   end
 
   def validate_scheme_has_confirmed_locations_validation(record)
@@ -35,8 +35,8 @@ module Validations::SetupValidations
   end
 
   def validate_scheme(record)
-    location_during_startdate_validation(record, :scheme_id)
-    scheme_during_startdate_validation(record, :scheme_id)
+    location_during_startdate_validation(record)
+    scheme_during_startdate_validation(record)
   end
 
   def validate_organisation(record)

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -71,6 +71,7 @@ module Validations::SharedValidations
       date, scope, deactivation_date = location_inactive_status.values_at(:date, :scope, :deactivation_date)
       record.errors.add :startdate, :not_active, message: I18n.t("validations.setup.startdate.location.#{scope}.startdate", postcode: record.location.postcode, date:, deactivation_date:)
       record.errors.add :location_id, :not_active, message: I18n.t("validations.setup.startdate.location.#{scope}.location_id", postcode: record.location.postcode, date:, deactivation_date:)
+      record.errors.add :scheme_id, :not_active, message: I18n.t("validations.setup.startdate.location.#{scope}.location_id", postcode: record.location.postcode, date:, deactivation_date:)
     end
   end
 
@@ -98,8 +99,7 @@ module Validations::SharedValidations
            when :deactivated then open_deactivation.deactivation_date
            end
 
-    scope = status
-    { scope:, date: date&.to_formatted_s(:govuk_date), deactivation_date: closest_reactivation&.deactivation_date&.to_formatted_s(:govuk_date) }
+    { scope: status, date: date&.to_formatted_s(:govuk_date), deactivation_date: closest_reactivation&.deactivation_date&.to_formatted_s(:govuk_date) }
   end
 
   def shared_validate_partner_count(record, max_people)

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -96,7 +96,7 @@ module Validations::SharedValidations
            when :deactivated then open_deactivation.deactivation_date
            end
 
-    scope = date == :activating_soon ? "#{status}.#{status(scheme_location_validation_page(field))}" : status
+    scope = %i[activating_soon reactivating_soon].include?(status) ? "#{status}.#{scheme_location_validation_page(field)}" : status
     { scope:, date: date&.to_formatted_s(:govuk_date), deactivation_date: closest_reactivation&.deactivation_date&.to_formatted_s(:govuk_date) }
   end
 

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -130,11 +130,13 @@ module Validations::SharedValidations
 private
 
   def scheme_location_validation_page(field)
-    case field
-    when :startdate then "date_page"
-    when :location_id then "location_page"
-    when :scheme_id then "scheme_page"
-    end
+    field_mappings = {
+      startdate: "date_page",
+      location_id: "location_page",
+      scheme_id: "scheme_page",
+    }
+
+    field_mappings[field]
   end
 
   def person_is_partner?(relationship)

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -69,7 +69,8 @@ module Validations::SharedValidations
 
     if location_inactive_status.present?
       date, scope, deactivation_date = location_inactive_status.values_at(:date, :scope, :deactivation_date)
-      record.errors.add field, :not_active, message: I18n.t("validations.setup.startdate.location.#{scope}", postcode: record.location.postcode, date:, deactivation_date:)
+      page = scheme_location_validation_page(field)
+      record.errors.add field, :not_active, message: I18n.t("validations.setup.startdate.location.#{scope}.#{page}", postcode: record.location.postcode, date:, deactivation_date:)
     end
   end
 
@@ -77,7 +78,8 @@ module Validations::SharedValidations
     scheme_inactive_status = inactive_status(record.startdate, record.scheme)
     if scheme_inactive_status.present?
       date, scope, deactivation_date = scheme_inactive_status.values_at(:date, :scope, :deactivation_date)
-      record.errors.add field, I18n.t("validations.setup.startdate.scheme.#{scope}", name: record.scheme.service_name, date:, deactivation_date:)
+      page = scheme_location_validation_page(field)
+      record.errors.add field, I18n.t("validations.setup.startdate.scheme.#{scope}.#{page}", name: record.scheme.service_name, date:, deactivation_date:)
     end
   end
 
@@ -126,6 +128,14 @@ module Validations::SharedValidations
   end
 
 private
+
+  def scheme_location_validation_page(field)
+    case field
+    when :startdate then "date_page"
+    when :location_id then "location_page"
+    when :scheme_id then "scheme_page"
+    end
+  end
 
   def person_is_partner?(relationship)
     relationship == "P"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,23 +248,25 @@ en:
         ten_years_after_mrc_date: "Enter a tenancy start date that is no more than 10 years after the major repairs completion date"
 
         location:
-          deactivated: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered."
+          deactivated:
+            startdate: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered. Enter a tenancy start date after %{date}"
+            location_id: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered. Select another location or edit the tenancy start date"
           activating_soon:
-            date_page: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
-            location_page: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
-            scheme_page: "This scheme's only location %{postcode} is not available until %{date}. Select another scheme or edit the tenancy start date"
+            startdate: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
+            location_id: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
           reactivating_soon:
-            date_page: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
-            location_page: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
-            scheme_page: "This scheme's only location %{postcode} is not available until %{date}. Select another scheme or edit the tenancy start date"
+            startdate: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
+            location_id: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
         scheme:
-          deactivated: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered"
+          deactivated:
+            startdate: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Enter a tenancy start date after %{date}"
+            scheme_id: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Select another scheme or edit the tenancy start date"
           activating_soon:
-            date_page: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
-            scheme_page: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
+            startdate: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+            scheme_id: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
           reactivating_soon:
-            date_page: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
-            scheme_page: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
+            startdate: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+            scheme_id: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
       owning_organisation:
         invalid: "Please select the owning organisation or managing organisation that you belong to"
         data_sharing_agreement_not_signed: "The organisation must accept the Data Sharing Agreement before it can be selected as the owning organisation."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,7 +249,7 @@ en:
 
         location:
           deactivated:
-            startdate: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered. Enter a tenancy start date after %{date}"
+            startdate: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered. Select another location or edit the tenancy start date"
             location_id: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered. Select another location or edit the tenancy start date"
           activating_soon:
             startdate: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
@@ -259,7 +259,7 @@ en:
             location_id: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
         scheme:
           deactivated:
-            startdate: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Enter a tenancy start date after %{date}"
+            startdate: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Select another scheme or edit the tenancy start date"
             scheme_id: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Select another scheme or edit the tenancy start date"
           reactivating_soon:
             startdate: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,9 +261,6 @@ en:
           deactivated:
             startdate: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Enter a tenancy start date after %{date}"
             scheme_id: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered. Select another scheme or edit the tenancy start date"
-          activating_soon:
-            startdate: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
-            scheme_id: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
           reactivating_soon:
             startdate: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
             scheme_id: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,11 +250,16 @@ en:
         location:
           deactivated: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered."
           reactivating_soon: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
-          activating_soon: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
+          activating_soon:
+            date_page: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
+            location_page: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
+            scheme_page: "This scheme's only location %{postcode} is not available until %{date}. Select another scheme or edit the tenancy start date"
         scheme:
           deactivated: "%{name} was deactivated on %{date} and was not available on the day you entered"
           reactivating_soon: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
-          activating_soon: "%{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+          activating_soon:
+            date_page: "%{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+            scheme_page: "%{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
       owning_organisation:
         invalid: "Please select the owning organisation or managing organisation that you belong to"
         data_sharing_agreement_not_signed: "The organisation must accept the Data Sharing Agreement before it can be selected as the owning organisation."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,17 +249,22 @@ en:
 
         location:
           deactivated: "The location %{postcode} was deactivated on %{date} and was not available on the day you entered."
-          reactivating_soon: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
           activating_soon:
             date_page: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
             location_page: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
             scheme_page: "This scheme's only location %{postcode} is not available until %{date}. Select another scheme or edit the tenancy start date"
+          reactivating_soon:
+            date_page: "The location %{postcode} is not available until %{date}. Enter a tenancy start date after %{date}"
+            location_page: "The location %{postcode} is not available until %{date}. Select another location or edit the tenancy start date"
+            scheme_page: "This scheme's only location %{postcode} is not available until %{date}. Select another scheme or edit the tenancy start date"
         scheme:
-          deactivated: "%{name} was deactivated on %{date} and was not available on the day you entered"
-          reactivating_soon: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
+          deactivated: "The scheme %{name} was deactivated on %{date} and was not available on the day you entered"
           activating_soon:
-            date_page: "%{name} is not available until %{date}. Enter a tenancy start date after %{date}"
-            scheme_page: "%{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
+            date_page: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+            scheme_page: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
+          reactivating_soon:
+            date_page: "The scheme %{name} is not available until %{date}. Enter a tenancy start date after %{date}"
+            scheme_page: "The scheme %{name} is not available until %{date}. Select another scheme or edit the tenancy start date"
       owning_organisation:
         invalid: "Please select the owning organisation or managing organisation that you belong to"
         data_sharing_agreement_not_signed: "The organisation must accept the Data Sharing Agreement before it can be selected as the owning organisation."

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
         Timecop.unfreeze
       end
 
-      context "and all the locations have a future startdate" do
+      context "and all the locations have a startdate more than 2 weeks in the future" do
         before do
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 13))
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 6, 1))
           FactoryBot.create(:location, scheme:, startdate: Time.utc(2023, 1, 1))
           lettings_log.update!(scheme:)
         end

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
         end
       end
 
+      context "and all but one of the locations have a startdate more than 2 weeks in the future" do
+        before do
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 13))
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2023, 1, 1))
+          lettings_log.update!(scheme:)
+        end
+
+        it "the displayed_answer_options shows the locations" do
+          expect(question.displayed_answer_options(lettings_log).count).to eq(1)
+        end
+      end
+
       context "and the locations have no startdate" do
         before do
           FactoryBot.create(:location, scheme:, startdate: nil)

--- a/spec/models/form/lettings/questions/scheme_id_spec.rb
+++ b/spec/models/form/lettings/questions/scheme_id_spec.rb
@@ -90,13 +90,37 @@ RSpec.describe Form::Lettings::Questions::SchemeId, type: :model do
     end
 
     context "when a scheme with at least 1 location exists" do
-      before do
-        FactoryBot.create(:location, scheme:)
+      context "when the location is active" do
+        before do
+          FactoryBot.create(:location, startdate: Time.zone.yesterday, scheme:)
+        end
+
+        it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
+          expected_answer = { "" => "Select an option", scheme.id.to_s => scheme }
+          expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+        end
       end
 
-      it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
-        expected_answer = { "" => "Select an option", scheme.id.to_s => scheme }
-        expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+      context "when the location is activating soon" do
+        before do
+          FactoryBot.create(:location, startdate: Time.zone.tomorrow, scheme:)
+        end
+
+        it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
+          expected_answer = { "" => "Select an option", scheme.id.to_s => scheme }
+          expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+        end
+      end
+
+      context "when the location is activating more than 2 weeks in the future" do
+        before do
+          FactoryBot.create(:location, startdate: Time.zone.today + 3.weeks, scheme:)
+        end
+
+        it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
+          expected_answer = { "" => "Select an option" }
+          expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+        end
       end
     end
 

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.location.deactivated", postcode: location.postcode, date: "4 June 2022"))
+          .to include(match I18n.t("validations.setup.startdate.location.deactivated.startdate", postcode: location.postcode, date: "4 June 2022"))
+        expect(record.errors["location_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.deactivated.location_id", postcode: location.postcode, date: "4 June 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -86,6 +88,7 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["location_id"]).to be_empty
       end
     end
 
@@ -103,7 +106,9 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 August 2022"))
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.startdate", postcode: location.postcode, date: "4 August 2022"))
+        expect(record.errors["location_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -111,6 +116,7 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["location_id"]).to be_empty
       end
     end
 
@@ -130,7 +136,9 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon", postcode: location.postcode, date: "4 September 2022"))
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.startdate", postcode: location.postcode, date: "4 September 2022"))
+        expect(record.errors["location_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -138,10 +146,11 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["location_id"]).to be_empty
       end
     end
 
-    context "with a location with no deactivation periods" do
+    context "with a location that is activating soon (has no deactivation periods)" do
       let(:scheme) { create(:scheme) }
       let(:location) { create(:location, scheme:, startdate: Time.zone.local(2022, 9, 15)) }
 
@@ -150,6 +159,7 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["location_id"]).to be_empty
       end
 
       it "produces an error when the date is before available_from date" do
@@ -157,7 +167,37 @@ RSpec.describe Validations::DateValidations do
         record.location = location
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.location.activating_soon", postcode: location.postcode, date: "15 September 2022"))
+          .to include(match I18n.t("validations.setup.startdate.location.activating_soon.startdate", postcode: location.postcode, date: "15 September 2022"))
+        expect(record.errors["location_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.activating_soon.location_id", postcode: location.postcode, date: "15 September 2022"))
+      end
+    end
+
+    context "with a deactivated scheme" do
+      let(:scheme) { create(:scheme) }
+
+      before do
+        create(:location, scheme:)
+        create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2022, 6, 4), scheme:)
+        scheme.reload
+      end
+
+      it "produces error when tenancy start date is during deactivated scheme period" do
+        record.startdate = Time.zone.local(2022, 7, 5)
+        record.scheme = scheme
+        date_validator.validate_startdate(record)
+        expect(record.errors["startdate"])
+          .to include(match I18n.t("validations.setup.startdate.scheme.deactivated.startdate", name: scheme.service_name, date: "4 June 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.scheme.deactivated.scheme_id", name: scheme.service_name, date: "4 June 2022"))
+      end
+
+      it "produces no error when tenancy start date is during an active scheme period" do
+        record.startdate = Time.zone.local(2022, 6, 1)
+        record.scheme = scheme
+        date_validator.validate_startdate(record)
+        expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
 
@@ -175,7 +215,9 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 August 2022"))
+          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon.startdate", name: scheme.service_name, date: "4 August 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon.scheme_id", name: scheme.service_name, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do
@@ -183,6 +225,7 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
 
@@ -202,7 +245,9 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon", name: scheme.service_name, date: "4 September 2022"))
+          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon.startdate", name: scheme.service_name, date: "4 September 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.scheme.reactivating_soon.scheme_id", name: scheme.service_name, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active scheme period" do
@@ -210,6 +255,7 @@ RSpec.describe Validations::DateValidations do
         record.scheme = scheme
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
   end

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe Validations::DateValidations do
           .to include(match I18n.t("validations.setup.startdate.location.deactivated.startdate", postcode: location.postcode, date: "4 June 2022"))
         expect(record.errors["location_id"])
           .to include(match I18n.t("validations.setup.startdate.location.deactivated.location_id", postcode: location.postcode, date: "4 June 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.deactivated.location_id", postcode: location.postcode, date: "4 June 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -89,6 +91,7 @@ RSpec.describe Validations::DateValidations do
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
         expect(record.errors["location_id"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
 
@@ -109,6 +112,8 @@ RSpec.describe Validations::DateValidations do
           .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.startdate", postcode: location.postcode, date: "4 August 2022"))
         expect(record.errors["location_id"])
           .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 August 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 August 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -117,6 +122,7 @@ RSpec.describe Validations::DateValidations do
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
         expect(record.errors["location_id"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
 
@@ -139,6 +145,8 @@ RSpec.describe Validations::DateValidations do
           .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.startdate", postcode: location.postcode, date: "4 September 2022"))
         expect(record.errors["location_id"])
           .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 September 2022"))
+        expect(record.errors["scheme_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.reactivating_soon.location_id", postcode: location.postcode, date: "4 September 2022"))
       end
 
       it "produces no error when tenancy start date is during an active location period" do
@@ -147,6 +155,7 @@ RSpec.describe Validations::DateValidations do
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
         expect(record.errors["location_id"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
     end
 
@@ -160,6 +169,7 @@ RSpec.describe Validations::DateValidations do
         date_validator.validate_startdate(record)
         expect(record.errors["startdate"]).to be_empty
         expect(record.errors["location_id"]).to be_empty
+        expect(record.errors["scheme_id"]).to be_empty
       end
 
       it "produces an error when the date is before available_from date" do
@@ -169,6 +179,8 @@ RSpec.describe Validations::DateValidations do
         expect(record.errors["startdate"])
           .to include(match I18n.t("validations.setup.startdate.location.activating_soon.startdate", postcode: location.postcode, date: "15 September 2022"))
         expect(record.errors["location_id"])
+          .to include(match I18n.t("validations.setup.startdate.location.activating_soon.location_id", postcode: location.postcode, date: "15 September 2022"))
+        expect(record.errors["scheme_id"])
           .to include(match I18n.t("validations.setup.startdate.location.activating_soon.location_id", postcode: location.postcode, date: "15 September 2022"))
       end
     end


### PR DESCRIPTION
Adds validations for schemes and locations depending on status when compared with tenancy start date for supported housing logs. Some of these were already present, but the set is now complete. Note, we also now allow schemes/locations to be selected if they will activate in the next 2 weeks but the tenancy start date must be strictly after the activation date.

ticket: https://dluhcdigital.atlassian.net/browse/CLDC-1770