### PR TITLE
Only set soc tenant fields for 2022 or if they're given

### DIFF
--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -583,9 +583,8 @@ module Imports
 
     def set_soctenant_fields?(attributes)
       return false if attributes["ownershipsch"] != 1
-      return false if %w[socprevten frombeds fromprop].all? { |field| attributes[field].blank? } && collection_start_year_for_date(attributes["saledate"]) >= 2023
 
-      true
+      %w[socprevten frombeds fromprop].any? { |field| attributes[field].present? } || collection_start_year_for_date(attributes["saledate"]) < 2023
     end
 
     def set_default_values(attributes)


### PR DESCRIPTION
In old CORE, the question "Was the buyer a private registered provider, housing association or local authority tenant immediately before this sale?" doesn't exist. The questions that follow that are conditional on this question (`frombeds`, `fromprop`, `socprevten`) are optional. We didn't want to make them answer it in 22/23 if they hadn't already, therefore for 22/23, we have a secret "don't know" option that we mark as the answer to this, as well as `fromprop` and `socprevten`, and then we make `frombeds` optional (if they're not answered in old CORE)

For 23/24, we do want to get them to answer this question

We remove this inferring for 23/24, so that if none of the subsequent questions are answered (`frombeds`, `fromprop`, `socpreveten`) then "Was the buyer a private registered provider, housing association or local authority tenant immediately before this sale?" is blank and needs to be answered, and we don't have the "don't know" options available.