### PR TITLE
CLDC-2621 Flag orgs without coordinators

### DIFF
--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -8,7 +8,7 @@ module Imports
 
     BYTE_ORDER_MARK = "\uFEFF".freeze # Required to ensure Excel always reads CSV as UTF-8
 
-    def create_report(report_suffix)
+    def create_reports(report_suffix)
       generate_missing_data_coordinators_report(report_suffix)
       generate_logs_report(report_suffix)
     end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -8,11 +8,11 @@ module Imports
 
     BYTE_ORDER_MARK = "\uFEFF".freeze # Required to ensure Excel always reads CSV as UTF-8
 
-    def create_report(report_directory)
-      write_missing_data_coordinators_report(report_directory)
+    def create_report(report_suffix)
+      generate_missing_data_coordinators_report(report_suffix)
     end
 
-    def write_missing_data_coordinators_report(report_directory)
+    def generate_missing_data_coordinators_report(report_suffix)
       csv_string = "Organisation ID,Old Organisation ID,Organisation Name\n"
       @old_organisation_ids.each do |old_organisation_id|
         organisation = Organisation.find_by(old_visible_id: old_organisation_id)
@@ -21,7 +21,7 @@ module Imports
         end
       end
 
-      @storage_service.write_file("#{report_directory}/organisations_without_data_coordinators.csv", BYTE_ORDER_MARK + csv_string)
+      @storage_service.write_file("OrganisationsWithoutDataCoordinators_#{report_suffix}.csv", BYTE_ORDER_MARK + csv_string)
     end
   end
 end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -1,27 +1,57 @@
 module Imports
   class ImportReportService
-    def initialize(storage_service, old_organisation_ids, logger = Rails.logger)
+    def initialize(storage_service, institutions_csv, logger = Rails.logger)
       @storage_service = storage_service
       @logger = logger
-      @old_organisation_ids = old_organisation_ids
+      @institutions_csv = institutions_csv
     end
 
     BYTE_ORDER_MARK = "\uFEFF".freeze # Required to ensure Excel always reads CSV as UTF-8
 
     def create_report(report_suffix)
       generate_missing_data_coordinators_report(report_suffix)
+      generate_logs_report(report_suffix)
     end
 
     def generate_missing_data_coordinators_report(report_suffix)
-      csv_string = "Organisation ID,Old Organisation ID,Organisation Name\n"
-      @old_organisation_ids.each do |old_organisation_id|
-        organisation = Organisation.find_by(old_visible_id: old_organisation_id)
+      report_csv = "Organisation ID,Old Organisation ID,Organisation Name\n"
+      organisations = @institutions_csv.map { |row| Organisation.find_by(name: row[0]) }.compact
+      organisations.each do |organisation|
         if organisation.users.none?(&:data_coordinator?)
-          csv_string += "#{organisation.id},#{old_organisation_id},#{organisation.name}\n"
+          report_csv += "#{organisation.id},#{organisation.old_visible_id},#{organisation.name}\n"
         end
       end
 
