### PR TITLE
CLDC-2391 Update content on bulk upload pages

### DIFF
--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -41,9 +41,15 @@ module LogsHelper
     end
   end
 
-  def pluralize_logs_and_errors_warning(log_count, error_count)
-    is_or_are = log_count == 1 ? "is" : "are"
-    need_or_needs = error_count == 1 ? "needs" : "need"
-    "There #{is_or_are} #{pluralize(log_count, 'log')} in this bulk upload with #{pluralize(error_count, 'error')} that still #{need_or_needs} to be fixed after upload."
+  def logs_and_errors_warning(bulk_upload)
+    this_or_these_errors = bulk_upload.bulk_upload_errors.count == 1 ? "This error" : "These errors"
+
+    "You will upload #{pluralize(bulk_upload.total_logs_count, 'log')}. There are errors in #{pluralize(bulk_upload.logs_with_errors_count, 'log')}, and #{pluralize(bulk_upload.bulk_upload_errors.count, 'error')} in total. #{this_or_these_errors} will need to be fixed on the CORE site."
+  end
+
+  def logs_and_soft_validations_warning(bulk_upload)
+    this_or_these_unexpected_answers = bulk_upload.bulk_upload_errors.count == 1 ? "This unexpected answer" : "These unexpected answers"
+
+    "You will upload #{pluralize(bulk_upload.total_logs_count, 'log')}. There are unexpected answers in #{pluralize(bulk_upload.logs_with_errors_count, 'log')}, and #{pluralize(bulk_upload.bulk_upload_errors.count, 'unexpected answer')} in total. #{this_or_these_unexpected_answers} will be marked as correct."
   end
 end

--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -52,4 +52,8 @@ module LogsHelper
 
     "You will upload #{pluralize(bulk_upload.total_logs_count, 'log')}. There are unexpected answers in #{pluralize(bulk_upload.logs_with_errors_count, 'log')}, and #{pluralize(bulk_upload.bulk_upload_errors.count, 'unexpected answer')} in total. #{this_or_these_unexpected_answers} will be marked as correct."
   end
+
+  def bulk_upload_error_summary(bulk_upload)
+    "You have tried to upload #{bulk_upload.total_logs_count ? pluralize(bulk_upload.total_logs_count, 'log') : 'logs'}. There are errors in #{pluralize(bulk_upload.logs_with_errors_count, 'log')}, and #{pluralize(bulk_upload.bulk_upload_errors.count, 'error')} in total."
+  end
 end

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -107,6 +107,10 @@ class BulkUpload < ApplicationRecord
     end
   end
 
+  def logs_with_errors_count
+    bulk_upload_errors.distinct.count("row")
+  end
+
 private
 
   def generate_identifier

--- a/app/models/forms/bulk_upload_lettings_resume/fix_choice.rb
+++ b/app/models/forms/bulk_upload_lettings_resume/fix_choice.rb
@@ -39,9 +39,9 @@ module Forms
 
       def recommendation
         if BulkUploadErrorSummaryTableComponent.new(bulk_upload:).errors?
-          "For this many errors we recommend to fix errors in the CSV and re-upload as you may be able to edit many fields at once in a CSV."
+          "We recommend fixing these errors in the CSV, as you may be able to edit multiple fields at once. However, you can also upload these logs and fix the errors on the CORE site."
         else
-          "For this many errors we recommend to upload logs and fix errors on site as you can easily see the questions and select the appropriate answer."
+          "We recommend uploading logs and fixing errors on site as you can easily see the questions and select the appropriate answer. However, you can also fix these errors in the CSV."
         end
       end
 

--- a/app/models/forms/bulk_upload_sales_resume/fix_choice.rb
+++ b/app/models/forms/bulk_upload_sales_resume/fix_choice.rb
@@ -39,9 +39,9 @@ module Forms
 
       def recommendation
         if BulkUploadErrorSummaryTableComponent.new(bulk_upload:).errors?
-          "For this many errors we recommend to fix errors in the CSV and re-upload as you may be able to edit many fields at once in a CSV."
+          "We recommend fixing these errors in the CSV, as you may be able to edit multiple fields at once. However, you can also upload these logs and fix the errors on the CORE site."
         else
