### PR TITLE
CLDC-2570 Add merge organisations service and rake task

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -170,7 +170,7 @@ class LocationsController < ApplicationController
   end
 
   def deactivate_confirm
-    @affected_logs = @location.lettings_logs.visible.filter_by_before_startdate(params[:deactivation_date])
+    @affected_logs = @location.lettings_logs.visible.after_date(params[:deactivation_date])
     if @affected_logs.count.zero?
       deactivate
     else
@@ -271,7 +271,7 @@ private
   end
 
   def reset_location_and_scheme_for_logs!
-    logs = @location.lettings_logs.visible.filter_by_before_startdate(params[:deactivation_date].to_time)
+    logs = @location.lettings_logs.visible.after_date(params[:deactivation_date].to_time)
     logs.update!(location: nil, scheme: nil, unresolved: true)
     logs
   end

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -51,7 +51,7 @@ class SchemesController < ApplicationController
   end
 
   def deactivate_confirm
-    @affected_logs = @scheme.lettings_logs.visible.filter_by_before_startdate(params[:deactivation_date])
+    @affected_logs = @scheme.lettings_logs.visible.after_date(params[:deactivation_date])
     if @affected_logs.count.zero?
       deactivate
     else
@@ -335,7 +335,7 @@ private
   end
 
   def reset_location_and_scheme_for_logs!
-    logs = @scheme.lettings_logs.visible.filter_by_before_startdate(params[:deactivation_date].to_time)
+    logs = @scheme.lettings_logs.visible.after_date(params[:deactivation_date].to_time)
     logs.update!(location: nil, scheme: nil, unresolved: true)
     logs
   end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -50,7 +50,7 @@ class LettingsLog < Log
         .or(filter_by_postcode(param))
         .or(filter_by_id(param))
   }
-  scope :filter_by_before_startdate, ->(date) { where("lettings_logs.startdate >= ?", date) }
+  scope :after_date, ->(date) { where("lettings_logs.startdate >= ?", date) }
   scope :unresolved, -> { where(unresolved: true) }
 
   scope :filter_by_organisation, ->(org, _user = nil) { where(owning_organisation: org).or(where(managing_organisation: org)) }

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -51,6 +51,7 @@ class SalesLog < Log
     .where.not(postcode_full: nil)
     .where("age1 IS NOT NULL OR age1_known = 1 OR age1_known = 2")
   }
+  scope :after_date, ->(date) { where("saledate >= ?", date) }
 
   OPTIONAL_FIELDS = %w[purchid othtype].freeze
   RETIREMENT_AGES = { "M" => 65, "F" => 60, "X" => 65 }.freeze

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -93,13 +93,13 @@ private
   end
 
   def merge_sales_logs(merging_organisation)
-    merging_organisation.owned_sales_logs.after_date(Time.zone.today).each do |sales_log|
+    merging_organisation.sales_logs.after_date(Time.zone.today).each do |sales_log|
       sales_log.update(owning_organisation: @absorbing_organisation)
     end
   end
 
   def mark_organisation_as_merged(merging_organisation)
-    merging_organisation.update(merge_date: Time.zone.today)
+    merging_organisation.update(merge_date: Time.zone.today, absorbing_organisation: @absorbing_organisation)
   end
 
   def log_success_message

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -6,14 +6,16 @@ class Merge::MergeOrganisationsService
 
   def call
     merge_organisation_details
-    merge_rent_periods
-    merge_organisation_relationships
-    merge_users
-    merge_schemes_and_locations
-    merge_lettings_logs
-    merge_sales_logs
-    mark_organisations_as_merged
+    @merging_organisations.each do |merging_organisation|
+      merge_rent_periods(merging_organisation)
+      merge_organisation_relationships(merging_organisation)
+      merge_users(merging_organisation)
+      merge_schemes_and_locations(merging_organisation)
+      merge_lettings_logs(merging_organisation)
+      merge_sales_logs(merging_organisation)
+    end
     @absorbing_organisation.save!
+    mark_organisations_as_merged
   end
 
 private
@@ -22,78 +24,66 @@ private
     @absorbing_organisation.holds_own_stock = merge_boolean_organisation_attribute("holds_own_stock")
   end
 
