### PR TITLE
CLDC-2725 Add missing sales data report

### DIFF
--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -109,16 +109,16 @@ module Imports
       unanswered_question_counts = {}
       missing_answers_example_sets = {}
 
-      log_class.where.not(old_id: nil).where(status: "in_progress").each do |sales_log|
-        applicable_questions = sales_log.form.subsections.map { |s| s.applicable_questions(sales_log).select { |q| q.enabled?(sales_log) } }.flatten
-        unanswered_questions = (applicable_questions.filter { |q| q.unanswered?(sales_log) }.map(&:id) - sales_log.optional_fields).join(", ")
+      log_class.where.not(old_id: nil).where(status: "in_progress").each do |log|
+        applicable_questions = log.form.subsections.map { |s| s.applicable_questions(log).select { |q| q.enabled?(log) } }.flatten
+        unanswered_questions = (applicable_questions.filter { |q| q.unanswered?(log) }.map(&:id) - log.optional_fields).join(", ")
 
         if unanswered_question_counts[unanswered_questions].present?
           unanswered_question_counts[unanswered_questions] += 1
-          missing_answers_example_sets[unanswered_questions] << { id: sales_log.id, old_form_id: sales_log.old_form_id, owning_organisation_id: sales_log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
+          missing_answers_example_sets[unanswered_questions] << { id: log.id, old_form_id: log.old_form_id, owning_organisation_id: log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
         else
           unanswered_question_counts[unanswered_questions] = 1
-          missing_answers_example_sets[unanswered_questions] = [{ id: sales_log.id, old_form_id: sales_log.old_form_id, owning_organisation_id: sales_log.owning_organisation_id }]
+          missing_answers_example_sets[unanswered_questions] = [{ id: log.id, old_form_id: log.old_form_id, owning_organisation_id: log.owning_organisation_id }]
         end
       end
 

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -100,37 +100,77 @@ RSpec.describe Imports::ImportReportService do
   end
 
   describe "#generate_missing_answers_report" do
-    context "when there are in progress imported logs" do
+    context "when there are in progress imported lettings logs" do
       let(:institutions_csv) { nil }
       let(:expected_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv") }
-      let(:expected__answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
+      let(:expected_answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
 
       before do
         create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, i|
           log.old_form_id = "100#{i}"
           log.old_id = "old_id_age1_known_#{i}"
           log.save!
-          expected__answers_examples_content.sub!("{id#{i}}", log.id.to_s)
-          expected__answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
+          expected_answers_examples_content.sub!("{id#{i}}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
         end
         create_list(:lettings_log, 4, :completed, beds: nil) do |log, i|
           log.old_form_id = "200#{i}"
           log.old_id = "old_id_beds_#{i}"
-          expected__answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
-          expected__answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
+          expected_answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
           log.save!
         end
         create(:lettings_log, :completed, age1_known: nil, beds: nil, old_form_id: "300", old_id: "123") do |log|
-          expected__answers_examples_content.sub!("{id}", log.id.to_s)
-          expected__answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
+          expected_answers_examples_content.sub!("{id}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
         end
 
         create_list(:lettings_log, 2, :completed, age1_known: nil)
       end
 
       it "generates a csv with expected missing fields" do
-        expect(storage_service).to receive(:write_file).with("MissingAnswersReport_report_suffix.csv", "﻿#{expected_content}")
-        expect(storage_service).to receive(:write_file).with("MissingAnswersExamples_report_suffix.csv", "﻿#{expected__answers_examples_content}")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersReportLettingsLog_report_suffix.csv", "﻿#{expected_content}")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesLettingsLog_report_suffix.csv", "﻿#{expected_answers_examples_content}")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersReportSalesLog_report_suffix.csv", "\uFEFFMissing answers,Total number of affected logs\n")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesSalesLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID\n")
+
+        report_service.generate_missing_answers_report("report_suffix")
+      end
+    end
+
+    context "when there are in progress imported sales logs" do
+      let(:institutions_csv) { nil }
+      let(:expected_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv") }
+      let(:expected_answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
+
+      before do
+        create_list(:sales_log, 11, :completed, age1_known: nil) do |log, i|
+          log.old_id = "age1_known_#{i}"
+          log.old_form_id = "100#{i}"
+          log.save!
+          expected_answers_examples_content.sub!("{id#{i}}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
+        end
+        create_list(:sales_log, 4, :completed, beds: nil) do |log, i|
+          log.old_id = "beds_#{i}"
+          log.old_form_id = "200#{i}"
+          expected_answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
+          log.save!
+        end
+        create(:sales_log, :completed, age1_known: nil, beds: nil, old_id: "beds_and_age", old_form_id: "300") do |log|
+          expected_answers_examples_content.sub!("{id}", log.id.to_s)
+          expected_answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
+        end
+
+        create_list(:sales_log, 2, :completed, age1_known: nil)
+      end
+
+      it "generates a csv with expected missing fields" do
+        expect(storage_service).to receive(:write_file).with("MissingAnswersReportLettingsLog_report_suffix.csv", "\uFEFFMissing answers,Total number of affected logs\n")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesLettingsLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID\n")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersReportSalesLog_report_suffix.csv", "﻿#{expected_content}")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesSalesLog_report_suffix.csv", "﻿#{expected_answers_examples_content}")
 
         report_service.generate_missing_answers_report("report_suffix")
       end


### PR DESCRIPTION
This builds on top of https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1892
and adds the same reports for sales logs