-          "For this many errors we recommend to upload logs and fix errors on site as you can easily see the questions and select the appropriate answer."
+          "We recommend uploading logs and fixing errors on site as you can easily see the questions and select the appropriate answer. However, you can also fix these errors in the CSV."
         end
       end
 

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -73,6 +73,10 @@ class BulkUpload::Lettings::Validator
     row_parsers.any?(&:log_already_exists?)
   end
 
+  def total_logs_count
+    csv_parser.body_rows.count
+  end
+
 private
 
   # n^2 algo

--- a/app/services/bulk_upload/processor.rb
+++ b/app/services/bulk_upload/processor.rb
@@ -10,6 +10,7 @@ class BulkUpload::Processor
 
     download
 
+    @bulk_upload.update!(total_logs_count: validator.total_logs_count)
     return send_failure_mail(errors: validator.errors.full_messages) if validator.invalid?
 
     validator.call

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -67,6 +67,10 @@ class BulkUpload::Sales::Validator
     errors.count == errors.where(category: "soft_validation").count && errors.count.positive?
   end
 
+  def total_logs_count
+    csv_parser.body_rows.count
+  end
+
 private
 
   # n^2 algo

--- a/app/views/bulk_upload_lettings_resume/confirm.html.erb
+++ b/app/views/bulk_upload_lettings_resume/confirm.html.erb
@@ -5,12 +5,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>
-    <h1 class="govuk-heading-l">Are you sure you want to upload all logs from this bulk upload?</h1>
+    <h1 class="govuk-heading-l">You have chosen to upload all logs from this bulk upload.</h1>
 
-    <p class="govuk-body"><%= pluralize_logs_and_errors_warning(@bulk_upload.logs.count, @bulk_upload.bulk_upload_errors.count) %> </p>
+    <p class="govuk-body"><%= logs_and_errors_warning(@bulk_upload) %></p>
 
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_lettings_resume_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
-      <%= f.govuk_submit %>
+      <%= f.govuk_submit "Confirm" %>
 
       <%= govuk_button_link_to "Cancel", @form.back_path, secondary: true %>
     <% end %>

--- a/app/views/bulk_upload_lettings_resume/fix_choice.html.erb
+++ b/app/views/bulk_upload_lettings_resume/fix_choice.html.erb
@@ -11,7 +11,7 @@
       </div>
 
       <div class="govuk-body">
-        You have tried to upload <%= @bulk_upload.total_logs_count ? pluralize(@bulk_upload.total_logs_count, "log") : "logs" %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total.
+        <%= bulk_upload_error_summary(@bulk_upload) %>
       </div>
 
       <div class="govuk-body">

--- a/app/views/bulk_upload_lettings_resume/fix_choice.html.erb
+++ b/app/views/bulk_upload_lettings_resume/fix_choice.html.erb
@@ -4,10 +4,14 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>
-      <h1 class="govuk-heading-l">How would you like to fix <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %>?</h1>
+      <h1 class="govuk-heading-l">How would you like to fix the errors?</h1>
 
       <div class="govuk-body-l">
         File: <%= @bulk_upload.filename %>
+      </div>
+
+      <div class="govuk-body">
+        You have tried to upload <%= @bulk_upload.total_logs_count ? pluralize(@bulk_upload.total_logs_count, "log") : "logs" %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total.
       </div>
 
       <div class="govuk-body">
@@ -15,13 +19,18 @@
       </div>
 
       <%= govuk_details(summary_text: "How to choose between fixing errors on the CORE site or in the CSV") do %>
-        <p class="govuk-body">When it comes to fixing errors, there are pros and cons to doing it on a CSV versus doing it on a website.</p>
-
-        <p class="govuk-body">Fixing errors on a CSV file can be beneficial because it allows you to easily make changes to multiple records at once, and you can use tools like Excel to quickly identify and correct errors. However, if the CSV file is not properly formatted, it can be difficult to identify which records contain errors.</p>
-
-        <p class="govuk-body">Fixing errors on a website can be convenient because you can see the data in context and make changes in real-time. However, this approach can be time-consuming if you need to make changes to multiple records, and it may be more difficult to identify errors in a large dataset.</p>
-
-        <p class="govuk-body">Ultimately, the best approach will depend on the specific situation and the nature of the errors that need to be fixed.</p>
+        <p class="govuk-body govuk-!-margin-bottom-2">You may find it easier to fix the errors in the CSV file if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you have a lot of errors</li>
+          <li>the CSV file is formatted incorrectly and you can see where the errors are</li>
+          <li>you need to fix multiple errors at once</li>
+        </ul>
+        <p class="govuk-body govuk-!-margin-bottom-2">You may find it easier to fix the errors on the CORE site if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you need to see the data in context</li>
+          <li>you have a smaller file, with a few errors</li>
+          <li>you are not sure where the errors are</li>
+        </ul>
       <% end %>
 
       <%= f.govuk_collection_radio_buttons :choice,

