### PR TITLE
CLDC-2151 ensure new discarded_at field is in the correct date format on export

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -185,6 +185,7 @@ module Exports
       attribute_hash["mrcdate"] = lettings_log.mrcdate&.iso8601
       attribute_hash["startdate"] = lettings_log.startdate&.iso8601
       attribute_hash["voiddate"] = lettings_log.voiddate&.iso8601
+      attribute_hash["discarded_at"] = lettings_log.discarded_at&.iso8601
 
       attribute_hash["cbl"] = 2 if attribute_hash["cbl"]&.zero?
       attribute_hash["cap"] = 2 if attribute_hash["cap"]&.zero?


### PR DESCRIPTION
ensure new date field converted to ISO 8601 format

I had a look at the spec file for the exporter and it does not seem to be considered necessary to test the formats of individual fields