### PR TITLE
Add owned sales logs method in for clarity and use in rake task

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -75,6 +75,10 @@ class Organisation < ApplicationRecord
     LettingsLog.filter_by_owning_organisation(absorbed_organisations + [self])
   end
 
+  def owned_sales_logs
+    sales_logs
+  end
+
   def managed_lettings_logs
     LettingsLog.filter_by_managing_organisation(absorbed_organisations + [self])
   end


### PR DESCRIPTION
Sales doesn't have a concept of managing agent so and org's sales logs and its **owned** sales logs are the same collection.