### PR TITLE
CLDC-2719 Add button to add locations from scheme page

### DIFF
--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -21,8 +21,8 @@
           <% row.key { attr[:name] } %>
           <% row.value do %>
             <%= details_html(attr) %>
-            <% if attr[:name] == "Status" && @scheme.confirmed? && @scheme.locations.confirmed.none? %>
-              <span class="app-!-colour-muted">Add a location to complete this scheme</span>
+            <% if attr[:name] == "Status" && @scheme.confirmed? && @scheme.locations.confirmed.none? && LocationPolicy.new(current_user, @scheme.locations.new).create? %>
+              <span class="app-!-colour-muted">Complete this scheme by adding a location using the <%= govuk_link_to("‘locations’ tab", scheme_locations_path(@scheme)) %>.</span>
             <% end %>
           <% end %>
           <% if SchemePolicy.new(current_user, @scheme).update? %>

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -603,7 +603,8 @@ RSpec.describe SchemesController, type: :request do
         it "shows the scheme as incomplete with text to explain" do
           get scheme_path(specific_scheme)
           expect(page).to have_content "Incomplete"
-          expect(page).to have_content "Add a location to complete this scheme"
+          expect(page).to have_content "Complete this scheme by adding a location using the"
+          expect(page).to have_link "‘locations’ tab"
         end
       end
 
@@ -612,7 +613,8 @@ RSpec.describe SchemesController, type: :request do
           create(:location, scheme: specific_scheme)
           get scheme_path(specific_scheme)
           expect(page).to have_content "Active"
-          expect(page).not_to have_content "Add a location to complete this scheme"
+          expect(page).not_to have_content "Complete this scheme by adding a location using the"
+          expect(page).not_to have_link "‘locations’ tab"
         end
       end
     end


### PR DESCRIPTION
Add a link to the hint text under the incomplete tag to encourage completing the scheme more easily.
<img width="819" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/14ebda29-4169-4ed1-9cbe-39facdf0c2e8">