-      @storage_service.write_file("OrganisationsWithoutDataCoordinators_#{report_suffix}.csv", BYTE_ORDER_MARK + csv_string)
+      report_name = "OrganisationsWithoutDataCoordinators_#{report_suffix}.csv"
+      @storage_service.write_file(report_name, BYTE_ORDER_MARK + report_csv)
+
+      @logger.info("Missing data coordinators report available in s3 import bucket at #{report_name}")
+    end
+
+    def generate_logs_report(report_suffix)
+      Rails.logger.info("Generating migrated logs report")
+
+      rep = CSV.generate do |report|
+        headers = ["Institution name", "Id", "Old Completed lettings logs", "Old In progress lettings logs", "Old Completed sales logs", "Old In progress sales logs", "New Completed lettings logs", "New In Progress lettings logs", "New Completed sales logs", "New In Progress sales logs"]
+        report << headers
+
+        @institutions_csv.each do |row|
+          name = row[0]
+          organisation = Organisation.find_by(name:)
+          next unless organisation
+
+          completed_sales_logs = organisation.owned_sales_logs.where(status: "completed").count
+          in_progress_sales_logs = organisation.owned_sales_logs.where(status: "in_progress").count
+          completed_lettings_logs = organisation.owned_lettings_logs.where(status: "completed").count
+          in_progress_lettings_logs = organisation.owned_lettings_logs.where(status: "in_progress").count
+          report << row.push(completed_lettings_logs, in_progress_lettings_logs, completed_sales_logs, in_progress_sales_logs)
+        end
+      end
+
+      report_name = "MigratedLogsReport_#{report_suffix}.csv"
+      @storage_service.write_file(report_name, BYTE_ORDER_MARK + rep)
+
+      @logger.info("Logs report available in s3 import bucket at #{report_name}")
     end
   end
 end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -17,7 +17,7 @@ module Imports
       report_csv = "Organisation ID,Old Organisation ID,Organisation Name\n"
       organisations = @institutions_csv.map { |row| Organisation.find_by(name: row[0]) }.compact
       organisations.each do |organisation|
-        if organisation.users.none?(&:data_coordinator?)
+        if organisation.users.none? { |user| user.data_coordinator? && user.active? }
           report_csv += "#{organisation.id},#{organisation.old_visible_id},#{organisation.name}\n"
         end
       end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -1,0 +1,27 @@
+module Imports
+  class ImportReportService
+    def initialize(storage_service, old_organisation_ids, logger = Rails.logger)
+      @storage_service = storage_service
+      @logger = logger
+      @old_organisation_ids = old_organisation_ids
+    end
+
+    BYTE_ORDER_MARK = "\uFEFF".freeze # Required to ensure Excel always reads CSV as UTF-8
+
+    def create_report(report_directory)
+      write_missing_data_coordinators_report(report_directory)
+    end
+
+    def write_missing_data_coordinators_report(report_directory)
+      csv_string = "Organisation ID,Old Organisation ID,Organisation Name\n"
+      @old_organisation_ids.each do |old_organisation_id|
+        organisation = Organisation.find_by(old_visible_id: old_organisation_id)
+        if organisation.users.none?(&:data_coordinator?)
+          csv_string += "#{organisation.id},#{old_organisation_id},#{organisation.name}\n"
+        end
+      end
+
+      @storage_service.write_file("#{report_directory}/organisations_without_data_coordinators.csv", BYTE_ORDER_MARK + csv_string)
+    end
+  end
+end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -22,7 +22,7 @@ module Imports
         end
       end
 
-      report_name = "OrganisationsWithoutDataCoordinators_#{report_suffix}.csv"
+      report_name = "OrganisationsWithoutDataCoordinators_#{report_suffix}"
       @storage_service.write_file(report_name, BYTE_ORDER_MARK + report_csv)
 
       @logger.info("Missing data coordinators report available in s3 import bucket at #{report_name}")
@@ -48,7 +48,7 @@ module Imports
         end
       end
 
-      report_name = "MigratedLogsReport_#{report_suffix}.csv"
+      report_name = "MigratedLogsReport_#{report_suffix}"
       @storage_service.write_file(report_name, BYTE_ORDER_MARK + rep)
 
       @logger.info("Logs report available in s3 import bucket at #{report_name}")

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -36,8 +36,6 @@ namespace :import do
     end
 
     Rails.logger.info("Finished initial imports")
-    reports_service = Imports::ImportReportService.new(s3_service, csv.map { |row| row[1] })
-    Rails.logger.info("Running report generation")
   end
 
   desc "Run logs import steps"
@@ -101,34 +99,9 @@ namespace :import do
     raise "Usage: rake import:generate_report['institutions_csv_name']" if institutions_csv_name.blank?
 
     s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
-    csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
+    institutions_csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
 
