### PR TITLE
CLDC-2658 Export additional id fields

### DIFF
--- a/app/services/exports/lettings_log_export_constants.rb
+++ b/app/services/exports/lettings_log_export_constants.rb
@@ -130,6 +130,13 @@ module Exports::LettingsLogExportConstants
     "wsupchrg",
     "wtcharge",
     "wtshortfall",
+    "location_code",
+    "scheme_old",
+    "log_id",
+    "scheme_status",
+    "location_status",
+    "created_by",
+    "amended_by"
   ]
 
   (1..8).each do |index|

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -196,6 +196,10 @@ module Exports
         attribute_hash["age#{index}"] = -9 if attribute_hash["age#{index}_known"] == 1
       end
 
+      attribute_hash["log_id"] = lettings_log.id
+      attribute_hash["created_by"] = lettings_log.created_by&.email
+      attribute_hash["amended_by"] = lettings_log.updated_by&.email
+
       # Supported housing fields
       if lettings_log.is_supported_housing?
         attribute_hash["unittype_sh"] = lettings_log.unittype_sh
@@ -219,12 +223,16 @@ module Exports
       attribute_hash["schtype"] = scheme.scheme_type_before_type_cast
       attribute_hash["support"] = scheme.support_type_before_type_cast
       attribute_hash["units_scheme"] = scheme.locations.map(&:units).compact.sum
+      attribute_hash["scheme"] = scheme.id
+      attribute_hash["scheme_status"] = scheme.status_at(attribute_hash["startdate"])
     end
 
     def add_location_fields!(location, attribute_hash)
       attribute_hash["mobstand"] = location.mobility_type_before_type_cast
-      attribute_hash["scheme"] = location.old_visible_id || (location.id + LOG_ID_OFFSET)
+      attribute_hash["scheme_old"] = location.old_visible_id
       attribute_hash["units"] = location.units
+      attribute_hash["location_code"] = location.id
+      attribute_hash["location_status"] = location.status_at(attribute_hash["startdate"])
     end
 
     def filter_keys!(attributes)

--- a/spec/fixtures/exports/general_needs_log.xml
+++ b/spec/fixtures/exports/general_needs_log.xml
@@ -153,6 +153,9 @@
     <manhcnum>1234</manhcnum>
     <createddate>2022-05-01T00:00:00+01:00</createddate>
     <uploaddate>2022-05-01T00:00:00+01:00</uploaddate>
+    <log_id>{log_id}</log_id>
+    <created_by>test1@example.com</created_by>
+    <amended_by/>
     <providertype>1</providertype>
   </form>
 </forms>

--- a/spec/fixtures/exports/general_needs_log_23_24.xml
+++ b/spec/fixtures/exports/general_needs_log_23_24.xml
@@ -154,6 +154,9 @@
     <manhcnum>1234</manhcnum>
     <createddate>2023-04-03T00:00:00+01:00</createddate>
     <uploaddate>2023-04-03T00:00:00+01:00</uploaddate>
+    <log_id>{log_id}</log_id>
+    <created_by>test1@example.com</created_by>
+    <amended_by/>
     <providertype>1</providertype>
   </form>
 </forms>

--- a/spec/fixtures/exports/supported_housing_logs.xml
+++ b/spec/fixtures/exports/supported_housing_logs.xml
@@ -152,6 +152,9 @@
     <manhcnum>1234</manhcnum>
     <createddate>2022-05-01T00:00:00+01:00</createddate>
     <uploaddate>2022-05-01T00:00:00+01:00</uploaddate>
+    <log_id>{log_id}</log_id>
+    <created_by>fake@email.com</created_by>
+    <amended_by>other@email.com</amended_by>
     <unittype_sh>7</unittype_sh>
     <confidential>1</confidential>
     <cligrp1>G</cligrp1>
@@ -162,9 +165,13 @@
     <schtype>7</schtype>
     <support>4</support>
     <units_scheme>20</units_scheme>
+    <scheme>{scheme_id}</scheme>
+    <scheme_status>active</scheme_status>
     <mobstand>A</mobstand>
-    <scheme>111</scheme>
+    <scheme_old>111</scheme_old>
     <units>20</units>
+    <location_code>{location_id}</location_code>
+    <location_status>active</location_status>
     <providertype>1</providertype>
   </form>
 </forms>

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -17,11 +17,15 @@ RSpec.describe Exports::LettingsLogExportService do
   let(:expected_data_filename) { "core_2021_2022_apr_mar_f0001_inc0001_pt001.xml" }
   let(:expected_manifest_filename) { "manifest.xml" }
   let(:start_time) { Time.zone.local(2022, 5, 1) }
