### PR TITLE
CLDC-2724 Add missing data reporting for imported lettings logs

### DIFF
--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -96,10 +96,10 @@ module Imports
 
         if unanswered_question_counts[unanswered_questions].present?
           unanswered_question_counts[unanswered_questions] += 1
-          missing_answers_example_sets[unanswered_questions] << { id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
+          missing_answers_example_sets[unanswered_questions] << { id: lettings_log.id, old_form_id: lettings_log.old_form_id, owning_organisation_id: lettings_log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
         else
           unanswered_question_counts[unanswered_questions] = 1
-          missing_answers_example_sets[unanswered_questions] = [{ id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id }]
+          missing_answers_example_sets[unanswered_questions] = [{ id: lettings_log.id, old_form_id: lettings_log.old_form_id, owning_organisation_id: lettings_log.owning_organisation_id }]
         end
       end
 
@@ -113,12 +113,12 @@ module Imports
       end
 
       missing_answers_examples = CSV.generate do |report|
-        headers = ["Missing answers", "Organisation ID", "Log ID", "Old Log ID"]
+        headers = ["Missing answers", "Organisation ID", "Log ID", "Old Form ID"]
         report << headers
 
         missing_answers_example_sets.each do |missing_answers, examples|
           examples.each do |example|
-            report << [missing_answers, example[:owning_organisation_id], example[:id], example[:old_id]]
+            report << [missing_answers, example[:owning_organisation_id], example[:id], example[:old_form_id]]
           end
         end
       end

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -92,14 +92,14 @@ module Imports
 
       LettingsLog.where.not(old_id: nil).where(status: "in_progress").each do |lettings_log|
         applicable_questions = lettings_log.form.subsections.map { |s| s.applicable_questions(lettings_log).select { |q| q.enabled?(lettings_log) } }.flatten
-        unanswered_questions = applicable_questions.filter { |q| q.unanswered?(lettings_log) }.map(&:id) - lettings_log.optional_fields
+        unanswered_questions = (applicable_questions.filter { |q| q.unanswered?(lettings_log) }.map(&:id) - lettings_log.optional_fields).join(", ")
 
-        if unanswered_question_counts[unanswered_questions.join(", ")].present?
-          unanswered_question_counts[unanswered_questions.join(", ")] += 1
-          missing_answers_example_sets[unanswered_questions.join(", ")] << { id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions.join(", ")] > 10
+        if unanswered_question_counts[unanswered_questions].present?
+          unanswered_question_counts[unanswered_questions] += 1
+          missing_answers_example_sets[unanswered_questions] << { id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
         else
-          unanswered_question_counts[unanswered_questions.join(", ")] = 1
-          missing_answers_example_sets[unanswered_questions.join(", ")] = [{ id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id }]
+          unanswered_question_counts[unanswered_questions] = 1
+          missing_answers_example_sets[unanswered_questions] = [{ id: lettings_log.id, old_id: lettings_log.old_id, owning_organisation_id: lettings_log.owning_organisation_id }]
         end
       end
 

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -117,6 +117,15 @@ namespace :import do
     Imports::ImportReportService.new(s3_service, institutions_csv).create_reports(institutions_csv_name)
   end
 
+  desc "Generate migrated logs report"
+  task :generate_missing_answers_report, %i[file_suffix] => :environment do |_task, args|
+    file_suffix = args[:file_suffix]
+    raise "Usage: rake import:generate_reports['file_suffix']" if file_suffix.blank?
+
+    s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
+    Imports::ImportReportService.new(s3_service, nil).generate_missing_answers_report(file_suffix)
+  end
+
   desc "Run import from logs step to end"
   task :logs_onwards, %i[institutions_csv_name] => %i[environment logs trigger_invites generate_reports]
 

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -117,7 +117,7 @@ namespace :import do
     Imports::ImportReportService.new(s3_service, institutions_csv).create_reports(institutions_csv_name)
   end
 
-  desc "Generate migrated logs report"
+  desc "Generate missing answers report"
   task :generate_missing_answers_report, %i[file_suffix] => :environment do |_task, args|
     file_suffix = args[:file_suffix]
     raise "Usage: rake import:generate_reports['file_suffix']" if file_suffix.blank?

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
@@ -1,16 +1,16 @@
-Missing answers,Organisation ID,Log ID,Old Log ID
-age1_known,{org_id0},{id0},age1_known_0
-age1_known,{org_id1},{id1},age1_known_1
-age1_known,{org_id2},{id2},age1_known_2
-age1_known,{org_id3},{id3},age1_known_3
-age1_known,{org_id4},{id4},age1_known_4
-age1_known,{org_id5},{id5},age1_known_5
-age1_known,{org_id6},{id6},age1_known_6
-age1_known,{org_id7},{id7},age1_known_7
-age1_known,{org_id8},{id8},age1_known_8
-age1_known,{org_id9},{id9},age1_known_9
-beds,{org_id2_0},{id2_0},beds_0
-beds,{org_id2_1},{id2_1},beds_1
-beds,{org_id2_2},{id2_2},beds_2
-beds,{org_id2_3},{id2_3},beds_3
-"beds, age1_known",{org_id},{id},beds_and_age
+Missing answers,Organisation ID,Log ID,Old Form ID
+age1_known,{org_id0},{id0},1000
+age1_known,{org_id1},{id1},1001
+age1_known,{org_id2},{id2},1002
+age1_known,{org_id3},{id3},1003
+age1_known,{org_id4},{id4},1004
+age1_known,{org_id5},{id5},1005
+age1_known,{org_id6},{id6},1006
+age1_known,{org_id7},{id7},1007
+age1_known,{org_id8},{id8},1008
+age1_known,{org_id9},{id9},1009
+beds,{org_id2_0},{id2_0},2000
+beds,{org_id2_1},{id2_1},2001
+beds,{org_id2_2},{id2_2},2002
+beds,{org_id2_3},{id2_3},2003
+"beds, age1_known",{org_id},{id},300

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
@@ -1,0 +1,16 @@
+Missing answers,Organisation ID,Log ID,Old Log ID
+age1_known,{org_id0},{id0},age1_known_0
+age1_known,{org_id1},{id1},age1_known_1
+age1_known,{org_id2},{id2},age1_known_2
+age1_known,{org_id3},{id3},age1_known_3
+age1_known,{org_id4},{id4},age1_known_4
+age1_known,{org_id5},{id5},age1_known_5
+age1_known,{org_id6},{id6},age1_known_6
+age1_known,{org_id7},{id7},age1_known_7
+age1_known,{org_id8},{id8},age1_known_8
+age1_known,{org_id9},{id9},age1_known_9
+beds,{org_id2_0},{id2_0},beds_0
+beds,{org_id2_1},{id2_1},beds_1
+beds,{org_id2_2},{id2_2},beds_2
+beds,{org_id2_3},{id2_3},beds_3
+"beds, age1_known",{org_id},{id},beds_and_age

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
@@ -1,0 +1,2 @@
+Missing answers,Total number of affected logs
+age1_known,11

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
@@ -1,2 +1,4 @@
 Missing answers,Total number of affected logs
 age1_known,11
+beds,4
+"beds, age1_known",1

--- a/spec/lib/tasks/full_import_spec.rb
+++ b/spec/lib/tasks/full_import_spec.rb
@@ -54,6 +54,32 @@ describe "full import", type: :task do
     end
   end
 
+  describe "import:generate_missing_answers_report" do
+    subject(:task) { Rake::Task["import:generate_missing_answers_report"] }
+
+    before do
+      Rake.application.rake_require("tasks/full_import")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when generating a missing answers report" do
+      let(:import_report_service) { instance_double(Imports::ImportReportService) }
+
+      before do
+        allow(Imports::ImportReportService).to receive(:new).and_return(import_report_service)
+        allow(ENV).to receive(:[]).with("VCAP_SERVICES").and_return("dummy")
+      end
+
+      it "creates a missing answers report" do
+        expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+        expect(Imports::ImportReportService).to receive(:new).with(storage_service, nil)
+        expect(import_report_service).to receive(:generate_missing_answers_report).with("some_name")
+        task.invoke("some_name")
+      end
+    end
+  end
+
   describe "import:initial" do
     subject(:task) { Rake::Task["import:initial"] }
 

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -107,18 +107,20 @@ RSpec.describe Imports::ImportReportService do
 
       before do
         create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, i|
-          log.old_id = "age1_known_#{i}"
+          log.old_form_id = "100#{i}"
+          log.old_id = "old_id_age1_known_#{i}"
           log.save!
           expected__answers_examples_content.sub!("{id#{i}}", log.id.to_s)
           expected__answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
         end
         create_list(:lettings_log, 4, :completed, beds: nil) do |log, i|
-          log.old_id = "beds_#{i}"
+          log.old_form_id = "200#{i}"
+          log.old_id = "old_id_beds_#{i}"
           expected__answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
           expected__answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
           log.save!
         end
-        create(:lettings_log, :completed, age1_known: nil, beds: nil, old_id: "beds_and_age") do |log|
+        create(:lettings_log, :completed, age1_known: nil, beds: nil, old_form_id: "300", old_id: "123") do |log|
           expected__answers_examples_content.sub!("{id}", log.id.to_s)
           expected__answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
         end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -98,4 +98,25 @@ RSpec.describe Imports::ImportReportService do
       end
     end
   end
+
+  describe "#generate_missing_answers_report" do
+    context "when there are in progress imported logs" do
+      let(:institutions_csv) { nil }
+      let(:expected_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv") }
+
+      before do
+        create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, _i|
+          log.old_id = Faker::Name.initials(number: 10)
+          log.save!
+        end
+        create_list(:lettings_log, 2, :completed, age1_known: nil)
+      end
+
+      it "generates a csv with expected missing fields" do
+        expect(storage_service).to receive(:write_file).with("MissingAnswersReport_report_suffix.csv", "﻿#{expected_content}")
+
+        report_service.generate_missing_answers_report("report_suffix")
+      end
+    end
+  end
 end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -103,17 +103,32 @@ RSpec.describe Imports::ImportReportService do
     context "when there are in progress imported logs" do
       let(:institutions_csv) { nil }
       let(:expected_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv") }
+      let(:expected__answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
 
       before do
-        create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, _i|
-          log.old_id = Faker::Name.initials(number: 10)
+        create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, i|
+          log.old_id = "age1_known_#{i}"
+          log.save!
+          expected__answers_examples_content.sub!("{id#{i}}", log.id.to_s)
+          expected__answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
+        end
+        create_list(:lettings_log, 4, :completed, beds: nil) do |log, i|
+          log.old_id = "beds_#{i}"
+          expected__answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
+          expected__answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
           log.save!
         end
+        create(:lettings_log, :completed, age1_known: nil, beds: nil, old_id: "beds_and_age") do |log|
+          expected__answers_examples_content.sub!("{id}", log.id.to_s)
+          expected__answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
+        end
+
         create_list(:lettings_log, 2, :completed, age1_known: nil)
       end
 
       it "generates a csv with expected missing fields" do
         expect(storage_service).to receive(:write_file).with("MissingAnswersReport_report_suffix.csv", "﻿#{expected_content}")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamples_report_suffix.csv", "﻿#{expected__answers_examples_content}")
 
         report_service.generate_missing_answers_report("report_suffix")
       end


### PR DESCRIPTION
Add a task that creates 2 files. 
- A report of all imported, in progress logs with missing answers count, for example if there are 30 logs that are only missing an answer to `beds` question, the report will have a `beds,30` row. If there are 10 logs that are only missing answers to age1_known and beds, there would be a row with `"age1_known,beds",10` etc
- Example log IDs for all the combinations of missing answers

This is to identify if there are fields that are getting cleared in large quantities during the imports (for example due to validations). However this does not identify whether the fields have been cleared during the import or they haven't existed on the old service either.