### PR TITLE
CLDC-2810 Create all addresses CSV

### DIFF
--- a/app/jobs/create_addresses_csv_job.rb
+++ b/app/jobs/create_addresses_csv_job.rb
@@ -1,0 +1,22 @@
+class CreateAddressesCsvJob < ApplicationJob
+  queue_as :default
+
+  BYTE_ORDER_MARK = "\uFEFF".freeze # Required to ensure Excel always reads CSV as UTF-8
+
+  def perform(organisation, log_type)
+    csv_service = Csv::MissingAddressesCsvService.new(organisation, [])
+    case log_type
+    when "lettings"
+      csv_string = csv_service.create_lettings_addresses_csv
+      filename = "#{['lettings-logs-addresses', organisation.name, Time.zone.now].compact.join('-')}.csv"
+    when "sales"
+      csv_string = csv_service.create_sales_addresses_csv
+      filename = "#{['sales-logs-addresses', organisation.name, Time.zone.now].compact.join('-')}.csv"
+    end
+
+    storage_service = Storage::S3Service.new(Configuration::EnvConfigurationService.new, ENV["CSV_DOWNLOAD_PAAS_INSTANCE"])
+    storage_service.write_file(filename, BYTE_ORDER_MARK + csv_string)
+
+    Rails.logger.info("Created addresses file: #{filename}")
+  end
+end

--- a/app/services/csv/missing_addresses_csv_service.rb
+++ b/app/services/csv/missing_addresses_csv_service.rb
@@ -31,15 +31,15 @@ module Csv
         csv << ["Issue type", "Log ID", "Tenancy start date", "Tenant code", "Property reference", "Log owner", "Owning organisation", "Managing organisation", "UPRN", "Address Line 1", "Address Line 2 (optional)", "Town or City", "County (optional)", "Property’s postcode"]
 
         logs_with_missing_addresses.each do |log|
-          csv << lettings_log_to_csv_row(log, "Full address required")
+          csv << ["Full address required"] + lettings_log_to_csv_row(log)
         end
 
         logs_with_missing_town_or_city.each do |log|
-          csv << lettings_log_to_csv_row(log, "Missing town or city")
+          csv << ["Missing town or city"] + lettings_log_to_csv_row(log)
         end
 
         logs_with_wrong_uprn.each do |log|
-          csv << lettings_log_to_csv_row(log, "UPRN issues")
+          csv << ["UPRN issues"] + lettings_log_to_csv_row(log)
         end
       end
     end
@@ -68,24 +68,49 @@ module Csv
         csv << ["Issue type", "Log ID", "Sale completion date", "Purchaser code", "Log owner", "Owning organisation", "UPRN", "Address Line 1", "Address Line 2 (optional)", "Town or City", "County (optional)", "Property’s postcode"]
 
         logs_with_missing_addresses.each do |log|
-          csv << sales_log_to_csv_row(log, "Full address required")
+          csv << ["Full address required"] + sales_log_to_csv_row(log)
         end
 
         logs_with_missing_town_or_city.each do |log|
-          csv << sales_log_to_csv_row(log, "Missing town or city")
+          csv << ["Missing town or city"] + sales_log_to_csv_row(log)
         end
 
         logs_with_wrong_uprn.each do |log|
-          csv << sales_log_to_csv_row(log, "UPRN issues")
+          csv << ["UPRN issues"] + sales_log_to_csv_row(log)
+        end
+      end
+    end
+
+    def create_lettings_addresses_csv
+      logs = @organisation.managed_lettings_logs.filter_by_year(2023)
+      return if logs.empty?
+
+      CSV.generate(headers: true) do |csv|
+        csv << ["Lettings log ID", "Tenancy start date", "Tenant code", "Property code", "Log owner", "Owning organisation name", "Managing organisation name", "UPRN", "Address line 1", "Address line 2 (optional)", "Town or City", "County (optional)", "Postcode"]
+
+        logs.each do |log|
+          csv << lettings_log_to_csv_row(log)
+        end
+      end
+    end
+
+    def create_sales_addresses_csv
+      logs = @organisation.sales_logs.filter_by_year(2023)
+      return if logs.empty?
+
+      CSV.generate(headers: true) do |csv|
+        csv << ["Sales log ID", "Sale completion date", "Purchaser code", "Log owner", "Owning organisation name", "UPRN", "Address line 1", "Address line 2 (optional)", "Town or City", "County (optional)", "Postcode"]
+
+        logs.each do |log|
+          csv << sales_log_to_csv_row(log)
         end
       end
     end
 
   private
 
