### PR TITLE
CLDC-2772 Report on imported logs only

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -44,6 +44,7 @@ class Log < ApplicationRecord
       .where(bulk_upload: { id: bulk_upload_id, user: })
   }
   scope :created_by, ->(user) { where(created_by: user) }
+  scope :imported, -> { where.not(old_id: nil) }
 
   attr_accessor :skip_update_status, :skip_update_uprn_confirmed
 

--- a/app/services/imports/import_report_service.rb
+++ b/app/services/imports/import_report_service.rb
@@ -41,10 +41,10 @@ module Imports
           organisation = Organisation.find_by(name:)
           next unless organisation
 
-          completed_sales_logs = organisation.owned_sales_logs.where(status: "completed").count
-          in_progress_sales_logs = organisation.owned_sales_logs.where(status: "in_progress").count
-          completed_lettings_logs = organisation.owned_lettings_logs.where(status: "completed").count
-          in_progress_lettings_logs = organisation.owned_lettings_logs.where(status: "in_progress").count
+          completed_sales_logs = organisation.owned_sales_logs.imported.where(status: "completed").count
+          in_progress_sales_logs = organisation.owned_sales_logs.imported.where(status: "in_progress").count
+          completed_lettings_logs = organisation.owned_lettings_logs.imported.where(status: "completed").count
+          in_progress_lettings_logs = organisation.owned_lettings_logs.imported.where(status: "in_progress").count
           report << row.push(completed_lettings_logs, in_progress_lettings_logs, completed_sales_logs, in_progress_sales_logs)
         end
       end
@@ -70,10 +70,10 @@ module Imports
           unassigned_user = organisation.users.find_by(name: "Unassigned")
           next unless unassigned_user
 
-          organisation.owned_lettings_logs.where(created_by: unassigned_user).each do |lettings_log|
+          organisation.owned_lettings_logs.imported.where(created_by: unassigned_user).each do |lettings_log|
             report << [organisation.id, organisation.old_org_id, lettings_log.managing_organisation.id, lettings_log.managing_organisation.old_org_id, lettings_log.id, lettings_log.old_id, lettings_log.tenancycode, nil]
           end
-          organisation.owned_sales_logs.where(created_by: unassigned_user).each do |sales_log|
+          organisation.owned_sales_logs.imported.where(created_by: unassigned_user).each do |sales_log|
             report << [organisation.id, organisation.old_org_id, nil, nil, sales_log.id, sales_log.old_id, nil, sales_log.purchid]
           end
         end

--- a/spec/services/imports/import_report_service_spec.rb
+++ b/spec/services/imports/import_report_service_spec.rb
@@ -58,12 +58,16 @@ RSpec.describe Imports::ImportReportService do
     let(:institutions_csv) { CSV.parse("Institution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs\norg1,1,2,1,4,3\norg2,2,5,6,5,7", headers: true) }
 
     before do
-      create(:organisation, old_visible_id: "1", name: "org1")
+      org1 = create(:organisation, old_visible_id: "1", name: "org1")
       create(:organisation, old_visible_id: "2", name: "org2")
+      create(:lettings_log, :completed, owning_organisation: org1, old_id: "fake_old_id")
+      create(:lettings_log, :completed, owning_organisation: org1, old_id: nil)
+      create(:sales_log, :completed, owning_organisation: org1, old_id: "fake_sales_old_id")
+      create(:sales_log, :completed, owning_organisation: org1, old_id: nil)
     end
 
     it "generates a report with imported logs" do
-      expect(storage_service).to receive(:write_file).with("MigratedLogsReport_report_suffix.csv", "\uFEFFInstitution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs,New Completed lettings logs,New In Progress lettings logs,New Completed sales logs,New In Progress sales logs\norg1,1,2,1,4,3,0,0,0,0\norg2,2,5,6,5,7,0,0,0,0\n")
+      expect(storage_service).to receive(:write_file).with("MigratedLogsReport_report_suffix.csv", "\uFEFFInstitution name,Id,Old Completed lettings logs,Old In progress lettings logs,Old Completed sales logs,Old In progress sales logs,New Completed lettings logs,New In Progress lettings logs,New Completed sales logs,New In Progress sales logs\norg1,1,2,1,4,3,1,0,1,0\norg2,2,5,6,5,7,0,0,0,0\n")
       report_service.generate_logs_report("report_suffix.csv")
     end
   end
@@ -89,6 +93,8 @@ RSpec.describe Imports::ImportReportService do
 
       before do
         create(:organisation_relationship, parent_organisation: organisation, child_organisation: organisation2)
+        create(:sales_log, owning_organisation: organisation, created_by: unassigned_user, purchid: "purchid_2", old_id: nil)
+        create(:lettings_log, owning_organisation: organisation, managing_organisation: organisation2, created_by: unassigned_user, tenancycode: "tenancycode_2", old_id: nil)
       end
 
       it "writes a report with all unassigned logs" do


### PR DESCRIPTION
If we run the reports some time after the migration, there might be logs that have need created in the new service. We shouldn't report on those.