-  def merge_rent_periods
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.rent_periods.each do |rent_period|
-        @absorbing_organisation.organisation_rent_periods << OrganisationRentPeriod.new(rent_period:) unless @absorbing_organisation.rent_periods.include?(rent_period)
+  def merge_rent_periods(merging_organisation)
+    merging_organisation.rent_periods.each do |rent_period|
+      @absorbing_organisation.organisation_rent_periods << OrganisationRentPeriod.new(rent_period:) unless @absorbing_organisation.rent_periods.include?(rent_period)
+    end
+  end
+
+  def merge_organisation_relationships(merging_organisation)
+    merging_organisation.parent_organisation_relationships.each do |parent_organisation_relationship|
+      if parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
+        parent_organisation_relationship.destroy!
+      else
+        parent_organisation_relationship.update!(child_organisation: @absorbing_organisation)
+      end
+    end
+    merging_organisation.child_organisation_relationships.each do |child_organisation_relationship|
+      if child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
+        child_organisation_relationship.destroy!
+      else
+        child_organisation_relationship.update!(parent_organisation: @absorbing_organisation)
       end
     end
   end
 
-  def merge_organisation_relationships
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.parent_organisation_relationships.each do |parent_organisation_relationship|
-        if parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
-          parent_organisation_relationship.destroy!
-        else
-          parent_organisation_relationship.update!(child_organisation: @absorbing_organisation)
-        end
+  def merge_users(merging_organisation)
+    merging_organisation.users.update_all(organisation_id: @absorbing_organisation.id)
+  end
+
+  def merge_schemes_and_locations(merging_organisation)
+    merging_organisation.owned_schemes.each do |scheme|
+      next if scheme.deactivated?
+
+      new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id").merge(owning_organisation: @absorbing_organisation))
+      scheme.locations.each do |location|
+        new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id")) unless location.deactivated?
       end
-      merging_organisation.child_organisation_relationships.each do |child_organisation_relationship|
-        if child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
-          child_organisation_relationship.destroy!
-        else
-          child_organisation_relationship.update!(parent_organisation: @absorbing_organisation)
-        end
-      end
+      SchemeDeactivationPeriod.create!(scheme:, deactivation_date: Time.zone.now)
     end
   end
 
-  def merge_users
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.users.update_all(organisation_id: @absorbing_organisation.id)
+  def merge_lettings_logs(merging_organisation)
+    merging_organisation.owned_lettings_logs.after_date(Time.zone.today).each do |lettings_log|
+      if lettings_log.scheme.present?
+        scheme_to_set = @absorbing_organisation.owned_schemes.find_by(service_name: lettings_log.scheme.service_name)
+        location_to_set = scheme_to_set.locations.find_by(name: lettings_log.location&.name, postcode: lettings_log.location&.postcode)
+
+        lettings_log.scheme = scheme_to_set if scheme_to_set.present?
+        lettings_log.location = location_to_set if location_to_set.present?
+      end
+      lettings_log.owning_organisation = @absorbing_organisation
+      lettings_log.save!
+    end
+    merging_organisation.managed_lettings_logs.after_date(Time.zone.today).each do |lettings_log|
+      lettings_log.managing_organisation = @absorbing_organisation
+      lettings_log.save!
     end
   end
 
-  def merge_schemes_and_locations
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.owned_schemes.each do |scheme|
-        next if scheme.deactivated?
-
-        new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id").merge(owning_organisation: @absorbing_organisation))
-        scheme.locations.each do |location|
-          new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id")) unless location.deactivated?
-        end
-        SchemeDeactivationPeriod.create!(scheme:, deactivation_date: Time.zone.now)
-      end
-    end
-  end
-
-  def merge_lettings_logs
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.owned_lettings_logs.after_date(Time.zone.today).each do |lettings_log|
-        if lettings_log.scheme.present?
-          scheme_to_set = @absorbing_organisation.owned_schemes.find_by(service_name: lettings_log.scheme.service_name)
-          location_to_set = scheme_to_set.locations.find_by(name: lettings_log.location&.name, postcode: lettings_log.location&.postcode)
-
-          lettings_log.scheme = scheme_to_set if scheme_to_set.present?
-          lettings_log.location = location_to_set if location_to_set.present?
-        end
-        lettings_log.owning_organisation = @absorbing_organisation
-        lettings_log.save!
-      end
-      merging_organisation.managed_lettings_logs.after_date(Time.zone.today).each do |lettings_log|
-        lettings_log.managing_organisation = @absorbing_organisation
-        lettings_log.save!
-      end
-    end
-  end
-
-  def merge_sales_logs
-    @merging_organisations.each do |merging_organisation|
-      merging_organisation.owned_sales_logs.after_date(Time.zone.today).each do |sales_log|
-        sales_log.update(owning_organisation: @absorbing_organisation)
-      end
+  def merge_sales_logs(merging_organisation)
+    merging_organisation.owned_sales_logs.after_date(Time.zone.today).each do |sales_log|
+      sales_log.update(owning_organisation: @absorbing_organisation)
     end
   end
 

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -11,6 +11,7 @@ class Merge::MergeOrganisationsService
     merge_users
     merge_schemes_and_locations
     merge_lettings_logs
