### PR TITLE
Keep the logs in memory when exporting

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -90,11 +90,11 @@ module Exports
                                 retrieve_lettings_logs(start_time, recent_export, full_update).filter_by_year(collection)
                                       .where("created_at > ?", last_processed_marker)
                                       .order(:created_at)
-                                      .limit(MAX_XML_RECORDS)
+                                      .limit(MAX_XML_RECORDS).to_a
                               else
                                 retrieve_lettings_logs(start_time, recent_export, full_update).filter_by_year(collection)
                                 .order(:created_at)
-                                .limit(MAX_XML_RECORDS)
+                                .limit(MAX_XML_RECORDS).to_a
                               end
 
         break if lettings_logs_slice.empty?


### PR DESCRIPTION
lettings_logs_slice was ActiveRecord Relation, which has been lazy-loading this entire time, so the result of it when trying to iterate over it vs when trying to count it further down the line was always dynamic.

.to_a keeps it in memory, .load didn't work for some reason