### PR TITLE
CLDC-2793 Blank relevant soctenant values

### DIFF
--- a/lib/tasks/blank_migrated_soctenant_values.rake
+++ b/lib/tasks/blank_migrated_soctenant_values.rake
@@ -1,0 +1,4 @@
+desc "Alter soctenant values for sales logs in the database if the subsequent questions are blank or inferred as don't know"
+task blank_migrated_soctenant_values: :environment do
+  SalesLog.imported.filter_by_year(2023).where(frombeds: nil, fromprop: 0, socprevten: 10, soctenant: 0).update_all(soctenant: nil, fromprop: nil, socprevten: nil, values_updated_at: Time.zone.now)
+end

--- a/spec/lib/tasks/blank_migrated_soctenant_values_spec.rb
+++ b/spec/lib/tasks/blank_migrated_soctenant_values_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "blank_migrated_soctenant_values" do
+  describe ":blank_migrated_soctenant_values", type: :task do
+    subject(:task) { Rake::Task["blank_migrated_soctenant_values"] }
+
+    before do
+      Rake.application.rake_require("tasks/blank_migrated_soctenant_values")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let!(:sales_log) { create(:sales_log, :completed, :shared_ownership, values_updated_at: nil) }
+
+      it "blanks soctenant (and subsequent questions) values from relevant migrated logs" do
+        sales_log.old_id = "404"
+        sales_log.frombeds = nil
+        sales_log.fromprop = 0 # don't know
+        sales_log.socprevten = 10 # don't know
+        sales_log.soctenant = 0 # don't know
+        sales_log.save!
+        task.invoke
+        sales_log.reload
+        expect(sales_log.soctenant).to eq(nil)
+        expect(sales_log.frombeds).to eq(nil)
+        expect(sales_log.fromprop).to eq(nil)
+        expect(sales_log.socprevten).to eq(nil)
+        expect(sales_log.values_updated_at).not_to be_nil
+      end
+
+      it "does not blank soctenant (and subsequent questions) values from 2022 logs" do
+        sales_log.old_id = "404"
+        sales_log.frombeds = nil
+        sales_log.fromprop = 0 # don't know
+        sales_log.socprevten = 10 # don't know
+        sales_log.soctenant = 0 # don't know
+        sales_log.saledate = Time.zone.local(2022, 5, 5)
+        sales_log.save!
+        task.invoke
+        sales_log.reload
+        expect(sales_log.soctenant).to eq(0)
+        expect(sales_log.frombeds).to eq(nil)
+        expect(sales_log.fromprop).to eq(0)
+        expect(sales_log.socprevten).to eq(10)
+        expect(sales_log.values_updated_at).to be_nil
+      end
+
+      it "does not blank soctenant (and subsequent questions) values from non imported logs" do
+        sales_log.old_id = nil
+        sales_log.frombeds = nil
+        sales_log.fromprop = 0 # don't know
+        sales_log.socprevten = 10 # don't know
+        sales_log.soctenant = 0 # don't know
+        sales_log.save!
+        task.invoke
+        sales_log.reload
+        expect(sales_log.soctenant).to eq(0)
+        expect(sales_log.frombeds).to eq(nil)
+        expect(sales_log.fromprop).to eq(0)
+        expect(sales_log.socprevten).to eq(10)
+        expect(sales_log.values_updated_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've inferred some values when migrating the logs as don't know, but they are more difficult to fix because they're conditionally routed to based on soctenant question and might not be relevant for every sales log. Instead we want to blank the soctenant question if there is no useful information in subsequent questions (don't know etc)