### PR TITLE
CLDC-2772 Deduplicate logs on import

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -45,6 +45,7 @@ class Log < ApplicationRecord
   }
   scope :created_by, ->(user) { where(created_by: user) }
   scope :imported, -> { where.not(old_id: nil) }
+  scope :not_imported, -> { where(old_id: nil) }
 
   attr_accessor :skip_update_status, :skip_update_uprn_confirmed
 

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -298,7 +298,7 @@ module Imports
           end
           record
         else
-          duplicate_logs = lettings_log.owning_organisation.owned_lettings_logs.duplicate_logs(lettings_log)
+          duplicate_logs = lettings_log.owning_organisation.owned_lettings_logs.not_imported.duplicate_logs(lettings_log)
           if duplicate_logs.count.positive?
             @logger.info("Duplicate log with id #{duplicate_logs.map(&:id).join(', ')} found for log #{lettings_log.old_id}, skipping log")
           else

--- a/app/services/imports/lettings_logs_import_service.rb
+++ b/app/services/imports/lettings_logs_import_service.rb
@@ -298,7 +298,7 @@ module Imports
           end
           record
         else
-          duplicate_logs = lettings_log.created_by.lettings_logs.duplicate_logs(lettings_log)
+          duplicate_logs = lettings_log.owning_organisation.owned_lettings_logs.duplicate_logs(lettings_log)
           if duplicate_logs.count.positive?
             @logger.info("Duplicate log with id #{duplicate_logs.map(&:id).join(', ')} found for log #{lettings_log.old_id}, skipping log")
           else

--- a/app/services/imports/sales_logs_import_service.rb
+++ b/app/services/imports/sales_logs_import_service.rb
@@ -232,7 +232,7 @@ module Imports
           end
           record
         else
-          duplicate_logs = sales_log.owning_organisation.owned_sales_logs.duplicate_logs(sales_log)
+          duplicate_logs = sales_log.owning_organisation.owned_sales_logs.not_imported.duplicate_logs(sales_log)
           if duplicate_logs.count.positive?
             @logger.info("Duplicate log with id #{duplicate_logs.map(&:id).join(', ')} found for log #{sales_log.old_id}, skipping log")
           else

--- a/spec/fixtures/imports/sales_logs/shared_ownership_sales_log2.xml
+++ b/spec/fixtures/imports/sales_logs/shared_ownership_sales_log2.xml
@@ -17,7 +17,7 @@
   <Group>
     <Qdp>Yes</Qdp>
     <CompletionDate>2023-01-17</CompletionDate>
-    <PurchaserCode>Shared ownership example</PurchaserCode>
+    <PurchaserCode>Shared ownership example 2</PurchaserCode>
     <Ownership>1 Yes - a shared ownership scheme</Ownership>
     <Q16SaleType>2 Shared Ownership</Q16SaleType>
     <Q30SaleType/>

--- a/spec/services/imports/lettings_logs_import_service_spec.rb
+++ b/spec/services/imports/lettings_logs_import_service_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Imports::LettingsLogsImportService do
         expect(updated_logs).to eq(0)
       end
 
-      it "does not import the log if a duplicate log exists on the system" do
+      it "does not import the log if a duplicate log exists on the system (that was not migrated from old CORE)" do
         expect(logger).not_to receive(:error)
         expect(logger).not_to receive(:warn)
         expect(logger).not_to receive(:info).with(/Updating lettings log/)

--- a/spec/services/imports/sales_logs_import_service_spec.rb
+++ b/spec/services/imports/sales_logs_import_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Imports::SalesLogsImportService do
       expect(updated_logs).to eq(0)
     end
 
-    it "does not import the log if a duplicate log exists on the system" do
+    it "does not import the log if a duplicate log exists on the system (that was not migrated from old CORE)" do
       expect(logger).not_to receive(:error)
       expect(logger).not_to receive(:warn)
       expect(logger).not_to receive(:info).with(/Updating sales log/)


### PR DESCRIPTION
We have recently changed some validations to increase the number of logs migrated from old CORE.
These changes might now also allow some of the skipped logs from previous migrations to be reimported.

In order to avoid reimporting logs that might have already been recreated by the users on the new system we want to skip any of the logs that get marked as duplicates using the existing duplicate logs scope.

We only skip the log if there is a duplicate that was created on this service. If duplicates existed on old CORE, we will attempt to import both of the logs.