### PR TITLE
CLDC-2769 Reimport unassigned logs

### DIFF
--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -29,7 +29,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "owning_organisation_id", "old_form_id"
+    when "owning_organisation_id", "old_form_id", "created_by"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -229,6 +229,27 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the created_by field" do
+        let(:field) { "created_by" }
+
+        it "updates the logs from the given XML file when the VCAP_SERVICES environment variable exists" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/sales_logs")
+          expect(Imports::SalesLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+
+        it "updates the logs from the given XML file when the VCAP_SERVICES environment variable does not exist" do
+          allow(ENV).to receive(:[]).with("VCAP_SERVICES")
+          expect(Storage::S3Service).to receive(:new).with(env_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/sales_logs")
+          expect(Imports::SalesLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -128,6 +128,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the created_by field" do
+        let(:field) { "created_by" }
+
+        it "updates the 2023 logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end

--- a/spec/services/imports/sales_logs_field_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_field_import_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Imports::SalesLogsFieldImportService do
   let(:fixture_directory) { "spec/fixtures/imports/sales_logs" }
   let(:sales_log_filename) { "shared_ownership_sales_log" }
   let(:sales_log_file) { File.open("#{fixture_directory}/#{sales_log_filename}.xml") }
+  let(:sales_log_xml) { Nokogiri::XML(sales_log_file) }
   let(:organisation) { create(:organisation, old_visible_id: "1", old_org_id: "7c5bd5fb549c09a2c55d7cb90d7ba84927e64618") }
   let(:old_user_id) { "c3061a2e6ea0b702e6f6210d5c52d2a92612d2aa" }
 
@@ -144,6 +145,79 @@ RSpec.describe Imports::SalesLogsFieldImportService do
         expect(logger).to receive(:info).with(/sales log \d+ has a value for old_form_id, skipping update/)
         expect { import_service.send(:update_field, field, remote_folder) }
           .not_to(change { sales_log.reload.old_form_id })
+      end
+    end
+  end
+
+  context "when updating created_by" do
+    let(:field) { "created_by" }
+    let(:sales_log_filename) { "shared_ownership_sales_log" }
+    let(:sales_log) { SalesLog.find_by(old_id: sales_log_filename) }
+    let(:old_log_id) { sales_log.id }
+
+    before do
+      Imports::SalesLogsImportService.new(storage_service, logger).create_logs(fixture_directory)
+      old_log_id
+      sales_log_file.rewind
+      sales_log.update!(values_updated_at: nil)
+    end
+
+    context "when the sales log has created_by value" do
+      it "skips the update" do
+        expect(logger).to receive(:info).with(/sales log \d+ has created_by value, skipping update/)
+        import_service.send(:update_created_by, sales_log_xml)
+
+        old_sales_log = SalesLog.find(old_log_id)
+        expect(old_sales_log).not_to be_nil
+
+        new_sales_log = SalesLog.find_by(old_id: sales_log_filename)
+        expect(new_sales_log).to eq(old_sales_log)
+        expect(new_sales_log.values_updated_at).to be_nil
+      end
+    end
+
+    context "when the sales log has no created_by value" do
+      before do
+        sales_log.update!(created_by: nil)
+      end
+
+      it "deletes the existing sales log and creates a new log with correct created_by" do
+        expect(logger).to receive(:info).with(/sales log \d+ has been deleted/)
+        expect(logger).to receive(:info).with(/sales log "shared_ownership_sales_log" has been reimported with id \d+/)
+        import_service.send(:update_created_by, sales_log_xml)
+
+        old_sales_log = SalesLog.find_by(id: old_log_id)
+        expect(old_sales_log).to be_nil
+
+        new_sales_log = SalesLog.find_by(old_id: sales_log_filename)
+        expect(new_sales_log).not_to eq(old_sales_log)
+        expect(new_sales_log.values_updated_at).not_to be_nil
+      end
+
+      it "deletes the existing sales log and creates a new log with correct unassigned created_by" do
+        sales_log_xml.at_xpath("//meta:owner-user-id").content = "fake_id"
+
+        expect(logger).to receive(:info).with(/sales log \d+ has been deleted/)
+        expect(logger).to receive(:info).with(/sales log "shared_ownership_sales_log" has been reimported with id \d+/)
+        expect(logger).to receive(:error).with(/Sales log 'shared_ownership_sales_log' belongs to legacy user with owner-user-id: 'fake_id' which cannot be found. Assigning log to 'Unassigned' user./)
+
+        import_service.send(:update_created_by, sales_log_xml)
+
+        old_sales_log = SalesLog.find_by(id: old_log_id)
+        expect(old_sales_log).to be_nil
+
+        new_sales_log = SalesLog.find_by(old_id: sales_log_filename)
+        expect(new_sales_log).not_to eq(old_sales_log)
+        expect(new_sales_log.created_by.name).to eq("Unassigned")
+        expect(new_sales_log.values_updated_at).not_to be_nil
+      end
+    end
+
+    context "and the log was not previously imported" do
+      it "logs a warning that the log has not been found in the db" do
+        sales_log.destroy!
+        expect(logger).to receive(:warn).with("sales log with old id #{sales_log_filename} not found")
+        expect { import_service.send(:update_created_by, sales_log_xml) }.not_to change(SalesLog, :count)
       end
     end
   end


### PR DESCRIPTION
There is a number of logs that have imported with missing created_by values. 
Logs without created_by would in most cases have cleared all the data for non setup sections (provided that the before hooks have ran), due to clearing out the non routed questions.

When importing logs we have now started to assign all the logs that cannot be assigned to a real user, to a fake, deactivated user with name "Unassigned"
As most of the data (anything past the setup section) cannot be edited unless the log is assigned to someone, it is relatively safe to delete and reimport all the logs that do not have created_by value set