### PR TITLE
CLDC-2924 Correct location admin district

### DIFF
--- a/lib/tasks/correct_location_admin_district.rake
+++ b/lib/tasks/correct_location_admin_district.rake
@@ -1,0 +1,6 @@
+desc "Infers location admin district for locations from location code where it's missing"
+task correct_location_admin_district: :environment do
+  Location.where.not(location_code: nil).where(location_admin_district: nil).each do |location|
+    location.update(location_admin_district: LocalAuthority.all.active(Time.zone.today).england.find_by(code: location.location_code)&.name)
+  end
+end

--- a/spec/lib/tasks/correct_location_admin_district_spec.rb
+++ b/spec/lib/tasks/correct_location_admin_district_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "correct_location_admin_district" do
+  describe ":correct_location_admin_district", type: :task do
+    subject(:task) { Rake::Task["correct_location_admin_district"] }
+
+    before do
+      Rake.application.rake_require("tasks/correct_location_admin_district")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let!(:scheme) { create(:scheme) }
+      let!(:location) { create(:location, postcode: "A11AA", location_code: "E06000009", location_admin_district: nil, startdate: nil) }
+
+      it "updates location with missing location admin district and marks it as complete" do
+        expect(location.confirmed).to eq(false)
+        task.invoke
+        location.reload
+        scheme.reload
+        expect(location.confirmed).to eq(true)
+        expect(location.location_admin_district).to eq("Blackpool")
+      end
+
+      it "does not mark location as complete if other fields are missing" do
+        location.update!(units: nil)
+        expect(location.confirmed).to eq(false)
+        task.invoke
+        location.reload
+        scheme.reload
+        expect(location.confirmed).to eq(false)
+        expect(location.location_admin_district).to eq("Blackpool")
+      end
+
+      it "does not override existing location admin district" do
+        location.location_admin_district = "Babergh"
+        location.save!(validate: false)
+        task.invoke
+        expect(location.reload.location_admin_district).to eq("Babergh")
+      end
+
+      it "does not set location admin district if it cannot be found" do
+        location.location_code = "123"
+        location.save!(validate: false)
+        task.invoke
+        expect(location.reload.location_admin_district).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need both location_admin_district and location_code to be answered for a location to be marked completed. 
If it cannot be inferred from postcode we ask location_admin_district question and infer location_code from that answer.
Upon import we import location_code which doesn’t set location_admin_district. 
Because we displayed linked local authorities based on the location_code instead of location_admin_district it’s not clear that something is missing.
This task infers location_admin_district value from location_code where it’s not present.