### PR TITLE
CLDC-2496 Correct duplicate data

### DIFF
--- a/app/controllers/duplicate_logs_controller.rb
+++ b/app/controllers/duplicate_logs_controller.rb
@@ -2,7 +2,7 @@ class DuplicateLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource_by_named_id
   before_action :find_duplicate_logs
-  before_action :find_original_log_id
+  before_action :find_original_log
 
   def show
     if @log
@@ -61,8 +61,13 @@ private
     end
   end
 
-  def find_original_log_id
+  def find_original_log
     query_params = URI.parse(request.url).query
-    @original_log_id = CGI.parse(query_params)["original_log_id"][0]&.to_i if query_params.present?
+    original_log_id = CGI.parse(query_params)["original_log_id"][0]&.to_i if query_params.present?
+    @original_log = if params[:sales_log_id].present?
+                      current_user.sales_logs.find_by(id: original_log_id)
+                    else
+                      current_user.lettings_logs.find_by(id: original_log_id)
+                    end
   end
 end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -257,6 +257,9 @@ private
   end
 
   def deduplication_success_banner
-    "<a class=\"govuk-notification-banner__link govuk-!-font-weight-bold\" href=\"#{send("#{@log.class.name.underscore}_path", @log)}\">Log #{@log.id}</a> is no longer a duplicate and has been removed from the list".html_safe
+    deduplicated_log_link = "<a class=\"govuk-notification-banner__link govuk-!-font-weight-bold\" href=\"#{send("#{@log.class.name.underscore}_path", @log)}\">Log #{@log.id}</a>"
+    changed_question_label = (@page.questions.first.check_answer_label.to_s.presence || @page.questions.first.header.to_s).downcase
+
+    I18n.t("notification.duplicate_logs.deduplication_success_banner", log_link: deduplicated_log_link, changed_question_label:).html_safe
   end
 end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -252,7 +252,7 @@ private
       send("#{class_name}_duplicate_logs_path", original_log, original_log_id: original_log.id)
     else
       flash[:notice] = deduplication_success_banner
-      send("#{class_name}_duplicate_logs_path", "#{class_name}_id".to_sym => from_referrer_query("remaining_duplicate_id"), original_log_id: from_referrer_query("original_log_id"))
+      send("#{class_name}_duplicate_logs_path", "#{class_name}_id".to_sym => from_referrer_query("first_remaining_duplicate_id"), original_log_id: from_referrer_query("original_log_id"))
     end
   end
 

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -247,7 +247,7 @@ private
 
     original_log = current_user.send(class_name.pluralize).find_by(id: from_referrer_query("original_log_id"))
 
-    if current_user.send(class_name.pluralize).duplicate_logs(original_log).count.positive?
+    if original_log.present? && current_user.send(class_name.pluralize).duplicate_logs(original_log).count.positive?
       flash[:notice] = deduplication_success_banner unless current_user.send(class_name.pluralize).duplicate_logs(@log).count.positive?
       send("#{class_name}_duplicate_logs_path", original_log, original_log_id: original_log.id)
     else
@@ -258,7 +258,16 @@ private
 
   def deduplication_success_banner
     deduplicated_log_link = "<a class=\"govuk-notification-banner__link govuk-!-font-weight-bold\" href=\"#{send("#{@log.class.name.underscore}_path", @log)}\">Log #{@log.id}</a>"
-    changed_question_label = (@page.questions.first.check_answer_label.to_s.presence || @page.questions.first.header.to_s).downcase
+    changed_labels = {
+      property_postcode: "postcode",
+      lead_tenant_age: "lead tenant’s age",
+      rent_4_weekly: "household rent and charges",
+      rent_bi_weekly: "household rent and charges",
+      rent_monthly: "household rent and charges",
+      rent_or_other_charges: "household rent and charges",
+      address: "postcode",
+    }
+    changed_question_label = changed_labels[@page.id.to_sym] || (@page.questions.first.check_answer_label.to_s.presence || @page.questions.first.header.to_s).downcase
 
     I18n.t("notification.duplicate_logs.deduplication_success_banner", log_link: deduplicated_log_link, changed_question_label:).html_safe
   end

--- a/app/helpers/duplicate_logs_helper.rb
+++ b/app/helpers/duplicate_logs_helper.rb
@@ -1,17 +1,17 @@
 module DuplicateLogsHelper
   include GovukLinkHelper
 
-  def duplicate_logs_continue_button(all_duplicates, duplicate_log, original_log_id)
+  def duplicate_logs_continue_button(all_duplicates, duplicate_log, original_log)
     if all_duplicates.count > 1
       return govuk_button_link_to "Keep this log and delete duplicates", url_for(
         controller: "duplicate_logs",
         action: "delete_duplicates",
         "#{duplicate_log.class.name.underscore}_id": duplicate_log.id,
-        original_log_id:,
+        original_log_id: original_log.id,
       )
     end
 
-    if original_log_id == duplicate_log.id
+    if !original_log.deleted?
       govuk_button_link_to "Back to Log #{duplicate_log.id}", send("#{duplicate_log.class.name.underscore}_path", duplicate_log)
     else
       type = duplicate_log.lettings? ? "lettings" : "sales"