-    def sales_log_to_csv_row(log, issue_type)
-      [issue_type,
-       log.id,
+    def sales_log_to_csv_row(log)
+      [log.id,
        log.saledate&.to_date,
        log.purchid,
        log.created_by&.email,
@@ -98,9 +123,8 @@ module Csv
        log.postcode_full]
     end
 
-    def lettings_log_to_csv_row(log, issue_type)
-      [issue_type,
-       log.id,
+    def lettings_log_to_csv_row(log)
+      [log.id,
        log.startdate&.to_date,
        log.tenancycode,
        log.propcode,

--- a/app/services/csv/missing_addresses_csv_service.rb
+++ b/app/services/csv/missing_addresses_csv_service.rb
@@ -83,10 +83,9 @@ module Csv
 
     def create_lettings_addresses_csv
       logs = @organisation.managed_lettings_logs.filter_by_year(2023)
-      return if logs.empty?
 
       CSV.generate(headers: true) do |csv|
-        csv << ["Lettings log ID", "Tenancy start date", "Tenant code", "Property code", "Log owner", "Owning organisation name", "Managing organisation name", "UPRN", "Address line 1", "Address line 2 (optional)", "Town or City", "County (optional)", "Postcode"]
+        csv << ["Log ID", "Tenancy start date", "Tenant code", "Property reference", "Log owner", "Owning organisation", "Managing organisation", "UPRN", "Address Line 1", "Address Line 2 (optional)", "Town or City", "County (optional)", "Property’s postcode"]
 
         logs.each do |log|
           csv << lettings_log_to_csv_row(log)
@@ -96,10 +95,9 @@ module Csv
 
     def create_sales_addresses_csv
       logs = @organisation.sales_logs.filter_by_year(2023)
-      return if logs.empty?
 
       CSV.generate(headers: true) do |csv|
-        csv << ["Sales log ID", "Sale completion date", "Purchaser code", "Log owner", "Owning organisation name", "UPRN", "Address line 1", "Address line 2 (optional)", "Town or City", "County (optional)", "Postcode"]
+        csv << ["Log ID", "Sale completion date", "Purchaser code", "Log owner", "Owning organisation", "UPRN", "Address Line 1", "Address Line 2 (optional)", "Town or City", "County (optional)", "Property’s postcode"]
 
         logs.each do |log|
           csv << sales_log_to_csv_row(log)

--- a/lib/tasks/send_missing_addresses_csv.rake
+++ b/lib/tasks/send_missing_addresses_csv.rake
@@ -87,4 +87,32 @@ namespace :correct_addresses do
       end
     end
   end
+
+  desc "Send all 2023 lettings addresses csv"
+  task :create_addresses_lettings_csv, %i[organisation_id] => :environment do |_task, args|
+    organisation_id = args[:organisation_id]
+    raise "Usage: rake correct_addresses:create_addresses_lettings_csv['organisation_id']" if organisation_id.blank?
+
+    organisation = Organisation.find_by(id: organisation_id)
+    if organisation.present?
+      CreateAddressesCsvJob.perform_later(organisation, "lettings")
+      Rails.logger.info("Creating lettings addresses CSV for #{organisation.name}")
+    else
+      Rails.logger.error("Organisation with ID #{organisation_id} not found")
+    end
+  end
+
+  desc "Send all 2023 sales addresses csv"
+  task :create_addresses_sales_csv, %i[organisation_id] => :environment do |_task, args|
+    organisation_id = args[:organisation_id]
+    raise "Usage: rake correct_addresses:create_addresses_sales_csv['organisation_id']" if organisation_id.blank?
+
+    organisation = Organisation.find_by(id: organisation_id)
+    if organisation.present?
+      CreateAddressesCsvJob.perform_later(organisation, "sales")
+      Rails.logger.info("Creating sales addresses CSV for #{organisation.name}")
+    else
+      Rails.logger.error("Organisation with ID #{organisation_id} not found")
+    end
+  end
 end

--- a/lib/tasks/send_missing_addresses_csv.rake
+++ b/lib/tasks/send_missing_addresses_csv.rake
@@ -89,9 +89,9 @@ namespace :correct_addresses do
   end
 
   desc "Send all 2023 lettings addresses csv"
-  task :create_addresses_lettings_csv, %i[organisation_id] => :environment do |_task, args|
+  task :create_lettings_addresses_csv, %i[organisation_id] => :environment do |_task, args|
     organisation_id = args[:organisation_id]
-    raise "Usage: rake correct_addresses:create_addresses_lettings_csv['organisation_id']" if organisation_id.blank?
+    raise "Usage: rake correct_addresses:create_lettings_addresses_csv['organisation_id']" if organisation_id.blank?
 
     organisation = Organisation.find_by(id: organisation_id)
     if organisation.present?
@@ -103,9 +103,9 @@ namespace :correct_addresses do
   end
 
   desc "Send all 2023 sales addresses csv"
-  task :create_addresses_sales_csv, %i[organisation_id] => :environment do |_task, args|
+  task :create_sales_addresses_csv, %i[organisation_id] => :environment do |_task, args|
     organisation_id = args[:organisation_id]
-    raise "Usage: rake correct_addresses:create_addresses_sales_csv['organisation_id']" if organisation_id.blank?
+    raise "Usage: rake correct_addresses:create_sales_addresses_csv['organisation_id']" if organisation_id.blank?
 
     organisation = Organisation.find_by(id: organisation_id)
     if organisation.present?

--- a/spec/jobs/create_addresses_csv_job_spec.rb
+++ b/spec/jobs/create_addresses_csv_job_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe CreateAddressesCsvJob do
+  include Helpers
+
+  let(:job) { described_class.new }
+  let(:storage_service) { instance_double(Storage::S3Service) }
+  let(:mailer) { instance_double(CsvDownloadMailer) }
+  let(:missing_addresses_csv_service) { instance_double(Csv::MissingAddressesCsvService) }
+  let(:organisation) { build(:organisation) }
+  let(:users) { create_list(:user, 2) }
+
+  before do
+    allow(Storage::S3Service).to receive(:new).and_return(storage_service)
+    allow(storage_service).to receive(:write_file)
+
+    allow(Csv::MissingAddressesCsvService).to receive(:new).and_return(missing_addresses_csv_service)
+    allow(missing_addresses_csv_service).to receive(:create_lettings_addresses_csv).and_return("")
+    allow(missing_addresses_csv_service).to receive(:create_sales_addresses_csv).and_return("")
+  end
+
+  context "when sending all lettings logs csv" do
+    it "uses an appropriate filename in S3" do
+      expect(storage_service).to receive(:write_file).with(/lettings-logs-addresses-#{organisation.name}-.*\.csv/, anything)
+      expect(Rails.logger).to receive(:info).with(/Created addresses file: lettings-logs-addresses-#{organisation.name}-.*\.csv/)
+      job.perform(organisation, "lettings")
+    end
+
+    it "creates a MissingAddressesCsvService with the correct organisation and calls create all lettings logs adresses csv" do
+      expect(Csv::MissingAddressesCsvService).to receive(:new).with(organisation, [])
+      expect(missing_addresses_csv_service).to receive(:create_lettings_addresses_csv)
+      job.perform(organisation, "lettings")
+    end
+  end
+
+  context "when sending all sales logs csv" do
+    it "uses an appropriate filename in S3" do
+      expect(storage_service).to receive(:write_file).with(/sales-logs-addresses-#{organisation.name}-.*\.csv/, anything)
+      expect(Rails.logger).to receive(:info).with(/Created addresses file: sales-logs-addresses-#{organisation.name}-.*\.csv/)
+      job.perform(organisation, "sales")
+    end
+
+    it "creates a MissingAddressesCsvService with the correct organisation and calls create all sales logs adresses csv" do
+      expect(Csv::MissingAddressesCsvService).to receive(:new).with(organisation, [])
+      expect(missing_addresses_csv_service).to receive(:create_sales_addresses_csv)
+      job.perform(organisation, "sales")
+    end
+  end
+end

--- a/spec/lib/tasks/send_missing_addresses_csv_spec.rb
+++ b/spec/lib/tasks/send_missing_addresses_csv_spec.rb
@@ -478,8 +478,8 @@ RSpec.describe "correct_addresses" do
     end
   end
 
-  describe ":create_addresses_lettings_csv", type: :task do
-    subject(:task) { Rake::Task["correct_addresses:create_addresses_lettings_csv"] }
+  describe ":create_lettings_addresses_csv", type: :task do
+    subject(:task) { Rake::Task["correct_addresses:create_lettings_addresses_csv"] }
 
     before do
       organisation.users.destroy_all
@@ -512,14 +512,14 @@ RSpec.describe "correct_addresses" do
 
       context "when organisation ID is not given" do
         it "raises an error" do
-          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_addresses_lettings_csv['organisation_id']")
+          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_lettings_addresses_csv['organisation_id']")
         end
       end
     end
   end
 
-  describe ":create_addresses_sales_csv", type: :task do
-    subject(:task) { Rake::Task["correct_addresses:create_addresses_sales_csv"] }
+  describe ":create_sales_addresses_csv", type: :task do
+    subject(:task) { Rake::Task["correct_addresses:create_sales_addresses_csv"] }
 
     before do
       organisation.users.destroy_all
@@ -552,7 +552,7 @@ RSpec.describe "correct_addresses" do
 
       context "when organisation ID is not given" do
         it "raises an error" do
-          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_addresses_sales_csv['organisation_id']")
+          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_sales_addresses_csv['organisation_id']")
         end
       end
     end

--- a/spec/lib/tasks/send_missing_addresses_csv_spec.rb
+++ b/spec/lib/tasks/send_missing_addresses_csv_spec.rb
@@ -477,4 +477,84 @@ RSpec.describe "correct_addresses" do
       end
     end
   end
+
+  describe ":create_addresses_lettings_csv", type: :task do
+    subject(:task) { Rake::Task["correct_addresses:create_addresses_lettings_csv"] }
+
+    before do
+      organisation.users.destroy_all
+      Rake.application.rake_require("tasks/send_missing_addresses_csv")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let(:organisation) { create(:organisation, name: "test organisation") }
+
+      context "and organisation ID is provided" do
+        it "enqueues the job with correct organisation" do
+          expect { task.invoke(organisation.id) }.to enqueue_job(CreateAddressesCsvJob).with(organisation, "lettings")
+        end
+
+        it "prints out the jobs enqueued" do
+          expect(Rails.logger).to receive(:info).with(nil)
+          expect(Rails.logger).to receive(:info).with("Creating lettings addresses CSV for test organisation")
+          task.invoke(organisation.id)
+        end
+      end
+
+      context "when organisation with given ID cannot be found" do
+        it "prints out error" do
+          expect(Rails.logger).to receive(:error).with("Organisation with ID fake not found")
+          task.invoke("fake")
+        end
+      end
+
+      context "when organisation ID is not given" do
+        it "raises an error" do
+          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_addresses_lettings_csv['organisation_id']")
+        end
+      end
+    end
+  end
+
+  describe ":create_addresses_sales_csv", type: :task do
+    subject(:task) { Rake::Task["correct_addresses:create_addresses_sales_csv"] }
+
+    before do
+      organisation.users.destroy_all
+      Rake.application.rake_require("tasks/send_missing_addresses_csv")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let(:organisation) { create(:organisation, name: "test organisation") }
+
+      context "and organisation ID is provided" do
+        it "enqueues the job with correct organisation" do
+          expect { task.invoke(organisation.id) }.to enqueue_job(CreateAddressesCsvJob).with(organisation, "sales")
+        end
+
+        it "prints out the jobs enqueued" do
+          expect(Rails.logger).to receive(:info).with(nil)
+          expect(Rails.logger).to receive(:info).with("Creating sales addresses CSV for test organisation")
+          task.invoke(organisation.id)
+        end
+      end
+
+      context "when organisation with given ID cannot be found" do
+        it "prints out error" do
+          expect(Rails.logger).to receive(:error).with("Organisation with ID fake not found")
+          task.invoke("fake")
+        end
+      end
+
+      context "when organisation ID is not given" do
+        it "raises an error" do
+          expect { task.invoke }.to raise_error(RuntimeError, "Usage: rake correct_addresses:create_addresses_sales_csv['organisation_id']")
+        end
+      end
+    end
+  end
 end

--- a/spec/services/csv/missing_addresses_csv_service_spec.rb
+++ b/spec/services/csv/missing_addresses_csv_service_spec.rb
@@ -406,8 +406,9 @@ RSpec.describe Csv::MissingAddressesCsvService do
         create(:lettings_log, managing_organisation: organisation, startdate: Time.zone.local(2022, 4, 5))
       end
 
-      it "returns nil" do
-        expect(service.create_lettings_addresses_csv).to be_nil
+      it "returns only headers" do
+        csv = service.create_lettings_addresses_csv
+        expect(csv).to eq "Log ID,Tenancy start date,Tenant code,Property reference,Log owner,Owning organisation,Managing organisation,UPRN,Address Line 1,Address Line 2 (optional),Town or City,County (optional),Property’s postcode\n"
       end
     end
   end
@@ -502,8 +503,9 @@ RSpec.describe Csv::MissingAddressesCsvService do
         create(:sales_log, :completed, saledate: Time.zone.local(2022, 4, 5))
       end
 
-      it "returns nil" do
-        expect(service.create_sales_addresses_csv).to be_nil
+      it "returns only headers" do
+        csv = service.create_sales_addresses_csv
+        expect(csv).to eq("Log ID,Sale completion date,Purchaser code,Log owner,Owning organisation,UPRN,Address Line 1,Address Line 2 (optional),Town or City,County (optional),Property’s postcode\n")
       end
     end
   end


### PR DESCRIPTION
This PR builds on top of [CLDC-2810-addresses-template](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/tree/CLDC-2810-addresses-template)

Add a rake task which creates a csv template for all 2023 addresses for a specific organisation