--- a/app/views/bulk_upload_lettings_soft_validations_check/confirm.html.erb
+++ b/app/views/bulk_upload_lettings_soft_validations_check/confirm.html.erb
@@ -5,9 +5,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>
-    <h1 class="govuk-heading-l">Are you sure you want to upload all logs from this bulk upload?</h1>
+    <h1 class="govuk-heading-l">You have chosen to upload all logs from this bulk upload.</h1>
 
-    <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "unexpected answer") %> will be marked as correct.</p>
+    <p class="govuk-body"><%= logs_and_soft_validations_warning(@bulk_upload) %></p>
 
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_lettings_soft_validations_check_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/bulk_upload_sales_resume/confirm.html.erb
+++ b/app/views/bulk_upload_sales_resume/confirm.html.erb
@@ -5,9 +5,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for sales (<%= @bulk_upload.year_combo %>)</span>
-    <h1 class="govuk-heading-l">Are you sure you want to upload all logs from this bulk upload?</h1>
+    <h1 class="govuk-heading-l">You have chosen to upload all logs from this bulk upload.</h1>
 
-    <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload with <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> that still need to be fixed after upload.</p>
+    <p class="govuk-body"><%= logs_and_errors_warning(@bulk_upload) %></p>
 
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_sales_resume_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/bulk_upload_sales_resume/fix_choice.html.erb
+++ b/app/views/bulk_upload_sales_resume/fix_choice.html.erb
@@ -11,7 +11,7 @@
       </div>
 
       <div class="govuk-body">
-        You have tried to upload <%= @bulk_upload.total_logs_count ? pluralize(@bulk_upload.total_logs_count, "log") : "logs" %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total.
+        <%= bulk_upload_error_summary(@bulk_upload) %>
       </div>
 
       <div class="govuk-body">

--- a/app/views/bulk_upload_sales_resume/fix_choice.html.erb
+++ b/app/views/bulk_upload_sales_resume/fix_choice.html.erb
@@ -4,10 +4,14 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Bulk upload for sales (<%= @bulk_upload.year_combo %>)</span>
-      <h1 class="govuk-heading-l">How would you like to fix <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %>?</h1>
+      <h1 class="govuk-heading-l">How would you like to fix the errors?</h1>
 
       <div class="govuk-body-l">
         File: <%= @bulk_upload.filename %>
+      </div>
+
+      <div class="govuk-body">
+        You have tried to upload <%= @bulk_upload.total_logs_count ? pluralize(@bulk_upload.total_logs_count, "log") : "logs" %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total.
       </div>
 
       <div class="govuk-body">
@@ -15,13 +19,18 @@
       </div>
 
       <%= govuk_details(summary_text: "How to choose between fixing errors on the CORE site or in the CSV") do %>
-        <p class="govuk-body">When it comes to fixing errors, there are pros and cons to doing it on a CSV versus doing it on a website.</p>
-
-        <p class="govuk-body">Fixing errors on a CSV file can be beneficial because it allows you to easily make changes to multiple records at once, and you can use tools like Excel to quickly identify and correct errors. However, if the CSV file is not properly formatted, it can be difficult to identify which records contain errors.</p>
-
-        <p class="govuk-body">Fixing errors on a website can be convenient because you can see the data in context and make changes in real-time. However, this approach can be time-consuming if you need to make changes to multiple records, and it may be more difficult to identify errors in a large dataset.</p>
-
-        <p class="govuk-body">Ultimately, the best approach will depend on the specific situation and the nature of the errors that need to be fixed.</p>
+         <p class="govuk-body govuk-!-margin-bottom-2">You may find it easier to fix the errors in the CSV file if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you have a lot of errors</li>
+          <li>the CSV file is formatted incorrectly and you can see where the errors are</li>
+          <li>you need to fix multiple errors at once</li>
+        </ul>
+        <p class="govuk-body govuk-!-margin-bottom-2">You may find it easier to fix the errors on the CORE site if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you need to see the data in context</li>
+          <li>you have a smaller file, with a few errors</li>
+          <li>you are not sure where the errors are</li>
+        </ul>
       <% end %>
 
       <%= f.govuk_collection_radio_buttons :choice,