@@ -23,8 +23,8 @@ module DuplicateLogsHelper
     send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "interruption_screen", original_log_id:)
   end
 
-  def change_duplicate_logs_action_href(log, page_id, all_duplicates)
+  def change_duplicate_logs_action_href(log, page_id, all_duplicates, original_log_id)
     remaining_duplicate_id = all_duplicates.map(&:id).reject { |id| id == log.id }.first
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "duplicate_logs", remaining_duplicate_id:)
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "duplicate_logs", remaining_duplicate_id:, original_log_id:)
   end
 end

--- a/app/helpers/duplicate_logs_helper.rb
+++ b/app/helpers/duplicate_logs_helper.rb
@@ -24,7 +24,7 @@ module DuplicateLogsHelper
   end
 
   def change_duplicate_logs_action_href(log, page_id, all_duplicates, original_log_id)
-    remaining_duplicate_id = all_duplicates.map(&:id).reject { |id| id == log.id }.first
-    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "duplicate_logs", remaining_duplicate_id:, original_log_id:)
+    first_remaining_duplicate_id = all_duplicates.map(&:id).reject { |id| id == log.id }.first
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "duplicate_logs", first_remaining_duplicate_id:, original_log_id:)
   end
 end

--- a/app/helpers/duplicate_logs_helper.rb
+++ b/app/helpers/duplicate_logs_helper.rb
@@ -12,7 +12,7 @@ module DuplicateLogsHelper
     end
 
     if !original_log.deleted?
-      govuk_button_link_to "Back to Log #{duplicate_log.id}", send("#{duplicate_log.class.name.underscore}_path", duplicate_log)
+      govuk_button_link_to "Back to Log #{original_log.id}", send("#{original_log.class.name.underscore}_path", original_log)
     else
       type = duplicate_log.lettings? ? "lettings" : "sales"
       govuk_button_link_to "Back to #{type} logs", url_for(duplicate_log.class)

--- a/app/helpers/duplicate_logs_helper.rb
+++ b/app/helpers/duplicate_logs_helper.rb
@@ -22,4 +22,9 @@ module DuplicateLogsHelper
   def duplicate_logs_action_href(log, page_id, original_log_id)
     send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "interruption_screen", original_log_id:)
   end
+
+  def change_duplicate_logs_action_href(log, page_id, all_duplicates)
+    remaining_duplicate_id = all_duplicates.map(&:id).reject { |id| id == log.id }.first
+    send("#{log.model_name.param_key}_#{page_id}_path", log, referrer: "duplicate_logs", remaining_duplicate_id:)
+  end
 end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -79,7 +79,7 @@ class LettingsLog < Log
   NUM_OF_WEEKS_FROM_PERIOD = { 2 => 26, 3 => 13, 4 => 12, 5 => 50, 6 => 49, 7 => 48, 8 => 47, 9 => 46, 1 => 52, 10 => 53 }.freeze
   SUFFIX_FROM_PERIOD = { 2 => "every 2 weeks", 3 => "every 4 weeks", 4 => "every month" }.freeze
   RETIREMENT_AGES = { "M" => 67, "F" => 60, "X" => 67 }.freeze
-  DUPLICATE_LOG_ATTRIBUTES = %w[tenancycode startdate age1_known age1 sex1 ecstat1 tcharge household_charge chcharge].freeze
+  DUPLICATE_LOG_ATTRIBUTES = %w[owning_organisation_id tenancycode startdate age1_known age1 sex1 ecstat1 tcharge household_charge chcharge].freeze
 
   def form
     FormHandler.instance.get_form(form_name) || FormHandler.instance.current_lettings_form

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -55,7 +55,7 @@ class SalesLog < Log
 
   OPTIONAL_FIELDS = %w[purchid othtype].freeze
   RETIREMENT_AGES = { "M" => 65, "F" => 60, "X" => 65 }.freeze
-  DUPLICATE_LOG_ATTRIBUTES = %w[purchid saledate age1_known age1 sex1 ecstat1 postcode_full].freeze
+  DUPLICATE_LOG_ATTRIBUTES = %w[owning_organisation_id purchid saledate age1_known age1 sex1 ecstat1 postcode_full].freeze
 
   def lettings?
     false

--- a/app/views/duplicate_logs/_duplicate_log_check_answers.erb
+++ b/app/views/duplicate_logs/_duplicate_log_check_answers.erb
@@ -7,14 +7,14 @@
 
           <% row.value do %>
             <%= simple_format(
-              get_answer_label(question, @log),
+              get_answer_label(question, log),
               wrapper_tag: "span",
               class: "govuk-!-margin-right-4",
             ) %>
 
-            <% extra_value = question.get_extra_check_answer_value(@log) %>
+            <% extra_value = question.get_extra_check_answer_value(log) %>
 
-            <% if extra_value && question.answer_label(@log, current_user).present? %>
+            <% if extra_value && question.answer_label(log, current_user).present? %>
               <%= simple_format(
                 extra_value,
                 wrapper_tag: "span",
@@ -22,14 +22,14 @@
               ) %>
             <% end %>
 
