### PR TITLE
CLDC 1863: Prevent non-stock organisations appearing in search for who owns property questions.

### DIFF
--- a/app/models/form/lettings/questions/stock_owner.rb
+++ b/app/models/form/lettings/questions/stock_owner.rb
@@ -24,7 +24,7 @@ class Form::Lettings::Questions::StockOwner < ::Form::Question
     end
 
     stock_owners_answer_options = if user.support?
-                                    Organisation
+                                    Organisation.where(holds_own_stock: true)
                                   else
                                     user.organisation.stock_owners
                                   end.pluck(:id, :name).to_h

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -132,30 +132,6 @@ RSpec.describe "Lettings Log Features" do
     end
 
     context "when the owning organisation question is answered" do
-      context "and the owning organisation doesn't hold stock" do
-        let(:managing_org) { create(:organisation, name: "Managing org") }
-        let!(:org_rel) { create(:organisation_relationship, parent_organisation: support_user.organisation, child_organisation: managing_org) }
-
-        before do
-          support_user.organisation.update!(holds_own_stock: false)
-        end
-
-        it "shows the managing organisation question" do
-          visit("/lettings-logs")
-          click_button("Create a new lettings log")
-          click_link("Set up this lettings log")
-          log_id = page.current_path.scan(/\d/).join
-          select(support_user.organisation.name, from: "lettings-log-owning-organisation-id-field")
-          click_button("Save and continue")
-          expect(page).to have_current_path("/lettings-logs/#{log_id}/managing-organisation")
-          select(managing_org.name, from: "lettings-log-managing-organisation-id-field")
-          click_button("Save and continue")
-          visit("lettings-logs/#{log_id}/setup/check-answers")
-          expect(page).to have_content("Managing agent Managing org", normalize_ws: true)
-          expect(support_user.organisation.managing_agents).to eq([org_rel.child_organisation])
-        end
-      end
-
       context "and the owning organisation does hold stock" do
         before do
           support_user.organisation.update!(holds_own_stock: true)

--- a/spec/models/form/lettings/questions/stock_owner_spec.rb
+++ b/spec/models/form/lettings/questions/stock_owner_spec.rb
@@ -107,15 +107,17 @@ RSpec.describe Form::Lettings::Questions::StockOwner, type: :model do
 
       let(:log) { create(:lettings_log) }
 
+      let(:non_stock_organisation) { create(:organisation, holds_own_stock: false) }
       let(:expected_opts) do
-        Organisation.all.each_with_object(options) do |organisation, hsh|
+        Organisation.where(holds_own_stock: true).each_with_object(options) do |organisation, hsh|
           hsh[organisation.id] = organisation.name
           hsh
         end
       end
 
-      it "shows all orgs" do
+      it "shows orgs where organisation holds own stock" do
         expect(question.displayed_answer_options(log, user)).to eq(expected_opts)
+        expect(question.displayed_answer_options(log, user)).not_to include(non_stock_organisation.id)
       end
     end
   end


### PR DESCRIPTION
This ticket - https://dluhcdigital.atlassian.net/browse/CLDC-1863 is concerned with preventing non-stock owning organisations from appearing to support users as a valid option for who owns a property.

![image](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/62190777/453a0e05-f100-4d49-a44c-a65a0917a719)

Previously we would have seen the non-stock owning organisation as an available option.

