### PR TITLE
CLDC-2753 Add unassigned user for imported logs

### DIFF
--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -11,6 +11,7 @@ module Imports
     def create_reports(report_suffix)
       generate_missing_data_coordinators_report(report_suffix)
       generate_logs_report(report_suffix)
+      generate_unassigned_logs_report(report_suffix)
     end
 
     def generate_missing_data_coordinators_report(report_suffix)
@@ -52,6 +53,36 @@ module Imports
       @storage_service.write_file(report_name, BYTE_ORDER_MARK + rep)
 
       @logger.info("Logs report available in s3 import bucket at #{report_name}")
+    end
+
+    def generate_unassigned_logs_report(report_suffix)
+      Rails.logger.info("Generating unassigned logs report")
+
+      rep = CSV.generate do |report|
+        headers = ["Owning Organisation ID", "Old Owning Organisation ID", "Managing Organisation ID", "Old Managing Organisation ID", "Log ID", "Old Log ID", "Tenancy code", "Purchaser code"]
+        report << headers
+
+        @institutions_csv.each do |row|
+          name = row[0]
+          organisation = Organisation.find_by(name:)
+          next unless organisation
+
+          unassigned_user = organisation.users.find_by(name: "Unassigned")
+          next unless unassigned_user
+
+          organisation.owned_lettings_logs.where(created_by: unassigned_user).each do |lettings_log|
+            report << [organisation.id, organisation.old_org_id, lettings_log.managing_organisation.id, lettings_log.managing_organisation.old_org_id, lettings_log.id, lettings_log.old_id, lettings_log.tenancycode, nil]
+          end
+          organisation.owned_sales_logs.where(created_by: unassigned_user).each do |sales_log|
+            report << [organisation.id, organisation.old_org_id, nil, nil, sales_log.id, sales_log.old_id, nil, sales_log.purchid]
+          end
+        end
+      end
+
+      report_name = "UnassignedLogsReport_#{report_suffix}"
+      @storage_service.write_file(report_name, BYTE_ORDER_MARK + rep)
+
+      @logger.info("Unassigned logs report available in s3 import bucket at #{report_name}")
     end
   end
 end

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -251,6 +251,23 @@ module Imports
       owner_id = meta_field_value(xml_doc, "owner-user-id").strip
       if owner_id.present?
         user = LegacyUser.find_by(old_user_id: owner_id)&.user
+        if user.blank?
+          @logger.error("Lettings log '#{attributes['old_id']}' belongs to legacy user with owner-user-id: '#{owner_id}' which cannot be found. Assigning log to 'Unassigned' user.")
+          if User.find_by(name: "Unassigned")
+            user = User.find_by(name: "Unassigned")
+          else
+            user = User.new(
+              name: "Unassigned",
+              organisation_id: attributes["managing_organisation_id"],
+              is_dpo: false,
+              encrypted_password: SecureRandom.hex(10),
+              email: SecureRandom.uuid,
+              confirmed_at: Time.zone.now,
+              active: false,
+            )
+            user.save!(validate: false)
+          end
+        end
 
         attributes["created_by"] = user
       end

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -179,6 +179,23 @@ module Imports
       if owner_id.present?
         user = LegacyUser.find_by(old_user_id: owner_id)&.user
 
+        if user.blank?
+          @logger.error("Sales log '#{attributes['old_id']}' belongs to legacy user with owner-user-id: '#{owner_id}' which cannot be found. Assigning log to 'Unassigned' user.")
+          if User.find_by(name: "Unassigned")
+            user = User.find_by(name: "Unassigned")
+          else
+            user = User.new(
+              name: "Unassigned",
+              organisation_id: attributes["managing_organisation_id"],
+              is_dpo: false,
+              encrypted_password: SecureRandom.hex(10),
+              email: SecureRandom.uuid,
+              confirmed_at: Time.zone.now,
+              active: false,
+            )
+            user.save!(validate: false)
+          end
+        end
         attributes["created_by"] = user
       end
 

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -39,9 +39,15 @@ module Imports
         user.active = user_field_value(xml_document, "active")
 
         user.skip_confirmation_notification!
-        user.save!
-        user.legacy_users.create!(old_user_id:)
-        user
+
+        begin
+          user.save!
+          user.legacy_users.create!(old_user_id:)
+          user
+        rescue ActiveRecord::RecordInvalid => e
+          @logger.error(e.message)
+          @logger.error("Could not save user with email: #{email}")
+        end
       end
     end
 

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -135,6 +135,30 @@ RSpec.describe Imports::LettingsLogsImportService do
       let(:lettings_log_file) { open_file(fixture_directory, lettings_log_id) }
       let(:lettings_log_xml) { Nokogiri::XML(lettings_log_file) }
 
+      context "and the user does not exist" do
+        before { lettings_log_xml.at_xpath("//meta:owner-user-id").content = "fake_id" }
+
+        it "creates a new unassigned user" do
+          expect(logger).to receive(:error).with("Lettings log '0ead17cb-1668-442d-898c-0d52879ff592' belongs to legacy user with owner-user-id: 'fake_id' which cannot be found. Assigning log to 'Unassigned' user.")
+          lettings_log_service.send(:create_log, lettings_log_xml)
+
+          lettings_log = LettingsLog.where(old_id: lettings_log_id).first
+          expect(lettings_log&.created_by&.name).to eq("Unassigned")
+        end
+
+        it "only creates one unassigned user" do
+          expect(logger).to receive(:error).with("Lettings log '0ead17cb-1668-442d-898c-0d52879ff592' belongs to legacy user with owner-user-id: 'fake_id' which cannot be found. Assigning log to 'Unassigned' user.")
+          expect(logger).to receive(:error).with("Lettings log 'fake_id' belongs to legacy user with owner-user-id: 'fake_id' which cannot be found. Assigning log to 'Unassigned' user.")
+          lettings_log_service.send(:create_log, lettings_log_xml)
+          lettings_log_xml.at_xpath("//meta:document-id").content = "fake_id"
+          lettings_log_service.send(:create_log, lettings_log_xml)
+
+          lettings_log = LettingsLog.where(old_id: lettings_log_id).first
+          second_lettings_log = LettingsLog.where(old_id: "fake_id").first
+          expect(lettings_log&.created_by).to eq(second_lettings_log&.created_by)
+        end
+      end
+
       context "and the void date is after the start date" do
         before { lettings_log_xml.at_xpath("//xmlns:VYEAR").content = 2023 }
 

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -44,8 +44,22 @@ RSpec.describe Imports::UserImportService do
     end
 
     it "refuses to create a user belonging to a non existing organisation" do
-      expect(logger).to receive(:error).with(/ActiveRecord::RecordInvalid/)
+      expect(logger).to receive(:error).with(/Could not save user with email: john.doe@gov.uk/)
+      expect(logger).to receive(:error).with(/Validation failed: Organisation Select the user’s organisation/)
       import_service.create_users("user_directory")
+    end
+
+    context "when the user with the same email already exists" do
+      before do
+        create(:organisation, old_org_id:)
+        create(:user, email: "john.doe@gov.uk")
+      end
+
+      it "logs an error and user email" do
+        expect(logger).to receive(:error).with(/Could not save user with email: john.doe@gov.uk/)
+        expect(logger).to receive(:error).with(/Validation failed: email Enter an email address that hasn’t already been used to sign up/)
+        import_service.create_users("user_directory")
+      end
     end
 
     context "when the user is a data coordinator" do


### PR DESCRIPTION
Assign imported logs that we cannot find a user for to "Unassigned" user and add logging and reporting on the logs without user.