### PR TITLE
Fix interruption screen success banner

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -11,7 +11,7 @@ class FormController < ApplicationController
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
       if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page.merge(updated_by: current_user))
-        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).first.downcase}" if previous_interruption_screen_page_id.present?
+        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).reject { |e| e.to_s.empty? }.first&.downcase}" if previous_interruption_screen_page_id.present?
         redirect_to(successful_redirect_path)
       else
         mandatory_questions_with_no_response.map do |question|

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -11,7 +11,7 @@ class FormController < ApplicationController
       mandatory_questions_with_no_response = mandatory_questions_with_no_response(responses_for_page)
 
       if mandatory_questions_with_no_response.empty? && @log.update(responses_for_page.merge(updated_by: current_user))
-        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).reject { |e| e.to_s.empty? }.first&.downcase}" if previous_interruption_screen_page_id.present?
+        flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).reject { |label| label.to_s.empty? }.first&.downcase}" if previous_interruption_screen_page_id.present?
         redirect_to(successful_redirect_path)
       else
         mandatory_questions_with_no_response.map do |question|

--- a/spec/features/form/check_answers_page_lettings_logs_spec.rb
+++ b/spec/features/form/check_answers_page_lettings_logs_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Lettings Log Check Answers Page" do
 
     it "has question headings based on the subsection" do
       visit("/lettings-logs/#{id}/#{subsection}/check-answers")
-      question_labels = ["Tenant code", "Lead tenant’s age", "Lead tenant’s gender identity", "Number of Household Members"]
+      question_labels = ["Tenant code", "Lead tenant’s age", "Number of Household Members"]
       question_labels.each do |label|
         expect(page).to have_content(label)
       end
@@ -91,7 +91,7 @@ RSpec.describe "Lettings Log Check Answers Page" do
     # This way only the links in the table will get picked up
     it "has an answer link for questions missing an answer" do
       visit("/lettings-logs/#{empty_lettings_log.id}/#{subsection}/check-answers?referrer=check_answers")
-      assert_selector "a", text: /Answer (?!the missing questions)/, count: 5
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 4
       assert_selector "a", text: "Change", count: 0
       expect(page).to have_link("Answer", href: "/lettings-logs/#{empty_lettings_log.id}/person-1-age?referrer=check_answers")
     end
@@ -99,7 +99,7 @@ RSpec.describe "Lettings Log Check Answers Page" do
     it "has a change link for answered questions" do
       fill_in_number_question(empty_lettings_log.id, "age1", 28, "person-1-age")
       visit("/lettings-logs/#{empty_lettings_log.id}/#{subsection}/check-answers")
-      assert_selector "a", text: /Answer (?!the missing questions)/, count: 4
+      assert_selector "a", text: /Answer (?!the missing questions)/, count: 3
       assert_selector "a", text: "Change", count: 1
       expect(page).to have_link("Change", href: "/lettings-logs/#{empty_lettings_log.id}/person-1-age?referrer=check_answers")
     end

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -57,7 +57,6 @@
               "questions": {
                 "sex1": {
                   "check_answers_card_number": 1,
-                  "check_answer_label": "Lead tenant’s gender identity",
                   "header": "Which of these best describes the tenant’s gender identity?",
                   "type": "radio",
                   "answer_options": {

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe FormController, type: :request do
           end
 
           before do
-            post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}?referrer=interruption_screen", params:
+            post "/lettings-logs/#{lettings_log.id}/lead-tenant-age?referrer=interruption_screen", params:
           end
 
           it "redirects back to the soft validation page" do
@@ -557,6 +557,29 @@ RSpec.describe FormController, type: :request do
             follow_redirect!
             follow_redirect!
             expect(response.body).to include("You have successfully updated lead tenant’s age")
+          end
+        end
+
+        context "when the question was accessed from an interruption screen and it has no check answers" do
+          let(:params) do
+            {
+              id: lettings_log.id,
+              lettings_log: {
+                page: "person_1_gender",
+                sex1: "F",
+                interruption_page_id: "retirement_value_check",
+              },
+            }
+          end
+
+          before do
+            post "/lettings-logs/#{lettings_log.id}/lead-tenant-gender-identity?referrer=interruption_screen", params:
+          end
+
+          it "displays a success banner without crashing" do
+            follow_redirect!
+            follow_redirect!
+            expect(response.body).to include("You have successfully updated")
           end
         end
 


### PR DESCRIPTION
```
undefined method `downcase' for nil:NilClass
flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).first.downcase}" if previous_interruption_screen_page_id.present?
```

This error happens because we have some empty check_answer_label values, we should now be filtering them out.