### PR TITLE
CLDC-2795 Confirm scharge, pscharge and supcharge soft validations

### DIFF
--- a/lib/tasks/confirm_charges_soft_validations.rake
+++ b/lib/tasks/confirm_charges_soft_validations.rake
@@ -1,0 +1,8 @@
+desc "Confirms scharge, pscharge and supcharge soft validations for completed logs"
+task confirm_charges_soft_validations: :environment do
+  LettingsLog.where(status: "completed").each do |log|
+    log.update!(scharge_value_check: 0, values_updated_at: Time.zone.now) if log.scharge_value_check.blank? && log.scharge_over_soft_max?
+    log.update!(pscharge_value_check: 0, values_updated_at: Time.zone.now) if log.pscharge_value_check.blank? && log.pscharge_over_soft_max?
+    log.update!(supcharg_value_check: 0, values_updated_at: Time.zone.now) if log.supcharg_value_check.blank? && log.supcharg_over_soft_max?
+  end
+end

--- a/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
+++ b/spec/fixtures/files/imported_lettings_logs_missing_answers_report.csv
@@ -1,4 +1,4 @@
 Missing answers,Total number of affected logs
-age1_known,11
+age1_known,10
 beds,4
 "beds, age1_known",1

--- a/spec/lib/tasks/confirm_charges_soft_validations_spec.rb
+++ b/spec/lib/tasks/confirm_charges_soft_validations_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "confirm_charges_soft_validations" do
+  describe ":confirm_charges_soft_validations", type: :task do
+    subject(:task) { Rake::Task["confirm_charges_soft_validations"] }
+
+    before do
+      Rake.application.rake_require("tasks/confirm_charges_soft_validations")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let!(:lettings_log) { create(:lettings_log, :completed) }
+
+      it "confirms scharge value check for lettings logs with scharge over soft max" do
+        lettings_log.scharge = 404
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.scharge_value_check).to eq(0)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+
+      it "does not confirm scharge value check for lettings logs with scharge under soft max" do
+        lettings_log.scharge = 40
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.scharge_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm scharge value check for in progress logs" do
+        lettings_log.update!(scharge: 404, reason: nil, status: "in_progress")
+        expect(lettings_log.reload.status).to eq("in_progress")
+        task.invoke
+        expect(lettings_log.reload.scharge_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("in_progress")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm scharge value check if it already is confirmed" do
+        lettings_log.update!(scharge: 404, scharge_value_check: 0)
+        expect(lettings_log.reload.status).to eq("completed")
+        task.invoke
+        expect { task.invoke }.not_to change(lettings_log.reload, :scharge_value_check)
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "confirms pscharge value check for lettings logs with pscharge over soft max" do
+        lettings_log.pscharge = 204
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.pscharge_value_check).to eq(0)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+
+      it "does not confirm pscharge value check for lettings logs with pscharge under soft max" do
+        lettings_log.pscharge = 40
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.pscharge_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm pscharge value check for in progress logs" do
+        lettings_log.update!(pscharge: 204, reason: nil, status: "in_progress")
+        expect(lettings_log.reload.status).to eq("in_progress")
+        task.invoke
+        expect(lettings_log.reload.pscharge_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("in_progress")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm pscharge value check if it already is confirmed" do
+        lettings_log.update!(pscharge: 204, pscharge_value_check: 0)
+        expect(lettings_log.reload.status).to eq("completed")
+        task.invoke
+        expect { task.invoke }.not_to change(lettings_log.reload, :pscharge_value_check)
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "confirms supcharg value check for lettings logs with supcharg over soft max" do
+        lettings_log.supcharg = 204
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.supcharg_value_check).to eq(0)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+
+      it "does not confirm supcharg value check for lettings logs with supcharg under soft max" do
+        lettings_log.supcharg = 40
+        lettings_log.skip_update_status = true
+        lettings_log.save!(validate: false)
+        lettings_log.skip_update_status = nil
+        task.invoke
+        expect(lettings_log.reload.supcharg_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("completed")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm supcharg value check for in progress logs" do
+        lettings_log.update!(supcharg: 204, reason: nil, status: "in_progress")
+        expect(lettings_log.reload.status).to eq("in_progress")
+        task.invoke
+        expect(lettings_log.reload.supcharg_value_check).to eq(nil)
+        expect(lettings_log.status).to eq("in_progress")
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+
+      it "does not confirm supcharg value check if it already is confirmed" do
+        lettings_log.update!(supcharg: 204, supcharg_value_check: 0)
+        expect(lettings_log.reload.status).to eq("completed")
+        task.invoke
+        expect { task.invoke }.not_to change(lettings_log.reload, :supcharg_value_check)
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Imports::ImportReportService do
       let(:expected_answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
 
       before do
-        create_list(:lettings_log, 11, :completed, age1_known: nil) do |log, i|
+        create_list(:lettings_log, 10, :completed, age1_known: nil) do |log, i|
           log.old_form_id = "100#{i}"
           log.old_id = "old_id_age1_known_#{i}"
           log.save!
@@ -144,7 +144,7 @@ RSpec.describe Imports::ImportReportService do
       let(:expected_answers_examples_content) { File.read("spec/fixtures/files/imported_lettings_logs_missing_answers_examples.csv") }
 
       before do
-        create_list(:sales_log, 11, :completed, age1_known: nil) do |log, i|
+        create_list(:sales_log, 10, :completed, age1_known: nil) do |log, i|
           log.old_id = "old_id_age1_known_#{i}"
           log.old_form_id = "100#{i}"
           log.save!


### PR DESCRIPTION
We've added new soft validations, but would like to keep the previously completed logs as completed. 
This PR is to confirm those soft validations for completed logs