### PR TITLE
CLDC-2790 Reimport person details

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -572,6 +572,10 @@ class LettingsLog < Log
     is_general_needs? && referral == 4
   end
 
+  def has_any_person_details?(person_index)
+    ["sex#{person_index}", "relat#{person_index}", "ecstat#{person_index}"].any? { |field| public_send(field).present? } || public_send("age#{person_index}_known") == 1
+  end
+
 private
 
   def reset_invalid_unresolved_log_fields!

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -576,6 +576,10 @@ class LettingsLog < Log
     ["sex#{person_index}", "relat#{person_index}", "ecstat#{person_index}"].any? { |field| public_send(field).present? } || public_send("age#{person_index}_known") == 1
   end
 
+  def details_not_known_for_person?(person_index)
+    public_send("details_known_#{person_index}") == 1
+  end
+
 private
 
   def reset_invalid_unresolved_log_fields!

--- a/app/services/imports/lettings_logs_field_import_service.rb
+++ b/app/services/imports/lettings_logs_field_import_service.rb
@@ -309,6 +309,8 @@ module Imports
       record = LettingsLog.find_by(old_id:)
 
       return @logger.warn("lettings log with old id #{old_id} not found") unless record
+      return @logger.info("lettings log #{record.id} has no hhmemb, skipping update") unless record.hhmemb
+
       if (2..record.hhmemb).all? { |person_index| record.has_any_person_details?(person_index) || record["details_known_#{person_index}"] == 1 }
         return @logger.info("lettings log #{record.id} has all household member details, skipping update")
       end

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "person_details"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral", "person_details"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "person_details"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -164,6 +164,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the person_details field" do
+        let(:field) { "person_details" }
+
+        it "updates the 2023 logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end

--- a/spec/services/imports/lettings_logs_field_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_field_import_service_spec.rb
@@ -1134,8 +1134,8 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
 
       it "moves the details of all the household members" do
