### PR TITLE
CLDC-2689 Export migrated logs

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -119,7 +119,7 @@ module Exports
     def retrieve_lettings_logs(start_time, recent_export, full_update)
       if !full_update && recent_export
         params = { from: recent_export.started_at, to: start_time }
-        LettingsLog.exportable.where("updated_at >= :from and updated_at <= :to", params)
+        LettingsLog.exportable.where("(updated_at >= :from AND updated_at <= :to) OR (imported_at IS NOT NULL AND imported_at >= :from AND imported_at <= :to)", params)
       else
         params = { to: start_time }
         LettingsLog.exportable.where("updated_at <= :to", params)

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -119,7 +119,7 @@ module Exports
     def retrieve_lettings_logs(start_time, recent_export, full_update)
       if !full_update && recent_export
         params = { from: recent_export.started_at, to: start_time }
-        LettingsLog.exportable.where("(updated_at >= :from AND updated_at <= :to) OR (imported_at IS NOT NULL AND imported_at >= :from AND imported_at <= :to)", params)
+        LettingsLog.exportable.where("(updated_at >= :from AND updated_at <= :to) OR (values_updated_at IS NOT NULL AND values_updated_at >= :from AND values_updated_at <= :to)", params)
       else
         params = { to: start_time }
         LettingsLog.exportable.where("updated_at <= :to", params)

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -271,7 +271,7 @@ module Imports
 
         attributes["created_by"] = user
       end
-      attributes["imported_at"] = Time.zone.now
+      attributes["values_updated_at"] = Time.zone.now
 
       apply_date_consistency!(attributes)
       apply_household_consistency!(attributes)

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -271,6 +271,7 @@ module Imports
 
         attributes["created_by"] = user
       end
+      attributes["imported_at"] = Time.zone.now
 
       apply_date_consistency!(attributes)
       apply_household_consistency!(attributes)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -198,6 +198,7 @@ module Imports
         end
         attributes["created_by"] = user
       end
+      attributes["imported_at"] = Time.zone.now
 
       set_default_values(attributes) if previous_status.include?("submitted")
       sales_log = save_sales_log(attributes, previous_status)

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -198,7 +198,7 @@ module Imports
         end
         attributes["created_by"] = user
       end
-      attributes["imported_at"] = Time.zone.now
+      attributes["values_updated_at"] = Time.zone.now
 
       set_default_values(attributes) if previous_status.include?("submitted")
       sales_log = save_sales_log(attributes, previous_status)

--- a/db/migrate/20230828145454_add_migrated_on_fields.rb
+++ b/db/migrate/20230828145454_add_migrated_on_fields.rb
@@ -1,0 +1,6 @@
+class AddMigratedOnFields < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lettings_logs, :imported_at, :datetime
+    add_column :sales_logs, :imported_at, :datetime
+  end
+end

--- a/db/migrate/20230828145454_add_migrated_on_fields.rb
+++ b/db/migrate/20230828145454_add_migrated_on_fields.rb
@@ -1,6 +1,6 @@
 class AddMigratedOnFields < ActiveRecord::Migration[7.0]
   def change
-    add_column :lettings_logs, :imported_at, :datetime
-    add_column :sales_logs, :imported_at, :datetime
+    add_column :lettings_logs, :values_updated_at, :datetime
+    add_column :sales_logs, :values_updated_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,7 +297,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_145454) do
     t.integer "status_cache", default: 0, null: false
     t.datetime "discarded_at"
     t.integer "creation_method", default: 1
-    t.datetime "imported_at"
+    t.datetime "values_updated_at"
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"
@@ -618,7 +618,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_145454) do
     t.integer "stairowned_value_check"
     t.integer "creation_method", default: 1
     t.integer "old_form_id"
-    t.datetime "imported_at"
+    t.datetime "values_updated_at"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_16_083950) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_28_145454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -297,6 +297,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_16_083950) do
     t.integer "status_cache", default: 0, null: false
     t.datetime "discarded_at"
     t.integer "creation_method", default: 1
+    t.datetime "imported_at"
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"
@@ -617,6 +618,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_16_083950) do
     t.integer "stairowned_value_check"
     t.integer "creation_method", default: 1
     t.integer "old_form_id"
+    t.datetime "imported_at"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -328,6 +328,26 @@ RSpec.describe Exports::LettingsLogExportService do
         expect(LogsExport.last.increment_number).to eq(1)
       end
     end
+
+    context "and a log has been migrated since the previous partial export" do
+      before do
+        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), imported_at: Time.zone.local(2022, 4, 29))
+        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), imported_at: Time.zone.local(2022, 4, 29))
+        LogsExport.create!(started_at: Time.zone.local(2022, 4, 28), base_number: 1, increment_number: 1)
+      end
+
+      it "generates an XML manifest file with the expected content within the ZIP file" do
+        expected_content = replace_record_number(local_manifest_file.read, 2)
+        expect(storage_service).to receive(:write_file).with(expected_master_manifest_rerun, any_args)
+        expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args) do |_, content|
+          entry = Zip::File.open_buffer(content).find_entry(expected_manifest_filename)
+          expect(entry).not_to be_nil
+          expect(entry.get_input_stream.read).to eq(expected_content)
+        end
+
+        export_service.export_xml_lettings_logs
+      end
+    end
   end
 
   context "when exporting a supported housing lettings logs in XML" do

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -331,8 +331,8 @@ RSpec.describe Exports::LettingsLogExportService do
 
     context "and a log has been migrated since the previous partial export" do
       before do
