### PR TITLE
Migration fixes

### DIFF
--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -174,7 +174,7 @@ module Imports
                                      0
                                    end
 
-      attributes["offered"] = safe_string_as_integer(xml_doc, "Q20")
+      attributes["offered"] = unsafe_string_as_integer(xml_doc, "Q20")
       attributes["propcode"] = string_or_nil(xml_doc, "Q21a")
       attributes["beds"] = safe_string_as_integer(xml_doc, "Q22")
       attributes["unittype_gn"] = unsafe_string_as_integer(xml_doc, "Q23")

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -174,7 +174,7 @@ module Imports
                                      0
                                    end
 
-      attributes["offered"] = unsafe_string_as_integer(xml_doc, "Q20")
+      attributes["offered"] = safe_string_as_decimal(xml_doc, "Q20")
       attributes["propcode"] = string_or_nil(xml_doc, "Q21a")
       attributes["beds"] = safe_string_as_integer(xml_doc, "Q22")
       attributes["unittype_gn"] = unsafe_string_as_integer(xml_doc, "Q23")

--- a/app/services/imports/logs_import_service.rb
+++ b/app/services/imports/logs_import_service.rb
@@ -106,7 +106,7 @@ module Imports
         "F"
       when "Other", "Non-binary"
         "X"
-      when "Refused"
+      when "Refused", "Person prefers not to say", "Buyer prefers not to say"
         "R"
       end
     end
@@ -120,7 +120,7 @@ module Imports
         "P"
       when "Other", "Non-binary"
         "X"
-      when "Refused", "Buyer prefers not to say"
+      when "Refused", "Person prefers not to say", "Buyer prefers not to say"
         "R"
       end
     end

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -480,7 +480,6 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
-
       context "and the relationship is refused" do
         before do
           lettings_log_xml.at_xpath("//xmlns:P2Rel").content = "Person prefers not to say"

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -461,6 +461,45 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      context "and the gender identity is refused" do
+        before do
+          lettings_log_xml.at_xpath("//xmlns:P1Sex").content = "Person prefers not to say"
+        end
+
+        it "does not raise an error" do
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "saves the correct answer" do
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.sex1).to eq("R")
+        end
+      end
+
+
+      context "and the relationship is refused" do
+        before do
+          lettings_log_xml.at_xpath("//xmlns:P2Rel").content = "Person prefers not to say"
+        end
+
+        it "does not raise an error" do
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "saves the correct answer" do
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.relat2).to eq("R")
+        end
+      end
+
       context "when the log being imported was manually entered" do
         it "sets the creation method correctly" do
           lettings_log_service.send(:create_log, lettings_log_xml)

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -442,6 +442,25 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
+      context "and the number of times the property was relet is 0.00" do
+        before do
+          lettings_log_xml.at_xpath("//xmlns:Q20").content = "0.00"
+        end
+
+        it "does not raise an error" do
+          expect { lettings_log_service.send(:create_log, lettings_log_xml) }
+            .not_to raise_error
+        end
+
+        it "does not clear offered answer" do
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log = LettingsLog.find_by(old_id: lettings_log_id)
+
+          expect(lettings_log).not_to be_nil
+          expect(lettings_log.offered).to equal(0)
+        end
+      end
+
       context "when the log being imported was manually entered" do
         it "sets the creation method correctly" do
           lettings_log_service.send(:create_log, lettings_log_xml)


### PR DESCRIPTION
2 fixes in advance of the migration: 

1. accept decimals as values for offered as some orgs list 0 as 0.00
2. add in additional options for sex and relat questions as the "refused" values being exported from old core are different to what the code previously expected
