### PR TITLE
CLDC-2423 Update hint text on conditional questions

### DIFF
--- a/app/models/form/lettings/questions/reason_renewal.rb
+++ b/app/models/form/lettings/questions/reason_renewal.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Questions::ReasonRenewal < ::Form::Question
     @header = "What is the tenant’s main reason for the household leaving their last settled home?"
     @type = "radio"
     @check_answers_card_number = 0
-    @hint_text = ""
+    @hint_text = "You told us this letting is a renewal. We have removed some options because of this."
     @answer_options = ANSWER_OPTIONS
     @question_number = 77
   end

--- a/app/models/form/lettings/questions/referral.rb
+++ b/app/models/form/lettings/questions/referral.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Questions::Referral < ::Form::Question
     @header = "What was the source of referral for this letting?"
     @type = "radio"
     @check_answers_card_number = 0
-    @hint_text = ""
+    @hint_text = "You told us that you are a local authority and that the needs type is general needs. We have removed some options because of this."
     @answer_options = ANSWER_OPTIONS
     @question_number = 85
   end

--- a/app/models/form/lettings/questions/referral_prp.rb
+++ b/app/models/form/lettings/questions/referral_prp.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Questions::ReferralPrp < ::Form::Question
     @header = "What was the source of referral for this letting?"
     @type = "radio"
     @check_answers_card_number = 0
-    @hint_text = ""
+    @hint_text = "You told us that the needs type is general needs. We have removed some options because of this."
     @answer_options = ANSWER_OPTIONS
     @question_number = 85
   end

--- a/app/models/form/lettings/questions/referral_supported_housing.rb
+++ b/app/models/form/lettings/questions/referral_supported_housing.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Questions::ReferralSupportedHousing < ::Form::Question
     @header = "What was the source of referral for this letting?"
     @type = "radio"
     @check_answers_card_number = 0
-    @hint_text = ""
+    @hint_text = "You told us that you are a local authority. We have removed some options because of this."
     @answer_options = ANSWER_OPTIONS
     @question_number = 85
   end

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -6220,7 +6220,7 @@
                 "reason": {
                   "check_answer_label": "Reason for leaving last settled home",
                   "header": "What is the tenant’s main reason for the household leaving their last settled home?",
-                  "hint_text": "",
+                  "hint_text": "You told us this letting is a renewal. We have removed some options because of this.",
                   "type": "radio",
                   "answer_options": {
                     "40": {
@@ -6966,7 +6966,7 @@
                 "referral": {
                   "check_answer_label": "Source of referral for letting",
                   "header": "What was the source of referral for this letting?",
-                  "hint_text": "",
+                  "hint_text": "You told us that you are a local authority and that the needs type is general needs. We have removed some options because of this.",
                   "type": "radio",
                   "answer_options": {
                     "1": {
@@ -7023,7 +7023,7 @@
                 "referral": {
                   "check_answer_label": "Source of referral for letting",
                   "header": "What was the source of referral for this letting?",
-                  "hint_text": "",
+                  "hint_text": "You told us that the needs type is general needs. We have removed some options because of this.",
                   "type": "radio",
                   "answer_options": {
                     "1": {
@@ -7080,7 +7080,7 @@
                 "referral": {
                   "check_answer_label": "Source of referral for letting",
                   "header": "What was the source of referral for this letting?",
-                  "hint_text": "",
+                  "hint_text": "You told us that you are a local authority. We have removed some options because of this.",
                   "type": "radio",
                   "answer_options": {
                     "1": {

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -418,14 +418,14 @@ RSpec.describe SalesLogsController, type: :request do
               let(:other_user) { create(:user, organisation:) }
               let(:bulk_upload) { create(:bulk_upload, :sales, user: other_user) }
 
-              let!(:excluded_log) { create(:sales_log, bulk_upload:, owning_organisation: organisation) }
-              let!(:also_excluded_log) { create(:sales_log, owning_organisation: organisation) }
+              let!(:excluded_log) { create(:sales_log, bulk_upload:, owning_organisation: organisation, purchid: "fake_tenancy_code") }
+              let!(:also_excluded_log) { create(:sales_log, owning_organisation: organisation, purchid: "fake_tenancy_code_too") }
 
               it "does not return any logs" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
-                expect(page).not_to have_content(excluded_log.id)
-                expect(page).not_to have_content(also_excluded_log.id)
+                expect(page).not_to have_content(excluded_log.purchid)
+                expect(page).not_to have_content(also_excluded_log.purchid)
               end
             end
 


### PR DESCRIPTION
We conditionally remove some options on certain questions, and it has been causing some confusion. This PR adds hint text for questions explaining why some options are removed