### PR TITLE
CLDC-2934 Export LA and postcode_full for logs with locations

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -203,6 +203,9 @@ module Exports
       attribute_hash["created_by"] = lettings_log.created_by&.email
       attribute_hash["amended_by"] = lettings_log.updated_by&.email
 
+      attribute_hash["la"] = lettings_log.la
+      attribute_hash["postcode_full"] = lettings_log.postcode_full
+
       # Supported housing fields
       if lettings_log.is_supported_housing?
         attribute_hash["unittype_sh"] = lettings_log.unittype_sh

--- a/spec/fixtures/exports/supported_housing_logs.xml
+++ b/spec/fixtures/exports/supported_housing_logs.xml
@@ -82,7 +82,7 @@
     <irproduct_other/>
     <reason>4</reason>
     <propcode>MYPROP</propcode>
-    <la>E09000003</la>
+    <la>E09000033</la>
     <prevloc>E07000105</prevloc>
     <hb>6</hb>
     <hbrentshortfall>1</hbrentshortfall>

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -425,6 +425,9 @@ RSpec.describe Exports::LettingsLogExportService do
     let(:lettings_log) { FactoryBot.create(:lettings_log, :completed, :export, :sh, scheme:, location:, created_by: user, updated_by: other_user, owning_organisation: organisation, startdate: Time.zone.local(2022, 2, 2, 10, 36, 49), voiddate: Time.zone.local(2019, 11, 3), mrcdate: Time.zone.local(2020, 5, 5, 10, 36, 49), underoccupation_benefitcap: 4, sheltered: 1) }
 
     before do
+      lettings_log.postcode_full = nil
+      lettings_log.la = nil
+      lettings_log.save!(validate: false)
       FactoryBot.create(:location, scheme:, startdate: Time.zone.local(2021, 4, 1), units: nil)
     end
 


### PR DESCRIPTION
When we're exporting logs with locations, we expect to export the postcode and la as well. 
We have methods to get postcode and la on lettings log model which takes into account whether a log has a location or not. We have previously also inferred postcode (and possibly la) values on logs from location values, but stopped doing that because we have that data by association.

Because `attribute_hash = lettings_log.attributes_before_type_cast` would only get the values from the database, it wasn't getting the LA and postcode using the methods we expected it to use.

We need to reexport any logs that don't have postcode_full or la values but have a location, and any logs that have postcode or la values not matching the ones of their locations.