### PR TITLE
CLDC-2318 Update duplicate logs errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -450,7 +450,7 @@ class BulkUpload::Lettings::Year2022::RowParser
       "field_96",  # startdate
       "field_97",  # startdate
       "field_98",  # startdate
-      bulk_upload.needstype != 2 ? "field_100" : nil, # propcode
+      "field_100", # propcode
       bulk_upload.needstype != 2 ? "field_108" : nil, # postcode
       bulk_upload.needstype != 2 ? "field_109" : nil, # postcode
       "field_111", # owning org

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -442,7 +442,7 @@ class BulkUpload::Lettings::Year2022::RowParser
 
   def spreadsheet_duplicate_hash
     attributes.slice(
-      "field_5",   # location
+      bulk_upload.needstype != 1 ? "field_5" : nil,   # location
       "field_12",  # age1
       "field_20",  # sex1
       "field_35",  # ecstat1
@@ -450,9 +450,9 @@ class BulkUpload::Lettings::Year2022::RowParser
       "field_96",  # startdate
       "field_97",  # startdate
       "field_98",  # startdate
-      "field_100", # propcode
-      "field_108", # postcode
-      "field_109", # postcode
+      bulk_upload.needstype != 2 ? "field_100" : nil, # propcode
+      bulk_upload.needstype != 2 ? "field_108" : nil, # postcode
+      bulk_upload.needstype != 2 ? "field_109" : nil, # postcode
       "field_111", # owning org
     )
   end
@@ -518,17 +518,17 @@ private
   end
 
   def duplicate_check_fields
-    %w[
-      startdate
-      age1
-      sex1
-      ecstat1
-      owning_organisation
-      tcharge
-      propcode
-      postcode_full
-      location
-    ]
+    [
+      "startdate",
+      "age1",
+      "sex1",
+      "ecstat1",
+      "owning_organisation",
+      "tcharge",
+      "propcode",
+      bulk_upload.needstype != 2 ? "postcode_full" : nil,
+      bulk_upload.needstype != 1 ? "location" : nil,
+    ].compact
   end
 
   def validate_location_related
@@ -853,7 +853,8 @@ private
     if log_already_exists?
       error_message = "This is a duplicate log"
 
-      errors.add(:field_5, error_message) # location
+      errors.add(:field_5, error_message) unless bulk_upload.needstype == 1 # location
+      errors.add(:field_7, error_message) # tenancycode
       errors.add(:field_12, error_message) # age1
       errors.add(:field_20, error_message) # sex1
       errors.add(:field_35, error_message) # ecstat1
@@ -862,8 +863,8 @@ private
       errors.add(:field_97, error_message) # startdate
       errors.add(:field_98, error_message) # startdate
       errors.add(:field_100, error_message) # propcode
-      errors.add(:field_108, error_message) # postcode_full
-      errors.add(:field_109, error_message) # postcode_full
+      errors.add(:field_108, error_message) unless bulk_upload.needstype == 2  # postcode_full
+      errors.add(:field_109, error_message) unless bulk_upload.needstype == 2  # postcode_full
       errors.add(:field_111, error_message) # owning_organisation
     end
   end

--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -853,7 +853,7 @@ private
     if log_already_exists?
       error_message = "This is a duplicate log"
 
-      errors.add(:field_5, error_message) unless bulk_upload.needstype == 1 # location
+      errors.add(:field_5, error_message) if bulk_upload.needstype != 1 # location
       errors.add(:field_7, error_message) # tenancycode
       errors.add(:field_12, error_message) # age1
       errors.add(:field_20, error_message) # sex1
@@ -863,8 +863,8 @@ private
       errors.add(:field_97, error_message) # startdate
       errors.add(:field_98, error_message) # startdate
       errors.add(:field_100, error_message) # propcode
-      errors.add(:field_108, error_message) unless bulk_upload.needstype == 2  # postcode_full
-      errors.add(:field_109, error_message) unless bulk_upload.needstype == 2  # postcode_full
+      errors.add(:field_108, error_message) if bulk_upload.needstype != 2  # postcode_full
+      errors.add(:field_109, error_message) if bulk_upload.needstype != 2  # postcode_full
       errors.add(:field_111, error_message) # owning_organisation
     end
   end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -463,10 +463,11 @@ class BulkUpload::Lettings::Year2023::RowParser
       "field_7",   # startdate
       "field_8",   # startdate
       "field_9",   # startdate
+      "field_13",  # tenancycode
       "field_14",  # propcode
-      "field_17",  # location
-      "field_23",  # postcode
-      "field_24",  # postcode
+      field_4 != 1 ? "field_17" : nil,  # location
+      field_4 != 2 ? "field_23" : nil,  # postcode
+      field_4 != 2 ? "field_24" : nil,  # postcode
       "field_46",  # age1
       "field_47",  # sex1
       "field_50",  # ecstat1
@@ -553,17 +554,18 @@ private
   end
 
   def duplicate_check_fields
