### PR TITLE
Count lettings logs after writting export files

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -123,7 +123,7 @@ module Exports
       if !full_update && recent_export
         params = { from: recent_export.started_at, to: start_time }
         LettingsLog.exportable.where("(updated_at >= :from AND updated_at <= :to) OR (values_updated_at IS NOT NULL AND values_updated_at >= :from AND values_updated_at <= :to)", params)
-     else
+      else
         params = { to: start_time }
         LettingsLog.exportable.where("updated_at <= :to", params)
       end

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -77,14 +77,13 @@ module Exports
 
       logs_count = retrieve_lettings_logs(start_time, recent_export, full_update).filter_by_year(collection).count
       @logger.info("Creating #{archive} - #{logs_count} logs")
-      manifest_xml = build_manifest_xml(logs_count)
       return {} if logs_count.zero?
 
       zip_file = Zip::File.open_buffer(StringIO.new)
-      zip_file.add("manifest.xml", manifest_xml)
 
       part_number = 1
       last_processed_marker = nil
+      total_logs = 0
 
       loop do
         lettings_logs_slice = if last_processed_marker.present?
@@ -105,8 +104,12 @@ module Exports
         zip_file.add("#{archive}_#{part_number_str}.xml", data_xml)
         part_number += 1
         last_processed_marker = lettings_logs_slice.last.created_at
+        total_logs += lettings_logs_slice.count
         @logger.info("Added #{archive}_#{part_number_str}.xml")
       end
+
+      manifest_xml = build_manifest_xml(logs_count)
+      zip_file.add("manifest.xml", manifest_xml)
 
       # Required by S3 to avoid Aws::S3::Errors::BadDigest
       zip_io = zip_file.write_buffer
@@ -120,7 +123,7 @@ module Exports
       if !full_update && recent_export
         params = { from: recent_export.started_at, to: start_time }
         LettingsLog.exportable.where("(updated_at >= :from AND updated_at <= :to) OR (values_updated_at IS NOT NULL AND values_updated_at >= :from AND values_updated_at <= :to)", params)
-      else
+     else
         params = { to: start_time }
         LettingsLog.exportable.where("updated_at <= :to", params)
       end


### PR DESCRIPTION
If records are updated while the export is running, the update time for those records now falls into the next export. As we get the count for exportable logs prior to exporting them, that number might not match the exported logs count.
Instead we only want to count the logs if they got exported