### PR TITLE
CLDC-2577 Update allowed lead tenant's age in foster care validation

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -60,9 +60,9 @@ module Validations::HouseholdValidations
       record.errors.add :prevten, :non_temp_accommodation, message: I18n.t("validations.household.prevten.non_temp_accommodation")
     end
 
-    if record.age1.present? && record.age1 > 19 && record.previous_tenancy_was_foster_care?
-      record.errors.add :prevten, :over_20_foster_care, message: I18n.t("validations.household.prevten.over_20_foster_care")
-      record.errors.add :age1, I18n.t("validations.household.age.lead.over_20")
+    if record.age1.present? && record.age1 > 25 && record.previous_tenancy_was_foster_care?
+      record.errors.add :prevten, :over_25_foster_care, message: I18n.t("validations.household.prevten.over_25_foster_care")
+      record.errors.add :age1, I18n.t("validations.household.age.lead.over_25")
     end
 
     if record.sex1 == "M" && record.previous_tenancy_was_refuge?

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -308,7 +308,7 @@ module Imports
         %i[referral internal_transfer_non_social_housing] => %w[referral],
         %i[referral internal_transfer_fixed_or_lifetime] => %w[referral],
         %i[tenancylength tenancylength_invalid] => %w[tenancylength tenancy],
-        %i[prevten over_20_foster_care] => %w[prevten age1],
+        %i[prevten over_25_foster_care] => %w[prevten age1],
         %i[prevten non_temp_accommodation] => %w[prevten rsnvac],
         %i[joint not_joint_tenancy] => %w[joint],
         %i[offered outside_the_range] => %w[offered],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,7 @@ en:
           must_be_16_19: "Person must be aged 16-19 if they are a student and have relationship ‘child’"
         partner_under_16: "Cannot be under 16 if the relationship is partner"
         lead:
-          over_20: "The lead tenant must be under 20 as you told us their housing situation immediately before this letting was a children’s home or foster care"
+          over_25: "The lead tenant must be under 26 as you told us their housing situation immediately before this letting was a children’s home or foster care"
       ecstat:
         retired_over_70: "Person %{person_num} must be retired if over 70"
         child_under_16: "Person %{person_num}’s working situation must be ‘child under 16’ as you told us they’re under 16"
@@ -475,7 +475,7 @@ en:
         no_and_dont_know_disabled_needs_conjunction: "No disabled access needs and don’t know disabled access needs cannot be selected together"
       prevten:
         non_temp_accommodation: "Answer cannot be non-temporary accommodation as this is a re-let to a tenant who occupied the same property as temporary accommodation"
-        over_20_foster_care: "Answer cannot be a children’s home or foster care as the lead tenant is 20 or older"
+        over_25_foster_care: "Answer cannot be a children’s home or foster care as the lead tenant is 26 or older"
         male_refuge: "Answer cannot be a refuge as the lead tenant identifies as male"
         internal_transfer: "Answer cannot be %{prevten} as this tenancy is an internal transfer"
         la_general_needs:

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -624,15 +624,15 @@ RSpec.describe Validations::HouseholdValidations do
       end
     end
 
-    context "when the lead tenant is over 20" do
+    context "when the lead tenant is over 25" do
       it "cannot be children's home/foster care" do
         record.prevten = 13
-        record.age1 = 21
+        record.age1 = 26
         household_validator.validate_previous_housing_situation(record)
         expect(record.errors["prevten"])
-          .to include(match I18n.t("validations.household.prevten.over_20_foster_care"))
+          .to include(match I18n.t("validations.household.prevten.over_25_foster_care"))
         expect(record.errors["age1"])
-          .to include(match I18n.t("validations.household.age.lead.over_20"))
+          .to include(match I18n.t("validations.household.age.lead.over_25"))
       end
     end
 

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -296,16 +296,16 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
-      context "and an lead tenant must be under 20 if childrens home or foster care" do
+      context "and an lead tenant must be under 26 if childrens home or foster care" do
         before do
           lettings_log_xml.at_xpath("//meta:status").content = "submitted"
           lettings_log_xml.at_xpath("//xmlns:Q11").content = "13"
-          lettings_log_xml.at_xpath("//xmlns:P1Age").content = "22"
+          lettings_log_xml.at_xpath("//xmlns:P1Age").content = "26"
         end
 
         it "intercepts the relevant validation error" do
-          expect(logger).to receive(:warn).with(/Removing prevten with error: Answer cannot be a children’s home or foster care as the lead tenant is 20 or older/)
-          expect(logger).to receive(:warn).with(/Removing age1 with error: Answer cannot be a children’s home or foster care as the lead tenant is 20 or older/)
+          expect(logger).to receive(:warn).with(/Removing prevten with error: Answer cannot be a children’s home or foster care as the lead tenant is 26 or older/)
+          expect(logger).to receive(:warn).with(/Removing age1 with error: Answer cannot be a children’s home or foster care as the lead tenant is 26 or older/)
           expect { lettings_log_service.send(:create_log, lettings_log_xml) }
             .not_to raise_error
         end


### PR DESCRIPTION
There has been a policy change and now the leaving age for foster care can be up to and including 25 years old