### PR TITLE
Disable duplicate check on staging

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -35,6 +35,6 @@ class FeatureToggle
   end
 
   def self.deduplication_flow_enabled?
-    !Rails.env.production?
+    !Rails.env.production? && !Rails.env.staging?
   end
 end


### PR DESCRIPTION
We don't want the duplicate check on staging as it interferes with testing