### PR TITLE
Increase disk and memory on staging worker instance

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,8 +9,10 @@ defaults: &defaults
       memory: 1G
     - type: worker
       command: bundle exec sidekiq -t 3
+      disk_quota: 4G
       health-check-type: process
       instances: 2
+      memory: 4G
   health-check-type: http
   health-check-http-endpoint: /health
 


### PR DESCRIPTION
The full export still runs out of memory and further optimisation would likely mean restructure to what files we're saving. As the full export at the moment is a one off task that needs to be ran, it makes more sense to temporarily increase resources