-    Rails.logger.info("Generating migrated logs report")
-
-    rep = CSV.generate do |report|
-      headers = ["Institution name", "Id", "Old Completed lettings logs", "Old In progress lettings logs", "Old Completed sales logs", "Old In progress sales logs", "New Completed lettings logs", "New In Progress lettings logs", "New Completed sales logs", "New In Progress sales logs"]
-      report << headers
-
-      csv.each do |row|
-        name = row[0]
-        organisation = Organisation.find_by(name:)
-        next unless organisation
-
-        completed_sales_logs = organisation.owned_sales_logs.where(status: "completed").count
-        in_progress_sales_logs = organisation.owned_sales_logs.where(status: "in_progress").count
-        completed_lettings_logs = organisation.owned_lettings_logs.where(status: "completed").count
-        in_progress_lettings_logs = organisation.owned_lettings_logs.where(status: "in_progress").count
-        report << row.push(completed_lettings_logs, in_progress_lettings_logs, completed_sales_logs, in_progress_sales_logs)
-      end
-    end
-
-    report_name = "MigratedLogsReport_#{institutions_csv_name}"
-    s3_service.write_file(report_name, rep)
-
-    old_organisation_ids = csv.map { |row| Organisation.find_by(name: row[0]).old_visible_id }.compact
-    Imports::ImportReportService.new(s3_service, old_organisation_ids).generate_missing_data_coordinators_report(institutions_csv_name)
-
-    Rails.logger.info("Logs report available in s3 import bucket at #{report_name}")
+    Imports::ImportReportService.new(s3_service, institutions_csv).create_report(institutions_csv_name)
   end
 
   desc "Run import from logs step to end"

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -94,19 +94,19 @@ namespace :import do
   end
 
   desc "Generate migrated logs report"
-  task :generate_report, %i[institutions_csv_name] => :environment do |_task, args|
+  task :generate_reports, %i[institutions_csv_name] => :environment do |_task, args|
     institutions_csv_name = args[:institutions_csv_name]
-    raise "Usage: rake import:generate_report['institutions_csv_name']" if institutions_csv_name.blank?
+    raise "Usage: rake import:generate_reports['institutions_csv_name']" if institutions_csv_name.blank?
 
     s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
     institutions_csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
 
-    Imports::ImportReportService.new(s3_service, institutions_csv).create_report(institutions_csv_name)
+    Imports::ImportReportService.new(s3_service, institutions_csv).create_reports(institutions_csv_name)
   end
 
   desc "Run import from logs step to end"
-  task :logs_onwards, %i[institutions_csv_name] => %i[environment logs trigger_invites generate_report]
+  task :logs_onwards, %i[institutions_csv_name] => %i[environment logs trigger_invites generate_reports]
 
   desc "Run a full import for the institutions listed in the named file on s3"
-  task :full, %i[institutions_csv_name] => %i[environment initial logs trigger_invites generate_report]
+  task :full, %i[institutions_csv_name] => %i[environment initial logs trigger_invites generate_reports]
 end

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+require "rake"
+
+describe "full import", type: :task do
+  let(:instance_name) { "paas_import_instance" }
+  let(:paas_config_service) { instance_double(Configuration::PaasConfigurationService) }
+  let(:storage_service) { instance_double(Storage::S3Service) }
+  let(:orgs_list) { "Institution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs\norg1,1.zip,0,0,0,0\norg2,2.zip,0,0,0,0" }
+
+  before do
+    allow(Storage::S3Service).to receive(:new).and_return(storage_service)
+    allow(storage_service).to receive(:write_file).and_return(nil)
+    allow(storage_service).to receive(:get_file_io).and_return(orgs_list)
+    allow(Configuration::PaasConfigurationService).to receive(:new).and_return(paas_config_service)
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("IMPORT_PAAS_INSTANCE").and_return(instance_name)
+  end
+
+  describe "import:generate_report" do
+    subject(:task) { Rake::Task["import:generate_report"] }
+
+    before do
+      Rake.application.rake_require("tasks/full_import")
+      Rake::Task.define_task(:environment)
+      task.reenable
+
+      create(:organisation, old_visible_id: 1, name: "org1")
+      create(:organisation, old_visible_id: 2, name: "org2")
+    end
+
+    context "when generating report" do
+      let(:import_report_service) { instance_double(Imports::ImportReportService) }
+
+      before do
+        allow(Imports::ImportReportService).to receive(:new).and_return(import_report_service)
+      end
+
+      it "creates an organisation from the given XML file" do
+        expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+        expect(Imports::ImportReportService).to receive(:new).with(storage_service, %w[1 2])
+        expect(import_report_service).to receive(:generate_missing_data_coordinators_report).with("some_name")
+
+        task.invoke("some_name")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -23,9 +23,6 @@ describe "full import", type: :task do
       Rake.application.rake_require("tasks/full_import")
       Rake::Task.define_task(:environment)
       task.reenable