--- a/app/views/bulk_upload_sales_soft_validations_check/confirm.html.erb
+++ b/app/views/bulk_upload_sales_soft_validations_check/confirm.html.erb
@@ -5,9 +5,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for sales (<%= @bulk_upload.year_combo %>)</span>
-    <h1 class="govuk-heading-l">Are you sure you want to upload all logs from this bulk upload?</h1>
+    <h1 class="govuk-heading-l">You have chosen to upload all logs from this bulk upload.</h1>
 
-    <p class="govuk-body">There are <%= pluralize(@bulk_upload.logs.count, "log") %> in this bulk upload, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "unexpected answer") %> will be marked as correct.</p>
+    <p class="govuk-body"><%= logs_and_soft_validations_warning(@bulk_upload) %></p>
 
     <%= form_with model: @form, scope: :form, url: page_bulk_upload_sales_soft_validations_check_path(@bulk_upload, page: "confirm"), method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -28,7 +28,7 @@
 <% else %>
   <%= render partial: "organisations/headings",
              locals: {
-               main: "You need to fix #{pluralize(@pagy.count, 'log')} from your bulk upload",
+               main: "Fix the errors from this bulk upload",
                sub: "#{log_type_for_controller(controller).capitalize} logs (#{@bulk_upload.year_combo})",
              } %>
 
@@ -36,7 +36,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body-l">
-          The following logs are from your recent bulk upload. They have some incorrect or incomplete data. You’ll need to answer a few more questions for each one to mark them as complete.
+          You have uploaded <%= pluralize(@bulk_upload.logs.count, "log") %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %> and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total. Select the log to fix the errors.
         </p>
 
         <p class="govuk-body">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -36,7 +36,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body-l">
-          You have uploaded <%= pluralize(@bulk_upload.logs.count, "log") %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %> and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total. Select the log to fix the errors.
+          You have uploaded <%= pluralize(@bulk_upload.logs.count, "log") %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total. Select the log to fix the errors.
         </p>
 
         <p class="govuk-body">

--- a/db/migrate/20230713140231_add_total_logs_count_to_bulk_upload.rb
+++ b/db/migrate/20230713140231_add_total_logs_count_to_bulk_upload.rb
@@ -1,0 +1,5 @@
+class AddTotalLogsCountToBulkUpload < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_uploads, :total_logs_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_10_101532) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_140231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_10_101532) do
     t.text "filename"
     t.integer "needstype"
     t.text "choice"
+    t.integer "total_logs_count"
     t.index ["identifier"], name: "index_bulk_uploads_on_identifier", unique: true
     t.index ["user_id"], name: "index_bulk_uploads_on_user_id"
   end

--- a/spec/requests/bulk_upload_lettings_resume_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_resume_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BulkUploadLettingsResumeController, type: :request do
 
       expect(response.body).to include("Bulk upload for lettings")
       expect(response.body).to include("2022/23")
-      expect(response.body).to include("How would you like to fix 2 errors?")
+      expect(response.body).to include("How would you like to fix the errors?")
       expect(response.body).to include(bulk_upload.filename)
       expect(response.body).not_to include("Cancel")
     end
@@ -106,7 +106,7 @@ RSpec.describe BulkUploadLettingsResumeController, type: :request do
 
       expect(response).to be_successful
 
-      expect(response.body).to include("Are you sure")
+      expect(response.body).to include("You have chosen to upload all logs from this bulk upload.")
     end
 
     it "sets no cache headers" do

--- a/spec/requests/bulk_upload_lettings_soft_validations_check_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_soft_validations_check_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe BulkUploadLettingsSoftValidationsCheckController, type: :request do
   let(:user) { create(:user) }