+    merge_sales_logs
     mark_organisations_as_merged
     @absorbing_organisation.save!
   end
@@ -84,6 +85,14 @@ private
       merging_organisation.managed_lettings_logs.after_date(Time.zone.today).each do |lettings_log|
         lettings_log.managing_organisation = @absorbing_organisation
         lettings_log.save!
+      end
+    end
+  end
+
+  def merge_sales_logs
+    @merging_organisations.each do |merging_organisation|
+      merging_organisation.owned_sales_logs.after_date(Time.zone.today).each do |sales_log|
+        sales_log.update(owning_organisation: @absorbing_organisation)
       end
     end
   end

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -16,9 +16,9 @@ class Merge::MergeOrganisationsService
         merge_schemes_and_locations(merging_organisation)
         merge_lettings_logs(merging_organisation)
         merge_sales_logs(merging_organisation)
+        mark_organisation_as_merged(merging_organisation)
       end
       @absorbing_organisation.save!
-      mark_organisations_as_merged
       Rails.logger.info(@users_success_message)
       Rails.logger.info(@schemes_success_message)
     rescue ActiveRecord::RecordInvalid => e
@@ -99,8 +99,8 @@ private
     end
   end
 
-  def mark_organisations_as_merged
-    # @merging_organisations.update_all(merge_date: Time.zone.today)
+  def mark_organisation_as_merged(merging_organisation)
+    merging_organisation.update(merge_date: Time.zone.today)
   end
 
   def merge_boolean_organisation_attribute(attribute)

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -1,0 +1,73 @@
+class Merge::MergeOrganisationsService
+  def initialize(absorbing_organisation_id:, merging_organisation_ids:)
+    @absorbing_organisation = Organisation.find(absorbing_organisation_id)
+    @merging_organisations = Organisation.find(merging_organisation_ids)
+  end
+
+  def call
+    merge_organisation_details
+    merge_rent_periods
+    merge_organisation_relationships
+    merge_users
+    mark_organisations_as_merged
+    @absorbing_organisation.save!
+  end
+
+private
+
+  def merge_organisation_details
+    @absorbing_organisation.holds_own_stock = merge_boolean_organisation_attribute("holds_own_stock")
+    @absorbing_organisation.choice_based_lettings = merge_boolean_organisation_attribute("choice_based_lettings")
+    @absorbing_organisation.common_housing_register = merge_boolean_organisation_attribute("common_housing_register")
+    @absorbing_organisation.choice_allocation_policy = merge_boolean_organisation_attribute("choice_allocation_policy")
+  end
+
+  def merge_rent_periods
+    @merging_organisations.each do |merging_organisation|
+      merging_organisation.rent_periods.each do |rent_period|
+        @absorbing_organisation.organisation_rent_periods << OrganisationRentPeriod.new(rent_period:) unless @absorbing_organisation.rent_periods.include?(rent_period)
+      end
+    end
+  end
+
+  def merge_organisation_relationships
+    @merging_organisations.each do |merging_organisation|
+      merging_organisation.parent_organisation_relationships.each do |parent_organisation_relationship|
+        if parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
+          parent_organisation_relationship.destroy!
+        else
+          parent_organisation_relationship.update!(child_organisation: @absorbing_organisation)
+        end
+      end
+      merging_organisation.child_organisation_relationships.each do |child_organisation_relationship|
+        if child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
+          child_organisation_relationship.destroy!
+        else
+          child_organisation_relationship.update!(parent_organisation: @absorbing_organisation)
+        end
+      end
+    end
+  end
+
+  def merge_users
+    @merging_organisations.each do |merging_organisation|
+      merging_organisation.users.update_all(organisation_id: @absorbing_organisation.id)
+    end
+  end
+
+  def mark_organisations_as_merged
+    # @merging_organisations.update_all(merge_date: Time.zone.today)
+  end
+
+  def merge_boolean_organisation_attribute(attribute)
+    @absorbing_organisation[attribute] ||= @merging_organisations.any? { |merging_organisation| merging_organisation[attribute] }
+  end
+
+  def parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
+    parent_organisation_relationship.parent_organisation == @absorbing_organisation || @absorbing_organisation.parent_organisation_relationships.where(parent_organisation: parent_organisation_relationship.parent_organisation).exists?
+  end
+
+  def child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
+    child_organisation_relationship.child_organisation == @absorbing_organisation || @absorbing_organisation.child_organisation_relationships.where(child_organisation: child_organisation_relationship.child_organisation).exists?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_081029) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_150610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/merge_organisations.rake
+++ b/lib/tasks/merge_organisations.rake
@@ -2,7 +2,7 @@ namespace :merge do
   desc "Merge organisations into one"
   task :merge_organisations, %i[absorbing_organisation_id merging_organisation_ids] => :environment do |_task, args|
     absorbing_organisation_id = args[:absorbing_organisation_id]
