### PR TITLE
CLDC-1801 Add a cancel button to add stock owners/managing organisations page

### DIFF
--- a/app/views/organisation_relationships/add_managing_agent.html.erb
+++ b/app/views/organisation_relationships/add_managing_agent.html.erb
@@ -22,7 +22,10 @@
     question: Form::Question.new("", { "answer_options" => answer_options }, nil),
     f:,
   } %>
-  <%= f.govuk_submit "Add" %>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= f.govuk_submit "Add" %>
+    <%= govuk_button_link_to("Cancel", managing_agents_organisation_path(@organisation), secondary: true) %>
+  </div>
   <%= govuk_details(summary_text: "Can't find the managing agent you're looking for?") do %>
     <ul class="govuk-list govuk-list--bullet">
       <li>Double check the spelling and try again</li>

--- a/app/views/organisation_relationships/add_stock_owner.html.erb
+++ b/app/views/organisation_relationships/add_stock_owner.html.erb
@@ -22,7 +22,10 @@
     question: Form::Question.new("", { "answer_options" => answer_options }, nil),
     f:,
   } %>
-  <%= f.govuk_submit "Add" %>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= f.govuk_submit "Add" %>
+    <%= govuk_button_link_to("Cancel", stock_owners_organisation_path(@organisation), secondary: true) %>
+  </div>
   <%= govuk_details(summary_text: "Can't find the stock owner you're looking for?") do %>
     <ul class="govuk-list govuk-list--bullet">
       <li>Double check the spelling and try again</li>

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
             it "shows an add button" do
               expect(page).to have_button("Add")
             end
+
+            it "shows a cancel button" do
+              expect(page).to have_link("Cancel", href: "/organisations/#{organisation.id}/stock-owners")
+            end
           end
         end
 
@@ -562,7 +566,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           expect(response.body).to include("Remove")
         end
 
-        context "when adding a stock owner" do
+        context "when adding a managing agent" do
           before do
             get "/organisations/#{organisation.id}/managing-agents/add", headers:, params: {}
           end
@@ -573,6 +577,10 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
 
           it "shows an add button" do
             expect(page).to have_button("Add")
+          end
+
+          it "shows a cancel button" do
+            expect(page).to have_link("Cancel", href: "/organisations/#{organisation.id}/managing-agents")
           end
         end
       end


### PR DESCRIPTION
- Add a cancel button to add managing organisations page
- Add a cancel button to add stock owners page (CLDC-1802)
 
<img width="1177" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/ee17222d-8ecd-44b4-8469-e532c878f65b">