-  let(:bulk_upload) { create(:bulk_upload, :lettings, user:, bulk_upload_errors:) }
+  let(:bulk_upload) { create(:bulk_upload, :lettings, user:, bulk_upload_errors:, total_logs_count: 2) }
   let(:bulk_upload_errors) { create_list(:bulk_upload_error, 2) }
 
   before do
@@ -98,8 +98,8 @@ RSpec.describe BulkUploadLettingsSoftValidationsCheckController, type: :request 
 
       expect(response).to be_successful
 
-      expect(response.body).to include("Are you sure you want to upload all logs from this bulk upload?")
-      expect(response.body).to include("There are 2 logs in this bulk upload, and 2 unexpected answers will be marked as correct.")
+      expect(response.body).to include("You have chosen to upload all logs from this bulk upload.")
+      expect(response.body).to include("You will upload 2 logs. There are unexpected answers in 2 logs, and 2 unexpected answers in total. These unexpected answers will be marked as correct.")
       expect(response.body).not_to include("You’ve successfully uploaded")
     end
   end

--- a/spec/requests/bulk_upload_sales_resume_controller_spec.rb
+++ b/spec/requests/bulk_upload_sales_resume_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BulkUploadSalesResumeController, type: :request do
 
       expect(response.body).to include("Bulk upload for sales")
       expect(response.body).to include("2022/23")
-      expect(response.body).to include("How would you like to fix 2 errors?")
+      expect(response.body).to include("How would you like to fix the errors?")
       expect(response.body).to include(bulk_upload.filename)
       expect(response.body).not_to include("Cancel")
     end
@@ -106,7 +106,7 @@ RSpec.describe BulkUploadSalesResumeController, type: :request do
 
       expect(response).to be_successful
 
-      expect(response.body).to include("Are you sure")
+      expect(response.body).to include("You have chosen to upload all logs from this bulk upload.")
     end
 
     it "sets no cache headers" do

--- a/spec/requests/bulk_upload_sales_soft_validations_check_controller_spec.rb
+++ b/spec/requests/bulk_upload_sales_soft_validations_check_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe BulkUploadSalesSoftValidationsCheckController, type: :request do
   let(:user) { create(:user) }
-  let(:bulk_upload) { create(:bulk_upload, :sales, user:, bulk_upload_errors:) }
+  let(:bulk_upload) { create(:bulk_upload, :sales, user:, bulk_upload_errors:, total_logs_count: 2) }
   let(:bulk_upload_errors) { create_list(:bulk_upload_error, 2) }
 
   before do
@@ -98,8 +98,8 @@ RSpec.describe BulkUploadSalesSoftValidationsCheckController, type: :request do
 
       expect(response).to be_successful
 
-      expect(response.body).to include("Are you sure you want to upload all logs from this bulk upload?")
-      expect(response.body).to include("There are 2 logs in this bulk upload, and 2 unexpected answers will be marked as correct.")
+      expect(response.body).to include("You have chosen to upload all logs from this bulk upload.")
+      expect(response.body).to include("You will upload 2 logs. There are unexpected answers in 2 logs, and 2 unexpected answers in total. These unexpected answers will be marked as correct.")
       expect(response.body).not_to include("You’ve successfully uploaded")
     end
   end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -521,7 +521,7 @@ RSpec.describe LettingsLogsController, type: :request do
 
               it "displays card with help info" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log and 1 error in total. Select the log to fix the errors.")
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 1 error in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -477,6 +477,10 @@ RSpec.describe LettingsLogsController, type: :request do
               let!(:included_log) { create(:lettings_log, :in_progress, bulk_upload:, owning_organisation: organisation) }
               let!(:excluded_log) { create(:lettings_log, :in_progress, owning_organisation: organisation, tenancycode: "fake_code") }
 
+              before do
+                create(:bulk_upload_error, bulk_upload:, col: "A", row: 1)
+              end
+
               it "returns logs only associated with the bulk upload" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
@@ -484,9 +488,9 @@ RSpec.describe LettingsLogsController, type: :request do
                 expect(page).not_to have_content(excluded_log.tenancycode)
               end
 
