### PR TITLE
CLDC-1636 Update new logs end date tests

### DIFF
--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -33,7 +33,7 @@
               <% end %>
             <% end %>
 
-            <% if @log.collection_period_open? %>
+            <% if @log.collection_period_open_for_editing? %>
               <% row.action(
                 text: question.action_text(log),
                 href: action_href(log, question.page.id),

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -347,6 +347,7 @@ RSpec.describe "Schemes scheme Features" do
 
       context "when I press create a new scheme" do
         before do
+          allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
           click_link "Create a new supported housing scheme"
         end
 

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe LocationsHelper do
 
     before do
       Timecop.freeze(2023, 10, 10)
+      allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
     end
 
     after do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe FormController, type: :request do
     allow(fake_2021_2022_form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
     allow(fake_2021_2022_form).to receive(:edit_end_date).and_return(Time.zone.today + 2.months)
     allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
+    allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
   end
 
   context "when a user is not signed in" do

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1395,12 +1395,14 @@ RSpec.describe LocationsController, type: :request do
       let!(:scheme) { create(:scheme, owning_organisation: user.organisation) }
       let!(:location) { create(:location, scheme:, created_at: Time.zone.local(2022, 4, 1)) }
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
-      let!(:lettings_log) { create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
+      let(:lettings_log) { create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation) }
       let(:startdate) { Time.utc(2022, 10, 11) }
       let(:add_deactivations) { nil }
       let(:setup_locations) { nil }
 
       before do
+        allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
+        lettings_log
         Timecop.freeze(Time.utc(2023, 10, 10))
         sign_in user
         add_deactivations

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -1888,11 +1888,13 @@ RSpec.describe SchemesController, type: :request do
       let!(:scheme) { create(:scheme, owning_organisation: user.organisation, created_at: Time.zone.today) }
       let!(:location) { create(:location, scheme:) }
       let(:deactivation_date) { Time.utc(2022, 10, 10) }
-      let!(:lettings_log) { create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation, created_by: user) }
+      let(:lettings_log) { create(:lettings_log, :sh, location:, scheme:, startdate:, owning_organisation: user.organisation, created_by: user) }
       let(:startdate) { Time.utc(2022, 10, 11) }
       let(:setup_schemes) { nil }
 
       before do
+        allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
+        lettings_log
         Timecop.freeze(Time.utc(2023, 10, 10))
         sign_in user
         setup_schemes

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -347,6 +347,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
       let(:target_path) { file_fixture("2022_23_lettings_bulk_upload.csv") }
 
       before do
+        allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
         target_array = File.open(target_path).readlines
         target_array[0..71].each do |line|
           file.write line

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
   end
 
   before do
+    allow(FormHandler.instance).to receive(:lettings_in_crossover_period?).and_return(true)
     create(:organisation_relationship, parent_organisation: owning_org, child_organisation: managing_org)
 
     LaRentRange.create!(

--- a/spec/services/csv/sales_log_csv_service_spec.rb
+++ b/spec/services/csv/sales_log_csv_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Csv::SalesLogCsvService do
   let(:organisation) { create(:organisation) }
   let(:fixed_time) { Time.zone.local(2023, 2, 8) }
   let(:user) { create(:user, email: "billyboy@eyeKLAUD.com") }
-  let!(:log) do
+  let(:log) do
     create(
       :sales_log,
       :completed,
@@ -19,6 +19,12 @@ RSpec.describe Csv::SalesLogCsvService do
   end
   let(:service) { described_class.new(export_type: "labels") }
   let(:csv) { CSV.parse(service.prepare_csv(SalesLog.all)) }
+
+  before do
+    allow(Time).to receive(:now).and_return(fixed_time)
+    Singleton.__init__(FormHandler)
+    log
+  end
 
   it "calls the form handler to get all questions in order when initialized" do
     allow(FormHandler).to receive(:instance).and_return(form_handler_mock)


### PR DESCRIPTION
We will need to eventually move the new end date forward and there are a lot of tests that will fail when that happens. This PR adds some stubs to reduce the number of affected tests.