-            <% question.get_inferred_answers(@log).each do |inferred_answer| %>
+            <% question.get_inferred_answers(log).each do |inferred_answer| %>
               <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
             <% end %>
           <% end %>
 
           <% row.action(
-            text: question.action_text(@log),
-            href: duplicate_logs_action_href(@log, question.page.id, @original_log_id),
+            text: question.action_text(log),
+            href: duplicate_logs_action_href(log, question.page.id, @original_log_id),
             visually_hidden_text: question.check_answer_label.to_s.downcase,
           ) %>
         <% end %>

--- a/app/views/duplicate_logs/_duplicate_log_check_answers.erb
+++ b/app/views/duplicate_logs/_duplicate_log_check_answers.erb
@@ -29,13 +29,13 @@
           <% if @all_duplicates.count > 1 %>
             <% row.action(
                 text: question.action_text(log),
-                href: change_duplicate_logs_action_href(log, question.page.id, @all_duplicates),
+                href: change_duplicate_logs_action_href(log, question.page.id, @all_duplicates, @original_log.id),
                 visually_hidden_text: question.check_answer_label.to_s.downcase,
               ) %>
           <% else %>
             <% row.action(
               text: question.action_text(log),
-              href: duplicate_logs_action_href(log, question.page.id, @original_log_id),
+              href: duplicate_logs_action_href(log, question.page.id, @original_log.id),
               visually_hidden_text: question.check_answer_label.to_s.downcase,
             ) %>
           <% end %>

--- a/app/views/duplicate_logs/_duplicate_log_check_answers.erb
+++ b/app/views/duplicate_logs/_duplicate_log_check_answers.erb
@@ -26,12 +26,19 @@
               <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
             <% end %>
           <% end %>
