### PR TITLE
CLDC-2539: configure application for PaaS and AWS

### DIFF
--- a/app/helpers/platform_helper.rb
+++ b/app/helpers/platform_helper.rb
@@ -1,0 +1,5 @@
+module PlatformHelper
+  def self.is_paas?
+    !ENV["VCAP_SERVICES"].nil?
+  end
+end

--- a/app/jobs/data_export_xml_job.rb
+++ b/app/jobs/data_export_xml_job.rb
@@ -2,7 +2,7 @@ class DataExportXmlJob < ApplicationJob
   queue_as :default
 
   def perform(full_update: false)
-    storage_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["EXPORT_PAAS_INSTANCE"])
+    storage_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["EXPORT_PAAS_INSTANCE"])
     export_service = Exports::LettingsLogExportService.new(storage_service)
 
     export_service.export_xml_lettings_logs(full_update:)

--- a/app/models/forms/bulk_upload_lettings/upload_your_file.rb
+++ b/app/models/forms/bulk_upload_lettings/upload_your_file.rb
@@ -57,7 +57,7 @@ module Forms
       def storage_service
         @storage_service ||= if upload_enabled?
                                Storage::S3Service.new(
-                                 Configuration::PaasConfigurationService.new,
+                                 PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new,
                                  ENV["CSV_DOWNLOAD_PAAS_INSTANCE"],
                                )
                              else

--- a/app/models/forms/bulk_upload_sales/upload_your_file.rb
+++ b/app/models/forms/bulk_upload_sales/upload_your_file.rb
@@ -50,7 +50,7 @@ module Forms
       def storage_service
         @storage_service ||= if FeatureToggle.upload_enabled?
                                Storage::S3Service.new(
-                                 Configuration::PaasConfigurationService.new,
+                                 PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new,
                                  ENV["CSV_DOWNLOAD_PAAS_INSTANCE"],
                                )
                              else

--- a/app/services/bulk_upload/downloader.rb
+++ b/app/services/bulk_upload/downloader.rb
@@ -38,7 +38,7 @@ private
 
   def s3_storage_service
     Storage::S3Service.new(
-      Configuration::PaasConfigurationService.new,
+      PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new,
       ENV["CSV_DOWNLOAD_PAAS_INSTANCE"],
     )
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,10 @@
 require "sidekiq/web"
 require "sidekiq/cron/web"
 
+configuration_service = PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new
+
 if Rails.env.staging? || Rails.env.production?
-  redis_url = Configuration::PaasConfigurationService.new.redis_uris[:"dluhc-core-#{Rails.env}-redis"]
+  redis_url = configuration_service.redis_uris[:"dluhc-core-#{Rails.env}-redis"]
 
   Sidekiq.configure_server do |config|
     config.redis = { url: redis_url }
@@ -14,7 +16,7 @@ if Rails.env.staging? || Rails.env.production?
 end
 
 if Rails.env.review?
-  redis_url = Configuration::PaasConfigurationService.new.redis_uris.to_a[0][1]
+  redis_url = configuration_service.redis_uris.to_a[0][1]
 
   Sidekiq.configure_server do |config|
     config.redis = { url: redis_url }

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -5,7 +5,7 @@ namespace :core do
     path = args[:path]
     raise "Usage: rake core:data_import['data_type', 'path/to/xml_files']" if path.blank? || type.blank?
 
-    storage_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    storage_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
 
     case type
     when "organisation"

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -8,7 +8,7 @@ namespace :core do
     # We only allow a reduced list of known fields to be updatable
     case field
     when "tenancycode", "major_repairs", "lettings_allocation", "offered"
-      s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+      s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)
       if archive_service.folder_present?("logs")

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -6,7 +6,7 @@ namespace :import do
     institutions_csv_name = args[:institutions_csv_name]
     raise "Usage: rake import:initial['institutions_csv_name']" if institutions_csv_name.blank?
 
-    s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
     csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
     org_count = csv.length
 
@@ -43,7 +43,7 @@ namespace :import do
     institutions_csv_name = args[:institutions_csv_name]
     raise "Usage: rake import:logs['institutions_csv_name']" if institutions_csv_name.blank?
 
-    s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
     csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
     org_count = csv.length
 
@@ -77,7 +77,7 @@ namespace :import do
     institutions_csv_name = args[:institutions_csv_name]
     raise "Usage: rake import:trigger_invites['institutions_csv_name']" if institutions_csv_name.blank?
 
-    s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
     csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
 
     Rails.logger.info("Triggering user invite emails")
@@ -98,7 +98,7 @@ namespace :import do
     institutions_csv_name = args[:institutions_csv_name]
     raise "Usage: rake import:generate_reports['institutions_csv_name']" if institutions_csv_name.blank?
 
-    s3_service = Storage::S3Service.new(Configuration::PaasConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
     institutions_csv = CSV.parse(s3_service.get_file_io(institutions_csv_name), headers: true)
 
     Imports::ImportReportService.new(s3_service, institutions_csv).create_reports(institutions_csv_name)

--- a/spec/helpers/platform_helper_spec.rb
+++ b/spec/helpers/platform_helper_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe PlatformHelper do
+  describe "is_paas?" do
+    it "returns true if the VCAP_SERVICES environment variable exists" do
+      allow(ENV).to receive(:[]).with("VCAP_SERVICES").and_return("dummy")
+      expect(described_class.is_paas?).to eq(true)
+    end
+
+    it "returns false if the VCAP_SERVICES environment variable doesn't exist" do
+      allow(ENV).to receive(:[]).with("VCAP_SERVICES")
+      expect(described_class.is_paas?).to eq(false)
+    end
+  end
+end

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -16,7 +16,6 @@ describe "full import", type: :task do
     allow(Configuration::EnvConfigurationService).to receive(:new).and_return(env_config_service)
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with("IMPORT_PAAS_INSTANCE").and_return(instance_name)
-
   end
 
   describe "import:generate_reports" do
@@ -35,7 +34,7 @@ describe "full import", type: :task do
         allow(Imports::ImportReportService).to receive(:new).and_return(import_report_service)
       end
 
-      it "creates a report using given organisation csv" do
+      it "creates a report using given organisation csv when the VCAP_SERVICES environment variable exists" do
         allow(ENV).to receive(:[]).with("VCAP_SERVICES").and_return("dummy")
         expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
         expect(Imports::ImportReportService).to receive(:new).with(storage_service, CSV.parse(orgs_list, headers: true))
@@ -44,7 +43,7 @@ describe "full import", type: :task do
         task.invoke("some_name")
       end
 
-      it "creates a report using given organisation csv" do
+      it "creates a report using given organisation csv when the VCAP_SERVICES environment variable does not exist" do
         allow(ENV).to receive(:[]).with("VCAP_SERVICES")
         expect(Storage::S3Service).to receive(:new).with(env_config_service, instance_name)
         expect(Imports::ImportReportService).to receive(:new).with(storage_service, CSV.parse(orgs_list, headers: true))


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/CLDC-2539

- Added a helper module to determine if the platform is PaaS
- Updated codebase to use existing `EnvConfigurationService` instead of `PaasConfigurationService` if platform is _not_ PaaS
- Make the updates in such a way that we can remove all PaaS specific code easily in the future