+  let(:user) { FactoryBot.create(:user, email: "test1@example.com") }
 
   def replace_entity_ids(lettings_log, export_template)
     export_template.sub!(/\{id\}/, (lettings_log["id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
     export_template.sub!(/\{owning_org_id\}/, (lettings_log["owning_organisation_id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
     export_template.sub!(/\{managing_org_id\}/, (lettings_log["managing_organisation_id"] + Exports::LettingsLogExportService::LOG_ID_OFFSET).to_s)
+    export_template.sub!(/\{location_id\}/, (lettings_log["location_id"]).to_s) if lettings_log.needstype == 2
+    export_template.sub!(/\{scheme_id\}/, (lettings_log["scheme_id"]).to_s) if lettings_log.needstype == 2
+    export_template.sub!(/\{log_id\}/, lettings_log["id"].to_s)
   end
 
   def replace_record_number(export_template, record_number)
@@ -89,7 +93,7 @@ RSpec.describe Exports::LettingsLogExportService do
     end
 
     context "and one lettings log is available for export" do
-      let!(:lettings_log) { FactoryBot.create(:lettings_log, :completed, propcode: "123", ppostcode_full: "SE2 6RT", postcode_full: "NW1 5TY", tenancycode: "BZ737", startdate: Time.zone.local(2022, 2, 2, 10, 36, 49), voiddate: Time.zone.local(2019, 11, 3), mrcdate: Time.zone.local(2020, 5, 5, 10, 36, 49), tenancylength: 5, underoccupation_benefitcap: 4) }
+      let!(:lettings_log) { FactoryBot.create(:lettings_log, :completed, created_by: user, propcode: "123", ppostcode_full: "SE2 6RT", postcode_full: "NW1 5TY", tenancycode: "BZ737", startdate: Time.zone.local(2022, 2, 2, 10, 36, 49), voiddate: Time.zone.local(2019, 11, 3), mrcdate: Time.zone.local(2020, 5, 5, 10, 36, 49), tenancylength: 5, underoccupation_benefitcap: 4) }
 
       it "generates a ZIP export file with the expected filename" do
         expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args)
@@ -172,7 +176,7 @@ RSpec.describe Exports::LettingsLogExportService do
       end
 
       context "and one lettings log is available for export" do
-        let!(:lettings_log) { FactoryBot.create(:lettings_log, :completed, uprn_known: 1, uprn: "100023336956", propcode: "123", postcode_full: "SE2 6RT", ppostcode_full: "SE2 6RT", tenancycode: "BZ737", startdate: Time.zone.local(2023, 4, 2, 10, 36, 49), voiddate: Time.zone.local(2021, 11, 3), mrcdate: Time.zone.local(2022, 5, 5, 10, 36, 49), tenancylength: 5, underoccupation_benefitcap: 4) }
+        let!(:lettings_log) { FactoryBot.create(:lettings_log, :completed, created_by: user, uprn_known: 1, uprn: "100023336956", propcode: "123", postcode_full: "SE2 6RT", ppostcode_full: "SE2 6RT", tenancycode: "BZ737", startdate: Time.zone.local(2023, 4, 2, 10, 36, 49), voiddate: Time.zone.local(2021, 11, 3), mrcdate: Time.zone.local(2022, 5, 5, 10, 36, 49), tenancylength: 5, underoccupation_benefitcap: 4) }
         let(:expected_zip_filename) { "core_2023_2024_apr_mar_f0001_inc0001.zip" }
         let(:expected_data_filename) { "core_2023_2024_apr_mar_f0001_inc0001_pt001.xml" }
         let(:xml_export_file) { File.open("spec/fixtures/exports/general_needs_log_23_24.xml", "r:UTF-8") }
@@ -306,14 +310,15 @@ RSpec.describe Exports::LettingsLogExportService do
     end
   end
 
-  context "when exporting a supporting housing lettings logs in XML" do
+  context "when exporting a supported housing lettings logs in XML" do
     let(:export_file) { File.open("spec/fixtures/exports/supported_housing_logs.xml", "r:UTF-8") }
     let(:organisation) { FactoryBot.create(:organisation, provider_type: "LA") }
-    let(:user) { FactoryBot.create(:user, organisation:) }
+    let(:user) { FactoryBot.create(:user, organisation:, email: "fake@email.com") }
+    let(:other_user) { FactoryBot.create(:user, organisation:, email: "other@email.com") }
     let(:scheme) { FactoryBot.create(:scheme, :export, owning_organisation: organisation) }
-    let(:location) { FactoryBot.create(:location, :export, scheme:, startdate: Time.zone.local(2021, 4, 1)) }
+    let(:location) { FactoryBot.create(:location, :export, scheme:, startdate: Time.zone.local(2021, 4, 1), old_id: "1a") }
 
-    let(:lettings_log) { FactoryBot.create(:lettings_log, :completed, :export, :sh, scheme:, location:, created_by: user, owning_organisation: organisation, startdate: Time.zone.local(2022, 2, 2, 10, 36, 49), voiddate: Time.zone.local(2019, 11, 3), mrcdate: Time.zone.local(2020, 5, 5, 10, 36, 49), underoccupation_benefitcap: 4, sheltered: 1) }
+    let(:lettings_log) { FactoryBot.create(:lettings_log, :completed, :export, :sh, scheme:, location:, created_by: user, updated_by: other_user, owning_organisation: organisation, startdate: Time.zone.local(2022, 2, 2, 10, 36, 49), voiddate: Time.zone.local(2019, 11, 3), mrcdate: Time.zone.local(2020, 5, 5, 10, 36, 49), underoccupation_benefitcap: 4, sheltered: 1) }
 
     before do
       FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2021, 4, 1), units: nil)


### PR DESCRIPTION
Add additional ID fields to the export to easier locate resources on the new core:
`log_id` - current log id
`scheme`  - current scheme id
`location_code` - current location id
`scheme_old` - old location/scheme id
`scheme_status` - scheme status during the startdate of the log
`location_status` - location status during the startdate of the log
`created_by` - created by user email
`amended_by` - updated by user email