-    merging_organisation_ids = args[:merging_organisation_ids]&.split(",")&.map(&:to_i)
+    merging_organisation_ids = args[:merging_organisation_ids]&.split(" ")&.map(&:to_i)
 
     raise "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]" if merging_organisation_ids.blank? || absorbing_organisation_id.blank?
 

--- a/lib/tasks/merge_organisations.rake
+++ b/lib/tasks/merge_organisations.rake
@@ -2,7 +2,7 @@ namespace :merge do
   desc "Merge organisations into one"
   task :merge_organisations, %i[absorbing_organisation_id merging_organisation_ids] => :environment do |_task, args|
     absorbing_organisation_id = args[:absorbing_organisation_id]
-    merging_organisation_ids = args[:merging_organisation_ids]
+    merging_organisation_ids = args[:merging_organisation_ids]&.split(",")&.map(&:to_i)
 
     raise "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]" if merging_organisation_ids.blank? || absorbing_organisation_id.blank?
 

--- a/lib/tasks/merge_organisations.rake
+++ b/lib/tasks/merge_organisations.rake
@@ -1,0 +1,12 @@
+namespace :merge do
+  desc "Merge organisations into one"
+  task :merge_organisations, %i[absorbing_organisation_id merging_organisation_ids] => :environment do |_task, args|
+    absorbing_organisation_id = args[:absorbing_organisation_id]
+    merging_organisation_ids = args[:merging_organisation_ids]
+
+    raise "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]" if merging_organisation_ids.blank? || absorbing_organisation_id.blank?
+
+    service = Merge::MergeOrganisationsService.new(absorbing_organisation_id:, merging_organisation_ids:)
+    service.call
+  end
+end

--- a/spec/lib/tasks/merge_organisations_spec.rb
+++ b/spec/lib/tasks/merge_organisations_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "emails" do
       end
 
       it "raises an error when only merging organisations are given" do
-        expect { task.invoke(nil, [1, 2]) }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
+        expect { task.invoke(nil, "1,2") }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
       end
 
       it "raises runs the service with correct organisation IDs" do
         expect(Merge::MergeOrganisationsService).to receive(:new).with(absorbing_organisation_id: 1, merging_organisation_ids: [2, 3]).once
         expect(merge_organisations_service).to receive(:call).once
-        task.invoke(1, [2, 3])
+        task.invoke(1, "2,3")
       end
     end
   end

--- a/spec/lib/tasks/merge_organisations_spec.rb
+++ b/spec/lib/tasks/merge_organisations_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "emails" do
+  describe ":merge_organisations", type: :task do
+    subject(:task) { Rake::Task["merge:merge_organisations"] }
+
+    let(:organisation) { create(:organisation) }
+    let(:merging_organisation) { create(:organisation) }
+
+    let(:merge_organisations_service) { Merge::MergeOrganisationsService.new(absorbing_organisation_id: organisation.id, merging_organisation_ids: [merging_organisation.id]) }
+
+    before do
+      allow(Merge::MergeOrganisationsService).to receive(:new).and_return(merge_organisations_service)
+      allow(merge_organisations_service).to receive(:call).and_return(nil)
+      Rake.application.rake_require("tasks/merge_organisations")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      it "raises an error when no parameters are given" do
+        expect { task.invoke(nil) }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
+      end
+
+      it "raises an error when only absorbing organisation is given" do
+        expect { task.invoke(1, nil) }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
+      end
+
+      it "raises an error when only merging organisations are given" do
+        expect { task.invoke(nil, [1, 2]) }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
+      end
+
+      it "raises runs the service with correct organisation IDs" do
+        expect(Merge::MergeOrganisationsService).to receive(:new).with(absorbing_organisation_id: 1, merging_organisation_ids: [2, 3]).once
+        expect(merge_organisations_service).to receive(:call).once
+        task.invoke(1, [2, 3])
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/merge_organisations_spec.rb
+++ b/spec/lib/tasks/merge_organisations_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "emails" do
       end
 
       it "raises an error when only merging organisations are given" do
