### PR TITLE
CLDC-2716 Add layear and prevloc validation for 2023

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -116,6 +116,19 @@ module Validations::HouseholdValidations
     end
   end
 
+  def validate_layear_and_prevloc(record)
+    return unless record.layear && record.la && record.prevloc && record.collection_start_year
+
+    if record.la == record.prevloc && record.layear == 1 && record.collection_start_year >= 2023
+      record.errors.add :layear, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.layear")
+      record.errors.add :la, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.current_la")
+      record.errors.add :postcode_full, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.current_la")
+      record.errors.add :uprn, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.current_la")
+      record.errors.add :ppostcode_full, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.previous_la")
+      record.errors.add :prevloc, :renewal_just_moved, message: I18n.t("validations.household.same_la_just_moved_to_area.previous_la")
+    end
+  end
+
   def validate_combination_of_housing_needs_responses(record)
     if record.housingneeds == 1 && record.housingneeds_type == 3 && record.housingneeds_other&.zero?
       record.errors.add :housingneeds, I18n.t("validations.household.housingneeds.invalid")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -532,6 +532,10 @@ en:
       renewal_just_moved_to_area:
         layear: 'The household cannot have just moved to the local authority area if this letting is a renewal'
         renewal: 'This letting cannot be a renewal if the household has just moved to the local authority area'
+      same_la_just_moved_to_area:
+        layear: 'You told us this tenant previously lived in this local authority. Check your answers are correct.'
+        current_la: 'You told us the tenant had just moved into the local authority, but this location is in the same local authority. Check your answers are correct'
+        previous_la: 'The local authority of the previous property should not be the same as the current local authority, as you told us they had just moved to the local authority area. Check your answers are correct.'
       gender:
         retired_male: "Answer cannot be ‘male’ as tenant is under 65 and retired"
         retired_female: "Answer cannot be ‘female’ as tenant is under 60 and retired"

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -580,6 +580,28 @@ RSpec.describe Validations::HouseholdValidations do
         expect(record.errors["renewal"])
           .to include(match I18n.t("validations.household.renewal_just_moved_to_area.renewal"))
       end
+
+      context "when validating layear and prevloc" do
+        it "household cannot have just moved to area if prevloc is the same as la" do
+          record.layear = 1
+          record.prevloc = "E07000084"
+          record.la = "E07000084"
+          record.startdate = Time.zone.now
+          household_validator.validate_layear_and_prevloc(record)
+          expect(record.errors["layear"])
+            .to include(match I18n.t("validations.household.same_la_just_moved_to_area.layear"))
+          expect(record.errors["prevloc"])
+            .to include(match I18n.t("validations.household.same_la_just_moved_to_area.previous_la"))
+          expect(record.errors["ppostcode_full"])
+          .to include(match I18n.t("validations.household.same_la_just_moved_to_area.previous_la"))
+          expect(record.errors["la"])
+            .to include(match I18n.t("validations.household.same_la_just_moved_to_area.current_la"))
+          expect(record.errors["postcode_full"])
+            .to include(match I18n.t("validations.household.same_la_just_moved_to_area.current_la"))
+          expect(record.errors["uprn"])
+            .to include(match I18n.t("validations.household.same_la_just_moved_to_area.current_la"))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Add a validation for 2023 to check if LA and previous LA are the same, but tenants just moved to la:
<img width="888" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/475b99c6-bb0c-4e39-b1c0-fb6ce29dd966">
