### PR TITLE
CLDC-2662 Add incomplete locations validation

### DIFF
--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -26,6 +26,11 @@ module Validations::SetupValidations
 
   def validate_location(record)
     location_during_startdate_validation(record)
+
+    if record.location&.status == :incomplete
+      record.errors.add :location_id, :incomplete, message: I18n.t("validations.setup.location.incomplete")
+      record.errors.add :scheme_id, :incomplete, message: I18n.t("validations.setup.location.incomplete")
+    end
   end
 
   def validate_scheme_has_confirmed_locations_validation(record)

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -323,6 +323,7 @@ module Imports
         %i[voiddate after_mrcdate] => %w[voiddate mrcdate majorrepairs],
         %i[tshortfall more_than_rent] => %w[tshortfall tshortfall_known],
         %i[scheme_id no_completed_locations] => %w[scheme_id location_id],
+        %i[location_id incomplete] => %w[scheme_id location_id],
         %i[beds one_three_bedroom_single_tenant_shared] => %w[beds],
       }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,6 +305,8 @@ en:
       lettype:
         general_needs_mismatch: Lettings type must be a general needs type because you selected general needs when uploading the file
         supported_housing_mismatch: Lettings type must be a supported housing type because you selected supported housing when uploading the file
+      location:
+        incomplete: "This location is incomplete"
 
     property:
       uprn:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,7 +306,7 @@ en:
         general_needs_mismatch: Lettings type must be a general needs type because you selected general needs when uploading the file
         supported_housing_mismatch: Lettings type must be a supported housing type because you selected supported housing when uploading the file
       location:
-        incomplete: "This location is incomplete"
+        incomplete: "This location is incomplete. Select another location or update this one"
 
     property:
       uprn:

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
 
       context "and some locations are not confirmed" do
         before do
-          FactoryBot.create(:location, scheme:, postcode: nil)
           FactoryBot.create(:location, scheme:)
+          FactoryBot.create(:location, :incomplete, scheme:)
           lettings_log.update!(scheme:)
         end
 

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe Validations::SetupValidations do
         record.location = location
         setup_validator.validate_location(record)
         expect(record.errors["location_id"])
-          .to include("This location is incomplete")
+          .to include("This location is incomplete. Select another location or update this one")
       end
 
       it "produces no error when location is completes" do

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -641,6 +641,26 @@ RSpec.describe Validations::SetupValidations do
           .to include(match I18n.t("validations.setup.startdate.location.activating_soon.location_id", postcode: location.postcode, date: "15 September 2022"))
       end
     end
+
+    context "with an incomplete location" do
+      let(:scheme) { create(:scheme) }
+      let(:location) { create(:location, :incomplete, scheme:) }
+
+      it "produces error when location is incomplete" do
+        record.location = location
+        setup_validator.validate_location(record)
+        expect(record.errors["location_id"])
+          .to include("This location is incomplete")
+      end
+
+      it "produces no error when location is completes" do
+        location.update!(units: 1)
+        location.reload
+        record.location = location
+        setup_validator.validate_location(record)
+        expect(record.errors["location_id"]).to be_empty
+      end
+    end
   end
 
   describe "#validate_organisation" do

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -901,6 +901,32 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      context "and unconfirmed/incomplete location is selected" do
+        let(:lettings_log_id) { "0b4a68df-30cc-474a-93c0-a56ce8fdad3b" }
+
+        before do
+          scheme = Scheme.find_by(old_visible_id: "0123")
+          scheme.locations.update!(confirmed: false, mobility_type: nil)
+          scheme.locations << create(:location)
+        end
+
+        it "intercepts the relevant validation error" do
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "clears out the location answers" do
+          allow(logger).to receive(:warn)
+
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.location).to be_nil
+          expect(lettings_log.scheme).to be_nil
+        end
+      end
+
       context "and carehome charges are out of range" do
         let(:lettings_log_id) { "0b4a68df-30cc-474a-93c0-a56ce8fdad3b" }
 


### PR DESCRIPTION
We are currently not validating if an incomplete location is selected for a log, because in the single log submission journey we don't display incomplete locations, therefore there is on way of it being selected.

It is causing issues during the import where some of those incomplete locations get set.

This PR adds a validation and clears the location fields if the validation is hit upon import.