### PR TITLE
CLDC-2628 Update schemes guidance page

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -200,6 +200,10 @@ class OrganisationsController < ApplicationController
     redirect_to details_organisation_path(@organisation)
   end
 
+  def changes
+    render "schemes/changes"
+  end
+
 private
 
   def filter_type

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -3,7 +3,7 @@ class SchemesController < ApplicationController
   include Modules::SearchFilter
 
   before_action :authenticate_user!
-  before_action :find_resource, except: %i[index create new]
+  before_action :find_resource, except: %i[index create new changes]
   before_action :redirect_if_scheme_confirmed, only: %i[primary_client_group confirm_secondary_client_group secondary_client_group support details]
   before_action :authorize_user
   before_action :session_filters, if: :current_user, only: %i[index]
@@ -199,6 +199,10 @@ class SchemesController < ApplicationController
     render_not_found and return unless @scheme
 
     render "schemes/edit_name"
+  end
+
+  def changes
+    render "schemes/changes"
   end
 
 private

--- a/app/models/form/lettings/pages/scheme.rb
+++ b/app/models/form/lettings/pages/scheme.rb
@@ -6,6 +6,7 @@ class Form::Lettings::Pages::Scheme < ::Form::Page
         "needstype" => 2,
       },
     ]
+    @header = "Scheme"
     @next_unresolved_page_id = "location"
   end
 

--- a/app/models/form/lettings/questions/declaration.rb
+++ b/app/models/form/lettings/questions/declaration.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Questions::Declaration < ::Form::Question
     @header = "Declaration"
     @type = "checkbox"
     @check_answers_card_number = 0
-    @guidance_partial = "privacy_notice_tenant"
+    @top_guidance_partial = "privacy_notice_tenant"
     @answer_options = ANSWER_OPTIONS
     @question_number = 30
   end

--- a/app/models/form/lettings/questions/earnings.rb
+++ b/app/models/form/lettings/questions/earnings.rb
@@ -8,8 +8,7 @@ class Form::Lettings::Questions::Earnings < ::Form::Question
     @width = 5
     @check_answers_card_number = 0
     @min = 0
-    @guidance_partial = "what_counts_as_income"
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = "what_counts_as_income"
     @hint_text = ""
     @step = 0.01
     @prefix = "£"

--- a/app/models/form/lettings/questions/net_income_known.rb
+++ b/app/models/form/lettings/questions/net_income_known.rb
@@ -6,8 +6,7 @@ class Form::Lettings::Questions::NetIncomeKnown < ::Form::Question
     @header = "Do you know the household’s combined income after tax?"
     @type = "radio"
     @check_answers_card_number = 0
-    @guidance_partial = "what_counts_as_income"
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = "what_counts_as_income"
     @hint_text = ""
     @answer_options = ANSWER_OPTIONS
     @question_number = 86

--- a/app/models/form/lettings/questions/rent_type.rb
+++ b/app/models/form/lettings/questions/rent_type.rb
@@ -5,8 +5,7 @@ class Form::Lettings::Questions::RentType < ::Form::Question
     @check_answer_label = "Rent type"
     @header = "What is the rent type?"
     @type = "radio"
-    @guidance_partial = "rent_type_definitions"
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = "rent_type_definitions"
     @answer_options = ANSWER_OPTIONS
     @conditional_for = { "irproduct_other" => [5] }
     @question_number = 6

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -6,6 +6,7 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
     @hint_text = "Enter scheme name or postcode"
     @type = "select"
     @answer_options = answer_options
