### PR TITLE
Update confirmation link timeout to 24 hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -152,7 +152,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 3.hours
+  config.confirm_within = 24.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email


### PR DESCRIPTION
Discussed needing this, particularly around the larger migrations - no ticket because it would take more time to write that than to make this PR.