### PR TITLE
CLDC-2106 Add merged organisations to managing org dropdown

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -102,9 +102,11 @@ private
         result[question.id] = question_params
       end
 
-      if current_user.support? && question.id == "owning_organisation_id" && @log.lettings? && @log.managing_organisation.blank?
+      if question.id == "owning_organisation_id" && @log.lettings?
         owning_organisation = Organisation.find(result["owning_organisation_id"])
-        if owning_organisation&.managing_agents&.empty?
+        if current_user.support? && @log.managing_organisation.blank? && owning_organisation&.managing_agents&.empty?
+          result["managing_organisation_id"] = owning_organisation.id
+        elsif owning_organisation&.absorbing_organisation == current_user.organisation
           result["managing_organisation_id"] = owning_organisation.id
         end
       end

--- a/app/models/form/lettings/questions/managing_organisation.rb
+++ b/app/models/form/lettings/questions/managing_organisation.rb
@@ -30,8 +30,12 @@ class Form::Lettings::Questions::ManagingOrganisation < ::Form::Question
     orgs = if user.support?
              log.owning_organisation.managing_agents
            else
-             user.organisation.managing_agents + user.organisation.absorbed_organisations
+             user.organisation.managing_agents
            end.pluck(:id, :name).to_h
+
+    user.organisation.absorbed_organisations.each do |absorbed_org|
+      opts[absorbed_org.id] = "#{absorbed_org.name} (active until #{absorbed_org.merge_date.to_fs(:govuk_date)})"
+    end
 
     opts.merge(orgs)
   end

--- a/app/models/form/lettings/questions/managing_organisation.rb
+++ b/app/models/form/lettings/questions/managing_organisation.rb
@@ -23,22 +23,22 @@ class Form::Lettings::Questions::ManagingOrganisation < ::Form::Question
       if log.owning_organisation.holds_own_stock?
         opts[log.owning_organisation.id] = "#{log.owning_organisation.name} (Owning organisation)"
       end
+    elsif user.organisation.absorbed_organisations.exists?
+      opts[user.organisation.id] = "#{user.organisation.name} (Your organisation, active as of #{user.organisation.created_at.to_fs(:govuk_date)})"
     else
       opts[user.organisation.id] = "#{user.organisation.name} (Your organisation)"
     end
 
     orgs = if user.support?
              log.owning_organisation.managing_agents
-           else
-            if user.organisation.absorbed_organisations.include?(log.owning_organisation)
+           elsif user.organisation.absorbed_organisations.include?(log.owning_organisation)
              user.organisation.managing_agents + log.owning_organisation.managing_agents
-            else
-              user.organisation.managing_agents
-            end
+           else
+             user.organisation.managing_agents
            end.pluck(:id, :name).to_h
 
     user.organisation.absorbed_organisations.each do |absorbed_org|
-      opts[absorbed_org.id] = "#{absorbed_org.name} (active until #{absorbed_org.merge_date.to_fs(:govuk_date)})"
+      opts[absorbed_org.id] = "#{absorbed_org.name} (inactive as of #{absorbed_org.merge_date.to_fs(:govuk_date)})"
     end
 
     opts.merge(orgs)

--- a/app/models/form/lettings/questions/managing_organisation.rb
+++ b/app/models/form/lettings/questions/managing_organisation.rb
@@ -30,7 +30,11 @@ class Form::Lettings::Questions::ManagingOrganisation < ::Form::Question
     orgs = if user.support?
              log.owning_organisation.managing_agents
            else
-             user.organisation.managing_agents
+            if user.organisation.absorbed_organisations.include?(log.owning_organisation)
+             user.organisation.managing_agents + log.owning_organisation.managing_agents
+            else
+              user.organisation.managing_agents
+            end
            end.pluck(:id, :name).to_h
 
     user.organisation.absorbed_organisations.each do |absorbed_org|

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -43,14 +43,14 @@ private
       if parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
         parent_organisation_relationship.destroy!
       else
-        parent_organisation_relationship.update!(child_organisation: @absorbing_organisation)
+        OrganisationRelationship.create!(parent_organisation: parent_organisation_relationship.parent_organisation, child_organisation: @absorbing_organisation)
       end
     end
     merging_organisation.child_organisation_relationships.each do |child_organisation_relationship|
       if child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
         child_organisation_relationship.destroy!
       else
-        child_organisation_relationship.update!(parent_organisation: @absorbing_organisation)
+        OrganisationRelationship.create!(parent_organisation: @absorbing_organisation, child_organisation: child_organisation_relationship.child_organisation)
       end
     end
   end
@@ -122,10 +122,10 @@ private
   end
 
   def parent_relationship_exists_on_absorbing_organisation?(parent_organisation_relationship)
-    parent_organisation_relationship.parent_organisation == @absorbing_organisation || @absorbing_organisation.parent_organisation_relationships.where(parent_organisation: parent_organisation_relationship.parent_organisation).exists?
+    parent_organisation_relationship.parent_organisation == @absorbing_organisation || @merging_organisations.include?(parent_organisation_relationship.parent_organisation) || @absorbing_organisation.parent_organisation_relationships.where(parent_organisation: parent_organisation_relationship.parent_organisation).exists?
   end
 
   def child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
