### PR TITLE
CLDC-2554 Update back to all logs link

### DIFF
--- a/app/views/bulk_upload_lettings_results/resume.html.erb
+++ b/app/views/bulk_upload_lettings_results/resume.html.erb
@@ -8,4 +8,4 @@
   You’ve completed all the logs that had errors from your bulk upload.
 </p>
 
-<%= govuk_button_link_to "Back to all logs", clear_filters_path(filter_type: "lettings_logs"), button: true %>
+<%= govuk_button_link_to "Return to lettings logs", clear_filters_path(filter_type: "lettings_logs"), button: true %>

--- a/app/views/bulk_upload_lettings_results/resume.html.erb
+++ b/app/views/bulk_upload_lettings_results/resume.html.erb
@@ -8,4 +8,4 @@
   You’ve completed all the logs that had errors from your bulk upload.
 </p>
 
-<%= govuk_button_link_to "Back to all logs", lettings_logs_path, button: true %>
+<%= govuk_button_link_to "Back to all logs", clear_filters_path(filter_type: "lettings_logs"), button: true %>

--- a/app/views/bulk_upload_sales_results/resume.html.erb
+++ b/app/views/bulk_upload_sales_results/resume.html.erb
@@ -8,4 +8,4 @@
   You’ve completed all the logs that had errors from your bulk upload.
 </p>
 
-<%= govuk_button_link_to "Back to all logs", clear_filters_path(filter_type: "sales_logs"), button: true %>
+<%= govuk_button_link_to "Return to sales logs", clear_filters_path(filter_type: "sales_logs"), button: true %>

--- a/app/views/bulk_upload_sales_results/resume.html.erb
+++ b/app/views/bulk_upload_sales_results/resume.html.erb
@@ -8,4 +8,4 @@
   You’ve completed all the logs that had errors from your bulk upload.
 </p>
 
-<%= govuk_button_link_to "Back to all logs", sales_logs_path, button: true %>
+<%= govuk_button_link_to "Back to all logs", clear_filters_path(filter_type: "sales_logs"), button: true %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_081029) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_150610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -562,6 +562,13 @@ RSpec.describe LettingsLogsController, type: :request do
 
                 expect(response).to redirect_to(resume_bulk_upload_lettings_result_path(bulk_upload))
               end
+
+              it "allows returning to all logs" do
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+
+                follow_redirect!
+                expect(page).to have_link("Back to all logs", href: clear_filters_path(filter_type: "lettings_logs"))
+              end
             end
           end
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -567,7 +567,7 @@ RSpec.describe LettingsLogsController, type: :request do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
                 follow_redirect!
-                expect(page).to have_link("Back to all logs", href: clear_filters_path(filter_type: "lettings_logs"))
+                expect(page).to have_link("Return to lettings logs", href: clear_filters_path(filter_type: "lettings_logs"))
               end
             end
           end

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -438,6 +438,13 @@ RSpec.describe SalesLogsController, type: :request do
 
                 expect(response).to redirect_to(resume_bulk_upload_sales_result_path(bulk_upload))
               end
+
+              it "allows returning to all logs" do
+                get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
+
+                follow_redirect!
+                expect(page).to have_link("Back to all logs", href: clear_filters_path(filter_type: "sales_logs"))
+              end
             end
           end
 

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe SalesLogsController, type: :request do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
 
                 follow_redirect!
-                expect(page).to have_link("Back to all logs", href: clear_filters_path(filter_type: "sales_logs"))
+                expect(page).to have_link("Return to sales logs", href: clear_filters_path(filter_type: "sales_logs"))
               end
             end
           end


### PR DESCRIPTION
Back to all logs button kept on redirecting back to the same page. It's now clearing all the filters instead.