### PR TITLE
CLDC-2105 Display merged orgs for owning organisation question

### DIFF
--- a/app/models/form/lettings/questions/managing_organisation.rb
+++ b/app/models/form/lettings/questions/managing_organisation.rb
@@ -23,8 +23,8 @@ class Form::Lettings::Questions::ManagingOrganisation < ::Form::Question
       if log.owning_organisation.holds_own_stock?
         opts[log.owning_organisation.id] = "#{log.owning_organisation.name} (Owning organisation)"
       end
-    elsif user.organisation.absorbed_organisations.exists?
-      opts[user.organisation.id] = "#{user.organisation.name} (Your organisation, active as of #{user.organisation.created_at.to_fs(:govuk_date)})"
+    elsif user.organisation.absorbed_organisations.exists? && user.organisation.available_from.present?
+      opts[user.organisation.id] = "#{user.organisation.name} (Your organisation, active as of #{user.organisation.available_from.to_fs(:govuk_date)})"
     else
       opts[user.organisation.id] = "#{user.organisation.name} (Your organisation)"
     end

--- a/app/models/form/lettings/questions/stock_owner.rb
+++ b/app/models/form/lettings/questions/stock_owner.rb
@@ -16,20 +16,38 @@ class Form::Lettings::Questions::StockOwner < ::Form::Question
     return answer_opts unless log
 
     if log.owning_organisation_id.present?
-      answer_opts = answer_opts.merge({ log.owning_organisation.id => log.owning_organisation.name })
+      answer_opts[log.owning_organisation.id] = log.owning_organisation.name
     end
 
+    recently_absorbed_organisations = user.organisation.absorbed_organisations.merged_during_open_collection_period
     if !user.support? && user.organisation.holds_own_stock?
-      answer_opts[user.organisation.id] = "#{user.organisation.name} (Your organisation)"
+      answer_opts[user.organisation.id] = if recently_absorbed_organisations.exists?
+                                            "#{user.organisation.name} (Your organisation, active as of #{user.organisation.created_at.to_fs(:govuk_date)})"
+                                          else
+                                            "#{user.organisation.name} (Your organisation)"
+                                          end
     end
 
-    user_answer_options = if user.support?
-                            Organisation.where(holds_own_stock: true)
-                          else
-                            user.organisation.stock_owners + user.organisation.absorbed_organisations.where(holds_own_stock: true)
-                          end.pluck(:id, :name).to_h
+    if user.support?
+      Organisation.where(holds_own_stock: true).find_each do |org|
+        if org.merge_date.present?
+          answer_opts[org.id] = "#{org.name} (inactive as of #{org.merge_date.to_fs(:govuk_date)})" if org.merge_date >= FormHandler.instance.start_date_of_earliest_open_for_editing_collection_period
+        elsif org.absorbed_organisations.merged_during_open_collection_period.exists?
+          answer_opts[org.id] = "#{org.name} (active as of #{org.created_at.to_fs(:govuk_date)})"
+        else
+          answer_opts[org.id] = org.name
+        end
+      end
+    else
+      user.organisation.stock_owners.each do |stock_owner|
+        answer_opts[stock_owner.id] = stock_owner.name
+      end
+      recently_absorbed_organisations.each do |absorbed_org|
+        answer_opts[absorbed_org.id] = merged_organisation_label(absorbed_org.name, absorbed_org.merge_date) if absorbed_org.holds_own_stock?
+      end
+    end
 
-    answer_opts.merge(user_answer_options)
+    answer_opts
   end
 
   def displayed_answer_options(log, user = nil)
@@ -70,5 +88,9 @@ private
 
   def selected_answer_option_is_derived?(_log)
     true
+  end
+
+  def merged_organisation_label(name, merge_date)
+    "#{name} (inactive as of #{merge_date.to_fs(:govuk_date)})"
   end
 end

--- a/app/models/form/lettings/questions/stock_owner.rb
+++ b/app/models/form/lettings/questions/stock_owner.rb
@@ -21,8 +21,8 @@ class Form::Lettings::Questions::StockOwner < ::Form::Question
 
     recently_absorbed_organisations = user.organisation.absorbed_organisations.merged_during_open_collection_period
     if !user.support? && user.organisation.holds_own_stock?
-      answer_opts[user.organisation.id] = if recently_absorbed_organisations.exists?
-                                            "#{user.organisation.name} (Your organisation, active as of #{user.organisation.created_at.to_fs(:govuk_date)})"
+      answer_opts[user.organisation.id] = if recently_absorbed_organisations.exists? && user.organisation.available_from.present?
+                                            "#{user.organisation.name} (Your organisation, active as of #{user.organisation.available_from.to_fs(:govuk_date)})"
                                           else
                                             "#{user.organisation.name} (Your organisation)"
                                           end

--- a/app/models/form/sales/questions/owning_organisation_id.rb
+++ b/app/models/form/sales/questions/owning_organisation_id.rb
@@ -22,8 +22,8 @@ class Form::Sales::Questions::OwningOrganisationId < ::Form::Question
 
       recently_absorbed_organisations = user.organisation.absorbed_organisations.merged_during_open_collection_period
       if !user.support? && user.organisation.holds_own_stock?
-        answer_opts[user.organisation.id] = if recently_absorbed_organisations.exists?
-                                              "#{user.organisation.name} (Your organisation, active as of #{user.organisation.created_at.to_fs(:govuk_date)})"
+        answer_opts[user.organisation.id] = if recently_absorbed_organisations.exists? && user.organisation.available_from.present?
+                                              "#{user.organisation.name} (Your organisation, active as of #{user.organisation.available_from.to_fs(:govuk_date)})"
                                             else
                                               "#{user.organisation.name} (Your organisation)"
                                             end

