### PR TITLE
CLDC-2791 Reimport childrens social care referral values

### DIFF
--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -7103,6 +7103,9 @@
                     "13": {
                       "value": "Youth offending team"
                     },
+                    "17": {
+                      "value": "Children’s Social Care"
+                    },
                     "16": {
                       "value": "Other"
                     }
@@ -7163,6 +7166,9 @@
                     "13": {
                       "value": "Youth offending team"
                     },
+                    "17": {
+                      "value": "Children’s Social Care"
+                    },
                     "16": {
                       "value": "Other"
                     }
@@ -7219,6 +7225,9 @@
                     },
                     "13": {
                       "value": "Youth offending team"
+                    },
+                    "17": {
+                      "value": "Children’s Social Care"
                     },
                     "16": {
                       "value": "Other"
@@ -7279,6 +7288,9 @@
                     },
                     "13": {
                       "value": "Youth offending team"
+                    },
+                    "17": {
+                      "value": "Children’s Social Care"
                     },
                     "16": {
                       "value": "Other"

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral", "person_details"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral", "person_details", "childrens_care_referral"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -176,6 +176,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the childrens_care_referral field" do
+        let(:field) { "childrens_care_referral" }
+
+        it "updates the 2023 logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end

--- a/spec/services/imports/lettings_logs_field_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_field_import_service_spec.rb
@@ -1016,7 +1016,7 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       it "skips update" do
         expect(logger).to receive(:info).with(/lettings log \d+ reimport referral value is not 4, skipping update/)
         expect { import_service.send(:update_general_needs_referral, lettings_log_xml) }
-          .not_to(change { lettings_log.reload.referral })
+        .not_to(change { lettings_log.reload.referral })
         expect(lettings_log.values_updated_at).to be_nil
       end
     end
@@ -1349,6 +1349,62 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
         expect(logger).to receive(:info).with(/lettings log \d+ has no hhmemb, skipping update/)
         import_service.send(:update_person_details, lettings_log_xml)
         lettings_log.reload
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+    end
+  end
+
+  context "when updating referral with children's care" do
+    let(:lettings_log) { LettingsLog.find_by(old_id: lettings_log_id) }
+
+    before do
+      Imports::LettingsLogsImportService.new(storage_service, logger).create_logs(fixture_directory)
+      lettings_log_file.rewind
+
+      lettings_log_xml.at_xpath("//xmlns:Q16").content = "17"
+      lettings_log.owning_organisation.update!(provider_type: "PRP")
+    end
+
+    context "when the lettings log has no referral value" do
+      before do
+        lettings_log.update!(renewal: 0, referral: nil, values_updated_at: nil)
+      end
+
+      it "updates the lettings_log referral value" do
+        expect(logger).to receive(:info).with(/lettings log \d+'s referral value has been set to 17/)
+        expect { import_service.send(:update_childrens_care_referral, lettings_log_xml) }
+          .to(change { lettings_log.reload.referral }.from(nil).to(17))
+        expect(lettings_log.values_updated_at).not_to be_nil
+      end
+    end
+
+    context "when the lettings log has a referral value" do
+      before do
+        lettings_log.update!(referral: 2, values_updated_at: nil)
+      end
+
+      it "does not update the lettings_log referral value" do
+        expect(logger).to receive(:info).with(/lettings log \d+ has a value for referral, skipping update/)
+
+        import_service.send(:update_childrens_care_referral, lettings_log_xml)
+        lettings_log.reload
+        expect(lettings_log.referral).to eq(2)
+        expect(lettings_log.values_updated_at).to be_nil
+      end
+    end
+
+    context "and the new value does not set referral to 17" do
+      let(:lettings_log) { LettingsLog.find_by(old_id: lettings_log_id) }
+
+      before do
+        lettings_log.update!(referral: nil, values_updated_at: nil)
+        lettings_log_xml.at_xpath("//xmlns:Q16").content = "1"
+      end
+
+      it "skips update" do
+        expect(logger).to receive(:info).with(/lettings log \d+ reimport referral value is not 17, skipping update/)
+        expect { import_service.send(:update_childrens_care_referral, lettings_log_xml) }
+          .not_to(change { lettings_log.reload.referral })
         expect(lettings_log.values_updated_at).to be_nil
       end
     end


### PR DESCRIPTION
Up until https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/1905 Children's social care was not an option for referral in all cases. We want to report this answer where we might have previously dropped it.