-        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 2, skipping update/)
-        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 3, skipping update/)
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 2, skipping person/)
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 3, skipping person/)
         expect(logger).to receive(:info).with(/lettings log \d+'s person 5 details moved to person 4 details/)
         expect(logger).to receive(:info).with(/lettings log \d+'s person 6 details moved to person 5 details/)
         expect(logger).to receive(:info).with(/lettings log \d+, reimported person 6 details/)
@@ -1189,8 +1189,8 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
 
       it "moves the details of all the relevant household members" do
-        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 2, skipping update/)
-        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 3, skipping update/)
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 2, skipping person/)
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 3, skipping person/)
         expect(logger).to receive(:info).with(/lettings log \d+'s person 6 details moved to person 4 details/)
         expect(logger).to receive(:info).with(/lettings log \d+, reimported person 5 details/)
         expect(logger).to receive(:info).with(/lettings log \d+, reimported person 6 details/)

--- a/spec/services/imports/lettings_logs_field_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_field_import_service_spec.rb
@@ -1039,6 +1039,8 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       lettings_log_xml.at_xpath("//xmlns:P7Sex").content = "Male"
       lettings_log_xml.at_xpath("//xmlns:P7Rel").content = "Child"
       lettings_log_xml.at_xpath("//xmlns:P7Eco").content = "9) Child under 16"
+
+      lettings_log_xml.at_xpath("//xmlns:P8Age").content = 21
     end
 
     context "when the lettings log has no details for person 2" do
@@ -1177,6 +1179,116 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
     end
 
+    context "when the lettings log has no details for several consecutive household members" do
+      before do
+        lettings_log.update(details_known_2: 1, age2_known: nil, age2: nil, sex2: nil, ecstat2: nil, relat2: nil, hhmemb: 6,
+                            details_known_3: 0, age3_known: 0, age3: 19, sex3: "F", ecstat3: 10, relat3: "X",
+                            details_known_4: 0, age4_known: nil, age4: nil, sex4: nil, ecstat4: nil, relat4: nil,
+                            details_known_5: 0, age5_known: nil, age5: nil, sex5: nil, ecstat5: nil, relat5: nil,
+                            details_known_6: 0, age6_known: 0, age6: 22, sex6: "R", ecstat6: 10, relat6: "R")
+      end
+
+      it "moves the details of all the relevant household members" do
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 2, skipping update/)
+        expect(logger).to receive(:info).with(/lettings log \d+ has details for person 3, skipping update/)
+        expect(logger).to receive(:info).with(/lettings log \d+'s person 6 details moved to person 4 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+, reimported person 5 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+, reimported person 6 details/)
+        import_service.send(:update_person_details, lettings_log_xml)
+        lettings_log.reload
+        expect(lettings_log.details_known_2).to eq(1)
+        expect(lettings_log.age2_known).to eq(nil)
+        expect(lettings_log.age2).to eq(nil)
+        expect(lettings_log.sex2).to eq(nil)
+        expect(lettings_log.ecstat2).to eq(nil)
+        expect(lettings_log.relat2).to eq(nil)
+
+        expect(lettings_log.age3_known).to eq(0)
+        expect(lettings_log.age3).to eq(19)
+        expect(lettings_log.sex3).to eq("F")
+        expect(lettings_log.ecstat3).to eq(10)
+        expect(lettings_log.relat3).to eq("X")
+
+        expect(lettings_log.details_known_4).to eq(0)
+        expect(lettings_log.age4_known).to eq(0)
+        expect(lettings_log.age4).to eq(22)
+        expect(lettings_log.sex4).to eq("R")
+        expect(lettings_log.ecstat4).to eq(10)
+        expect(lettings_log.relat4).to eq("R")
+
+        expect(lettings_log.details_known_5).to eq(0)
+        expect(lettings_log.age5_known).to eq(0)
+        expect(lettings_log.age5).to eq(7)
+        expect(lettings_log.sex5).to eq("M")
+        expect(lettings_log.ecstat5).to eq(9)
+        expect(lettings_log.relat5).to eq("C")
+
+        expect(lettings_log.details_known_6).to eq(0)
+        expect(lettings_log.age6_known).to eq(0)
+        expect(lettings_log.age6).to eq(21)
+        expect(lettings_log.sex6).to eq(nil)
+        expect(lettings_log.ecstat6).to eq(nil)
+        expect(lettings_log.relat6).to eq(nil)
+
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+    end
+
+    context "when the lettings log has no details for several non consecutive household members" do
+      before do
+        lettings_log.update(details_known_2: 0, age2_known: nil, age2: nil, sex2: nil, ecstat2: nil, relat2: nil, hhmemb: 6,
+                            details_known_3: 0, age3_known: 0, age3: 19, sex3: "F", ecstat3: 10, relat3: "X",
+                            details_known_4: 1, age4_known: nil, age4: nil, sex4: nil, ecstat4: nil, relat4: nil,
+                            details_known_5: 0, age5_known: nil, age5: nil, sex5: nil, ecstat5: nil, relat5: nil,
+                            details_known_6: 0, age6_known: 0, age6: 22, sex6: "R", ecstat6: 10, relat6: "R")
+      end
+
+      it "moves the details of all the relevant household members" do
+        expect(logger).to receive(:info).with(/lettings log \d+'s person 3 details moved to person 2 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+'s person 4 details moved to person 3 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+'s person 6 details moved to person 4 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+, reimported person 5 details/)
+        expect(logger).to receive(:info).with(/lettings log \d+, reimported person 6 details/)
+        import_service.send(:update_person_details, lettings_log_xml)
+        lettings_log.reload
+        expect(lettings_log.age2_known).to eq(0)
+        expect(lettings_log.age2).to eq(19)
+        expect(lettings_log.sex2).to eq("F")
+        expect(lettings_log.ecstat2).to eq(10)
+        expect(lettings_log.relat2).to eq("X")
+
+        expect(lettings_log.details_known_3).to eq(1)
+        expect(lettings_log.age3_known).to eq(nil)
+        expect(lettings_log.age3).to eq(nil)
+        expect(lettings_log.sex3).to eq(nil)
+        expect(lettings_log.ecstat3).to eq(nil)
+        expect(lettings_log.relat3).to eq(nil)
+
+        expect(lettings_log.details_known_4).to eq(0)
+        expect(lettings_log.age4_known).to eq(0)
+        expect(lettings_log.age4).to eq(22)
+        expect(lettings_log.sex4).to eq("R")
+        expect(lettings_log.ecstat4).to eq(10)
+        expect(lettings_log.relat4).to eq("R")
+
+        expect(lettings_log.details_known_5).to eq(0)
+        expect(lettings_log.age5_known).to eq(0)
+        expect(lettings_log.age5).to eq(7)
+        expect(lettings_log.sex5).to eq("M")
+        expect(lettings_log.ecstat5).to eq(9)
+        expect(lettings_log.relat5).to eq("C")
+
+        expect(lettings_log.details_known_6).to eq(0)
+        expect(lettings_log.age6_known).to eq(0)
+        expect(lettings_log.age6).to eq(21)
+        expect(lettings_log.sex6).to eq(nil)
+        expect(lettings_log.ecstat6).to eq(nil)
+        expect(lettings_log.relat6).to eq(nil)
+
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+    end
+
     context "when the lettings log has details for person 2" do
       let(:lettings_log) { LettingsLog.find_by(old_id: lettings_log_id) }
 
@@ -1201,6 +1313,25 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
 
       it "does not update the lettings_log person details" do
         expect(logger).to receive(:info).with(/lettings log \d+ has all household member details, skipping update/)
+        import_service.send(:update_person_details, lettings_log_xml)
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+    end
+
+    context "when none of the details past hhmemb are given in the reimport" do
+      let(:lettings_log) { LettingsLog.find_by(old_id: lettings_log_id) }
+
+      before do
+        lettings_log.update!(hhmemb: 7)
+        lettings_log_xml.at_xpath("//xmlns:P8Age").content = ""
+        lettings_log_xml.at_xpath("//xmlns:P8Sex").content = ""
+        lettings_log_xml.at_xpath("//xmlns:P8Rel").content = ""
+        lettings_log_xml.at_xpath("//xmlns:P8Eco").content = ""
+      end
+
+      it "does not update the lettings_log person details" do
+        expect(logger).to receive(:info).with(/lettings log \d+ has no additional household member details, skipping update/)
         import_service.send(:update_person_details, lettings_log_xml)
         lettings_log.reload
         expect(lettings_log.values_updated_at).to be_nil

--- a/spec/services/imports/lettings_logs_field_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_field_import_service_spec.rb
@@ -1337,5 +1337,20 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
         expect(lettings_log.values_updated_at).to be_nil
       end
     end
+
+    context "when the record has no hhmemb" do
+      let(:lettings_log) { LettingsLog.find_by(old_id: lettings_log_id) }
+
+      before do
+        lettings_log.update!(hhmemb: nil)
+      end
+
+      it "does not update the lettings_log person details" do
+        expect(logger).to receive(:info).with(/lettings log \d+ has no hhmemb, skipping update/)
+        import_service.send(:update_person_details, lettings_log_xml)
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
There is no validation on order in which person details are entered on old core, we changed how we're importing person details here: https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1903
This PR is to fix any missing data for previous imports