### PR TITLE
Check that bulk upload is present

### DIFF
--- a/app/components/check_answers_summary_list_card_component.rb
+++ b/app/components/check_answers_summary_list_card_component.rb
@@ -35,7 +35,7 @@ class CheckAnswersSummaryListCardComponent < ViewComponent::Base
 private
 
   def unanswered_value
-    if log.creation_method_bulk_upload?
+    if log.creation_method_bulk_upload? && log.bulk_upload.present?
       "<span class=\"app-!-colour-red\">You still need to answer this question</span>".html_safe
     else
       "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -54,7 +54,7 @@ private
   end
 
   def unanswered_value(log:)
-    if log.creation_method_bulk_upload?
+    if log.creation_method_bulk_upload? && log.bulk_upload.present?
       "<span class=\"app-!-colour-red\">You still need to answer this question</span>".html_safe
     else
       "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe

--- a/app/helpers/log_actions_helper.rb
+++ b/app/helpers/log_actions_helper.rb
@@ -16,7 +16,7 @@ private
 
   def back_button_for(log)
     if log.completed?
-      if log.creation_method_bulk_upload?
+      if log.creation_method_bulk_upload? && log.bulk_upload.present?
         if log.lettings?
           govuk_button_link_to "Back to uploaded logs", resume_bulk_upload_lettings_result_path(log.bulk_upload)
         else

--- a/spec/components/check_answers_summary_list_card_component_spec.rb
+++ b/spec/components/check_answers_summary_list_card_component_spec.rb
@@ -40,10 +40,21 @@ RSpec.describe CheckAnswersSummaryListCardComponent, type: :component do
       context "when log was created via a bulk upload and has an unanswered question" do
         subject(:component) { described_class.new(questions:, log:, user:) }
 
-        let(:log) { build(:lettings_log, :in_progress, creation_method: "bulk upload", age2: 99, startdate: Time.zone.local(2021, 5, 1)) }
+        let(:bulk_upload) { create(:bulk_upload) }
+        let(:log) { build(:lettings_log, :in_progress, creation_method: "bulk upload", age2: 99, startdate: Time.zone.local(2021, 5, 1), bulk_upload:) }
 
         it "displays tweaked copy in red" do
           expect(rendered).to have_selector("span", class: "app-!-colour-red", text: "You still need to answer this question")
+        end
+      end
+
+      context "when log was imported with a bulk upload creation method, without bulk upload id and has an unanswered question" do
+        subject(:component) { described_class.new(questions:, log:, user:) }
+
+        let(:log) { build(:lettings_log, :in_progress, creation_method: "bulk upload", age2: 99, startdate: Time.zone.local(2021, 5, 1), bulk_upload_id: nil) }
+
+        it "displays tweaked copy in red" do
+          expect(rendered).not_to have_selector("span", class: "app-!-colour-red", text: "You still need to answer this question")
         end
       end
 

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe CheckAnswersHelper do
   describe "#get_answer_label" do
     context "when unanswered and bulk upload" do
       let(:question) { log.form.questions.sample }
-      let(:log) { build(:sales_log, creation_method: "bulk upload") }
+      let(:bulk_upload) { create(:bulk_upload) }
+      let(:log) { build(:sales_log, creation_method: "bulk upload", bulk_upload:) }
 
       it "is red" do
         expect(get_answer_label(question, log)).to include("red")

--- a/spec/views/logs/edit.html.erb_spec.rb
+++ b/spec/views/logs/edit.html.erb_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe "logs/edit.html.erb" do
       end
     end
 
+    context "when lettings log is bulk uploaded without a bulk upload id" do
+      let(:log) { create(:lettings_log, :completed, bulk_upload: nil, creation_method: "bulk upload") }
+
+      it "does not have link 'Back to uploaded logs'" do
+        render
+
+        fragment = Capybara::Node::Simple.new(rendered)
+
+        expect(fragment).not_to have_link(text: "Back to uploaded logs")
+      end
+    end
+
     context "when sales log is bulk uploaded" do
       let(:bulk_upload) { create(:bulk_upload, :sales) }
       let(:log) { create(:sales_log, :completed, bulk_upload:, creation_method: "bulk upload") }


### PR DESCRIPTION
We have recently updated creation methods for imported logs. We now have logs on the service that have creation method "bulk upload" without an associated bulk upload ids/objects. 

When we try to construct bulk upload path for such log, it fails because there's no associated bulk upload. This PR checks that the bulk upload for a log has been done on our service before displaying link to all bulk uploaded logs or highlighting incomplete bulk upload answers.

This currently prevents any completed, imported, bulk uploaded logs from being viewed.