### PR TITLE
Update internal transfer validation

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -69,7 +69,6 @@ module Validations::HouseholdValidations
     # 3  Private Sector Tenancy
     # 4  Tied housing or rented with job
     # 7  Direct access hostel
-    # 9  Residential care home
     # 10 Hospital
     # 13 Children's home / Foster Care
     # 14 Bed and breakfast
@@ -82,7 +81,7 @@ module Validations::HouseholdValidations
     # 27 Owner occupation (low-cost home ownership)
     # 28 Living with Friends or Family
     # 29 Prison / Approved Probation Hostel
-    if record.is_internal_transfer? && [3, 4, 7, 9, 10, 13, 14, 19, 21, 23, 24, 25, 26, 27, 28, 29].include?(record.prevten)
+    if record.is_internal_transfer? && [3, 4, 7, 10, 13, 14, 19, 21, 23, 24, 25, 26, 27, 28, 29].include?(record.prevten)
       label = record.form.get_question("prevten", record).present? ? record.form.get_question("prevten", record).label_from_value(record.prevten) : ""
       record.errors.add :prevten, :internal_transfer_non_social_housing, message: I18n.t("validations.household.prevten.internal_transfer", prevten: label)
       record.errors.add :referral, :internal_transfer_non_social_housing, message: I18n.t("validations.household.referral.prevten_invalid", prevten: label)

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -619,17 +619,7 @@ RSpec.describe Validations::HouseholdValidations do
     end
 
     context "when the referral is internal transfer" do
-      it "cannot be 3" do
-        record.referral = 1
-        record.prevten = 3
-        household_validator.validate_previous_housing_situation(record)
-        expect(record.errors["prevten"])
-          .to include(match I18n.t("validations.household.prevten.internal_transfer", prevten: ""))
-        expect(record.errors["referral"])
-          .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
-      end
-
-      it "can be 9" do
+      it "prevten can be 9" do
         record.referral = 1
         record.prevten = 9
         household_validator.validate_previous_housing_situation(record)
@@ -639,7 +629,17 @@ RSpec.describe Validations::HouseholdValidations do
           .to be_empty
       end
 
-      it "cannot be 4, 10, 13, 19, 23, 24, 25, 26, 28, 29" do
+      it "prevten cannot be 3" do
+        record.referral = 1
+        record.prevten = 3
+        household_validator.validate_previous_housing_situation(record)
+        expect(record.errors["prevten"])
+          .to include(match I18n.t("validations.household.prevten.internal_transfer", prevten: ""))
+        expect(record.errors["referral"])
+          .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
+      end
+
+      it "prevten cannot be 4, 10, 13, 19, 23, 24, 25, 26, 28, 29" do
         record.referral = 1
         record.prevten = 4
         household_validator.validate_previous_housing_situation(record)

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -629,6 +629,16 @@ RSpec.describe Validations::HouseholdValidations do
           .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
       end
 
+      it "cannot be 9" do
+        record.referral = 1
+        record.prevten = 9
+        household_validator.validate_previous_housing_situation(record)
+        expect(record.errors["prevten"])
+          .to include(match I18n.t("validations.household.prevten.internal_transfer", prevten: ""))
+        expect(record.errors["referral"])
+          .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
+      end
+
       it "cannot be 4, 10, 13, 19, 23, 24, 25, 26, 28, 29" do
         record.referral = 1
         record.prevten = 4

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -629,14 +629,14 @@ RSpec.describe Validations::HouseholdValidations do
           .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
       end
 
-      it "cannot be 9" do
+      it "can be 9" do
         record.referral = 1
         record.prevten = 9
         household_validator.validate_previous_housing_situation(record)
         expect(record.errors["prevten"])
-          .to include(match I18n.t("validations.household.prevten.internal_transfer", prevten: ""))
+          .to be_empty
         expect(record.errors["referral"])
-          .to include(match I18n.t("validations.household.referral.prevten_invalid", prevten: ""))
+          .to be_empty
       end
 
       it "cannot be 4, 10, 13, 19, 23, 24, 25, 26, 28, 29" do

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -432,9 +432,9 @@ RSpec.describe Imports::LettingsLogsImportService do
         end
       end
 
-      context "and this is an internal transfer from a non social housing" do
+      context "and this is an internal transfer from a non social housing (and not residential care home)" do
         before do
-          lettings_log_xml.at_xpath("//xmlns:Q11").content = "9 Residential care home"
+          lettings_log_xml.at_xpath("//xmlns:Q11").content = "4 Tied housing or rented with job"
           lettings_log_xml.at_xpath("//xmlns:Q16").content = "1 Internal Transfer"
         end
 


### PR DESCRIPTION
Removes the residential care home option from `validate_previous_housing_situation`