### PR TITLE
CLDC-2803 Show frequency in rent range soft validation pages

### DIFF
--- a/app/models/form/lettings/pages/max_rent_value_check.rb
+++ b/app/models/form/lettings/pages/max_rent_value_check.rb
@@ -19,6 +19,6 @@ class Form::Lettings::Pages::MaxRentValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    %w[brent startdate uprn postcode_full la beds rent_type needstype period]
+    %w[brent period startdate uprn postcode_full la beds rent_type needstype]
   end
 end

--- a/app/models/form/lettings/pages/max_rent_value_check.rb
+++ b/app/models/form/lettings/pages/max_rent_value_check.rb
@@ -19,6 +19,6 @@ class Form::Lettings::Pages::MaxRentValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    %w[brent startdate uprn postcode_full la beds rent_type needstype]
+    %w[brent startdate uprn postcode_full la beds rent_type needstype period]
   end
 end

--- a/app/models/form/lettings/pages/min_rent_value_check.rb
+++ b/app/models/form/lettings/pages/min_rent_value_check.rb
@@ -19,6 +19,6 @@ class Form::Lettings::Pages::MinRentValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    %w[brent startdate uprn postcode_full la beds rent_type needstype period]
+    %w[brent period startdate uprn postcode_full la beds rent_type needstype]
   end
 end

--- a/app/models/form/lettings/pages/min_rent_value_check.rb
+++ b/app/models/form/lettings/pages/min_rent_value_check.rb
@@ -19,6 +19,6 @@ class Form::Lettings::Pages::MinRentValueCheck < ::Form::Page
   end
 
   def interruption_screen_question_ids
-    %w[brent startdate uprn postcode_full la beds rent_type needstype]
+    %w[brent startdate uprn postcode_full la beds rent_type needstype period]
   end
 end

--- a/app/views/logs/download_csv.html.erb
+++ b/app/views/logs/download_csv.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Download CSV</h2>
+    <h1 class="govuk-heading-l">Download CSV</h1>
 
     <p class="govuk-body">We'll send a secure download link to your email address <strong><%= @current_user.email %></strong>.</p>
     <p class="govuk-body">You've selected <%= count %> logs.</p>

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -8316,7 +8316,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype", "period"]
+              "interruption_screen_question_ids": ["brent", "period", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "max_rent_value_check": {
               "depends_on": [
@@ -8361,7 +8361,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype", "period"]
+              "interruption_screen_question_ids": ["brent", "period", "startdate", "la", "beds", "rent_type", "needstype"]
             },
             "scharge_value_check": {
               "depends_on": [

--- a/config/forms/2022_2023.json
+++ b/config/forms/2022_2023.json
@@ -7056,8 +7056,8 @@
                     "3": {
                       "value": "Nominated by a local housing authority"
                     },
-                    "4" : { 
-                      "value" : "Referred by local authority housing department" 
+                    "4" : {
+                      "value" : "Referred by local authority housing department"
                     },
                     "8": {
                       "value": "Re-located through official housing mobility scheme"
@@ -8316,7 +8316,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
+              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype", "period"]
             },
             "max_rent_value_check": {
               "depends_on": [
@@ -8361,7 +8361,7 @@
                   }
                 }
               },
-              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype"]
+              "interruption_screen_question_ids": ["brent", "startdate", "la", "beds", "rent_type", "needstype", "period"]
             },
             "scharge_value_check": {
               "depends_on": [

--- a/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe Form::Lettings::Pages::MaxRentValueCheck, type: :model do
   end
 
   it "has the correct interruption_screen_question_ids" do
-    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype period])
+    expect(page.interruption_screen_question_ids).to eq(%w[brent period startdate uprn postcode_full la beds rent_type needstype])
   end
 end

--- a/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/max_rent_value_check_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe Form::Lettings::Pages::MaxRentValueCheck, type: :model do
   end
 
   it "has the correct interruption_screen_question_ids" do
-    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype])
+    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype period])
   end
 end

--- a/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe Form::Lettings::Pages::MinRentValueCheck, type: :model do
   end
 
   it "has the correct interruption_screen_question_ids" do
-    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype period])
+    expect(page.interruption_screen_question_ids).to eq(%w[brent period startdate uprn postcode_full la beds rent_type needstype])
   end
 end

--- a/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
+++ b/spec/models/form/lettings/pages/min_rent_value_check_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe Form::Lettings::Pages::MinRentValueCheck, type: :model do
   end
 
   it "has the correct interruption_screen_question_ids" do
-    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype])
+    expect(page.interruption_screen_question_ids).to eq(%w[brent startdate uprn postcode_full la beds rent_type needstype period])
   end
 end


### PR DESCRIPTION
new behaviour for 22/23 and 23/24 logs: <img width="805" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/94526761/a08aa02f-e68b-4e44-a4b7-b683dee7f9a8">
ticket: https://dluhcdigital.atlassian.net/browse/CLDC-2803