+    @top_guidance_partial = "finding_scheme"
     @bottom_guidance_partial = "scheme_selection"
     @question_number = 9
     @inferred_answers = {

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -3,7 +3,7 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
     super("scheme_id", hsh, page)
     @check_answer_label = "Scheme name"
     @header = "What scheme is this log for?"
-    @hint_text = "Enter scheme name or postcode"
+    @hint_text = "Enter postcode or scheme name"
     @type = "select"
     @answer_options = answer_options
     @top_guidance_partial = "finding_scheme"

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -6,8 +6,7 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
     @hint_text = "Enter scheme name or postcode"
     @type = "select"
     @answer_options = answer_options
-    @guidance_position = GuidancePosition::BOTTOM
-    @guidance_partial = "scheme_selection"
+    @bottom_guidance_partial = "scheme_selection"
     @question_number = 9
     @inferred_answers = {
       "location.name": {

--- a/app/models/form/lettings/questions/voiddate.rb
+++ b/app/models/form/lettings/questions/voiddate.rb
@@ -7,7 +7,6 @@ class Form::Lettings::Questions::Voiddate < ::Form::Question
     @type = "date"
     @check_answers_card_number = 0
     @question_number = 23
-    @guidance_partial = "void_date"
-    @guidance_position = GuidancePosition::BOTTOM
+    @bottom_guidance_partial = "void_date"
   end
 end

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -3,13 +3,8 @@ class Form::Question
                 :type, :min, :max, :step, :width, :fields_to_add, :result_field,
                 :conditional_for, :readonly, :answer_options, :page, :check_answer_label,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
-                :guidance_partial, :prefix, :suffix, :requires_js, :fields_added, :derived,
+                :top_guidance_partial, :bottom_guidance_partial, :prefix, :suffix, :requires_js, :fields_added, :derived,
                 :check_answers_card_number, :unresolved_hint_text, :question_number, :hide_question_number_on_page, :plain_label, :error_label
-
-  module GuidancePosition
-    TOP = 1
-    BOTTOM = 2
-  end
 
   def initialize(id, hsh, page)
     @id = id
@@ -17,8 +12,8 @@ class Form::Question
     if hsh
       @check_answer_label = hsh["check_answer_label"]
       @header = hsh["header"]
-      @guidance_partial = hsh["guidance_partial"]
-      @guidance_position = hsh["guidance_position"] || GuidancePosition::TOP
+      @top_guidance_partial = hsh["top_guidance_partial"]
+      @bottom_guidance_partial = hsh["bottom_guidance_partial"]
       @hint_text = hsh["hint_text"]
       @type = hsh["type"]
       @min = hsh["min"]
@@ -232,11 +227,11 @@ class Form::Question
   end
 
   def top_guidance?
-    @guidance_partial && @guidance_position == GuidancePosition::TOP
+    @top_guidance_partial.present?
   end
 
   def bottom_guidance?
-    @guidance_partial && @guidance_position == GuidancePosition::BOTTOM
+    @bottom_guidance_partial.present?
   end
 
   def is_derived_or_has_inferred_check_answers_value?(log)

--- a/app/models/form/sales/questions/discounted_ownership_type.rb
+++ b/app/models/form/sales/questions/discounted_ownership_type.rb
@@ -5,8 +5,7 @@ class Form::Sales::Questions::DiscountedOwnershipType < ::Form::Question
     @check_answer_label = "Type of discounted ownership sale"
     @header = "What is the type of discounted ownership sale?"
     @type = "radio"
-    @guidance_partial = guidance_partial
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = guidance_partial
     @answer_options = ANSWER_OPTIONS
     @question_number = 5
   end

--- a/app/models/form/sales/questions/mortgage_lender.rb
+++ b/app/models/form/sales/questions/mortgage_lender.rb
@@ -8,8 +8,7 @@ class Form::Sales::Questions::MortgageLender < ::Form::Question
     @hint_text = ""
     @page = page
     @answer_options = ANSWER_OPTIONS
-    @guidance_position = GuidancePosition::BOTTOM
-    @guidance_partial = "mortgage_lender"
+    @bottom_guidance_partial = "mortgage_lender"
     @ownershipsch = ownershipsch
     @question_number = question_number
   end

--- a/app/models/form/sales/questions/outright_ownership_type.rb
+++ b/app/models/form/sales/questions/outright_ownership_type.rb
@@ -5,8 +5,7 @@ class Form::Sales::Questions::OutrightOwnershipType < ::Form::Question
     @check_answer_label = "Type of outright sale"
     @header = "What is the type of outright sale?"
     @type = "radio"
-    @guidance_partial = guidance_partial
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = guidance_partial
     @answer_options = ANSWER_OPTIONS
     @conditional_for = {
       "othtype" => [12],

--- a/app/models/form/sales/questions/privacy_notice.rb
+++ b/app/models/form/sales/questions/privacy_notice.rb
@@ -6,7 +6,7 @@ class Form::Sales::Questions::PrivacyNotice < ::Form::Question
     @header = "Declaration"
     @type = "checkbox"
     @answer_options = ANSWER_OPTIONS
-    @guidance_partial = "privacy_notice_buyer"
+    @top_guidance_partial = "privacy_notice_buyer"
     @question_number = 19
   end
 

--- a/app/models/form/sales/questions/shared_ownership_type.rb
+++ b/app/models/form/sales/questions/shared_ownership_type.rb
@@ -5,8 +5,7 @@ class Form::Sales::Questions::SharedOwnershipType < ::Form::Question
     @check_answer_label = "Type of shared ownership sale"
     @header = "What is the type of shared ownership sale?"
     @hint_text = "A shared ownership sale is when the purchaser buys up to 75% of the property value and pays rent to the Private Registered Provider (PRP) on the remaining portion"
-    @guidance_partial = guidance_partial
-    @guidance_position = GuidancePosition::TOP
+    @top_guidance_partial = guidance_partial
     @type = "radio"
     @answer_options = answer_options
     @question_number = 4

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -30,6 +30,10 @@ class SchemePolicy
     user.data_coordinator? && scheme_owned_by_user_org_or_stock_owner
   end
 
+  def changes?
+    true
+  end
+
   %w[
     show?
     check_answers?

--- a/app/views/form/_checkbox_question.html.erb
+++ b/app/views/form/_checkbox_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <%= f.govuk_check_boxes_fieldset question.id.to_sym,
     caption: caption(caption_text, page_header, conditional),
@@ -21,4 +21,4 @@
     <% end %>
 <% end %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_date_question.html.erb
+++ b/app/views/form/_date_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <%= f.govuk_date_field question.id.to_sym,
   caption: caption(caption_text, page_header, conditional),
@@ -9,4 +9,4 @@
   <%= govuk_inset_text(text: question.unresolved_hint_text) if question.unresolved_hint_text.present? && @log.unresolved %>
 <% end %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_numeric_output_question.html.erb
+++ b/app/views/form/_numeric_output_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <div class="govuk-form-group">
   <label class="govuk-label govuk-label--<%= label_size(page_header, conditional, question) %>" for="lettings-log-<%= question.id %>-field">
@@ -22,4 +22,4 @@
   </div>
 </div>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <%= f.govuk_number_field(
   question.id.to_sym,
@@ -16,4 +16,4 @@
   **stimulus_html_attributes(question),
 ) %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_radio_question.html.erb
+++ b/app/views/form/_radio_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
   <% banner = question.notification_banner(@log) %>
   <% if banner %>
     <%= govuk_notification_banner(
@@ -44,4 +44,4 @@
   <% end %>
 <% end %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -1,7 +1,8 @@
-<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <% selected = @log.public_send(question.id) || "" %>
 <% answers = question.displayed_answer_options(@log, current_user).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) } %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
+
 <%= f.govuk_select(question.id.to_sym,
   label: legend(question, page_header, conditional),
   "data-controller": "accessible-autocomplete",

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <% selected = @log.public_send(question.id) || "" %>
 <% answers = question.displayed_answer_options(@log, current_user).map { |key, value| OpenStruct.new(id: key, name: value.respond_to?(:service_name) ? value.service_name : nil, resource: value) } %>
@@ -17,4 +17,4 @@
     <% end %>
   <% end %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_text_question.html.erb
+++ b/app/views/form/_text_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <%= f.govuk_text_field question.id.to_sym,
   caption: caption(caption_text, page_header, conditional),
@@ -7,4 +7,4 @@
   width: question.width || nil,
   **stimulus_html_attributes(question) %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/_textarea_question.html.erb
+++ b/app/views/form/_textarea_question.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.top_guidance? %>
+<%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
 <%= f.govuk_text_area question.id.to_sym,
   caption: caption(caption_text, page_header, conditional),
@@ -7,4 +7,4 @@
   width: question.width || nil,
   **stimulus_html_attributes(question) %>
 
-<%= render partial: "form/guidance/#{question.guidance_partial}" if question.bottom_guidance? %>
+<%= render partial: "form/guidance/#{question.bottom_guidance_partial}" if question.bottom_guidance? %>

--- a/app/views/form/guidance/_finding_scheme.erb
+++ b/app/views/form/guidance/_finding_scheme.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "Can’t find your scheme?") do %>
+  <p class="govuk-body">If your organisation’s schemes were migrated from old CORE, they may have new names and codes. Search by postcode to find your scheme.</p>
+  <p class="govuk-body"><%= govuk_link_to("View your organisation’s schemes.", schemes_path) %></p>
+  <p class="govuk-body"><%= govuk_link_to("Read more about how schemes have changed", scheme_changes_path) %></p>
+<% end %>

--- a/app/views/form/guidance/_finding_scheme.erb
+++ b/app/views/form/guidance/_finding_scheme.erb
@@ -1,5 +1,5 @@
 <%= govuk_details(summary_text: "Can’t find your scheme?") do %>
   <p class="govuk-body">If your organisation’s schemes were migrated from old CORE, they may have new names and codes. Search by postcode to find your scheme.</p>
-  <p class="govuk-body"><%= govuk_link_to("View your organisation’s schemes.", schemes_path) %></p>
+  <p class="govuk-body"><%= govuk_link_to("View your organisation’s schemes", schemes_path) %></p>
   <p class="govuk-body"><%= govuk_link_to("Read more about how schemes have changed", scheme_changes_path) %></p>
 <% end %>

--- a/app/views/form/guidance/_scheme_selection.html.erb
+++ b/app/views/form/guidance/_scheme_selection.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.data_provider? %>
   <p class="govuk-body">If you can’t find the supported housing service you’re looking for or not sure which to choose, contact a data coordinator at <%= current_user.organisation.name %>.</p>
 <% elsif current_user.data_coordinator? %>
-  <p class="govuk-body">or <%= govuk_link_to "create a new supported housing service", new_scheme_path %></p>
+  <p class="govuk-body"><%= govuk_link_to "Create a new supported housing scheme", new_scheme_path %></p>
 <% end %>

--- a/app/views/form/guidance/_scheme_selection.html.erb
+++ b/app/views/form/guidance/_scheme_selection.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.data_provider? %>
-  <p class="govuk-body">If you can’t find the supported housing service you’re looking for or not sure which to choose, contact a data coordinator at <%= current_user.organisation.name %>.</p>
+  <p class="govuk-body">If you’re not sure which scheme to choose, ask a data coordinator. Find your data coordinators on the <%= govuk_link_to("users page", users_path) %>.</p>
 <% elsif current_user.data_coordinator? %>
   <p class="govuk-body"><%= govuk_link_to "Create a new supported housing scheme", new_scheme_path %></p>
 <% end %>

--- a/app/views/schemes/changes.html.erb
+++ b/app/views/schemes/changes.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Schemes and locations</h1>
+    <h2 class="govuk-heading-m">What is a scheme?</h2>
+    <p class="govuk-body">A supported housing scheme (also known as a ‘supported housing service’) provides shared or self-contained housing for a particular client group, for example younger or vulnerable people.</p>
+
+    <h2 class="govuk-heading-m">What is a location?</h2>
+    <p class="govuk-body">A location is a postcode where supported housing is provided under a scheme. A scheme can have multiple locations, and a location can have multiple units at the same postcode.</p>
+
+    <h2 class="govuk-heading-m">How schemes have changed</h2>
+    <p class="govuk-body">We have restructured the way we group supported housing scheme data.</p>
+    <p class="govuk-body">On old CORE, a scheme’s data was split into management group and scheme. On new CORE, the data is split into scheme and location.</p>
+    <p class="govuk-body">These are the main changes:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Schemes now store data about the stock owner and support provider. This was previously stored in management group.</li>
+      <li>Schemes still store data about the type of support, as they did in old CORE.</li>
+      <li>Schemes no longer store data about postcodes where support is provided. These are now in locations.</li>
+    </ul>
+    <p class="govuk-body">This new structure means data coordinators only needs to fill in support details once.</p>
+    <h2 class="govuk-heading-m">How schemes are migrated from old CORE</h2>
+    <p class="govuk-body">If your organisation has migrated from old CORE to new CORE, your existing schemes are on the <%= govuk_link_to("schemes page", schemes_path) %>, with the same details.</p>
+    <p class="govuk-body">Your migrated schemes have been restructured to match the new structure described above. Schemes with the same support details have been combined to prevent duplicates.</p>
+    <p class="govuk-body">All migrated schemes have new names and codes. The new scheme names were created automatically based on their support details. Some of these auto-generated names are quite long, so we recommend data coordinators rename them.</p>
+    <p class="govuk-body">If you upload logs in bulk, you can use either the new or old scheme codes in your template.</p>
+    <h2 class="govuk-heading-m">If you can’t find a scheme</h2>
+    <p class="govuk-body">You should be able to recognise a scheme migrated from old CORE by viewing its details or locations. Try searching for it by postcode.</p>
+    <p class="govuk-body">If you still can’t find a scheme that was migrated from old CORE, either create a new one if you know the details, or <%= govuk_link_to("contact the service desk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %> to report the problem. Only data coordinators can create and edit schemes.</p>
+  </div>
+</div>

--- a/app/views/schemes/changes.html.erb
+++ b/app/views/schemes/changes.html.erb
@@ -1,3 +1,7 @@
+<% content_for :before_content do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Schemes and locations</h1>
@@ -24,6 +28,6 @@
     <p class="govuk-body">If you upload logs in bulk, you can use either the new or old scheme codes in your template.</p>
     <h2 class="govuk-heading-m">If you can’t find a scheme</h2>
     <p class="govuk-body">You should be able to recognise a scheme migrated from old CORE by viewing its details or locations. Try searching for it by postcode.</p>
-    <p class="govuk-body">If you still can’t find a scheme that was migrated from old CORE, either create a new one if you know the details, or <%= govuk_link_to("contact the service desk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %> to report the problem. Only data coordinators can create and edit schemes.</p>
+    <p class="govuk-body">If you still can’t find a scheme that was migrated from old CORE, either create a new one if you know the details, or <%= govuk_link_to("contact the helpdesk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %> to report the problem. Only data coordinators can create and edit schemes.</p>
   </div>
 </div>

--- a/config/forms/2021_2022.json
+++ b/config/forms/2021_2022.json
@@ -1139,7 +1139,7 @@
               "questions": {
                 "declaration": {
                   "header": "",
-                  "guidance_partial": "privacy_notice_tenant",
+                  "top_guidance_partial": "privacy_notice_tenant",
                   "check_answer_label": "Tenant has seen the privacy notice",
                   "check_answers_card_number": 0,
                   "type": "checkbox",
@@ -7328,7 +7328,7 @@
                 "net_income_known": {
                   "check_answer_label": "Do you know the household’s combined income?",
                   "header": "Do you know the household’s combined income after tax?",
-                  "guidance_partial": "what_counts_as_income",
+                  "top_guidance_partial": "what_counts_as_income",
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
@@ -7360,7 +7360,7 @@
                 "earnings": {
                   "check_answer_label": "Total household income",
                   "header": "How much income does the household have in total?",
-                  "guidance_partial": "what_counts_as_income",
+                  "top_guidance_partial": "what_counts_as_income",
                   "hint_text": "",
                   "type": "numeric",
                   "min": 0,

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -721,8 +721,7 @@
                   "header": "What is the void date?",
                   "hint_text": "For example, 27 3 2021.",
                   "type": "date",
-                  "guidance_partial": "void_date",
-                  "guidance_position": 2
+                  "bottom_guidance_partial": "void_date"
                 }
               },
               "depends_on": [
@@ -1170,7 +1169,7 @@
               "questions": {
                 "declaration": {
                   "header": "",
-                  "guidance_partial": "privacy_notice_tenant",
+                  "top_guidance_partial": "privacy_notice_tenant",
                   "check_answer_label": "Tenant has seen the privacy notice",
                   "check_answers_card_number": 0,
                   "type": "checkbox",
@@ -7286,7 +7285,7 @@
                 "net_income_known": {
                   "check_answer_label": "Do you know the household’s combined income?",
                   "header": "Do you know the household’s combined income after tax?",
-                  "guidance_partial": "what_counts_as_income",
+                  "top_guidance_partial": "what_counts_as_income",
                   "hint_text": "",
                   "type": "radio",
                   "answer_options": {
@@ -7318,7 +7317,7 @@
                 "earnings": {
                   "check_answer_label": "Total household income",
                   "header": "How much income does the household have in total?",
-                  "guidance_partial": "what_counts_as_income",
+                  "top_guidance_partial": "what_counts_as_income",
                   "hint_text": "",
                   "type": "numeric",
                   "min": 0,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
       patch "reactivate", to: "locations#reactivate"
     end
   end
+  get "scheme-changes", to: "schemes#changes"
 
   resources :duplicate_logs, only: [:index], path: "/duplicate-logs"
 

--- a/spec/fixtures/forms/2021_2022.json
+++ b/spec/fixtures/forms/2021_2022.json
@@ -688,7 +688,7 @@
                 "earnings": {
                   "check_answer_label": "Income",
                   "header": "What is the tenant’s /and partner’s combined income after tax?",
-                  "guidance_partial": "what_counts_as_income",
+                  "top_guidance_partial": "what_counts_as_income",
                   "type": "numeric",
                   "min": 0,
                   "step": 1,

--- a/spec/models/form/lettings/pages/scheme_spec.rb
+++ b/spec/models/form/lettings/pages/scheme_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Form::Lettings::Pages::Scheme, type: :model do
   end
 
   it "has the correct header" do
-    expect(page.header).to be_nil
+    expect(page.header).to eq("Scheme")
   end
 
   it "has the correct description" do

--- a/spec/models/form/lettings/questions/rent_type_spec.rb
+++ b/spec/models/form/lettings/questions/rent_type_spec.rb
@@ -51,6 +51,6 @@ RSpec.describe Form::Lettings::Questions::RentType, type: :model do
   end
 
   it "has the guidance partial" do
-    expect(question.guidance_partial).to eq("rent_type_definitions")
+    expect(question.top_guidance_partial).to eq("rent_type_definitions")
   end
 end

--- a/spec/models/form/lettings/questions/scheme_id_spec.rb
+++ b/spec/models/form/lettings/questions/scheme_id_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Form::Lettings::Questions::SchemeId, type: :model do
   end
 
   it "has the correct hint_text" do
-    expect(question.hint_text).to eq("Enter scheme name or postcode")
+    expect(question.hint_text).to eq("Enter postcode or scheme name")
   end
 
   it "has the correct conditional_for" do

--- a/spec/models/form/lettings/questions/voiddate_spec.rb
+++ b/spec/models/form/lettings/questions/voiddate_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Form::Lettings::Questions::Voiddate, type: :model do
     expect(question.question_number).to eq(23)
   end
 
-  it "has the correct guidance_partial" do
-    expect(question.guidance_partial).to eq("void_date")
+  it "has the correct bottom_guidance_partial" do
+    expect(question.bottom_guidance_partial).to eq("void_date")
   end
 
   it "has the correct type" do

--- a/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/discounted_ownership_type_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
     context "when the form is for 2023/24" do
       let(:start_date) { Time.zone.local(2023, 4, 8) }
 
-      it "shows shows correct guidance_partial" do
-        expect(question.guidance_partial).to eq("discounted_ownership_type_definitions")
+      it "shows shows correct top_guidance_partial" do
+        expect(question.top_guidance_partial).to eq("discounted_ownership_type_definitions")
       end
 
       it "is at the top" do
@@ -62,8 +62,8 @@ RSpec.describe Form::Sales::Questions::DiscountedOwnershipType, type: :model do
     context "when the form is for before 2023/24" do
       let(:start_date) { Time.zone.local(2022, 4, 8) }
 
-      it "does not show a guidance_partial" do
-        expect(question.guidance_partial).to eq(nil)
+      it "does not show a top_guidance_partial" do
+        expect(question.top_guidance_partial).to eq(nil)
       end
     end
   end

--- a/spec/models/form/sales/questions/mortgage_lender_spec.rb
+++ b/spec/models/form/sales/questions/mortgage_lender_spec.rb
@@ -31,13 +31,17 @@ RSpec.describe Form::Sales::Questions::MortgageLender, type: :model do
     expect(question.derived?).to be false
   end
 
-  it "is has correct guidance_position" do
+  it "is has correct guidance position" do
     expect(question.top_guidance?).to be false
     expect(question.bottom_guidance?).to be true
   end
 
-  it "is has correct guidance_partial" do
-    expect(question.guidance_partial).to eq("mortgage_lender")
+  it "is has correct bottom_guidance_partial" do
+    expect(question.bottom_guidance_partial).to eq("mortgage_lender")
+  end
+
+  it "is has correct top_guidance_partial" do
+    expect(question.top_guidance_partial).to be_nil
   end
 
   it "has the correct answer_options" do

--- a/spec/models/form/sales/questions/outright_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/outright_ownership_type_spec.rb
@@ -50,8 +50,12 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
     context "when the form is for year 2023/24" do
       let(:start_date) { Time.zone.local(2023, 4, 8) }
 
-      it "has the correct guidance_partial" do
-        expect(question.guidance_partial).to eq("outright_sale_type_definitions")
+      it "has the correct top_guidance_partial" do
+        expect(question.top_guidance_partial).to eq("outright_sale_type_definitions")
+      end
+
+      it "has the correct bottom_guidance_partial" do
+        expect(question.bottom_guidance_partial).to be_nil
       end
 
       it "is at the top" do
@@ -63,8 +67,12 @@ RSpec.describe Form::Sales::Questions::OutrightOwnershipType, type: :model do
     context "when the form is for before year 2023/24" do
       let(:start_date) { Time.zone.local(2022, 4, 8) }
 
-      it "does not display a guidance partial" do
-        expect(question.guidance_partial).to eq(nil)
+      it "does not display a top guidance partial" do
+        expect(question.top_guidance_partial).to eq(nil)
+      end
+
+      it "does not display a bottom guidance partial" do
+        expect(question.bottom_guidance_partial).to eq(nil)
       end
     end
   end

--- a/spec/models/form/sales/questions/shared_ownership_type_spec.rb
+++ b/spec/models/form/sales/questions/shared_ownership_type_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
       })
     end
 
-    it "does not show a guidance_partial" do
-      expect(question.guidance_partial).to eq(nil)
+    it "does not show a top_guidance_partial" do
+      expect(question.top_guidance_partial).to eq(nil)
     end
   end
 
@@ -74,8 +74,8 @@ RSpec.describe Form::Sales::Questions::SharedOwnershipType, type: :model do
       })
     end
 
-    it "shows shows correct guidance_partial" do
-      expect(question.guidance_partial).to eq("shared_ownership_type_definitions")
+    it "shows shows correct top_guidance_partial" do
+      expect(question.top_guidance_partial).to eq("shared_ownership_type_definitions")
     end
   end
 end


### PR DESCRIPTION
Refactor guidance partials to allow top and bottom guidance at the same time.
Add/change guidance content for schemes question and add a new scheme changes page
<img width="1064" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/65fbb61c-872e-4514-bf48-6fa1d518982d">
