### PR TITLE
CLDC-2684 Allow full export per year

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -14,7 +14,7 @@ module Exports
       archives_for_manifest = {}
       base_number = LogsExport.where(empty_export: false).maximum(:base_number) || 1
       recent_export = LogsExport.order("started_at").last
-      available_collection_years(collection_year).each do |collection|
+      collection_years_to_export(collection_year).each do |collection|
         export = build_export_run(collection, start_time, base_number, full_update)
         archives = write_export_archive(export, collection, start_time, recent_export, full_update)
 
@@ -267,7 +267,7 @@ module Exports
       xml_doc_to_temp_file(doc)
     end
 
-    def available_collection_years(collection_year)
+    def collection_years_to_export(collection_year)
       return [collection_year] if collection_year.present?
 
       FormHandler.instance.lettings_forms.values.map { |f| f.start_date.year }.uniq

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -8,13 +8,13 @@ module Exports
       @logger = logger
     end
 
-    def export_xml_lettings_logs(full_update: false)
+    def export_xml_lettings_logs(full_update: false, collection_year: nil)
       start_time = Time.zone.now
       daily_run_number = get_daily_run_number
       archives_for_manifest = {}
       base_number = LogsExport.where(empty_export: false).maximum(:base_number) || 1
       recent_export = LogsExport.order("started_at").last
-      available_collection_years.each do |collection|
+      available_collection_years(collection_year).each do |collection|
         export = build_export_run(collection, start_time, base_number, full_update)
         archives = write_export_archive(export, collection, start_time, recent_export, full_update)
 
@@ -267,7 +267,9 @@ module Exports
       xml_doc_to_temp_file(doc)
     end
 
-    def available_collection_years
+    def available_collection_years(collection_year)
+      return [collection_year] if collection_year.present?
+
       FormHandler.instance.lettings_forms.values.map { |f| f.start_date.year }.uniq
     end
   end

--- a/lib/tasks/data_export.rake
+++ b/lib/tasks/data_export.rake
@@ -12,10 +12,11 @@ namespace :core do
   end
 
   desc "Export all data XMLs for import into Central Data System (CDS)"
-  task full_data_export_xml: :environment do |_task, _args|
+  task :full_data_export_xml, %i[year] => :environment do |_task, args|
+    collection_year = args[:year].presence || false
     storage_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["EXPORT_PAAS_INSTANCE"])
     export_service = Exports::LettingsLogExportService.new(storage_service)
 
-    export_service.export_xml_lettings_logs(full_update: true)
+    export_service.export_xml_lettings_logs(full_update: true, collection_year:)
   end
 end

--- a/lib/tasks/data_export.rake
+++ b/lib/tasks/data_export.rake
@@ -13,7 +13,7 @@ namespace :core do
 
   desc "Export all data XMLs for import into Central Data System (CDS)"
   task :full_data_export_xml, %i[year] => :environment do |_task, args|
-    collection_year = args[:year].presence || false
+    collection_year = args[:year].presence
     storage_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["EXPORT_PAAS_INSTANCE"])
     export_service = Exports::LettingsLogExportService.new(storage_service)
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -34,8 +34,10 @@ applications:
         memory: 1G
       - type: worker
         command: bundle exec sidekiq -t 3
+        disk_quota: 4G
         health-check-type: process
         instances: 2
+        memory: 8G
     env:
       RAILS_ENV: production
     host: submit-social-housing-lettings-sales-data

--- a/spec/lib/tasks/data_export_spec.rb
+++ b/spec/lib/tasks/data_export_spec.rb
@@ -32,7 +32,7 @@ describe "rake core:data_export", type: task do
 
     context "with all available years" do
       it "calls the export service" do
-        expect(export_service).to receive(:export_xml_lettings_logs).with(full_update: true, collection_year: false)
+        expect(export_service).to receive(:export_xml_lettings_logs).with(full_update: true, collection_year: nil)
 
         task.invoke
       end

--- a/spec/lib/tasks/data_export_spec.rb
+++ b/spec/lib/tasks/data_export_spec.rb
@@ -28,21 +28,22 @@ describe "rake core:data_export", type: task do
   end
 
   context "when running full export" do
-    let(:storage_service) { instance_double(Storage::S3Service) }
-    let(:paas_config_service) { instance_double(Configuration::PaasConfigurationService) }
-    let(:export_service) { instance_double(Exports::LettingsLogExportService) }
     let(:task) { Rake::Task["core:full_data_export_xml"] }
 
-    before do
-      allow(Storage::S3Service).to receive(:new).and_return(storage_service)
-      allow(Configuration::PaasConfigurationService).to receive(:new).and_return(paas_config_service)
-      allow(Exports::LettingsLogExportService).to receive(:new).and_return(export_service)
+    context "with all available years" do
+      it "calls the export service" do
+        expect(export_service).to receive(:export_xml_lettings_logs).with(full_update: true, collection_year: false)
+
+        task.invoke
+      end
     end
 
-    it "calls the export service" do
-      expect(export_service).to receive(:export_xml_lettings_logs).with(full_update: true)
+    context "with a specific year" do
+      it "calls the export service" do
+        expect(export_service).to receive(:export_xml_lettings_logs).with(full_update: true, collection_year: 2022)
 
-      task.invoke
+        task.invoke(2022)
+      end
     end
   end
 end

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -219,6 +219,16 @@ RSpec.describe Exports::LettingsLogExportService do
 
           export_service.export_xml_lettings_logs
         end
+
+        it "generates zip export files only for specified year" do
+          expect(storage_service).to receive(:write_file).with(expected_zip_filename2, any_args)
+          expect(Rails.logger).to receive(:info).with("Building export run for 2022")
+          expect(Rails.logger).to receive(:info).with("Creating core_2022_2023_apr_mar_f0001_inc0001 - 1 logs")
+          expect(Rails.logger).to receive(:info).with("Added core_2022_2023_apr_mar_f0001_inc0001_pt001.xml")
+          expect(Rails.logger).to receive(:info).with("Writing core_2022_2023_apr_mar_f0001_inc0001.zip")
+
+          export_service.export_xml_lettings_logs(collection_year: 2022)
+        end
       end
     end
 


### PR DESCRIPTION
Full exports are quite large, so processing them after they have been exported takes a lot of time.
As the processor runs once a day, the intention is to export logs for different years on separate days and this PR would enable us to do that.