### PR TITLE
CLDC-2729 Reimport referral for general needs PRP

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -7136,6 +7136,9 @@
                     "3": {
                       "value": "Nominated by a local housing authority"
                     },
+                    "4": {
+                      "value": "Referred by local authority housing department"
+                    },
                     "8": {
                       "value": "Re-located through official housing mobility scheme"
                     },

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -152,6 +152,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the referral (for general needs) field" do
+        let(:field) { "general_needs_referral" }
+
+        it "updates the 2023 logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end


### PR DESCRIPTION
We were previously not able to import referral value 4 for PRP General Needs logs, because it was not a valid option.
We since have added that option and added a soft validation if it was selected for General Needs PRP.
This PR reimports referral value which would have been previously dropped.