### PR TITLE
CLDC-2385 Update DPO DSA email logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -231,6 +231,7 @@ private
   def send_data_protection_confirmation_reminder
     return unless persisted?
     return unless is_dpo?
+    return if organisation.data_protection_confirmed?
 
     DataProtectionConfirmationMailer.send_confirmation_email(self).deliver_later
   end


### PR DESCRIPTION
This PR ensures we only send the email for a new DPO to sign the DSA if it hasn't already been confirmed