### PR TITLE
Delete obsolete data_export_csv task

### DIFF
--- a/lib/tasks/data_export.rake
+++ b/lib/tasks/data_export.rake
@@ -1,9 +1,4 @@
 namespace :core do
-  desc "Export data CSVs for import into Central Data System (CDS)"
-  task data_export_csv: :environment do |_task, _args|
-    DataExportCsvJob.perform_later
-  end
-
   desc "Export data XMLs for import into Central Data System (CDS)"
   task :data_export_xml, %i[full_update] => :environment do |_task, args|
     full_update = args[:full_update].present? && args[:full_update] == "true"


### PR DESCRIPTION
I spotted that there was a `data_export_csv` task in `lib/tasks/data_export.rake`. It referenced a class `DataExportCsvJob` which wasn't defined anywhere else in the codebase. @kosiakkatrina confirmed it was redundant.