### PR TITLE
CLDC-2746 Add floating support type to schemes

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -108,6 +108,7 @@ class Scheme < ApplicationRecord
     "Medium level": 3,
     "High level": 4,
     "Nursing care in a care home": 5,
+    "Floating support": 6,
   }.freeze
 
   enum support_type: SUPPORT_TYPE, _suffix: true
@@ -224,7 +225,7 @@ class Scheme < ApplicationRecord
       "Medium level": "Staff on site daily or making frequent visits with some out-of-hours cover.",
       "High level": "Intensive level of staffing provided on a 24-hour basis.",
     }
-    Scheme.support_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints[key.to_sym]) }
+    Scheme.support_types.keys.excluding("Missing").excluding("Floating support").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints[key.to_sym]) }
   end
 
   def intended_length_of_stay_options_with_hints

--- a/app/views/schemes/support.html.erb
+++ b/app/views/schemes/support.html.erb
@@ -15,7 +15,7 @@
 
       <% support_level_options_hints = { "Low level": "Staff visiting once a week, fortnightly or less.", "Medium level": "Staff on site daily or making frequent visits with some out-of-hours cover.", "High level": "Intensive level of staffing provided on a 24-hour basis." } %>
 
-      <% support_level_options_with_hints = Scheme.support_types.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: support_level_options_hints[key.to_sym]) } %>
+      <% support_level_options_with_hints = Scheme.support_types.keys.excluding("Missing").excluding("Floating support").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: support_level_options_hints[key.to_sym]) } %>
 
       <%= f.govuk_collection_radio_buttons :support_type,
                                            support_level_options_with_hints,

--- a/spec/services/imports/scheme_location_import_service_spec.rb
+++ b/spec/services/imports/scheme_location_import_service_spec.rb
@@ -229,6 +229,15 @@ RSpec.describe Imports::SchemeLocationImportService do
       end
     end
 
+    context "and support_type is floating support" do
+      before { location_xml.at_xpath("//scheme:support-type").content = "6" }
+
+      it "correctly sets the support type" do
+        location = location_service.create_scheme_location(location_xml)
+        expect(location.scheme.support_type).to eq("Floating support")
+      end
+    end
+
     context "and postcode does not return a location code" do
       before { location_xml.at_xpath("//scheme:postcode").content = "A1 1AA" }
 


### PR DESCRIPTION
Add floating support type for migrated schemes, but do not allow it to be chosen from the UI