-    %w[
-      startdate
-      age1
-      sex1
-      ecstat1
-      owning_organisation
-      tcharge
-      propcode
-      postcode_full
-      location
-    ]
+    [
+      "startdate",
+      "age1",
+      "sex1",
+      "ecstat1",
+      "owning_organisation",
+      "tcharge",
+      "propcode",
+      field_4 != 2 ? "postcode_full" : nil,
+      field_4 != 1 ? "location" : nil,
+      "tenancycode",
+    ].compact
   end
 
   def validate_needs_type_present
@@ -853,11 +855,12 @@ private
       errors.add(:field_7, error_message) # startdate
       errors.add(:field_8, error_message) # startdate
       errors.add(:field_9, error_message) # startdate
+      errors.add(:field_13, error_message) # tenancycode
       errors.add(:field_14, error_message) # propcode
-      errors.add(:field_17, error_message) # location
-      errors.add(:field_23, error_message) # postcode_full
-      errors.add(:field_24, error_message) # postcode_full
-      errors.add(:field_25, error_message) # la
+      errors.add(:field_17, error_message) unless field_4 == 1 # location
+      errors.add(:field_23, error_message) unless field_4 == 2 # postcode_full
+      errors.add(:field_24, error_message) unless field_4 == 2 # postcode_full
+      errors.add(:field_25, error_message) unless field_4 == 2 # la
       errors.add(:field_46, error_message) # age1
       errors.add(:field_47, error_message) # sex1
       errors.add(:field_50, error_message) # ecstat1

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -857,10 +857,10 @@ private
       errors.add(:field_9, error_message) # startdate
       errors.add(:field_13, error_message) # tenancycode
       errors.add(:field_14, error_message) # propcode
-      errors.add(:field_17, error_message) unless field_4 == 1 # location
-      errors.add(:field_23, error_message) unless field_4 == 2 # postcode_full
-      errors.add(:field_24, error_message) unless field_4 == 2 # postcode_full
-      errors.add(:field_25, error_message) unless field_4 == 2 # la
+      errors.add(:field_17, error_message) if field_4 != 1 # location
+      errors.add(:field_23, error_message) if field_4 != 2 # postcode_full
+      errors.add(:field_24, error_message) if field_4 != 2 # postcode_full
+      errors.add(:field_25, error_message) if field_4 != 2 # la
       errors.add(:field_46, error_message) # age1
       errors.add(:field_47, error_message) # sex1
       errors.add(:field_50, error_message) # ecstat1

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
       end
 
       it "creates errors" do
-        expect { validator.call }.to change(BulkUploadError.where(category: :setup, error: "This is a duplicate of a log in your file"), :count).by(24)
+        expect { validator.call }.to change(BulkUploadError.where(category: :setup, error: "This is a duplicate of a log in your file"), :count).by(22)
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -263,7 +263,9 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(questions.map(&:id)).to eql([])
         end
 
-        context "when the log already exists in the db" do
+        context "when a general needs log already exists in the db" do
+          let(:attributes) { { bulk_upload:, field_4: "1" } }
+
           before do
             parser.log.save!
             parser.instance_variable_set(:@valid, nil)
@@ -283,8 +285,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
               :field_7, # startdate
               :field_8, # startdate
               :field_9, # startdate
+              :field_13, # tenancycode
               :field_14, # propcode
-              :field_17, # location
               :field_23, # postcode_full
               :field_24, # postcode_full
               :field_25, # postcode_full
@@ -295,6 +297,47 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
             ].each do |field|
               expect(parser.errors[field]).to include(error_message)
             end
+
+            expect(parser.errors[:field_17]).not_to include(error_message)
+          end
+        end
+
+        context "when a supported housing log already exists in the db" do
+          let(:attributes) { { bulk_upload:, field_4: "2" } }
+
+          before do
+            parser.log.save!
+            parser.instance_variable_set(:@valid, nil)
+          end
+
+          it "is not a valid row" do
+            expect(parser).not_to be_valid
+          end
+
+          it "adds an error to all the fields used to determine duplicates" do
+            parser.valid?
+
+            error_message = "This is a duplicate log"
+
+            [
+              :field_1, # owning_organisation
+              :field_7, # startdate
+              :field_8, # startdate
+              :field_9, # startdate
+              :field_13, # tenancycode
+              :field_14, # propcode
+              :field_17, # location
+              :field_46, # age1
+              :field_47, # sex1
+              :field_50, # ecstat1
+              :field_132, # tcharge
+            ].each do |field|
+              expect(parser.errors[field]).to include(error_message)
+            end
+
+            expect(parser.errors[:field_23]).not_to include(error_message)
+            expect(parser.errors[:field_24]).not_to include(error_message)
+            expect(parser.errors[:field_25]).not_to include(error_message)
           end
         end
 


### PR DESCRIPTION
- Don't trigger location code error on general needs logs
- Don't trigger postcode error on supported housing logs
- Add the “tenancy code” field to the duplicate log check