### PR TITLE
CLDC-2715 Fix homeless value in reimport

### DIFF
--- a/app/services/imports/lettings_logs_field_import_service.rb
+++ b/app/services/imports/lettings_logs_field_import_service.rb
@@ -218,15 +218,15 @@ module Imports
       if record.present?
         return @logger.info("lettings log #{record.id} has a value for homeless and rp_homeless, skipping update") if record.rp_homeless == 1 && record.homeless.present?
         return @logger.info("lettings log #{record.id} has a value for homeless and reasonpref is not yes, skipping update") if record.reasonpref != 1 && record.homeless.present?
-        return @logger.info("lettings log #{record.id} reimport values are not homeless - 11 and rp_homeless - yes, skipping update") if unsafe_string_as_integer(xml_doc, "Q14b1").blank? || unsafe_string_as_integer(xml_doc, "Q13") != 11
+        return @logger.info("lettings log #{record.id} reimport values are not homeless - 1 (no) and rp_homeless - yes, skipping update") if unsafe_string_as_integer(xml_doc, "Q14b1").blank? || unsafe_string_as_integer(xml_doc, "Q13") != 1
 
         if record.rp_homeless != 1 && record.reasonpref == 1
           record.rp_homeless = 1
           @logger.info("updating lettings log #{record.id}'s rp_homeless value to 1")
         end
         if record.homeless.blank?
-          record.homeless = 11
-          @logger.info("updating lettings log #{record.id}'s homeless value to 11")
+          record.homeless = 1
+          @logger.info("updating lettings log #{record.id}'s homeless value to 1")
         end
         record.values_updated_at = Time.zone.now
         record.save!

--- a/spec/services/imports/lettings_logs_field_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_field_import_service_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       Imports::LettingsLogsImportService.new(storage_service, logger).create_logs(fixture_directory)
       lettings_log_file.rewind
       lettings_log_xml.at_xpath("//xmlns:Q14b1").content = "1"
-      lettings_log_xml.at_xpath("//xmlns:Q13").content = "11"
+      lettings_log_xml.at_xpath("//xmlns:Q13").content = "1"
       lettings_log.update!(values_updated_at: nil)
     end
 
@@ -641,12 +641,12 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
 
       it "updates homeless and rp_homeless" do
-        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 11/)
+        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 1/)
         expect(logger).to receive(:info).with(/updating lettings log \d+'s rp_homeless value to 1/)
         import_service.send(:update_homelessness, lettings_log_xml)
 
         lettings_log.reload
-        expect(lettings_log.homeless).to eq(11)
+        expect(lettings_log.homeless).to eq(1)
         expect(lettings_log.reasonpref).to eq(1)
         expect(lettings_log.rp_homeless).to eq(1)
         expect(lettings_log.values_updated_at).not_to be_nil
@@ -661,11 +661,11 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
 
       it "updates homeless" do
-        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 11/)
+        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 1/)
         import_service.send(:update_homelessness, lettings_log_xml)
 
         lettings_log.reload
-        expect(lettings_log.homeless).to eq(11)
+        expect(lettings_log.homeless).to eq(1)
         expect(lettings_log.reasonpref).to eq(1)
         expect(lettings_log.rp_homeless).to eq(1)
         expect(lettings_log.values_updated_at).not_to be_nil
@@ -680,11 +680,11 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
       end
 
       it "updates homeless" do
-        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 11/)
+        expect(logger).to receive(:info).with(/updating lettings log \d+'s homeless value to 1/)
         import_service.send(:update_homelessness, lettings_log_xml)
 
         lettings_log.reload
-        expect(lettings_log.homeless).to eq(11)
+        expect(lettings_log.homeless).to eq(1)
         expect(lettings_log.reasonpref).to eq(2)
         expect(lettings_log.rp_homeless).to eq(nil)
         expect(lettings_log.values_updated_at).not_to be_nil
@@ -696,11 +696,11 @@ RSpec.describe Imports::LettingsLogsFieldImportService do
 
       before do
         lettings_log_xml.at_xpath("//xmlns:Q14b1").content = ""
-        lettings_log_xml.at_xpath("//xmlns:Q13").content = "1"
+        lettings_log_xml.at_xpath("//xmlns:Q13").content = "11"
       end
 
       it "skips update for any fields" do
-        expect(logger).to receive(:info).with(/lettings log \d+ reimport values are not homeless - 11 and rp_homeless - yes, skipping update/)
+        expect(logger).to receive(:info).with(/lettings log \d+ reimport values are not homeless - 1 \(no\) and rp_homeless - yes, skipping update/)
         expect { import_service.send(:update_homelessness, lettings_log_xml) }
           .not_to(change { lettings_log.reload.homeless })
         expect(lettings_log.values_updated_at).to be_nil


### PR DESCRIPTION
In the past homeless validation would trigger if homeless value was 1 (not homeless), which is the case we want to reimport.
This PR fixes the value