-    child_organisation_relationship.child_organisation == @absorbing_organisation || @absorbing_organisation.child_organisation_relationships.where(child_organisation: child_organisation_relationship.child_organisation).exists?
+    child_organisation_relationship.child_organisation == @absorbing_organisation || @merging_organisations.include?(child_organisation_relationship.child_organisation) || @absorbing_organisation.child_organisation_relationships.where(child_organisation: child_organisation_relationship.child_organisation).exists?
   end
 end

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -161,6 +161,29 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
         expect(question.displayed_answer_options(log, user)).to eq(options)
       end
     end
+
+    context "when organisation has merged" do
+      let(:absorbing_org) { create(:organisation, name: "Absorbing org", holds_own_stock: true) }
+      let!(:merged_org) { create(:organisation, name: "Merged org", holds_own_stock: false) }
+      let(:user) { create(:user, :data_coordinator, organisation: absorbing_org) }
+
+      let(:log) do
+        merged_org.update!(merge_date: Time.zone.local(2023, 8, 2), absorbing_organisation_id: absorbing_org.id)
+        create(:lettings_log, owning_organisation: absorbing_org, managing_organisation: nil)
+      end
+
+      let(:options) do
+        {
+          "" => "Select an option",
+          absorbing_org.id => "Absorbing org (Your organisation)",
+          merged_org.id => "Merged org (active until 2 August 2023)",
+        }
+      end
+
+      it "displays merged organisation on the list of choices" do
+        expect(question.displayed_answer_options(log, user)).to eq(options)
+      end
+    end
   end
 
   it "is marked as derived" do

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
     end
 
     context "when organisation has merged" do
-      let(:absorbing_org) { create(:organisation, name: "Absorbing org", holds_own_stock: true) }
+      let(:absorbing_org) { create(:organisation, name: "Absorbing org", holds_own_stock: true, created_at: Time.zone.local(2023, 8, 3)) }
       let!(:merged_org) { create(:organisation, name: "Merged org", holds_own_stock: false) }
       let(:user) { create(:user, :data_coordinator, organisation: absorbing_org) }
 
@@ -175,24 +175,24 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       it "displays merged organisation on the list of choices" do
         options = {
           "" => "Select an option",
-          absorbing_org.id => "Absorbing org (Your organisation)",
-          merged_org.id => "Merged org (active until 2 August 2023)",
-          merged_org.id => "Merged org (active until 2 August 2023)",
+          absorbing_org.id => "Absorbing org (Your organisation, active as of 3 August 2023)",
+          merged_org.id => "Merged org (inactive as of 2 August 2023)",
+          merged_org.id => "Merged org (inactive as of 2 August 2023)",
         }
         expect(question.displayed_answer_options(log, user)).to eq(options)
       end
 
-      it "displays managing agents of merged organisation selected as owning org" do        
-        managing_agent = create(:organisation, name: "Managing org 1") 
+      it "displays managing agents of merged organisation selected as owning org" do
+        managing_agent = create(:organisation, name: "Managing org 1")
         create(:organisation_relationship, parent_organisation: merged_org, child_organisation: managing_agent)
 
         options = {
           "" => "Select an option",
-          merged_org.id => "Merged org (active until 2 August 2023)",
-          absorbing_org.id => "Absorbing org (Your organisation)",
+          merged_org.id => "Merged org (inactive as of 2 August 2023)",
+          absorbing_org.id => "Absorbing org (Your organisation, active as of 3 August 2023)",
           managing_agent.id => "Managing org 1",
         }
-        
+
         log.update!(owning_organisation: merged_org)
         expect(question.displayed_answer_options(log, user)).to eq(options)
       end

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -172,15 +172,28 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
         create(:lettings_log, owning_organisation: absorbing_org, managing_organisation: nil)
       end
 
-      let(:options) do
-        {
+      it "displays merged organisation on the list of choices" do
+        options = {
           "" => "Select an option",
           absorbing_org.id => "Absorbing org (Your organisation)",
           merged_org.id => "Merged org (active until 2 August 2023)",
+          merged_org.id => "Merged org (active until 2 August 2023)",
         }
+        expect(question.displayed_answer_options(log, user)).to eq(options)
       end
 
-      it "displays merged organisation on the list of choices" do
+      it "displays managing agents of merged organisation selected as owning org" do        
+        managing_agent = create(:organisation, name: "Managing org 1") 
+        create(:organisation_relationship, parent_organisation: merged_org, child_organisation: managing_agent)
+
+        options = {
+          "" => "Select an option",
+          merged_org.id => "Merged org (active until 2 August 2023)",
+          absorbing_org.id => "Absorbing org (Your organisation)",
+          managing_agent.id => "Managing org 1",
+        }
+        
+        log.update!(owning_organisation: merged_org)
         expect(question.displayed_answer_options(log, user)).to eq(options)
       end
     end


### PR DESCRIPTION
Allow merged organisations to be selected as managing organisations
Prepopulate managing organisation with chosen owning organisation if the owning organisation selected has been merged into current users organisation
Mark each organisation involved in the recent merge with the date they become active/inactive
<img width="957" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/f7237472-2da3-488b-a09c-551b8502bdc2">