-        expect { task.invoke(nil, "1,2") }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
+        expect { task.invoke(nil, "1 2") }.to raise_error(RuntimeError, "Usage: rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]")
       end
 
       it "raises runs the service with correct organisation IDs" do
         expect(Merge::MergeOrganisationsService).to receive(:new).with(absorbing_organisation_id: 1, merging_organisation_ids: [2, 3]).once
         expect(merge_organisations_service).to receive(:call).once
-        task.invoke(1, "2,3")
+        task.invoke(1, "2 3")
       end
     end
   end

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe Merge::MergeOrganisationsService do
       let!(:merging_organisation_user) { create(:user, organisation: merging_organisation, name: "fake name", email: "fake@email.com") }
 
       it "moves the users from merging organisation to absorbing organisation" do
-        expect(Rails.logger).to receive(:info).with("Absorbing organisation users: Danny Rojas (#{absorbing_organisation.data_protection_officers.first.email})\nMerged users from fake org: Danny Rojas (#{merging_organisation.data_protection_officers.first.email}), fake name (fake@email.com)\n")
-        expect(Rails.logger).to receive(:info).with("New schemes from fake org:\n")
+        expect(Rails.logger).to receive(:info).with("Merged users from fake org:")
+        expect(Rails.logger).to receive(:info).with("\tDanny Rojas (#{merging_organisation.data_protection_officers.first.email})")
+        expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
+        expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
         merge_organisations_service.call
 
         merging_organisation_user.reload
@@ -137,8 +139,11 @@ RSpec.describe Merge::MergeOrganisationsService do
         end
 
         it "combines organisation schemes and locations" do
-          expect(Rails.logger).to receive(:info).with("Absorbing organisation users: Danny Rojas (#{absorbing_organisation.data_protection_officers.first.email})\nMerged users from fake org: Danny Rojas (#{merging_organisation.data_protection_officers.first.email}), fake name (fake@email.com)\n")
-          expect(Rails.logger).to receive(:info).with("New schemes from fake org:\nScheme #{scheme.service_name} with locations: #{location.name} (#{location.postcode}), fake location (A1 1AA)\n")
+          expect(Rails.logger).to receive(:info).with("Merged users from fake org:")
+          expect(Rails.logger).to receive(:info).with("\tDanny Rojas (#{merging_organisation.data_protection_officers.first.email})")
+          expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
+          expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
+          expect(Rails.logger).to receive(:info).with(/\t#{scheme.service_name} \(S/)
           merge_organisations_service.call
 
           absorbing_organisation.reload
@@ -218,8 +223,13 @@ RSpec.describe Merge::MergeOrganisationsService do
       end
 
       it "moves the users from merging organisations to absorbing organisation" do
-        expect(Rails.logger).to receive(:info).with(/Merged users from second org:/)
-        expect(Rails.logger).to receive(:info).with("New schemes from fake org:\nNew schemes from second org:\n")
+        expect(Rails.logger).to receive(:info).with("Merged users from fake org:")
+        expect(Rails.logger).to receive(:info).with("\tDanny Rojas (#{merging_organisation.data_protection_officers.first.email})")
+        expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
+        expect(Rails.logger).to receive(:info).with("Merged users from second org:")
+        expect(Rails.logger).to receive(:info).with(/\tDanny Rojas/).exactly(6).times
+        expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
+        expect(Rails.logger).to receive(:info).with("New schemes from second org:")
         merge_organisations_service.call
 
         merging_organisation_user.reload

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Merge::MergeOrganisationsService do
 
         merging_organisation.reload
         expect(merging_organisation.merge_date.to_date).to eq(Time.zone.today)
+        expect(merging_organisation.absorbing_organisation_id).to eq(absorbing_organisation.id)
       end
 
       it "combines organisation data" do
@@ -46,8 +47,10 @@ RSpec.describe Merge::MergeOrganisationsService do
         merge_organisations_service.call
 
         absorbing_organisation.reload
+        merging_organisation.reload
         expect(absorbing_organisation.holds_own_stock).to eq(false)
         expect(merging_organisation.merge_date).to eq(nil)
+        expect(merging_organisation.absorbing_organisation_id).to eq(nil)
         expect(merging_organisation_user.organisation).to eq(merging_organisation)
       end
 
@@ -78,6 +81,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
+          merging_organisation.reload
           expect(absorbing_organisation.rent_periods.count).to eq(2)
           expect(merging_organisation.rent_periods.count).to eq(2)
         end
@@ -159,6 +163,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
+          merging_organisation.reload
           expect(absorbing_organisation.owned_lettings_logs.count).to eq(2)
           expect(absorbing_organisation.managed_lettings_logs.count).to eq(1)
           expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).scheme).to eq(absorbing_organisation.owned_schemes.first)