-
-          <% row.action(
-            text: question.action_text(log),
-            href: duplicate_logs_action_href(log, question.page.id, @original_log_id),
-            visually_hidden_text: question.check_answer_label.to_s.downcase,
-          ) %>
+          <% if @all_duplicates.count > 1 %>
+            <% row.action(
+                text: question.action_text(log),
+                href: change_duplicate_logs_action_href(log, question.page.id, @all_duplicates),
+                visually_hidden_text: question.check_answer_label.to_s.downcase,
+              ) %>
+          <% else %>
+            <% row.action(
+              text: question.action_text(log),
+              href: duplicate_logs_action_href(log, question.page.id, @original_log_id),
+              visually_hidden_text: question.check_answer_label.to_s.downcase,
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/duplicate_logs/_duplicate_log_check_answers.erb
+++ b/app/views/duplicate_logs/_duplicate_log_check_answers.erb
@@ -26,7 +26,7 @@
               <span class="govuk-!-font-weight-regular app-!-colour-muted"><%= inferred_answer %></span>
             <% end %>
           <% end %>
-          <% if @all_duplicates.count > 1 %>
+          <% if @all_duplicates.many? %>
             <% row.action(
                 text: question.action_text(log),
                 href: change_duplicate_logs_action_href(log, question.page.id, @all_duplicates, @original_log.id),

--- a/app/views/duplicate_logs/show.html.erb
+++ b/app/views/duplicate_logs/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Check duplicate logs" %>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <% if @all_duplicates.count > 1 %>
+        <% if @all_duplicates.many? %>
             <%= govuk_panel(
                 classes: "app-panel--interruption",
               ) do %>

--- a/app/views/duplicate_logs/show.html.erb
+++ b/app/views/duplicate_logs/show.html.erb
@@ -18,7 +18,7 @@
         <% @all_duplicates.each_with_index do |log, index| %>
             <%= render partial: "duplicate_log", locals: { log: } %>
             <%= render partial: "duplicate_log_check_answers", locals: { log: } %>
-            <%= duplicate_logs_continue_button(@all_duplicates, log, @original_log_id) %>
+            <%= duplicate_logs_continue_button(@all_duplicates, log, @original_log) %>
             <% if index < @all_duplicates.count - 1 %>
                 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             <% end %>

--- a/app/views/logs/delete_duplicates.html.erb
+++ b/app/views/logs/delete_duplicates.html.erb
@@ -29,7 +29,7 @@
       <%= govuk_button_to @duplicate_logs.count == 1 ? "Delete this log" : "Delete these logs",
         send("delete_logs_#{@log.class.name.underscore}s_path"),
         method: "delete",
-        params: { ids: @duplicate_logs.map(&:id), original_log_id: @original_log_id, remaining_log_id: @log.id } %>
+        params: { ids: @duplicate_logs.map(&:id), original_log_id: @original_log.id, remaining_log_id: @log.id } %>
       <%= govuk_button_link_to(
         "Cancel",
         send("#{@log.class.name.underscore}_duplicate_logs_path", @log),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,8 @@ en:
     duplicate_logs_deleted:
       one: "%{log_ids} has been deleted."
       other: "%{log_ids} have been deleted."
+    duplicate_logs:
+        deduplication_success_banner: "%{log_link} is no longer a duplicate and has been removed from the list.<p class=\"govuk-body govuk-!-margin-top-4\">You changed the %{changed_question_label}.</p>"
 
   validations:
     organisation:

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe "Lettings Log Features" do
 
       it "allows deduplicating logs by changing the answers on the duplicate log" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
-        click_link("Change", href: "/lettings-logs/#{duplicate_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
+        click_link("Change", href: "/lettings-logs/#{duplicate_log.id}/tenant-code?first_remaining_duplicate_id=#{lettings_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         fill_in("lettings-log-tenancycode-field", with: "something else")
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
@@ -519,7 +519,7 @@ RSpec.describe "Lettings Log Features" do
       end
 
       it "allows deduplicating logs by changing the answers on the original log" do
-        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}")
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         fill_in("lettings-log-tenancycode-field", with: "something else")
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe "Lettings Log Features" do
         fill_in("lettings-log-tenancycode-field", with: "something else")
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
-        # expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
+        expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
       end
     end
   end

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -513,6 +513,8 @@ RSpec.describe "Lettings Log Features" do
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
+        expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+        expect(page).to have_content("Log #{duplicate_log.id} is no longer a duplicate and has been removed from the list")
       end
 
       it "allows deduplicating logs by changing the answers on the original log" do
@@ -521,6 +523,8 @@ RSpec.describe "Lettings Log Features" do
         click_button("Save and continue")
         expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
+        expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+        expect(page).to have_content("Log #{lettings_log.id} is no longer a duplicate and has been removed from the list")
       end
     end
   end

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -505,6 +505,23 @@ RSpec.describe "Lettings Log Features" do
         expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
         expect(page).to have_link("Back to lettings logs", href: "/lettings-logs")
       end
+
+      it "allows deduplicating logs by changing the answers on the duplicate log" do
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
+        click_link("Change", href: "/lettings-logs/#{duplicate_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
+        fill_in("lettings-log-tenancycode-field", with: "something else")
+        click_button("Save and continue")
+        expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
+        expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
+      end
+
+      it "allows deduplicating logs by changing the answers on the original log" do
+        click_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}")
+        fill_in("lettings-log-tenancycode-field", with: "something else")
+        click_button("Save and continue")
+        expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
+        # expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
+      end
     end
   end
 end

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -515,6 +515,7 @@ RSpec.describe "Lettings Log Features" do
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
         expect(page).to have_content("Log #{duplicate_log.id} is no longer a duplicate and has been removed from the list")
+        expect(page).to have_content("You changed the tenant code.")
       end
 
       it "allows deduplicating logs by changing the answers on the original log" do
@@ -525,6 +526,7 @@ RSpec.describe "Lettings Log Features" do
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
         expect(page).to have_content("Log #{lettings_log.id} is no longer a duplicate and has been removed from the list")
+        expect(page).to have_content("You changed the tenant code.")
       end
     end
   end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -244,5 +244,22 @@ RSpec.describe "Sales Log Features" do
       expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
       expect(page).to have_link("Back to sales logs", href: "/sales-logs")
     end
+
+    it "allows deduplicating logs by changing the answers on the duplicate log" do
+      expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
+      click_link("Change", href: "/sales-logs/#{duplicate_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
+      fill_in("sales-log-purchid-field", with: "something else")
+      click_button("Save and continue")
+      expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
+      expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
+    end
+
+    it "allows deduplicating logs by changing the answers on the original log" do
+      click_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}")
+      fill_in("sales-log-purchid-field", with: "something else")
+      click_button("Save and continue")
+      expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
+      # expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
+    end
   end
 end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -252,6 +252,8 @@ RSpec.describe "Sales Log Features" do
       click_button("Save and continue")
       expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
+      expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+      expect(page).to have_content("Log #{duplicate_log.id} is no longer a duplicate and has been removed from the list")
     end
 
     it "allows deduplicating logs by changing the answers on the original log" do
@@ -260,6 +262,8 @@ RSpec.describe "Sales Log Features" do
       click_button("Save and continue")
       expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
+      expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
+      expect(page).to have_content("Log #{sales_log.id} is no longer a duplicate and has been removed from the list")
     end
   end
 end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe "Sales Log Features" do
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       expect(page).to have_content("Log #{duplicate_log.id} is no longer a duplicate and has been removed from the list")
+      expect(page).to have_content("You changed the purchaser code.")
     end
 
     it "allows deduplicating logs by changing the answers on the original log" do
@@ -264,6 +265,7 @@ RSpec.describe "Sales Log Features" do
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
       expect(page).to have_content("Log #{sales_log.id} is no longer a duplicate and has been removed from the list")
+      expect(page).to have_content("You changed the purchaser code.")
     end
   end
 end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Sales Log Features" do
       fill_in("sales-log-purchid-field", with: "something else")
       click_button("Save and continue")
       expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
-      # expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
+      expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
     end
   end
 end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe "Sales Log Features" do
 
     it "allows deduplicating logs by changing the answers on the duplicate log" do
       expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
-      click_link("Change", href: "/sales-logs/#{duplicate_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
+      click_link("Change", href: "/sales-logs/#{duplicate_log.id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       fill_in("sales-log-purchid-field", with: "something else")
       click_button("Save and continue")
       expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
@@ -258,7 +258,7 @@ RSpec.describe "Sales Log Features" do
     end
 
     it "allows deduplicating logs by changing the answers on the original log" do
-      click_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}")
+      click_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       fill_in("sales-log-purchid-field", with: "something else")
       click_button("Save and continue")
       expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -2831,8 +2831,9 @@ RSpec.describe LettingsLog do
     end
 
     context "when filtering duplicate logs" do
-      let(:log) { create(:lettings_log, :duplicate) }
-      let!(:duplicate_log) { create(:lettings_log, :duplicate) }
+      let(:organisation) { create(:organisation) }
+      let(:log) { create(:lettings_log, :duplicate, owning_organisation: organisation) }
+      let!(:duplicate_log) { create(:lettings_log, :duplicate, owning_organisation: organisation) }
 
       it "returns all duplicate logs for given log" do
         expect(described_class.duplicate_logs(log).count).to eq(1)
@@ -2847,7 +2848,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a deleted duplicate log" do
-        let!(:deleted_duplicate_log) { create(:lettings_log, :duplicate, discarded_at: Time.zone.now) }
+        let!(:deleted_duplicate_log) { create(:lettings_log, :duplicate, discarded_at: Time.zone.now, owning_organisation: organisation) }
 
         it "does not return the deleted log as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(deleted_duplicate_log)
@@ -2855,7 +2856,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different start date" do
-        let!(:different_start_date_log) { create(:lettings_log, :duplicate, startdate: Time.zone.tomorrow) }
+        let!(:different_start_date_log) { create(:lettings_log, :duplicate, startdate: Time.zone.tomorrow, owning_organisation: organisation) }
 
         it "does not return a log with a different start date as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_start_date_log)
@@ -2863,7 +2864,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different age1" do
-        let!(:different_age1) { create(:lettings_log, :duplicate, age1: 50) }
+        let!(:different_age1) { create(:lettings_log, :duplicate, age1: 50, owning_organisation: organisation) }
 
         it "does not return a log with a different age1 as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_age1)
@@ -2871,7 +2872,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different sex1" do
-        let!(:different_sex1) { create(:lettings_log, :duplicate, sex1: "F") }
+        let!(:different_sex1) { create(:lettings_log, :duplicate, sex1: "F", owning_organisation: organisation) }
 
         it "does not return a log with a different sex1 as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_sex1)
@@ -2879,7 +2880,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different ecstat1" do
-        let!(:different_ecstat1) { create(:lettings_log, :duplicate, ecstat1: 1) }
+        let!(:different_ecstat1) { create(:lettings_log, :duplicate, ecstat1: 1, owning_organisation: organisation) }
 
         it "does not return a log with a different ecstat1 as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_ecstat1)
@@ -2887,7 +2888,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different tcharge" do
-        let!(:different_tcharge) { create(:lettings_log, :duplicate, brent: 100) }
+        let!(:different_tcharge) { create(:lettings_log, :duplicate, brent: 100, owning_organisation: organisation) }
 
         it "does not return a log with a different tcharge as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_tcharge)
@@ -2895,7 +2896,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different tenancycode" do
-        let!(:different_tenancycode) { create(:lettings_log, :duplicate, tenancycode: "different") }
+        let!(:different_tenancycode) { create(:lettings_log, :duplicate, tenancycode: "different", owning_organisation: organisation) }
 
         it "does not return a log with a different tenancycode as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_tenancycode)
@@ -2903,7 +2904,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with a different postcode_full" do
-        let!(:different_postcode_full) { create(:lettings_log, :duplicate, postcode_full: "B1 1AA") }
+        let!(:different_postcode_full) { create(:lettings_log, :duplicate, postcode_full: "B1 1AA", owning_organisation: organisation) }
 
         it "does not return a log with a different postcode_full as a duplicate" do
           expect(described_class.duplicate_logs(log)).not_to include(different_postcode_full)
@@ -2911,7 +2912,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with nil values for duplicate check fields" do
-        let!(:duplicate_check_fields_not_given) { create(:lettings_log, :duplicate, age1: nil, sex1: nil, ecstat1: nil, postcode_known: 2, postcode_full: nil) }
+        let!(:duplicate_check_fields_not_given) { create(:lettings_log, :duplicate, age1: nil, sex1: nil, ecstat1: nil, postcode_known: 2, postcode_full: nil, owning_organisation: organisation) }
 
         it "does not return a log with nil values as a duplicate" do
           log.update!(age1: nil, sex1: nil, ecstat1: nil, postcode_known: 2, postcode_full: nil)
@@ -2920,7 +2921,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with nil values for tenancycode" do
-        let!(:tenancycode_not_given) { create(:lettings_log, :duplicate, tenancycode: nil) }
+        let!(:tenancycode_not_given) { create(:lettings_log, :duplicate, tenancycode: nil, owning_organisation: organisation) }
 
         it "returns the log as a duplicate if tenancy code is nil" do
           log.update!(tenancycode: nil)
@@ -2929,7 +2930,7 @@ RSpec.describe LettingsLog do
       end
 
       context "when there is a log with age1 not known" do
-        let!(:age1_not_known) { create(:lettings_log, :duplicate, age1_known: 1, age1: nil) }
+        let!(:age1_not_known) { create(:lettings_log, :duplicate, age1_known: 1, age1: nil, owning_organisation: organisation) }
 
         it "returns the log as a duplicate if age1 is not known" do
           log.update!(age1_known: 1, age1: nil)
@@ -2941,8 +2942,8 @@ RSpec.describe LettingsLog do
         let(:scheme) { create(:scheme) }
         let(:location) { create(:location, scheme:) }
         let(:location_2) { create(:location, scheme:) }
-        let(:supported_housing_log) { create(:lettings_log, :duplicate, needstype: 2, location:, scheme:) }
-        let!(:duplicate_supported_housing_log) { create(:lettings_log, :duplicate, needstype: 2, location:, scheme:) }
+        let(:supported_housing_log) { create(:lettings_log, :duplicate, needstype: 2, location:, scheme:, owning_organisation: organisation) }
+        let!(:duplicate_supported_housing_log) { create(:lettings_log, :duplicate, needstype: 2, location:, scheme:, owning_organisation: organisation) }
 
         it "returns the log as a duplicate" do
           expect(described_class.duplicate_logs(supported_housing_log)).to include(duplicate_supported_housing_log)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -161,8 +161,9 @@ RSpec.describe SalesLog, type: :model do
   end
 
   context "when filtering duplicate logs" do
-    let(:log) { create(:sales_log, :duplicate) }
-    let!(:duplicate_log) { create(:sales_log, :duplicate) }
+    let(:organisation) { create(:organisation) }
+    let(:log) { create(:sales_log, :duplicate, owning_organisation: organisation) }
+    let!(:duplicate_log) { create(:sales_log, :duplicate, owning_organisation: organisation) }
 
     it "returns all duplicate logs for given log" do
       expect(described_class.duplicate_logs(log).count).to eq(1)
@@ -177,7 +178,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a deleted duplicate log" do
-      let!(:deleted_duplicate_log) { create(:sales_log, :duplicate, discarded_at: Time.zone.now) }
+      let!(:deleted_duplicate_log) { create(:sales_log, :duplicate, discarded_at: Time.zone.now, owning_organisation: organisation) }
 
       it "does not return the deleted log as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(deleted_duplicate_log)
@@ -185,7 +186,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different sale date" do
-      let!(:different_sale_date_log) { create(:sales_log, :duplicate, saledate: Time.zone.tomorrow) }
+      let!(:different_sale_date_log) { create(:sales_log, :duplicate, saledate: Time.zone.tomorrow, owning_organisation: organisation) }
 
       it "does not return a log with a different sale date as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_sale_date_log)
@@ -193,7 +194,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different age1" do
-      let!(:different_age1) { create(:sales_log, :duplicate, age1: 50) }
+      let!(:different_age1) { create(:sales_log, :duplicate, age1: 50, owning_organisation: organisation) }
 
       it "does not return a log with a different age1 as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_age1)
@@ -201,7 +202,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different sex1" do
-      let!(:different_sex1) { create(:sales_log, :duplicate, sex1: "M") }
+      let!(:different_sex1) { create(:sales_log, :duplicate, sex1: "M", owning_organisation: organisation) }
 
       it "does not return a log with a different sex1 as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_sex1)
@@ -209,7 +210,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different ecstat1" do
-      let!(:different_ecstat1) { create(:sales_log, :duplicate, ecstat1: 0) }
+      let!(:different_ecstat1) { create(:sales_log, :duplicate, ecstat1: 0, owning_organisation: organisation) }
 
       it "does not return a log with a different ecstat1 as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_ecstat1)
@@ -217,7 +218,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different purchid" do
-      let!(:different_purchid) { create(:sales_log, :duplicate, purchid: "different") }
+      let!(:different_purchid) { create(:sales_log, :duplicate, purchid: "different", owning_organisation: organisation) }
 
       it "does not return a log with a different purchid as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_purchid)
@@ -225,7 +226,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with a different postcode_full" do
-      let!(:different_postcode_full) { create(:sales_log, :duplicate, postcode_full: "B1 1AA") }
+      let!(:different_postcode_full) { create(:sales_log, :duplicate, postcode_full: "B1 1AA", owning_organisation: organisation) }
 
       it "does not return a log with a different postcode_full as a duplicate" do
         expect(described_class.duplicate_logs(log)).not_to include(different_postcode_full)
@@ -233,7 +234,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with nil values for duplicate check fields" do
-      let!(:duplicate_check_fields_not_given) { create(:sales_log, :duplicate, age1: nil, sex1: nil, ecstat1: nil, pcodenk: 1, postcode_full: nil) }
+      let!(:duplicate_check_fields_not_given) { create(:sales_log, :duplicate, age1: nil, sex1: nil, ecstat1: nil, pcodenk: 1, postcode_full: nil, owning_organisation: organisation) }
 
       it "does not return a log with nil values as a duplicate" do
         log.update!(age1: nil, sex1: nil, ecstat1: nil, pcodenk: 1, postcode_full: nil)
@@ -242,7 +243,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log with nil values for purchid" do
-      let!(:purchid_not_given) { create(:sales_log, :duplicate, purchid: nil) }
+      let!(:purchid_not_given) { create(:sales_log, :duplicate, purchid: nil, owning_organisation: organisation) }
 
       it "returns the log as a duplicate if purchid is nil" do
         log.update!(purchid: nil)
@@ -251,7 +252,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log age not known" do
-      let!(:age1_not_known) { create(:sales_log, :duplicate, age1_known: 1, age1: nil) }
+      let!(:age1_not_known) { create(:sales_log, :duplicate, age1_known: 1, age1: nil, owning_organisation: organisation) }
 
       it "returns the log as a duplicate if age is not known" do
         log.update!(age1_known: 1, age1: nil)
@@ -260,7 +261,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log age pefers not to say" do
-      let!(:age1_prefers_not_to_say) { create(:sales_log, :duplicate, age1_known: 2, age1: nil) }
+      let!(:age1_prefers_not_to_say) { create(:sales_log, :duplicate, age1_known: 2, age1: nil, owning_organisation: organisation) }
 
       it "returns the log as a duplicate if age is prefers not to say" do
         log.update!(age1_known: 2, age1: nil)
@@ -269,7 +270,7 @@ RSpec.describe SalesLog, type: :model do
     end
 
     context "when there is a log age pefers not to say and not known" do
-      let!(:age1_prefers_not_to_say) { create(:sales_log, :duplicate, age1_known: 2, age1: nil) }
+      let!(:age1_prefers_not_to_say) { create(:sales_log, :duplicate, age1_known: 2, age1: nil, owning_organisation: organisation) }
 
       it "does not return the log as a duplicate if age is prefers not to say" do
         log.update!(age1_known: 1, age1: nil)

--- a/spec/requests/duplicate_logs_controller_spec.rb
+++ b/spec/requests/duplicate_logs_controller_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe DuplicateLogsController, type: :request do
           expect(page).to have_content("Q37 - Lead tenant’s working situation", count: 3)
           expect(page).to have_content("Household rent and charges", count: 3)
           expect(page).to have_link("Change", count: 21)
+          expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=interruption_screen")
+          expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[0].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=interruption_screen")
+          expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[1].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=interruption_screen")
         end
 
         it "displays buttons to delete" do

--- a/spec/requests/duplicate_logs_controller_spec.rb
+++ b/spec/requests/duplicate_logs_controller_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe DuplicateLogsController, type: :request do
             expect(page).to have_content("Q37 - Lead tenant’s working situation", count: 3)
             expect(page).to have_content("Household rent and charges", count: 3)
             expect(page).to have_link("Change", count: 21)
-            expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
-            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[0].id}/tenant-code?referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
-            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[1].id}/tenant-code?referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[0].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[1].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
           end
 
           it "displays buttons to delete" do
@@ -122,9 +122,9 @@ RSpec.describe DuplicateLogsController, type: :request do
             expect(page).to have_content("Q25 - Buyer 1's working situation", count: 3)
             expect(page).to have_content("Q15 - Postcode", count: 3)
             expect(page).to have_link("Change", count: 18)
-            expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
-            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
-            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
+            expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
+            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
+            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
           end
 
           it "displays buttons to delete" do

--- a/spec/requests/duplicate_logs_controller_spec.rb
+++ b/spec/requests/duplicate_logs_controller_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe DuplicateLogsController, type: :request do
             expect(page).to have_content("Q37 - Lead tenant’s working situation", count: 3)
             expect(page).to have_content("Household rent and charges", count: 3)
             expect(page).to have_link("Change", count: 21)
-            expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
-            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[0].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
-            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[1].id}/tenant-code?original_log_id=#{lettings_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{lettings_log.id}")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?first_remaining_duplicate_id=#{duplicate_logs[0].id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[0].id}/tenant-code?first_remaining_duplicate_id=#{lettings_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
+            expect(page).to have_link("Change", href: "/lettings-logs/#{duplicate_logs[1].id}/tenant-code?first_remaining_duplicate_id=#{lettings_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
           end
 
           it "displays buttons to delete" do
@@ -122,9 +122,9 @@ RSpec.describe DuplicateLogsController, type: :request do
             expect(page).to have_content("Q25 - Buyer 1's working situation", count: 3)
             expect(page).to have_content("Q15 - Postcode", count: 3)
             expect(page).to have_link("Change", count: 18)
-            expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_logs[0].id}")
-            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
-            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=duplicate_logs&remaining_duplicate_id=#{sales_log.id}")
+            expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?first_remaining_duplicate_id=#{duplicate_logs[0].id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
+            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
+            expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
           end
 
           it "displays buttons to delete" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -732,6 +732,54 @@ RSpec.describe FormController, type: :request do
             end
           end
         end
+
+        context "when the question was accessed from a duplicate logs screen" do
+          let(:lettings_log) { create(:lettings_log, :duplicate, created_by: user) }
+          let(:duplicate_log) { create(:lettings_log, :duplicate, created_by: user) }
+          let(:referrer) { "/lettings-logs/#{lettings_log.id}/lead-tenant-age?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{lettings_log.id}" }
+          let(:params) do
+            {
+              id: lettings_log.id,
+              lettings_log: {
+                page: "lead_tenant_age",
+                age1: 20,
+                age1_known: 1,
+              },
+            }
+          end
+
+          before do
+            post "/lettings-logs/#{lettings_log.id}/lead-tenant-age", params:, headers: headers.merge({ "HTTP_REFERER" => referrer })
+          end
+
+          it "redirects back to the duplicates page for remaining duplicates" do
+            expect(response).to redirect_to("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
+          end
+        end
+
+        context "when the sales question was accessed from a duplicate logs screen" do
+          let(:sales_log) { create(:sales_log, :duplicate, created_by: user) }
+          let(:duplicate_log) { create(:sales_log, :duplicate, created_by: user) }
+          let(:referrer) { "/sales-logs/#{sales_log.id}/buyer-1-age?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{sales_log.id}" }
+          let(:params) do
+            {
+              id: sales_log.id,
+              sales_log: {
+                page: "buyer_1_age",
+                age1: 20,
+                age1_known: 1,
+              },
+            }
+          end
+
+          before do
+            post "/sales-logs/#{sales_log.id}/buyer-1-age", params:, headers: headers.merge({ "HTTP_REFERER" => referrer })
+          end
+
+          it "redirects back to the duplicates page for remaining duplicates" do
+            expect(response).to redirect_to("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
+          end
+        end
       end
 
       context "with checkbox questions" do

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -755,6 +755,23 @@ RSpec.describe FormController, type: :request do
           it "redirects back to the duplicates page for remaining duplicates" do
             expect(response).to redirect_to("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
           end
+
+          context "and the answer didn't change" do
+            let(:params) do
+              {
+                id: lettings_log.id,
+                lettings_log: {
+                  page: "lead_tenant_age",
+                  age1: lettings_log.age1,
+                  age1_known: lettings_log.age1_known,
+                },
+              }
+            end
+
+            it "redirects back to the duplicates page for remaining duplicates" do
+              expect(response).to have_http_status(:ok)
+            end
+          end
         end
 
         context "when the sales question was accessed from a duplicate logs screen" do
@@ -778,6 +795,23 @@ RSpec.describe FormController, type: :request do
 
           it "redirects back to the duplicates page for remaining duplicates" do
             expect(response).to redirect_to("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
+          end
+
+          context "and the answer didn't change" do
+            let(:params) do
+              {
+                id: sales_log.id,
+                sales_log: {
+                  page: "buyer_1_age",
+                  age1: sales_log.age1,
+                  age1_known: sales_log.age1_known,
+                },
+              }
+            end
+
+            it "redirects back to the duplicates page for remaining duplicates" do
+              expect(response).to have_http_status(:ok)
+            end
           end
         end
       end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe FormController, type: :request do
         context "when the question was accessed from a duplicate logs screen" do
           let(:lettings_log) { create(:lettings_log, :duplicate, created_by: user) }
           let(:duplicate_log) { create(:lettings_log, :duplicate, created_by: user) }
-          let(:referrer) { "/lettings-logs/#{lettings_log.id}/lead-tenant-age?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{lettings_log.id}" }
+          let(:referrer) { "/lettings-logs/#{lettings_log.id}/lead-tenant-age?referrer=duplicate_logs&first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{lettings_log.id}" }
           let(:params) do
             {
               id: lettings_log.id,
@@ -777,7 +777,7 @@ RSpec.describe FormController, type: :request do
         context "when the sales question was accessed from a duplicate logs screen" do
           let(:sales_log) { create(:sales_log, :duplicate, created_by: user) }
           let(:duplicate_log) { create(:sales_log, :duplicate, created_by: user) }
-          let(:referrer) { "/sales-logs/#{sales_log.id}/buyer-1-age?referrer=duplicate_logs&remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{sales_log.id}" }
+          let(:referrer) { "/sales-logs/#{sales_log.id}/buyer-1-age?referrer=duplicate_logs&first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{sales_log.id}" }
           let(:params) do
             {
               id: sales_log.id,

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -354,8 +354,8 @@ RSpec.describe SalesLogsController, type: :request do
               let(:user) { create(:user, organisation:) }
               let(:bulk_upload) { create(:bulk_upload, :sales, user:) }
 
-              let!(:included_log) { create(:sales_log, :in_progress, bulk_upload:, owning_organisation: organisation) }
-              let!(:excluded_log) { create(:sales_log, :in_progress, owning_organisation: organisation) }
+              let!(:included_log) { create(:sales_log, :in_progress, purchid: "included_id", bulk_upload:, owning_organisation: organisation) }
+              let!(:excluded_log) { create(:sales_log, :in_progress, purchid: "excluded_id", owning_organisation: organisation) }
 
               before do
                 create(:bulk_upload_error, bulk_upload:, col: "A", row: 1)
@@ -364,8 +364,8 @@ RSpec.describe SalesLogsController, type: :request do
               it "returns logs only associated with the bulk upload" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
-                expect(page).to have_content(included_log.id)
-                expect(page).not_to have_content(excluded_log.id)
+                expect(page).to have_content(included_log.purchid)
+                expect(page).not_to have_content(excluded_log.purchid)
               end
 
               it "dislays bulk upload banner" do


### PR DESCRIPTION
Update the routing to allow correcting duplicate logs from this page.
<img width="1680" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/e113f30e-ff5e-47f6-8eef-805821a8f668">
After a log is corrected and is no longer a duplicate update the routing to go to the remaining duplicates with the updated log removed. 
<img width="1404" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/a58887c2-5c12-466c-921f-6903f23df34a">

Allow returning to the initial log that was interrupted after the logs have ben deduplicated. (Back to log button)
<img width="1196" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/a965c32a-6aa7-480d-b94d-a9ffd629f7f1">