--- a/spec/models/form/lettings/questions/managing_organisation_spec.rb
+++ b/spec/models/form/lettings/questions/managing_organisation_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
     end
 
     context "when organisation has merged" do
-      let(:absorbing_org) { create(:organisation, name: "Absorbing org", holds_own_stock: true, created_at: Time.zone.local(2023, 8, 3)) }
+      let(:absorbing_org) { create(:organisation, name: "Absorbing org", holds_own_stock: true) }
       let!(:merged_org) { create(:organisation, name: "Merged org", holds_own_stock: false) }
       let(:user) { create(:user, :data_coordinator, organisation: absorbing_org) }
 
@@ -173,6 +173,17 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
       end
 
       it "displays merged organisation on the list of choices" do
+        options = {
+          "" => "Select an option",
+          absorbing_org.id => "Absorbing org (Your organisation)",
+          merged_org.id => "Merged org (inactive as of 2 August 2023)",
+          merged_org.id => "Merged org (inactive as of 2 August 2023)",
+        }
+        expect(question.displayed_answer_options(log, user)).to eq(options)
+      end
+
+      it "displays active date for absorbing organisation if available from is given" do
+        absorbing_org.update!(available_from: Time.zone.local(2023, 8, 3))
         options = {
           "" => "Select an option",
           absorbing_org.id => "Absorbing org (Your organisation, active as of 3 August 2023)",
@@ -189,7 +200,7 @@ RSpec.describe Form::Lettings::Questions::ManagingOrganisation, type: :model do
         options = {
           "" => "Select an option",
           merged_org.id => "Merged org (inactive as of 2 August 2023)",
-          absorbing_org.id => "Absorbing org (Your organisation, active as of 3 August 2023)",
+          absorbing_org.id => "Absorbing org (Your organisation)",
           managing_agent.id => "Managing org 1",
         }
 

--- a/spec/models/form/lettings/questions/stock_owner_spec.rb
+++ b/spec/models/form/lettings/questions/stock_owner_spec.rb
@@ -100,6 +100,72 @@ RSpec.describe Form::Lettings::Questions::StockOwner, type: :model do
           expect(question.displayed_answer_options(log, user)).to eq(options)
         end
       end
+
+      context "when user's org has recently absorbed other orgs" do
+        let(:merged_organisation) { create(:organisation, name: "Merged org") }
+        let(:options) do
+          {
+            "" => "Select an option",
+            user.organisation.id => "User org (Your organisation, active as of 2 February 2021)",
+            owning_org_2.id => "Owning org 2",
+            owning_org_1.id => "Owning org 1",
+            merged_organisation.id => "Merged org (inactive as of 2 February 2023)",
+          }
+        end
+
+        before do
+          merged_organisation.update!(merge_date: Time.zone.local(2023, 2, 2), absorbing_organisation: user.organisation)
+          user.organisation.update!(created_at: Time.zone.local(2021, 2, 2))
+        end
+
+        it "shows merged organisation as an option" do
+          expect(question.displayed_answer_options(log, user)).to eq(options)
+        end
+      end
+
+      context "when user's org has recently absorbed other orgs with parent organisations" do
+        let(:merged_organisation) { create(:organisation, name: "Merged org") }
+        let(:options) do
+          {
+            "" => "Select an option",
+            user.organisation.id => "User org (Your organisation, active as of 2 February 2021)",
+            owning_org_1.id => "Owning org 1",
+            merged_organisation.id => "Merged org (inactive as of 2 February 2023)",
+          }
+        end
+
+        before do
+          org_rel.update!(child_organisation: merged_organisation)
+          merged_organisation.update!(merge_date: Time.zone.local(2023, 2, 2), absorbing_organisation: user.organisation)
+          user.organisation.update!(created_at: Time.zone.local(2021, 2, 2))
+        end
+
+        it "does not show merged organisations stock owners as options" do
+          expect(question.displayed_answer_options(log, user)).to eq(options)
+        end
+      end
+
+      context "when user's org has absorbed other orgs with parent organisations during closed collection periods" do
+        let(:merged_organisation) { create(:organisation, name: "Merged org") }
+        let(:options) do
+          {
+            "" => "Select an option",
+            user.organisation.id => "User org (Your organisation)",
+            owning_org_1.id => "Owning org 1",
+          }
+        end
+
+        before do
+          Timecop.freeze(Time.zone.local(2023, 4, 2))
+          org_rel.update!(child_organisation: merged_organisation)
+          merged_organisation.update!(merge_date: Time.zone.local(2021, 6, 2), absorbing_organisation: user.organisation)
+          user.organisation.update!(created_at: Time.zone.local(2021, 2, 2))
+        end
+
+        it "shows merged organisation as an option" do
+          expect(question.displayed_answer_options(log, user)).to eq(options)
+        end
+      end
     end
 
     context "when user is support" do


### PR DESCRIPTION
I think we were already displaying them but this also adds the dates in brackets:
<img width="783" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/e6cf2bef-9652-4148-9b81-303dcd04cc29">
<img width="773" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/921fafea-e7ae-40ea-b15f-3b4d07230aed">
For support:
<img width="906" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/60992087-0c53-4f9a-ad9c-46f39eb1487e">