-
-      create(:organisation, old_visible_id: 1, name: "org1")
-      create(:organisation, old_visible_id: 2, name: "org2")
     end
 
     context "when generating report" do
@@ -35,10 +32,10 @@ describe "full import", type: :task do
         allow(Imports::ImportReportService).to receive(:new).and_return(import_report_service)
       end
 
-      it "creates an organisation from the given XML file" do
+      it "creates a report using given organisation csv" do
         expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
-        expect(Imports::ImportReportService).to receive(:new).with(storage_service, %w[1 2])
-        expect(import_report_service).to receive(:generate_missing_data_coordinators_report).with("some_name")
+        expect(Imports::ImportReportService).to receive(:new).with(storage_service, CSV.parse(orgs_list, headers: true))
+        expect(import_report_service).to receive(:create_report).with("some_name")
 
         task.invoke("some_name")
       end

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -16,8 +16,8 @@ describe "full import", type: :task do
     allow(ENV).to receive(:[]).with("IMPORT_PAAS_INSTANCE").and_return(instance_name)
   end
 
-  describe "import:generate_report" do
-    subject(:task) { Rake::Task["import:generate_report"] }
+  describe "import:generate_reports" do
+    subject(:task) { Rake::Task["import:generate_reports"] }
 
     before do
       Rake.application.rake_require("tasks/full_import")
@@ -35,7 +35,7 @@ describe "full import", type: :task do
       it "creates a report using given organisation csv" do
         expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
         expect(Imports::ImportReportService).to receive(:new).with(storage_service, CSV.parse(orgs_list, headers: true))
-        expect(import_report_service).to receive(:create_report).with("some_name")
+        expect(import_report_service).to receive(:create_reports).with("some_name")
 
         task.invoke("some_name")
       end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Imports::ImportReportService do
+  subject(:report_service) { described_class.new(storage_service, old_organisation_ids) }
+
+  let(:storage_service) { instance_double(Storage::S3Service) }
+
+  context "when all organisations have data coordinators" do
+    let(:organisation) { create(:organisation, old_visible_id: "1") }
+    let(:old_organisation_ids) { [organisation.old_visible_id] }
+
+    before do
+      create(:user, :data_coordinator, organisation:)
+    end
+
+    it "writes an empty organisations without a data coordinators report" do
+      expect(storage_service).to receive(:write_file).with("report_directory/organisations_without_data_coordinators.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n")
+
+      report_service.create_report("report_directory")
+    end
+  end
+
+  context "when some organisations have no data coordinators" do
+    let(:organisation) { create(:organisation, old_visible_id: "") }
+    let(:organisation2) { create(:organisation, old_visible_id: "2") }
+    let(:organisation3) { create(:organisation, old_visible_id: "3") }
+    let(:old_organisation_ids) { [organisation.old_visible_id, organisation2.old_visible_id, organisation3.old_visible_id] }
+
+    before do
+      create(:user, :data_coordinator, organisation:)
+    end
+
+    it "writes an empty organisations without a data coordinators report" do
+      expect(storage_service).to receive(:write_file).with("report_directory/organisations_without_data_coordinators.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,#{organisation2.name}\n#{organisation3.id},3,#{organisation3.name}\n")
+
+      report_service.create_report("report_directory")
+    end
+  end
+end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Imports::ImportReportService do
       it "writes an empty organisations without a data coordinators report" do
         expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n")
 
