### PR TITLE
CLDC-2715 Reimport homeless values

### DIFF
--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -116,6 +116,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update homeless fields" do
+        let(:field) { "homeless" }
+
+        it "updates the logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end


### PR DESCRIPTION
Reimport homeless values if they failed to import in the past due to this validation that is now removed. https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1901
https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1877