### PR TITLE
Reimport postcodes for 2022

### DIFF
--- a/app/services/imports/logs_import_service.rb
+++ b/app/services/imports/logs_import_service.rb
@@ -77,8 +77,8 @@ module Imports
     end
 
     def compose_postcode(xml_doc, outcode, incode)
-      outcode_value = string_or_nil(xml_doc, outcode)
-      incode_value = string_or_nil(xml_doc, incode)
+      outcode_value = string_or_nil(xml_doc, outcode)&.strip
+      incode_value = string_or_nil(xml_doc, incode)&.strip
       if outcode_value.nil? || incode_value.nil? || !"#{outcode_value} #{incode_value}".match(POSTCODE_REGEXP)
         nil
       else

--- a/lib/tasks/data_import_field.rake
+++ b/lib/tasks/data_import_field.rake
@@ -7,7 +7,7 @@ namespace :core do
 
     # We only allow a reduced list of known fields to be updatable
     case field
-    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral", "person_details", "childrens_care_referral", "old_form_id"
+    when "tenancycode", "major_repairs", "lettings_allocation", "offered", "address", "reason", "homeless", "created_by", "sex_and_relat", "general_needs_referral", "person_details", "childrens_care_referral", "old_form_id", "postcode_full"
       s3_service = Storage::S3Service.new(PlatformHelper.is_paas? ? Configuration::PaasConfigurationService.new : Configuration::EnvConfigurationService.new, ENV["IMPORT_PAAS_INSTANCE"])
       archive_io = s3_service.get_file_io(path)
       archive_service = Storage::ArchiveService.new(archive_io)

--- a/spec/lib/tasks/data_import_field_spec.rb
+++ b/spec/lib/tasks/data_import_field_spec.rb
@@ -200,6 +200,18 @@ describe "data_import_field imports" do
         end
       end
 
+      context "and we update the postcode_full field" do
+        let(:field) { "postcode_full" }
+
+        it "updates the 2023 logs from the given XML file" do
+          expect(Storage::S3Service).to receive(:new).with(paas_config_service, instance_name)
+          expect(storage_service).to receive(:get_file_io).with("spec/fixtures/imports/logs")
+          expect(Imports::LettingsLogsFieldImportService).to receive(:new).with(archive_service)
+          expect(import_service).to receive(:update_field).with(field, "logs")
+          task.invoke(field, fixture_path)
+        end
+      end
+
       it "raises an exception if no parameters are provided" do
         expect { task.invoke }.to raise_error(/Usage/)
       end


### PR DESCRIPTION
Some postcodes in the imports have trailing spaces in them and we've been running postcode format validation before stripping them, we should reimport those logs to get the correct postcodes.
Addresses are different in 2023, so for for the time being this is only a fix for 2022