### PR TITLE
CLDC-1797 Do not route to managing org if it can be inferred

### DIFF
--- a/app/models/form/lettings/pages/managing_organisation.rb
+++ b/app/models/form/lettings/pages/managing_organisation.rb
@@ -20,6 +20,7 @@ class Form::Lettings::Pages::ManagingOrganisation < ::Form::Page
                    end
 
     return false unless organisation
+    return false if log.owning_organisation != organisation && !organisation.holds_own_stock?
     return true unless organisation.holds_own_stock?
 
     organisation.managing_agents.count >= 1

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe "Lettings Log Features" do
         let!(:org_rel1) { create(:organisation_relationship, child_organisation: user.organisation, parent_organisation: owning_org1) }
         let!(:org_rel2) { create(:organisation_relationship, child_organisation: user.organisation, parent_organisation: owning_org2) }
 
-        it "shows the managing organisation question" do
+        it "does not show the managing organisation question, because managing organisation can be inferred" do
           user.organisation.update!(holds_own_stock: false)
           visit("/lettings-logs")
           click_button("Create a new lettings log")
@@ -347,13 +347,11 @@ RSpec.describe "Lettings Log Features" do
           expect(page).to have_current_path("/lettings-logs/#{log_id}/stock-owner")
           select(owning_org1.name, from: "lettings-log-owning-organisation-id-field")
           click_button("Save and continue")
-          expect(page).to have_current_path("/lettings-logs/#{log_id}/managing-organisation")
-          select(user.organisation.name, from: "lettings-log-managing-organisation-id-field")
-          click_button("Save and continue")
           visit("lettings-logs/#{log_id}/setup/check-answers")
 
-          expect(page).to have_content("Managing agent User org", normalize_ws: true)
+          expect(page).not_to have_content("Managing agent User org", normalize_ws: true)
           expect(user.organisation.stock_owners).to eq([org_rel1.parent_organisation, org_rel2.parent_organisation])
+          expect(LettingsLog.find(log_id).managing_organisation).to eq(user.organisation)
         end
       end
 

--- a/spec/models/form/lettings/pages/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/pages/managing_organisation_spec.rb
@@ -105,12 +105,27 @@ RSpec.describe Form::Lettings::Pages::ManagingOrganisation, type: :model do
 
     context "when not support" do
       context "when does not hold own stock" do
-        let(:user) do
-          create(:user, :data_coordinator, organisation: create(:organisation, holds_own_stock: false))
+        let(:user) { create(:user, :data_coordinator, organisation: create(:organisation, holds_own_stock: false)) }
+
+        context "and the user's organisation is selected as owning organisation" do
+          let(:log) { create(:lettings_log, owning_organisation: user.organisation) }
+
+          it "is shown" do
+            expect(page.routed_to?(log, user)).to eq(true)
+          end
         end
 
-        it "is shown" do
-          expect(page.routed_to?(log, user)).to eq(true)
+        context "and a different than the user's organisation is selected as owning organisation" do
+          let(:stock_owner) { create(:organisation, holds_own_stock: true) }
+          let(:log) { create(:lettings_log, owning_organisation: stock_owner) }
+
+          before do
+            create(:organisation_relationship, parent_organisation: stock_owner, child_organisation: user.organisation)
+          end
+
+          it "is not shown" do
+            expect(page.routed_to?(log, user)).to eq(false)
+          end
         end
       end
 


### PR DESCRIPTION
We no longer route to managing organisation question if user is not support and user’s organisation does not own stock.
Stock owning organisation is selected to the question “Which organisation owns this letting” that is not their org
That user’s organisation must be the managing agent (because they couldn’t create a log that their org wasn’t associated with)