### PR TITLE
CLDC-2576 Add duplicate log error if the chcharges are the same

### DIFF
--- a/app/services/bulk_upload/lettings/year2022/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2022/row_parser.rb
@@ -526,6 +526,7 @@ private
       "tcharge",
       bulk_upload.needstype != 2 ? "postcode_full" : nil,
       bulk_upload.needstype != 1 ? "location" : nil,
+      log.chcharge.present? ? "chcharge" : nil,
     ].compact
   end
 
@@ -853,6 +854,8 @@ private
       errors.add(:field_20, error_message) # sex1
       errors.add(:field_35, error_message) # ecstat1
       errors.add(:field_84, error_message) # tcharge
+      errors.add(:field_85, error_message) if log.chcharge.present? # chcharge
+      errors.add(:field_86, error_message) if bulk_upload.needstype != 1 # household_charge
       errors.add(:field_96, error_message) # startdate
       errors.add(:field_97, error_message) # startdate
       errors.add(:field_98, error_message) # startdate

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -563,6 +563,7 @@ private
       field_4 != 2 ? "postcode_full" : nil,
       field_4 != 1 ? "location" : nil,
       "tenancycode",
+      log.chcharge.present? ? "chcharge" : nil,
     ].compact
   end
 
@@ -858,6 +859,8 @@ private
       errors.add(:field_47, error_message) # sex1
       errors.add(:field_50, error_message) # ecstat1
       errors.add(:field_132, error_message) # tcharge
+      errors.add(:field_127, error_message) if log.chcharge.present? # chcharge
+      errors.add(:field_125, error_message) if bulk_upload.needstype != 1 # household_charge
     end
   end
 
@@ -1170,6 +1173,7 @@ private
     attributes["supcharg"] = field_131
     attributes["tcharge"] = field_132
     attributes["chcharge"] = field_127
+    attributes["is_carehome"] = field_127.present? ? 1 : 0
     attributes["household_charge"] = field_125
     attributes["hbrentshortfall"] = field_133
     attributes["tshortfall_known"] = tshortfall_known


### PR DESCRIPTION
We use total charge as one of the fields to determine duplicate logs. 
Not all households pay these charges and sometimes they pay care home charges instead, in those cases we should compare appropriate fields to determine duplicates.

This PR also sets "is_carehome" field for 2023/24 bulk upload depending on whether the care home charges are given. (this is being set correctly for 2022)
Previously this field was not being set, so if the household was paying care home charges, we would get "you need to answer rent and charges" errors.