@@ -175,6 +180,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
+          merging_organisation.reload
           expect(absorbing_organisation.owned_schemes.count).to eq(0)
           expect(scheme.scheme_deactivation_periods.count).to eq(0)
           expect(owned_lettings_log.owning_organisation).to eq(merging_organisation)
@@ -193,8 +199,8 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
-          expect(absorbing_organisation.owned_sales_logs.count).to eq(1)
-          expect(absorbing_organisation.owned_sales_logs.first).to eq(sales_log)
+          expect(SalesLog.filter_by_owning_organisation(absorbing_organisation).count).to eq(1)
+          expect(SalesLog.filter_by_owning_organisation(absorbing_organisation).first).to eq(sales_log)
         end
 
         it "rolls back if there's an error" do
@@ -205,7 +211,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
-          expect(absorbing_organisation.owned_sales_logs.count).to eq(0)
+          expect(absorbing_organisation.sales_logs.count).to eq(0)
           expect(sales_log.owning_organisation).to eq(merging_organisation)
         end
       end
@@ -236,13 +242,15 @@ RSpec.describe Merge::MergeOrganisationsService do
         expect(merging_organisation_user.organisation).to eq(absorbing_organisation)
       end
 
-      it "sets merge date on merged organisations" do
+      it "sets merge date and absorbing organisation on merged organisations" do
         merge_organisations_service.call
 
         merging_organisation.reload
         merging_organisation_too.reload
         expect(merging_organisation.merge_date.to_date).to eq(Time.zone.today)
+        expect(merging_organisation.absorbing_organisation_id).to eq(absorbing_organisation.id)
         expect(merging_organisation_too.merge_date.to_date).to eq(Time.zone.today)
+        expect(merging_organisation_too.absorbing_organisation_id).to eq(absorbing_organisation.id)
       end
 
       it "combines organisation data" do
@@ -260,8 +268,10 @@ RSpec.describe Merge::MergeOrganisationsService do
         merge_organisations_service.call
 
         absorbing_organisation.reload
+        merging_organisation.reload
         expect(absorbing_organisation.holds_own_stock).to eq(false)
         expect(merging_organisation.merge_date).to eq(nil)
+        expect(merging_organisation.absorbing_organisation_id).to eq(nil)
         expect(merging_organisation_user.organisation).to eq(merging_organisation)
       end
 
@@ -300,6 +310,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merge_organisations_service.call
 
           absorbing_organisation.reload
+          merging_organisation.reload
           expect(absorbing_organisation.child_organisations.count).to eq(2)
           expect(absorbing_organisation.parent_organisations.count).to eq(1)
           expect(absorbing_organisation.child_organisations).to include(other_organisation)

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe Merge::MergeOrganisationsService do
         expect(merging_organisation_user.organisation).to eq(absorbing_organisation)
       end
 
-      xit "sets merge date on merged organisation" do
+      it "sets merge date on merged organisation" do
         merge_organisations_service.call
 
-        expect(merging_organisation.merge_date).to eq(Time.zone.today)
+        merging_organisation.reload
+        expect(merging_organisation.merge_date.to_date).to eq(Time.zone.today)
       end
 
       it "combines organisation data" do

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -116,6 +116,22 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(nil)
         end
       end