-              it "displays how many logs remaining to fix" do
+              it "dislays bulk uplaoad header" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("You need to fix 1 log")
+                expect(page).to have_content("Fix the errors from this bulk upload")
               end
 
               it "displays filter" do
@@ -517,7 +521,7 @@ RSpec.describe LettingsLogsController, type: :request do
 
               it "displays card with help info" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("The following logs are from your recent bulk upload")
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log and 1 error in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe SalesLogsController, type: :request do
 
               it "displays card with help info" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log and 1 error in total. Select the log to fix the errors.")
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 1 error in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -355,6 +355,10 @@ RSpec.describe SalesLogsController, type: :request do
               let!(:included_log) { create(:sales_log, :in_progress, bulk_upload:, owning_organisation: organisation) }
               let!(:excluded_log) { create(:sales_log, :in_progress, owning_organisation: organisation) }
 
+              before do
+                create(:bulk_upload_error, bulk_upload:, col: "A", row: 1)
+              end
+
               it "returns logs only associated with the bulk upload" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
@@ -362,9 +366,9 @@ RSpec.describe SalesLogsController, type: :request do
                 expect(page).not_to have_content(excluded_log.id)
               end
 
-              it "displays how many logs remaining to fix" do
+              it "dislays bulk upload banner" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("You need to fix 1 log")
+                expect(page).to have_content("Fix the errors from this bulk upload")
               end
 
               it "displays filter" do
@@ -395,7 +399,7 @@ RSpec.describe SalesLogsController, type: :request do
 
               it "displays card with help info" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
-                expect(page).to have_content("The following logs are from your recent bulk upload")
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log and 1 error in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe BulkUpload::Lettings::Validator do
           it "is valid" do
             expect(validator).to be_valid
           end
+
+          it "returns correct total logs count" do
+            expect(validator.total_logs_count).to be(1)
+          end
         end
 
         context "and file has too few valid headers" do

--- a/spec/services/bulk_upload/processor_spec.rb
+++ b/spec/services/bulk_upload/processor_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe BulkUpload::Processor do
           BulkUpload::Lettings::Validator,
           invalid?: true,
           call: nil,
+          total_logs_count: 1,
           errors: [],
         )
       end
@@ -58,6 +59,13 @@ RSpec.describe BulkUpload::Processor do
 
         expect(mock_validator).not_to have_received(:call)
       end
+
+      it "sets total number of logs on bulk upload" do
+        processor.call
+
+        bulk_upload.reload
+        expect(bulk_upload.total_logs_count).to eq(1)
+      end
     end
 
     context "when the bulk upload processing throws an error" do
@@ -74,6 +82,7 @@ RSpec.describe BulkUpload::Processor do
         instance_double(
           BulkUpload::Lettings::Validator,
           invalid?: false,
+          total_logs_count: 1,
         )
       end
 
@@ -119,6 +128,7 @@ RSpec.describe BulkUpload::Processor do
           BulkUpload::Lettings::Validator,
           invalid?: false,
           call: nil,
+          total_logs_count: 1,
           any_setup_errors?: true,
         )
       end

--- a/spec/services/bulk_upload/sales/validator_spec.rb
+++ b/spec/services/bulk_upload/sales/validator_spec.rb
@@ -246,4 +246,31 @@ RSpec.describe BulkUpload::Sales::Validator do
       end
     end
   end
+
+  describe "#total_logs_count?" do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2023, 2, 22)) do
+        Singleton.__init__(FormHandler)
+        example.run
+      end
+      Timecop.return
+      Singleton.__init__(FormHandler)
+    end
+
+    context "when all logs are valid" do
+      let(:target_path) { file_fixture("completed_2022_23_sales_bulk_upload.csv") }
+
+      before do
+        target_array = File.open(target_path).readlines
+        target_array[0..118].each do |line|
+          file.write line
+        end
+        file.rewind
+      end
+
+      it "returns correct total logs count" do
+        expect(validator.total_logs_count).to be(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add new content to say number of logs uploaded, number of logs with errors, and number of errors in total on fix choice page, confirmation page and the upload banner
Add new content in the details under "how to choose between fixing errors on the CORE site or in the CSV" on fix choice page
Change title on confirmation page

Store total_logs_count on bulk_upload, because bulk_upload.logs.count would return 0 before the logs get created