### PR TITLE
CLDC-2724 Display old log id in the missing answers examples

### DIFF
--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -115,10 +115,10 @@ module Imports
 
         if unanswered_question_counts[unanswered_questions].present?
           unanswered_question_counts[unanswered_questions] += 1
-          missing_answers_example_sets[unanswered_questions] << { id: log.id, old_form_id: log.old_form_id, owning_organisation_id: log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
+          missing_answers_example_sets[unanswered_questions] << { id: log.id, old_form_id: log.old_form_id, old_id: log.old_id, owning_organisation_id: log.owning_organisation_id } unless unanswered_question_counts[unanswered_questions] > 10
         else
           unanswered_question_counts[unanswered_questions] = 1
-          missing_answers_example_sets[unanswered_questions] = [{ id: log.id, old_form_id: log.old_form_id, owning_organisation_id: log.owning_organisation_id }]
+          missing_answers_example_sets[unanswered_questions] = [{ id: log.id, old_form_id: log.old_form_id, old_id: log.old_id, owning_organisation_id: log.owning_organisation_id }]
         end
       end
 
@@ -138,12 +138,12 @@ module Imports
 
     def missing_answers_examples(missing_answers_example_sets)
       CSV.generate do |report|
-        headers = ["Missing answers", "Organisation ID", "Log ID", "Old Form ID"]
+        headers = ["Missing answers", "Organisation ID", "Log ID", "Old Form ID", "Old Log ID"]
         report << headers
 
         missing_answers_example_sets.each do |missing_answers, examples|
           examples.each do |example|
-            report << [missing_answers, example[:owning_organisation_id], example[:id], example[:old_form_id]]
+            report << [missing_answers, example[:owning_organisation_id], example[:id], example[:old_form_id], example[:old_id]]
           end
         end
       end

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv
@@ -1,16 +1,16 @@
-Missing answers,Organisation ID,Log ID,Old Form ID
-age1_known,{org_id0},{id0},1000
-age1_known,{org_id1},{id1},1001
-age1_known,{org_id2},{id2},1002
-age1_known,{org_id3},{id3},1003
-age1_known,{org_id4},{id4},1004
-age1_known,{org_id5},{id5},1005
-age1_known,{org_id6},{id6},1006
-age1_known,{org_id7},{id7},1007
-age1_known,{org_id8},{id8},1008
-age1_known,{org_id9},{id9},1009
-beds,{org_id2_0},{id2_0},2000
-beds,{org_id2_1},{id2_1},2001
-beds,{org_id2_2},{id2_2},2002
-beds,{org_id2_3},{id2_3},2003
-"beds, age1_known",{org_id},{id},300
+Missing answers,Organisation ID,Log ID,Old Form ID,Old Log ID
+age1_known,{org_id0},{id0},1000,old_id_age1_known_0
+age1_known,{org_id1},{id1},1001,old_id_age1_known_1
+age1_known,{org_id2},{id2},1002,old_id_age1_known_2
+age1_known,{org_id3},{id3},1003,old_id_age1_known_3
+age1_known,{org_id4},{id4},1004,old_id_age1_known_4
+age1_known,{org_id5},{id5},1005,old_id_age1_known_5
+age1_known,{org_id6},{id6},1006,old_id_age1_known_6
+age1_known,{org_id7},{id7},1007,old_id_age1_known_7
+age1_known,{org_id8},{id8},1008,old_id_age1_known_8
+age1_known,{org_id9},{id9},1009,old_id_age1_known_9
+beds,{org_id2_0},{id2_0},2000,old_id_beds_0
+beds,{org_id2_1},{id2_1},2001,old_id_beds_1
+beds,{org_id2_2},{id2_2},2002,old_id_beds_2
+beds,{org_id2_3},{id2_3},2003,old_id_beds_3
+"beds, age1_known",{org_id},{id},300,beds_and_age

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Imports::ImportReportService do
           expected_answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
           log.save!
         end
-        create(:lettings_log, :completed, age1_known: nil, beds: nil, old_form_id: "300", old_id: "123") do |log|
+        create(:lettings_log, :completed, age1_known: nil, beds: nil, old_form_id: "300", old_id: "beds_and_age") do |log|
           expected_answers_examples_content.sub!("{id}", log.id.to_s)
           expected_answers_examples_content.sub!("{org_id}", log.owning_organisation_id.to_s)
         end
@@ -132,7 +132,7 @@ RSpec.describe Imports::ImportReportService do
         expect(storage_service).to receive(:write_file).with("MissingAnswersReportLettingsLog_report_suffix.csv", "﻿#{expected_content}")
         expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesLettingsLog_report_suffix.csv", "﻿#{expected_answers_examples_content}")
         expect(storage_service).to receive(:write_file).with("MissingAnswersReportSalesLog_report_suffix.csv", "\uFEFFMissing answers,Total number of affected logs\n")
-        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesSalesLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID\n")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesSalesLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID,Old Log ID\n")
 
         report_service.generate_missing_answers_report("report_suffix")
       end
@@ -145,14 +145,14 @@ RSpec.describe Imports::ImportReportService do
 
       before do
         create_list(:sales_log, 11, :completed, age1_known: nil) do |log, i|
-          log.old_id = "age1_known_#{i}"
+          log.old_id = "old_id_age1_known_#{i}"
           log.old_form_id = "100#{i}"
           log.save!
           expected_answers_examples_content.sub!("{id#{i}}", log.id.to_s)
           expected_answers_examples_content.sub!("{org_id#{i}}", log.owning_organisation_id.to_s)
         end
         create_list(:sales_log, 4, :completed, beds: nil) do |log, i|
-          log.old_id = "beds_#{i}"
+          log.old_id = "old_id_beds_#{i}"
           log.old_form_id = "200#{i}"
           expected_answers_examples_content.sub!("{id2_#{i}}", log.id.to_s)
           expected_answers_examples_content.sub!("{org_id2_#{i}}", log.owning_organisation_id.to_s)
@@ -168,7 +168,7 @@ RSpec.describe Imports::ImportReportService do
 
       it "generates a csv with expected missing fields" do
         expect(storage_service).to receive(:write_file).with("MissingAnswersReportLettingsLog_report_suffix.csv", "\uFEFFMissing answers,Total number of affected logs\n")
-        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesLettingsLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID\n")
+        expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesLettingsLog_report_suffix.csv", "\uFEFFMissing answers,Organisation ID,Log ID,Old Form ID,Old Log ID\n")
         expect(storage_service).to receive(:write_file).with("MissingAnswersReportSalesLog_report_suffix.csv", "﻿#{expected_content}")
         expect(storage_service).to receive(:write_file).with("MissingAnswersExamplesSalesLog_report_suffix.csv", "﻿#{expected_answers_examples_content}")
 


### PR DESCRIPTION
Add an extra old log id column in Missing answers examples report, because logs would only have Form ID if they were completed on old core.