### PR TITLE
CLDC-2837 Update import for washup migration 2

### DIFF
--- a/app/services/imports/import_service.rb
+++ b/app/services/imports/import_service.rb
@@ -22,6 +22,12 @@ module Imports
       end
     end
 
+    def dataprotect_xml
+      data_protect_filename = @storage_service.list_files("dataprotect").first
+      file_io = @storage_service.get_file_io(data_protect_filename)
+      Nokogiri::XML(file_io)
+    end
+
     def field_value(xml_document, namespace, field, *args)
       if namespace.present?
         xml_document.at_xpath("//#{namespace}:#{field}", *args)&.text

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -58,7 +58,7 @@ module Imports
     def create_user_who_signed_dpc(xml_document)
       dpc_signer_name = field_value(dataprotect_xml, "dataprotect", "dp-user")
       name = user_field_value(xml_document, "full-name")
-      if name == dpc_signer_name
+      if name == dpc_signer_name && is_dpo?(user_field_value(xml_document, "user-type"))
         create_user(xml_document)
       end
     end

--- a/app/services/imports/user_import_service.rb
+++ b/app/services/imports/user_import_service.rb
@@ -4,6 +4,10 @@ module Imports
       import_from(folder, :create_user)
     end
 
+    def update_users_who_signed_dpcs(folder)
+      import_from(folder, :update_user_who_signed_dpc)
+    end
+
   private
 
     PROVIDER_TYPE = {
@@ -48,6 +52,35 @@ module Imports
           @logger.error(e.message)
           @logger.error("Could not save user with email: #{email}")
         end
+      end
+    end
+
+    def update_user_who_signed_dpc(xml_document)
+      organisation = Organisation.find_by(old_org_id: user_field_value(xml_document, "institution"))
+      old_user_id = user_field_value(xml_document, "id")
+      email = user_field_value(xml_document, "email").downcase.strip
+      name = user_field_value(xml_document, "full-name") || email
+
+      dpo = organisation.data_protection_confirmation.data_protection_officer
+      dpo.email = email
+      dpo.name = name
+      dpo.password = Devise.friendly_token
+      dpo.phone = user_field_value(xml_document, "telephone-no")
+      dpo.organisation = organisation
+      dpo.role = role(user_field_value(xml_document, "user-type"))
+      dpo.is_dpo = is_dpo?(user_field_value(xml_document, "user-type"))
+      dpo.is_key_contact = is_key_contact?(user_field_value(xml_document, "contact-priority-id"))
+      dpo.active = user_field_value(xml_document, "active")
+
+      dpo.skip_confirmation_notification!
+
+      begin
+        dpo.save!
+        dpo.legacy_users.create!(old_user_id:)
+        dpo
+      rescue ActiveRecord::RecordInvalid => e
+        @logger.error(e.message)
+        @logger.error("Could not save user with email: #{email}")
       end
     end
 

--- a/lib/tasks/full_import.rake
+++ b/lib/tasks/full_import.rake
@@ -57,8 +57,8 @@ namespace :import do
 
     initial_import_list = [
       Import.new(Imports::OrganisationImportService, :create_organisations, "institution", logger),
+      Import.new(Imports::UserImportService, :create_users_who_signed_dpcs, "user", logger),
       Import.new(Imports::DataProtectionConfirmationImportService, :create_data_protection_confirmations, "dataprotect", logger),
-      Import.new(Imports::UserImportService, :update_users_who_signed_dpcs, "user", logger),
       Import.new(Imports::OrganisationRentPeriodImportService, :create_organisation_rent_periods, "rent-period", logger),
     ]
 

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe Imports::UserImportService do
       end
 
       context "when the user was deactivated in the old system" do
+        let(:old_user_id) { "9ed81a262215a1634f0809effa683e38924d8bcb" }
 
         it "marks them as not active" do
           import_service.create_users("user_directory")

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -236,8 +236,20 @@ RSpec.describe Imports::UserImportService do
         end
       end
 
-      context "when the user is not to be imported" do
+      context "when the user has a different name to the dsa signer" do
         let(:old_user_id) { "80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb" }
+
+        it "does not create a user" do
+          FactoryBot.create(:organisation, old_org_id:)
+          import_service.create_users_who_signed_dpcs("user_directory")
+
+          user = LegacyUser.find_by(old_user_id:)&.user
+          expect(user).to be_nil
+        end
+      end
+
+      context "when the user has the name of the dsa signer but is not a dpo" do
+        let(:old_user_id) { "9ed81a262215a1634f0809effa683e38924d8bcb" }
 
         it "does not create a user" do
           FactoryBot.create(:organisation, old_org_id:)

--- a/spec/services/imports/user_import_service_spec.rb
+++ b/spec/services/imports/user_import_service_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Imports::UserImportService do
-  let(:fixture_directory) { "spec/fixtures/imports/user" }
+  let(:fixture_directory) { "spec/fixtures/imports" }
   let(:old_user_id) { "fc7625a02b24ae16162aa63ae7cb33feeec0c373" }
   let(:old_org_id) { "7c5bd5fb549c09a2c55d7cb90d7ba84927e64618" }
-  let(:user_file) { File.open("#{fixture_directory}/#{old_user_id}.xml") }
+  let(:user_file) { File.open("#{fixture_directory}/user/#{old_user_id}.xml") }
   let(:storage_service) { instance_double(Storage::S3Service) }
   let(:logger) { instance_double(ActiveSupport::Logger) }
   let(:notify_client) { instance_double(Notifications::Client) }
@@ -21,6 +21,7 @@ RSpec.describe Imports::UserImportService do
 
     before do
       allow(storage_service).to receive(:list_files)
+                                  .with("user_directory")
                                   .and_return(["user_directory/#{old_user_id}.xml"])
       allow(storage_service).to receive(:get_file_io)
                                   .with("user_directory/#{old_user_id}.xml")
@@ -192,12 +193,57 @@ RSpec.describe Imports::UserImportService do
       end
 
       context "when the user was deactivated in the old system" do
-        let(:old_user_id) { "9ed81a262215a1634f0809effa683e38924d8bcb" }
 
         it "marks them as not active" do
           import_service.create_users("user_directory")
           user = LegacyUser.find_by(old_user_id:)&.user
           expect(user.active).to be false
+        end
+      end
+    end
+
+    context "when only creating specific dsa signers" do
+      let(:old_dataprotect_id) { "7c5bd5fb549c09a2c55d7cb90d7ba84927e64618" }
+      let(:dataprotect_file) { File.open("#{fixture_directory}/dataprotect/#{old_dataprotect_id}.xml") }
+
+      before do
+        allow(storage_service).to receive(:list_files)
+                                    .with("dataprotect")
+                                    .and_return(["dataprotect_directory/#{old_dataprotect_id}.xml"])
+        allow(storage_service).to receive(:get_file_io)
+                                    .with("dataprotect_directory/#{old_dataprotect_id}.xml")
+                                    .and_return(dataprotect_file)
+        allow(logger).to receive(:info)
+      end
+
+      context "when the user is to be imported" do
+        let(:old_user_id) { "10c887710550844e2551b3e0fb88dc9b4a8a642b" }
+
+        it "creates a user with the correct details" do
+          FactoryBot.create(:organisation, old_org_id:)
+          import_service.create_users_who_signed_dpcs("user_directory")
+
+          user = LegacyUser.find_by(old_user_id:)&.user
+          expect(user.name).to eq("John Doe")
+          expect(user.email).to eq("john.doe@gov.uk")
+          expect(user.encrypted_password).not_to be_nil
+          expect(user.phone).to eq("02012345678")
+          expect(user.is_data_protection_officer?).to be true
+          expect(user.organisation.old_org_id).to eq(old_org_id)
+          expect(user.is_key_contact?).to be false
+          expect(user.active).to be true
+        end
+      end
+
+      context "when the user is not to be imported" do
+        let(:old_user_id) { "80d9b73aa1c88b6e5c36ee49be9050b923b4a1bb" }
+
+        it "does not create a user" do
+          FactoryBot.create(:organisation, old_org_id:)
+          import_service.create_users_who_signed_dpcs("user_directory")
+
+          user = LegacyUser.find_by(old_user_id:)&.user
+          expect(user).to be_nil
         end
       end
     end


### PR DESCRIPTION
Here's the approach I've taken - we ordinarily import users before DSAs so the DSA can be assigned to the correct user. In this case we ONLY want to import the DSA-signing user from each org, so we have to peek at the name (that's all we have unfortunately) of the signer in the dataprotect xml, then only import users with that name. Now, one of the washup orgs has another user with the same name as the DSA-signer, so I've had to check that the user is also a DPO to ensure only the correct user is imported.

ticket: https://dluhcdigital.atlassian.net/browse/CLDC-2837