### PR TITLE
CLDC-2672 Update save and cancel buttons for duplicates

### DIFF
--- a/app/helpers/form_page_helper.rb
+++ b/app/helpers/form_page_helper.rb
@@ -2,4 +2,12 @@ module FormPageHelper
   def action_href(log, page_id, referrer = "check_answers")
     send("#{log.model_name.param_key}_#{page_id}_path", log, referrer:)
   end
+
+  def returning_to_question_page?(page, referrer)
+    page.interruption_screen? || referrer == "check_answers"
+  end
+
+  def accessed_from_duplicate_logs?(referrer)
+    %w[duplicate_logs duplicate_logs_banner].include?(referrer)
+  end
 end

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -63,20 +63,19 @@
       <%= f.hidden_field :interruption_page_referrer_type, value: @interruption_page_referrer_type %>
 
       <div class="govuk-button-group">
-        <% if !@page.interruption_screen? && if request.query_parameters["referrer"] != "check_answers" && request.query_parameters["referrer"] != "duplicate_logs" %>
-          <%= f.govuk_submit "Save and continue" %>
+      <% if accessed_from_duplicate_logs?(request.query_parameters["referrer"]) %>
+        <%= f.govuk_submit "Save changes" %>
+        <%= govuk_link_to "Cancel", send("#{@log.class.name.underscore}_duplicate_logs_path", @log, original_log_id: request.query_parameters["original_log_id"]) %>
+      <% elsif returning_to_question_page?(@page, request.query_parameters["referrer"]) %>
+        <%= f.govuk_submit "Save changes" %>
+        <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>
+      <% else %>
+        <%= f.govuk_submit "Save and continue" %>
           <%= govuk_link_to(
             (@page.skip_text || "Skip for now"),
             (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
           ) %>
-          <% elsif request.query_parameters["referrer"] == "duplicate_logs" %>
-          <%= f.govuk_submit "Save changes" %>
-            <%= govuk_link_to "Cancel", send("#{@log.class.name.underscore}_duplicate_logs_path", @log, original_log_id: request.query_parameters["original_log_id"]) %>
-          <% else %>
-          <%= f.govuk_submit "Save changes" %>
-            <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>
-          <% end %>
-        <% end %>
+      <% end %>
       </div>
     </div>
   </div>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -63,12 +63,15 @@
       <%= f.hidden_field :interruption_page_referrer_type, value: @interruption_page_referrer_type %>
 
       <div class="govuk-button-group">
-        <% if !@page.interruption_screen? && if request.query_parameters["referrer"] != "check_answers" %>
+        <% if !@page.interruption_screen? && if request.query_parameters["referrer"] != "check_answers" && request.query_parameters["referrer"] != "duplicate_logs" %>
           <%= f.govuk_submit "Save and continue" %>
           <%= govuk_link_to(
             (@page.skip_text || "Skip for now"),
             (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
           ) %>
+          <% elsif request.query_parameters["referrer"] == "duplicate_logs" %>
+          <%= f.govuk_submit "Save changes" %>
+            <%= govuk_link_to "Cancel", send("#{@log.class.name.underscore}_duplicate_logs_path", @log, original_log_id: request.query_parameters["original_log_id"]) %>
           <% else %>
           <%= f.govuk_submit "Save changes" %>
             <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -176,4 +176,18 @@ RSpec.describe "Form Navigation" do
       end
     end
   end
+
+  describe "fixing duplicate logs" do
+    it "shows a correct cancel link" do
+      visit("lettings-logs/#{id}/tenant-code-test?first_remaining_duplicate_id=x&original_log_id=#{id}&referrer=duplicate_logs")
+      click_link(text: "Cancel")
+      expect(page).to have_current_path("/lettings-logs/#{id}/duplicate-logs?original_log_id=#{id}")
+    end
+
+    it "shows a correct Save Changes buttons" do
+      visit("lettings-logs/#{id}/tenant-code-test?first_remaining_duplicate_id=#{id}&original_log_id=#{id}&referrer=duplicate_logs")
+      click_button(text: "Save changes")
+      expect(page).to have_current_path("/lettings-logs/#{id}/duplicate-logs?original_log_id=#{id}")
+    end
+  end
 end

--- a/spec/features/form/form_navigation_spec.rb
+++ b/spec/features/form/form_navigation_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "Form Navigation" do
     it "shows a correct Save Changes buttons" do
       visit("lettings-logs/#{id}/tenant-code-test?first_remaining_duplicate_id=#{id}&original_log_id=#{id}&referrer=duplicate_logs")
       click_button(text: "Save changes")
-      expect(page).to have_current_path("/lettings-logs/#{id}/duplicate-logs?original_log_id=#{id}")
+      expect(page).to have_current_path("/lettings-logs/#{id}/duplicate-logs?original_log_id=#{id}&referrer=duplicate_logs")
     end
   end
 end

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe "Lettings Log Features" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}")
         click_link("Change", href: "/lettings-logs/#{duplicate_log.id}/tenant-code?first_remaining_duplicate_id=#{lettings_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         fill_in("lettings-log-tenancycode-field", with: "something else")
-        click_button("Save and continue")
+        click_button("Save changes")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
@@ -521,7 +521,7 @@ RSpec.describe "Lettings Log Features" do
       it "allows deduplicating logs by changing the answers on the original log" do
         click_link("Change", href: "/lettings-logs/#{lettings_log.id}/tenant-code?first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         fill_in("lettings-log-tenancycode-field", with: "something else")
-        click_button("Save and continue")
+        click_button("Save changes")
         expect(page).to have_current_path("/lettings-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{lettings_log.id}&referrer=duplicate_logs")
         expect(page).to have_link("Back to Log #{lettings_log.id}", href: "/lettings-logs/#{lettings_log.id}")
         expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe "Sales Log Features" do
       expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}")
       click_link("Change", href: "/sales-logs/#{duplicate_log.id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       fill_in("sales-log-purchid-field", with: "something else")
-      click_button("Save and continue")
+      click_button("Save changes")
       expect(page).to have_current_path("/sales-logs/#{sales_log.id}/duplicate-logs?original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")
@@ -260,7 +260,7 @@ RSpec.describe "Sales Log Features" do
     it "allows deduplicating logs by changing the answers on the original log" do
       click_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?first_remaining_duplicate_id=#{duplicate_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       fill_in("sales-log-purchid-field", with: "something else")
-      click_button("Save and continue")
+      click_button("Save changes")
       expect(page).to have_current_path("/sales-logs/#{duplicate_log.id}/duplicate-logs?original_log_id=#{sales_log.id}&referrer=duplicate_logs")
       expect(page).to have_link("Back to Log #{sales_log.id}", href: "/sales-logs/#{sales_log.id}")
       expect(page).to have_css(".govuk-notification-banner.govuk-notification-banner--success")

--- a/spec/lib/tasks/send_missing_addresses_csv_spec.rb
+++ b/spec/lib/tasks/send_missing_addresses_csv_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "correct_addresses" do
     subject(:task) { Rake::Task["correct_addresses:send_missing_addresses_lettings_csv"] }
 
     before do
+      Timecop.travel(Time.zone.local(2023, 10, 10))
+      Singleton.__init__(FormHandler)
       organisation.users.destroy_all
       Rake.application.rake_require("tasks/send_missing_addresses_csv")
       Rake::Task.define_task(:environment)
@@ -40,6 +42,10 @@ RSpec.describe "correct_addresses" do
 
       stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=12")
       .to_return(status: 200, body: body_2, headers: {})
+    end
+
+    after do
+      Timecop.return
     end
 
     context "when the rake task is run" do


### PR DESCRIPTION
Instead of having `Save and continue` and `Skip for now` buttons when updating duplicate logs, we want it to act similar to check your answers and have `Save changes` and `Cancel`