### PR TITLE
CLDC-2630 Location fixes

### DIFF
--- a/app/helpers/details_table_helper.rb
+++ b/app/helpers/details_table_helper.rb
@@ -4,7 +4,9 @@ module DetailsTableHelper
       list = attribute[:value].map { |value| "<li>#{value}</li>" }.join
       simple_format(list, { class: "govuk-list govuk-list--bullet" }, wrapper_tag: "ul")
     else
-      value = attribute[:value].is_a?(Array) ? attribute[:value].first : attribute[:value] || "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe
+      return simple_format(attribute[:value].first.to_s, { class: "govuk-body" }, wrapper_tag: "p") if attribute[:value].is_a?(Array)
+
+      value = attribute[:value].presence || "<span class=\"app-!-colour-muted\">You didn’t answer this question</span>".html_safe
 
       simple_format(value.to_s, { class: "govuk-body" }, wrapper_tag: "p")
     end

--- a/app/views/locations/local_authority.html.erb
+++ b/app/views/locations/local_authority.html.erb
@@ -3,7 +3,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
         href: case params[:referrer]
-              when "check_local_authority"
+              when "check_local_authority", "check_answers"
                 scheme_location_check_answers_path(@scheme, @location, route: params[:route])
               else
                 scheme_location_postcode_path(@scheme, @location, route: params[:route], referrer: params[:referrer])

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe "Schemes scheme Features" do
             expect(page).to have_content "Check your answers"
           end
 
-          it "dispays correct text for uunanswered questions" do
+          it "dispays correct text for unanswered questions" do
             fill_in_and_save_location
             location.update!(location_code: nil)
             visit "/schemes/#{scheme.id}/locations/#{location.id}/check-answers"

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -552,6 +552,13 @@ RSpec.describe "Schemes scheme Features" do
             fill_in_and_save_second_location
             expect(page).to have_content "Check your answers"
           end
+
+          it "dispays correct text for uunanswered questions" do
+            fill_in_and_save_location
+            location.update!(location_code: nil)
+            visit "/schemes/#{scheme.id}/locations/#{location.id}/check-answers"
+            expect(page).to have_content "You didn’t answer this question"
+          end
         end
 
         context "when viewing locations" do


### PR DESCRIPTION
Show `You didn't answer this question` next to local authority answer. It was blank before because the value was and empty string instead of nil

Fix the back button for local authority to navigate back to check answers.