### PR TITLE
Search and filter at the same time

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -34,7 +34,6 @@ class Scheme < ApplicationRecord
     if scopes.any?
       filtered_records = filtered_records
       .left_outer_joins(:scheme_deactivation_periods)
-      .order("scheme_deactivation_periods.created_at DESC")
       .merge(scopes.reduce(&:or))
     end
 
@@ -44,9 +43,9 @@ class Scheme < ApplicationRecord
   scope :incomplete, lambda {
     where.not(confirmed: true)
     .or(where.not(id: Location.select(:scheme_id).where(confirmed: true).distinct))
-    .where.not(id: joins(:scheme_deactivation_periods).reactivating_soon.pluck(:id))
-    .where.not(id: joins(:scheme_deactivation_periods).deactivated.pluck(:id))
-    .where.not(id: joins(:scheme_deactivation_periods).deactivating_soon.pluck(:id))
+    .where.not(id: joins(:scheme_deactivation_periods).reactivating_soon.pluck(:id, :service_name, :confirmed))
+    .where.not(id: joins(:scheme_deactivation_periods).deactivated.pluck(:id, :service_name, :confirmed))
+    .where.not(id: joins(:scheme_deactivation_periods).deactivating_soon.pluck(:id, :service_name, :confirmed))
   }
 
   scope :deactivated, lambda {
@@ -65,10 +64,10 @@ class Scheme < ApplicationRecord
   }
 
   scope :active_status, lambda {
-    where.not(id: joins(:scheme_deactivation_periods).reactivating_soon.pluck(:id))
-    .where.not(id: joins(:scheme_deactivation_periods).deactivated.pluck(:id))
-    .where.not(id: incomplete.pluck(:id))
-    .where.not(id: joins(:scheme_deactivation_periods).deactivating_soon.pluck(:id))
+    where.not(id: joins(:scheme_deactivation_periods).reactivating_soon.pluck(:id, :service_name, :confirmed))
+    .where.not(id: joins(:scheme_deactivation_periods).deactivated.pluck(:id, :service_name, :confirmed))
+    .where.not(id: incomplete.pluck(:id, :service_name, :confirmed))
+    .where.not(id: joins(:scheme_deactivation_periods).deactivating_soon.pluck(:id, :service_name, :confirmed))
   }
 
   validate :validate_confirmed

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Scheme, type: :model do
       end
 
       context "when filtering by status" do
-        let!(:incomplete_scheme) { FactoryBot.create(:scheme, :incomplete) }
+        let!(:incomplete_scheme) { FactoryBot.create(:scheme, :incomplete, service_name: "name") }
         let(:active_scheme) { FactoryBot.create(:scheme) }
         let(:deactivating_soon_scheme) { FactoryBot.create(:scheme) }
         let(:deactivated_scheme) { FactoryBot.create(:scheme) }
@@ -138,6 +138,13 @@ RSpec.describe Scheme, type: :model do
           it "returns only incomplete schemes" do
             expect(described_class.filter_by_status(%w[incomplete]).count).to eq(1)
             expect(described_class.filter_by_status(%w[incomplete]).first).to eq(incomplete_scheme)
+          end
+        end
+
+        context "when filtering by incomplete status and searching" do
+          it "returns only incomplete schemes" do
+            expect(described_class.search_by("name").filter_by_status(%w[incomplete]).count).to eq(1)
+            expect(described_class.search_by("name").filter_by_status(%w[incomplete]).first).to eq(incomplete_scheme)
           end
         end
 


### PR DESCRIPTION
We were getting errors when chaining filter and search for schemes because we were not selecting all the columns we order by.