### PR TITLE
Fix a bug with not finding a managing organisation field for sales

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -102,7 +102,7 @@ private
         result[question.id] = question_params
       end
 
-      if current_user.support? && question.id == "owning_organisation_id" && @log.managing_organisation.blank?
+      if current_user.support? && question.id == "owning_organisation_id" && @log.lettings? && @log.managing_organisation.blank?
         owning_organisation = Organisation.find(result["owning_organisation_id"])
         if owning_organisation&.managing_agents&.empty?
           result["managing_organisation_id"] = owning_organisation.id

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -163,6 +163,32 @@ RSpec.describe FormController, type: :request do
       end
     end
 
+    context "when submitting a sales log for organisation that doesn't have any managing agents" do
+      let(:sales_log) { create(:sales_log) }
+      let(:params) do
+        {
+          id: sales_log.id,
+          sales_log: {
+            page: "organisation",
+            owning_organisation_id: managing_organisation.id,
+          },
+        }
+      end
+
+      before do
+        sales_log.update!(owning_organisation: nil, created_by: nil)
+        sales_log.reload
+      end
+
+      it "correctly sets owning organisation" do
+        post "/sales-logs/#{sales_log.id}/organisation", params: params
+        expect(response).to redirect_to("/sales-logs/#{sales_log.id}/created-by")
+        follow_redirect!
+        sales_log.reload
+        expect(sales_log.owning_organisation).to eq(managing_organisation)
+      end
+    end
+
     context "with valid managing organisation" do
       let(:params) do
         {


### PR DESCRIPTION
We started inferring managing organisation if it is created by support user, but sales logs don't have managing organisation so it would fail the creation. This PR adds a check for type.