### PR TITLE
CLDC-2796 Display managed logs for support

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -94,7 +94,7 @@ class OrganisationsController < ApplicationController
   end
 
   def lettings_logs
-    organisation_logs = LettingsLog.visible.where(owning_organisation_id: @organisation.id)
+    organisation_logs = LettingsLog.visible.filter_by_organisation(@organisation)
     unpaginated_filtered_logs = filter_manager.filtered_logs(organisation_logs, search_term, session_filters)
 
     @search_term = search_term

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -716,13 +716,20 @@ RSpec.describe OrganisationsController, type: :request do
         end
 
         context "when viewing a specific organisation's lettings logs" do
-          let(:number_of_org1_lettings_logs) { 2 }
-          let(:number_of_org1_managed_lettings_logs) { 2 }
+          let(:parent_organisation) { create(:organisation) }
+          let(:child_organisation) { create(:organisation) }
+          let(:number_of_owned_org1_lettings_logs) { 2 }
+          let(:number_of_managed_org1_lettings_logs) { 2 }
+          let(:number_of_owned_and_managed_org1_lettings_logs) { 2 }
+          let(:total_number_of_org1_logs) { number_of_owned_org1_lettings_logs + number_of_managed_org1_lettings_logs + number_of_owned_and_managed_org1_lettings_logs }
           let(:number_of_org2_lettings_logs) { 4 }
 
           before do
-            create_list(:lettings_log, number_of_org1_lettings_logs, created_by: user)
-            create_list(:lettings_log, number_of_org1_managed_lettings_logs, managing_organisation: user.organisation)
+            create(:organisation_relationship, child_organisation: organisation, parent_organisation:)
+            create(:organisation_relationship, child_organisation:, parent_organisation: organisation)
+            create_list(:lettings_log, number_of_owned_org1_lettings_logs, created_by: user, owning_organisation: organisation, managing_organisation: child_organisation)
+            create_list(:lettings_log, number_of_managed_org1_lettings_logs, created_by: user, owning_organisation: parent_organisation, managing_organisation: organisation)
+            create_list(:lettings_log, number_of_owned_and_managed_org1_lettings_logs, created_by: user, owning_organisation: organisation, managing_organisation: organisation)
             create(:lettings_log, created_by: user, status: "pending", skip_update_status: true)
             create_list(:lettings_log, number_of_org2_lettings_logs, created_by: nil, owning_organisation_id: unauthorised_organisation.id, managing_organisation_id: unauthorised_organisation.id)
 
@@ -730,7 +737,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "only shows logs for that organisation" do
-            expect(page).to have_content("#{number_of_org1_lettings_logs + number_of_org1_managed_lettings_logs} total logs")
+            expect(page).to have_content("#{total_number_of_org1_logs} total logs")
 
             organisation.lettings_logs.visible.map(&:id).each do |lettings_log_id|
               expect(page).to have_link lettings_log_id.to_s, href: "/lettings-logs/#{lettings_log_id}"

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -717,10 +717,12 @@ RSpec.describe OrganisationsController, type: :request do
 
         context "when viewing a specific organisation's lettings logs" do
           let(:number_of_org1_lettings_logs) { 2 }
+          let(:number_of_org1_managed_lettings_logs) { 2 }
           let(:number_of_org2_lettings_logs) { 4 }
 
           before do
             create_list(:lettings_log, number_of_org1_lettings_logs, created_by: user)
+            create_list(:lettings_log, number_of_org1_managed_lettings_logs, managing_organisation: user.organisation)
             create(:lettings_log, created_by: user, status: "pending", skip_update_status: true)
             create_list(:lettings_log, number_of_org2_lettings_logs, created_by: nil, owning_organisation_id: unauthorised_organisation.id, managing_organisation_id: unauthorised_organisation.id)
 
@@ -728,9 +730,13 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "only shows logs for that organisation" do
-            expect(page).to have_content("#{number_of_org1_lettings_logs} total logs")
+            expect(page).to have_content("#{number_of_org1_lettings_logs + number_of_org1_managed_lettings_logs} total logs")
 
             organisation.lettings_logs.visible.map(&:id).each do |lettings_log_id|
+              expect(page).to have_link lettings_log_id.to_s, href: "/lettings-logs/#{lettings_log_id}"
+            end
+
+            organisation.managed_lettings_logs.visible.map(&:id).each do |lettings_log_id|
               expect(page).to have_link lettings_log_id.to_s, href: "/lettings-logs/#{lettings_log_id}"
             end
 


### PR DESCRIPTION
We want to display both owned and managed logs in the organisation page for support users. Filter_by_organisation returns both managed and owned logs.