+
+      context "and merging sales logs" do
+        let!(:sales_log) { create(:sales_log, saledate: Time.zone.tomorrow, owning_organisation: merging_organisation) }
+
+        before do
+          create(:sales_log, saledate: Time.zone.yesterday, owning_organisation: merging_organisation)
+        end
+
+        it "moves relevant logs" do
+          merge_organisations_service.call
+
+          absorbing_organisation.reload
+          expect(absorbing_organisation.owned_sales_logs.count).to eq(1)
+          expect(absorbing_organisation.owned_sales_logs.first).to eq(sales_log)
+        end
+      end
     end
   end
 end

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -3,24 +3,12 @@ require "rails_helper"
 RSpec.describe Merge::MergeOrganisationsService do
   subject(:merge_organisations_service) { described_class.new(absorbing_organisation_id: absorbing_organisation.id, merging_organisation_ids: [merging_organisation_ids]) }
 
-  let(:absorbing_organisation) do
-    create(:organisation,
-           holds_own_stock: false,
-           choice_based_lettings: false,
-           common_housing_register: true,
-           choice_allocation_policy: true)
-  end
+  let(:absorbing_organisation) {    create(:organisation, holds_own_stock: false) }
   let(:absorbing_organisation_user) { create(:user, organisation: absorbing_organisation) }
 
   describe "#call" do
     context "when merging a single organisation into an existing organisation" do
-      let(:merging_organisation) do
-        create(:organisation,
-               holds_own_stock: true,
-               choice_based_lettings: false,
-               common_housing_register: false,
-               choice_allocation_policy: true)
-      end
+      let(:merging_organisation) { create(:organisation, holds_own_stock: true) }
 
       let(:merging_organisation_ids) { [merging_organisation.id] }
       let!(:merging_organisation_user) { create(:user, organisation: merging_organisation) }
@@ -43,15 +31,6 @@ RSpec.describe Merge::MergeOrganisationsService do
 
         absorbing_organisation.reload
         expect(absorbing_organisation.holds_own_stock).to eq(true)
-        expect(absorbing_organisation.choice_based_lettings).to eq(false)
-        expect(absorbing_organisation.common_housing_register).to eq(true)
-        expect(absorbing_organisation.choice_allocation_policy).to eq(true)
-        #   expect(absorbing_organisation.cbl_proportion_percentage).to eq(0)
-        #   expect(absorbing_organisation.enter_affordable_logs).to eq(true)
-        #   expect(absorbing_organisation.owns_affordable_logs).to eq(true)
-        #   expect(absorbing_organisation.general_needs_units).to eq(2)
-        #   expect(absorbing_organisation.supported_housing_units).to eq(2)
-        #   expect(absorbing_organisation.unspecified_units).to eq(2)
       end
 
       context "and merging organisation rent periods" do
@@ -93,6 +72,31 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(absorbing_organisation.child_organisations).not_to include(merging_organisation)
           expect(absorbing_organisation.parent_organisations.count).to eq(0)
           expect(absorbing_organisation.child_organisations.count).to eq(3)
