### PR TITLE
Allow non stock owning orgs to create sales logs

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def org_params
-    owning_organisation_id = current_user.organisation.holds_own_stock? ? current_user.organisation.id : nil
+    owning_organisation_id = instance_of?(SalesLogsController) || current_user.organisation.holds_own_stock? ? current_user.organisation.id : nil
     {
       "owning_organisation_id" => owning_organisation_id,
       "created_by_id" => current_user.id,

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -106,6 +106,61 @@ RSpec.describe SalesLogsController, type: :request do
         expect(whodunnit_actor).to be_a(User)
         expect(whodunnit_actor.id).to eq(user.id)
       end
+
+      context "when creating a new log" do
+        context "when the user is support" do
+          let(:organisation) { FactoryBot.create(:organisation) }
+          let(:support_user) { FactoryBot.create(:user, :support, organisation:) }
+
+          before do
+            allow(support_user).to receive(:need_two_factor_authentication?).and_return(false)
+            sign_in support_user
+            post "/sales-logs", headers:
+          end
+
+          it "sets the stock-owning org as nil" do
+            created_id = response.location.match(/[0-9]+/)[0]
+            sales_log = SalesLog.find_by(id: created_id)
+            expect(sales_log.owning_organisation).to eq(nil)
+          end
+        end
+
+        context "when the user is not support" do
+          context "when the user's org holds stock" do
+            let(:organisation) { FactoryBot.create(:organisation, name: "User org", holds_own_stock: true) }
+            let(:user) { FactoryBot.create(:user, :data_coordinator, organisation:) }
+
+            before do
+              RequestHelper.stub_http_requests
+              sign_in user
+              post "/sales-logs", headers:
+            end
+
+            it "sets the stock-owning org as the user's org" do
+              created_id = response.location.match(/[0-9]+/)[0]
+              sales_log = SalesLog.find_by(id: created_id)
+              expect(sales_log.owning_organisation.name).to eq("User org")
+            end
+          end
+
+          context "when the user's org doesn't hold stock" do
+            let(:organisation) { FactoryBot.create(:organisation, name: "User org", holds_own_stock: false) }
+            let(:user) { FactoryBot.create(:user, :data_coordinator, organisation:) }
+
+            before do
+              RequestHelper.stub_http_requests
+              sign_in user
+              post "/sales-logs", headers:
+            end
+
+            it "sets the stock-owning org as user's org" do
+              created_id = response.location.match(/[0-9]+/)[0]
+              sales_log = SalesLog.find_by(id: created_id)
+              expect(sales_log.owning_organisation.name).to eq("User org")
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We stopped setting owning organisation for sales in the routed_to? method
[#1821 CLDC-2108 Update sales owning organisation dropdown](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1821)

This should be set in the same place that it's being set for lettings logs, but there was a check for stock owning organisations which meant that non stock owning organisations couldn't create sales logs/the logs wouldn't get assigned to their org if they tried.

For the time being we're going to allow non stock owning organisations to log sales logs.