-        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), imported_at: Time.zone.local(2022, 4, 29))
-        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), imported_at: Time.zone.local(2022, 4, 29))
+        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), values_updated_at: Time.zone.local(2022, 4, 29))
+        FactoryBot.create(:lettings_log, startdate: Time.zone.local(2022, 2, 1), updated_at: Time.zone.local(2022, 4, 27), values_updated_at: Time.zone.local(2022, 4, 29))
         LogsExport.create!(started_at: Time.zone.local(2022, 4, 28), base_number: 1, increment_number: 1)
       end
 

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -159,6 +159,13 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      it "correctly sets imported at date" do
+        lettings_log_service.send(:create_log, lettings_log_xml)
+
+        lettings_log = LettingsLog.where(old_id: lettings_log_id).first
+        expect(lettings_log&.imported_at).to eq(Time.zone.local(2022, 1, 1))
+      end
+
       context "and the void date is after the start date" do
         before { lettings_log_xml.at_xpath("//xmlns:VYEAR").content = 2023 }
 

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Imports::LettingsLogsImportService do
         lettings_log_service.send(:create_log, lettings_log_xml)
 
         lettings_log = LettingsLog.where(old_id: lettings_log_id).first
-        expect(lettings_log&.imported_at).to eq(Time.zone.local(2022, 1, 1))
+        expect(lettings_log&.values_updated_at).to eq(Time.zone.local(2022, 1, 1))
       end
 
       context "and the void date is after the start date" do

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -102,8 +102,16 @@ RSpec.describe Imports::SalesLogsImportService do
   end
 
   context "when importing a specific log" do
+    let(:sales_log_id) { "shared_ownership_sales_log" }
     let(:sales_log_file) { open_file(fixture_directory, sales_log_id) }
     let(:sales_log_xml) { Nokogiri::XML(sales_log_file) }
+
+    it "correctly sets imported at date" do
+      sales_log_service.send(:create_log, sales_log_xml)
+
+      sales_log = SalesLog.where(old_id: sales_log_id).first
+      expect(sales_log&.imported_at).to eq(Time.zone.local(2023, 2, 1))
+    end
 
     context "and the organisation legacy ID does not exist" do
       let(:sales_log_id) { "shared_ownership_sales_log" }

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -173,6 +173,17 @@ RSpec.describe Imports::SalesLogsImportService do
       end
     end
 
+    context "when the log is valid" do
+      let(:sales_log_id) { "shared_ownership_sales_log" }
+
+      it "correctly sets old form id" do
+        sales_log_service.send(:create_log, sales_log_xml)
+
+        sales_log = SalesLog.find_by(old_id: sales_log_id)
+        expect(sales_log&.old_form_id).to eq(300_204)
+      end
+    end
+
     context "when the mortgage lender is set to an existing option" do
       let(:sales_log_id) { "discounted_ownership_sales_log" }
 

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -1718,7 +1718,24 @@ RSpec.describe Imports::SalesLogsImportService do
           expect(sales_log&.postcode_full).to eq("A1 1AA")
         end
 
-        it "correctly sets address and uprn if uprn is given" do
+        it "prioritises address and doesn't set UPRN if both address and UPRN is given" do
+          sales_log_service.send(:create_log, sales_log_xml)
+
+          sales_log = SalesLog.find_by(old_id: sales_log_id)
+          expect(sales_log&.uprn_known).to eq(0) # no
+          expect(sales_log&.uprn).to be_nil
+          expect(sales_log&.address_line1).to eq("address 1")
+          expect(sales_log&.address_line2).to eq("address 2")
+          expect(sales_log&.town_or_city).to eq("towncity")
+          expect(sales_log&.county).to eq("county")
+          expect(sales_log&.postcode_full).to eq("A1 1AA")
+        end
+
+        it "correctly sets address and uprn if uprn is given and address is not given" do
+          sales_log_xml.at_xpath("//xmlns:AddressLine1").content = ""
+          sales_log_xml.at_xpath("//xmlns:AddressLine2").content = ""
+          sales_log_xml.at_xpath("//xmlns:TownCity").content = ""
+          sales_log_xml.at_xpath("//xmlns:County").content = ""
           sales_log_service.send(:create_log, sales_log_xml)
 
           sales_log = SalesLog.find_by(old_id: sales_log_id)


### PR DESCRIPTION
We have been skipping imported logs in the partial export, because updated_at column is set getting set to what we get from the import source instead of current time.
We would also skip any logs that had their values corrected manually (for example fields were inferred incorrectly, we changed mapping or fields were re-imported).

We use updated_at for determining which logs have been modified and need to be exported.
We want to keep updated_at as it currently is for imported or corrected logs, so this PR adds an value_updated_at column to ensure we export all the logs that have changed.