+        end
+      end
+
+      context "and merging organisation schemes and locations" do
+        let!(:scheme) { create(:scheme, owning_organisation: merging_organisation) }
+        let!(:location) { create(:location, scheme:) }
+        let!(:deactivated_location) { create(:location, scheme:) }
+        let!(:deactivated_scheme) { create(:scheme, owning_organisation: merging_organisation) }
+        let!(:deactivated_scheme_location) { create(:location, scheme: deactivated_scheme) }
+
+        before do
+          create(:scheme_deactivation_period, scheme: deactivated_scheme, deactivation_date: Time.zone.today - 1.month)
+          create(:location_deactivation_period, location: deactivated_location, deactivation_date: Time.zone.today - 1.month)
+        end
+
+        it "combines organisation relationships" do
+          merge_organisations_service.call
+
+          absorbing_organisation.reload
+          expect(absorbing_organisation.owned_schemes.count).to eq(1)
+          expect(absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
+          expect(absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
+          expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
+          expect(scheme.scheme_deactivation_periods.count).to eq(1)
+          expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
         end
       end
     end

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Merge::MergeOrganisationsService do
+  subject(:merge_organisations_service) { described_class.new(absorbing_organisation_id: absorbing_organisation.id, merging_organisation_ids: [merging_organisation_ids]) }
+
+  let(:absorbing_organisation) do
+    create(:organisation,
+           holds_own_stock: false,
+           choice_based_lettings: false,
+           common_housing_register: true,
+           choice_allocation_policy: true)
+  end
+  let(:absorbing_organisation_user) { create(:user, organisation: absorbing_organisation) }
+
+  describe "#call" do
+    context "when merging a single organisation into an existing organisation" do
+      let(:other_organisation) { create(:organisation) }
+      let(:merging_organisation) do
+        create(:organisation,
+               holds_own_stock: true,
+               choice_based_lettings: false,
+               common_housing_register: false,
+               choice_allocation_policy: true)
+      end
+
+      let(:merging_organisation_ids) { [merging_organisation.id] }
+      let!(:merging_organisation_user) { create(:user, organisation: merging_organisation) }
+      let!(:merging_organisation_relationship) { create(:organisation_relationship, parent_organisation: merging_organisation) }
+      let!(:absorbing_organisation_relationship) { create(:organisation_relationship, parent_organisation: absorbing_organisation) }
+      let!(:absorbing_and_merging_organisation_relationship) { create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: merging_organisation) }
+      let!(:duplicate_merging_organisation_relationship) { create(:organisation_relationship, parent_organisation: merging_organisation, child_organisation: other_organisation) }
+      let!(:duplicate_absorbing_organisation_relationship) { create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: other_organisation) }
+
+      before do
+        OrganisationRentPeriod.create!(organisation: absorbing_organisation, rent_period: 1)
+        OrganisationRentPeriod.create!(organisation: absorbing_organisation, rent_period: 3)
+        OrganisationRentPeriod.create!(organisation: merging_organisation, rent_period: 1)
+        OrganisationRentPeriod.create!(organisation: merging_organisation, rent_period: 2)
+        merge_organisations_service.call
+      end
+
+      it "moves the users from merging organisation to absorbing organisation" do
+        merging_organisation_user.reload
+        expect(merging_organisation_user.organisation).to eq(absorbing_organisation)
+      end
+
+      xit "sets merge date on merged organisation" do
+        expect(merging_organisation.merge_date).to eq(Time.zone.today)
+      end
+
+      it "combines organisation data" do
+        absorbing_organisation.reload
+        expect(absorbing_organisation.holds_own_stock).to eq(true)
+        expect(absorbing_organisation.choice_based_lettings).to eq(false)
+        expect(absorbing_organisation.common_housing_register).to eq(true)
+        expect(absorbing_organisation.choice_allocation_policy).to eq(true)
+        #   expect(absorbing_organisation.cbl_proportion_percentage).to eq(0)
+        #   expect(absorbing_organisation.enter_affordable_logs).to eq(true)
+        #   expect(absorbing_organisation.owns_affordable_logs).to eq(true)
+        #   expect(absorbing_organisation.general_needs_units).to eq(2)
+        #   expect(absorbing_organisation.supported_housing_units).to eq(2)
+        #   expect(absorbing_organisation.unspecified_units).to eq(2)
+      end
+
+      it "combines organisation rent periods" do
+        absorbing_organisation.reload
+        expect(absorbing_organisation.rent_periods.count).to eq(3)
+        expect(absorbing_organisation.rent_periods).to include(1)
+        expect(absorbing_organisation.rent_periods).to include(2)
+        expect(absorbing_organisation.rent_periods).to include(3)
+      end
+
+      it "combines organisation relationships" do
+        absorbing_organisation.reload
+        expect(absorbing_organisation.child_organisations).to include(other_organisation)
+        expect(absorbing_organisation.child_organisations).to include(absorbing_organisation_relationship.child_organisation)
+        expect(absorbing_organisation.child_organisations).to include(merging_organisation_relationship.child_organisation)
+        expect(absorbing_organisation.child_organisations).not_to include(merging_organisation)
+        expect(absorbing_organisation.parent_organisations.count).to eq(0)
+        expect(absorbing_organisation.child_organisations.count).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `merge_organisations_service` which allows several merging organisations to be merged into a single absorbing organisation.

Service updates relevant absorbing organisation details and transfers or duplicates some resources from merging organisations to absorbing organisation. These include, rent periods, organisation relationships, users, schemes, locations.

Merge organisations get updated with merge_date and an absorbing_organisation_id, schemes get deactivated and some relationships get removed.

The `merge_organisation_service` is called from a rake task which can be triggered with an absorbing organisation id and a space separated list of merging organisation ids:
```
rake merge:merge_organisations[absorbing_organisation_id, merging_organisation_ids]
```

For example if running it on remote apps:
```
cf ssh <App-name> -t -c "/tmp/lifecycle/launcher /home/vcap/app 'rake merge:merge_organisations[9,\"10 11\"]' ''" 
```

or locally:
```
rake "merge:merge_organisations[2,1 3]”
```