-        report_service.generate_missing_data_coordinators_report("report_suffix")
+        report_service.generate_missing_data_coordinators_report("report_suffix.csv")
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Imports::ImportReportService do
       it "writes an empty organisations without a data coordinators report" do
         expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,org2\n#{organisation3.id},3,org3\n")
 
-        report_service.generate_missing_data_coordinators_report("report_suffix")
+        report_service.generate_missing_data_coordinators_report("report_suffix.csv")
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Imports::ImportReportService do
       it "includes that organisation in the data coordinators report" do
         expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation.id},1,org1\n")
 
-        report_service.generate_missing_data_coordinators_report("report_suffix")
+        report_service.generate_missing_data_coordinators_report("report_suffix.csv")
       end
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe Imports::ImportReportService do
 
     it "generates a report with imported logs" do
       expect(storage_service).to receive(:write_file).with("MigratedLogsReport_report_suffix.csv", "\uFEFFInstitution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs,New Completed lettings logs,New In Progress lettings logs,New Completed sales logs,New In Progress sales logs\norg1,1,2,1,4,3,0,0,0,0\norg2,2,5,6,5,7,0,0,0,0\n")
-      report_service.generate_logs_report("report_suffix")
+      report_service.generate_logs_report("report_suffix.csv")
     end
   end
 end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -32,7 +32,22 @@ RSpec.describe Imports::ImportReportService do
       end
 
       it "writes an empty organisations without a data coordinators report" do
-        expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,#{organisation2.name}\n#{organisation3.id},3,#{organisation3.name}\n")
+        expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,org2\n#{organisation3.id},3,org3\n")
+
+        report_service.generate_missing_data_coordinators_report("report_suffix")
+      end
+    end
+
+    context "when organisation has an inactive data coordinator" do
+      let!(:organisation) { create(:organisation, old_visible_id: "1", name: "org1") }
+      let(:institutions_csv) { CSV.parse("Institution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs\norg1,1,2,1,4,3", headers: true) }
+
+      before do
+        create(:user, :data_coordinator, organisation:, active: false)
+      end
+
+      it "includes that organisation in the data coordinators report" do
+        expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation.id},1,org1\n")
 
         report_service.generate_missing_data_coordinators_report("report_suffix")
       end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Imports::ImportReportService do
     end
 
     it "writes an empty organisations without a data coordinators report" do
-      expect(storage_service).to receive(:write_file).with("report_directory/organisations_without_data_coordinators.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n")
+      expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n")
 
-      report_service.create_report("report_directory")
+      report_service.create_report("report_suffix")
     end
   end
 
@@ -31,9 +31,9 @@ RSpec.describe Imports::ImportReportService do
     end
 
     it "writes an empty organisations without a data coordinators report" do
-      expect(storage_service).to receive(:write_file).with("report_directory/organisations_without_data_coordinators.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,#{organisation2.name}\n#{organisation3.id},3,#{organisation3.name}\n")
+      expect(storage_service).to receive(:write_file).with("OrganisationsWithoutDataCoordinators_report_suffix.csv", "\uFEFFOrganisation ID,Old Organisation ID,Organisation Name\n#{organisation2.id},2,#{organisation2.name}\n#{organisation3.id},3,#{organisation3.name}\n")
 
-      report_service.create_report("report_directory")
+      report_service.create_report("report_suffix")
     end
   end
 end


### PR DESCRIPTION
- Add import report service and move logs report generation from rake task to the new service
- Generate a separate report of organisations with missing data coordinators
