### PR TITLE
CLDC-2743 Search improvements

### DIFF
--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -10,6 +10,7 @@
       autocomplete: "off",
       class: "app-search__input" %>
 
-    <%= f.govuk_submit "Search", classes: "app-search__button govuk-button--secondary" %>
+    <%= f.govuk_submit "Search", classes: "app-search__button" %>
+    <%= govuk_button_link_to "Clear search", path(current_user), secondary: true, class: "app-search__button" %>
   </div>
 <% end %>

--- a/app/components/search_result_caption_component.html.erb
+++ b/app/components/search_result_caption_component.html.erb
@@ -1,10 +1,10 @@
 <span class="govuk-!-margin-right-4">
   <% if searched.present? && filters_count&.positive? %>
-    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search and filters
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search and filters<br>
   <% elsif searched.present? %>
-    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search<br>
   <% elsif filters_count&.positive? %>
-    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching filters
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching filters<br>
   <% else %>
     <strong><%= count %></strong> matching <%= item %>
   <% end %>

--- a/app/components/search_result_caption_component.html.erb
+++ b/app/components/search_result_caption_component.html.erb
@@ -1,6 +1,6 @@
 <span class="govuk-!-margin-right-4">
   <% if searched.present? %>
-    <strong><%= count %></strong> <%= item_label %> found matching ‘<%= searched %>’ of <strong><%= total_count %></strong> total <%= item %>. <%= govuk_link_to("Clear search", path) %>
+    <strong><%= count %></strong> <%= item_label %> found matching ‘<%= searched %>’ of <strong><%= total_count %></strong> total <%= item %>.
   <% else %>
     <strong><%= count %></strong> total <%= item %>
   <% end %>

--- a/app/components/search_result_caption_component.html.erb
+++ b/app/components/search_result_caption_component.html.erb
@@ -1,7 +1,11 @@
 <span class="govuk-!-margin-right-4">
-  <% if searched.present? %>
-    <strong><%= count %></strong> <%= item_label %> found matching ‘<%= searched %>’ of <strong><%= total_count %></strong> total <%= item %>.
+  <% if searched.present? && filters_count&.positive? %>
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search and filters
+  <% elsif searched.present? %>
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching search
+  <% elsif filters_count&.positive? %>
+    <strong><%= count %></strong> <%= item_label.pluralize(count) %> matching filters
   <% else %>
-    <strong><%= count %></strong> total <%= item %>
+    <strong><%= count %></strong> matching <%= item %>
   <% end %>
 </span>

--- a/app/components/search_result_caption_component.rb
+++ b/app/components/search_result_caption_component.rb
@@ -1,13 +1,12 @@
 class SearchResultCaptionComponent < ViewComponent::Base
   attr_reader :searched, :count, :item_label, :total_count, :item, :path
 
-  def initialize(searched:, count:, item_label:, total_count:, item:, path:)
+  def initialize(searched:, count:, item_label:, total_count:, item:)
     @searched = searched
     @count = count
     @item_label = item_label
     @total_count = total_count
     @item = item
-    @path = path
     super
   end
 end

--- a/app/components/search_result_caption_component.rb
+++ b/app/components/search_result_caption_component.rb
@@ -1,12 +1,13 @@
 class SearchResultCaptionComponent < ViewComponent::Base
-  attr_reader :searched, :count, :item_label, :total_count, :item, :path
+  attr_reader :searched, :count, :item_label, :total_count, :item, :filters_count
 
-  def initialize(searched:, count:, item_label:, total_count:, item:)
+  def initialize(searched:, count:, item_label:, total_count:, item:, filters_count:)
     @searched = searched
     @count = count
     @item_label = item_label
     @total_count = total_count
     @item = item
+    @filters_count = filters_count
     super
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
     session[session_name_for(params[:filter_type])] = "{}"
     path_params = params[:path_params].presence || {}
 
-    redirect_to send("#{params[:filter_type]}_path", scheme_id: path_params[:scheme_id])
+    redirect_to send("#{params[:filter_type]}_path", scheme_id: path_params[:scheme_id], search: path_params[:search])
   end
 
 private

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -139,11 +139,11 @@ module FiltersHelper
     request.path.include?("/lettings-logs")
   end
 
-private
-
   def applied_filters_count(filter_type)
     filters_count(applied_filters(filter_type))
   end
+
+private
 
   def applied_filters(filter_type)
     return {} unless session[session_name_for(filter_type)]

--- a/app/views/locations/_location_filters.html.erb
+++ b/app/views/locations/_location_filters.html.erb
@@ -23,6 +23,10 @@
                     category: "status",
                   } %>
 
+        <% if request.params["search"].present? %>
+          <%= f.hidden_field :search, value: request.params["search"] %>
+        <% end %>
+
         <%= f.govuk_submit "Apply filters", class: "govuk-!-margin-bottom-0" %>
       <% end %>
     </div>

--- a/app/views/locations/_location_filters.html.erb
+++ b/app/views/locations/_location_filters.html.erb
@@ -11,7 +11,7 @@
             <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type, { scheme_id: @scheme.id }) %>
+            <%= reset_filters_link(@filter_type, { scheme_id: @scheme.id, search: request.params["search"] }.compact) %>
           </p>
         </div>
 

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -24,7 +24,7 @@
 
     <%= govuk_table do |table| %>
       <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-        <%= render(SearchResultCaptionComponent.new(searched: @searched, count: @pagy.count, item_label:, total_count: @total_count, item: "locations")) %>
+        <%= render(SearchResultCaptionComponent.new(searched: @searched, count: @pagy.count, item_label:, total_count: @total_count, item: "locations", filters_count: applied_filters_count(@filter_type))) %>
       <% end %>
       <%= table.head do |head| %>
         <%= head.row do |row| %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -24,7 +24,7 @@
 
     <%= govuk_table do |table| %>
       <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-        <%= render(SearchResultCaptionComponent.new(searched: @searched, count: @pagy.count, item_label:, total_count: @total_count, item: "locations", path: request.path)) %>
+        <%= render(SearchResultCaptionComponent.new(searched: @searched, count: @pagy.count, item_label:, total_count: @total_count, item: "locations")) %>
       <% end %>
       <%= table.head do |head| %>
         <%= head.row do |row| %>

--- a/app/views/logs/_log_filters.html.erb
+++ b/app/views/logs/_log_filters.html.erb
@@ -113,6 +113,10 @@
           } %>
         <% end %>
 
+        <% if request.params["search"].present? %>
+          <%= f.hidden_field :search, value: request.params["search"] %>
+        <% end %>
+
         <%= f.govuk_submit "Apply filters", class: "govuk-!-margin-bottom-0" %>
       <% end %>
     </div>

--- a/app/views/logs/_log_filters.html.erb
+++ b/app/views/logs/_log_filters.html.erb
@@ -12,7 +12,7 @@
               <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
           </p>
         </div>
         <% if bulk_upload_options(@bulk_upload).present? %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-body">
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-three-quarters">
-  <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs", path: request.path)) %>
+  <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs")) %>
   <% if logs&.any? %>
     <%= govuk_link_to "Download (CSV)", csv_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
     <% if @current_user.support? %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-body">
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-three-quarters">
-  <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs")) %>
+  <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs", filters_count: applied_filters_count(@filter_type))) %>
   <% if logs&.any? %>
     <%= govuk_link_to "Download (CSV)", csv_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
     <% if @current_user.support? %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -1,19 +1,20 @@
 <h2 class="govuk-body">
 <div class="govuk-grid-row">
-<div class="govuk-grid-column-three-quarters">
-  <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs", filters_count: applied_filters_count(@filter_type))) %>
-  <% if logs&.any? %>
-    <%= govuk_link_to "Download (CSV)", csv_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
-    <% if @current_user.support? %>
-      <%= govuk_link_to "Download (CSV, codes only)", csv_codes_only_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
+  <div class="govuk-grid-column-three-quarters">
+    <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "logs", filters_count: applied_filters_count(@filter_type))) %>
+    <% if logs&.any? %>
+      <%= govuk_link_to "Download (CSV)", csv_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
+      <% if @current_user.support? %>
+        <%= govuk_link_to "Download (CSV, codes only)", csv_codes_only_download_url, type: "text/csv", class: "govuk-!-margin-right-4" %>
+      <% end %>
     <% end %>
-  <% end %>
-</div>
-<div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
-  <% if logs&.any? && (display_delete_logs?(@current_user, searched, filter_type) || in_organisations_tab?) %>
-    <%= govuk_link_to "Delete logs", delete_logs_path, class: "app-!-colour-red" %>
-  <% end %>
-</div>
+  </div>
+  <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
+    <br>
+    <% if logs&.any? && (display_delete_logs?(@current_user, searched, filter_type) || in_organisations_tab?) %>
+      <%= govuk_link_to "Delete logs", delete_logs_path, class: "app-!-colour-red" %>
+    <% end %>
+  </div>
 </div>
 </h2>
 <% logs.map do |log| %>

--- a/app/views/logs/_log_list.html.erb
+++ b/app/views/logs/_log_list.html.erb
@@ -10,7 +10,9 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
-    <br>
+    <% if searched || applied_filters_count(@filter_type).positive? %>
+      <br>
+    <% end %>
     <% if logs&.any? && (display_delete_logs?(@current_user, searched, filter_type) || in_organisations_tab?) %>
       <%= govuk_link_to "Delete logs", delete_logs_path, class: "app-!-colour-red" %>
     <% end %>

--- a/app/views/organisation_relationships/_managing_agent_list.erb
+++ b/app/views/organisation_relationships/_managing_agent_list.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "agents")) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "agents", filters_count: 0)) %>
     <% end %>
     <% @managing_agents.each do |managing_agent| %>
       <%= table.body do |body| %>

--- a/app/views/organisation_relationships/_managing_agent_list.erb
+++ b/app/views/organisation_relationships/_managing_agent_list.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "agents", path: request.path)) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "agents")) %>
     <% end %>
     <% @managing_agents.each do |managing_agent| %>
       <%= table.body do |body| %>

--- a/app/views/organisation_relationships/_stock_owner_list.erb
+++ b/app/views/organisation_relationships/_stock_owner_list.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "stock owners")) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "stock owners", filters_count: 0)) %>
     <% end %>
     <% @stock_owners.each do |stock_owner| %>
       <%= table.body do |body| %>

--- a/app/views/organisation_relationships/_stock_owner_list.erb
+++ b/app/views/organisation_relationships/_stock_owner_list.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "stock owners", path: request.path)) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "stock owners")) %>
     <% end %>
     <% @stock_owners.each do |stock_owner| %>
       <%= table.body do |body| %>

--- a/app/views/organisations/_organisation_list.html.erb
+++ b/app/views/organisations/_organisation_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "organisations")) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "organisations", filters_count: applied_filters_count(@filter_type))) %>
     <% end %>
     <%= table.head do |head| %>
       <%= head.row do |row| %>

--- a/app/views/organisations/_organisation_list.html.erb
+++ b/app/views/organisations/_organisation_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "organisations", path: request.path)) %>
+      <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "organisations")) %>
     <% end %>
     <%= table.head do |head| %>
       <%= head.row do |row| %>

--- a/app/views/schemes/_scheme_filters.html.erb
+++ b/app/views/schemes/_scheme_filters.html.erb
@@ -11,7 +11,7 @@
             <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
           </p>
         </div>
 

--- a/app/views/schemes/_scheme_filters.html.erb
+++ b/app/views/schemes/_scheme_filters.html.erb
@@ -43,6 +43,10 @@
           } %>
         <% end %>
 
+        <% if request.params["search"].present? %>
+          <%= f.hidden_field :search, value: request.params["search"] %>
+        <% end %>
+
         <%= f.govuk_submit "Apply filters", class: "govuk-!-margin-bottom-0" %>
       <% end %>
     </div>

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-    <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "schemes")) %>
+    <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "schemes", filters_count: applied_filters_count(@filter_type))) %>
       <% end %>
     <%= table.head do |head| %>
       <%= head.row do |row| %>

--- a/app/views/schemes/_scheme_list.html.erb
+++ b/app/views/schemes/_scheme_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-    <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "schemes", path: request.path)) %>
+    <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "schemes")) %>
       <% end %>
     <%= table.head do |head| %>
       <%= head.row do |row| %>

--- a/app/views/users/_user_filters.html.erb
+++ b/app/views/users/_user_filters.html.erb
@@ -11,7 +11,7 @@
             <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
           </p>
         </div>
 

--- a/app/views/users/_user_filters.html.erb
+++ b/app/views/users/_user_filters.html.erb
@@ -22,6 +22,11 @@
                     label: "Status",
                     category: "status",
                   } %>
+
+        <% if request.params["search"].present? %>
+          <%= f.hidden_field :search, value: request.params["search"] %>
+        <% end %>
+
         <%= f.govuk_submit "Apply filters", class: "govuk-!-margin-bottom-0" %>
       <% end %>
     </div>

--- a/app/views/users/_user_list.html.erb
+++ b/app/views/users/_user_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-     <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "users")) %>
+     <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "users", filters_count: applied_filters_count(@filter_type))) %>
        <% if current_user.support? %>
         <% query = searched.present? ? "?search=#{searched}" : nil %>
         <%= govuk_link_to "Download (CSV)", "#{request.path}.csv#{query}", type: "text/csv" %>

--- a/app/views/users/_user_list.html.erb
+++ b/app/views/users/_user_list.html.erb
@@ -1,7 +1,7 @@
 <section class="app-table-group" tabindex="0" aria-labelledby="<%= title.dasherize %>">
   <%= govuk_table do |table| %>
     <%= table.caption(classes: %w[govuk-!-font-size-19 govuk-!-font-weight-regular]) do |caption| %>
-     <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "users", path: request.path)) %>
+     <%= render(SearchResultCaptionComponent.new(searched:, count: pagy.count, item_label:, total_count:, item: "users")) %>
        <% if current_user.support? %>
         <% query = searched.present? ? "?search=#{searched}" : nil %>
         <%= govuk_link_to "Download (CSV)", "#{request.path}.csv#{query}", type: "text/csv" %>

--- a/spec/components/search_result_caption_component_spec.rb
+++ b/spec/components/search_result_caption_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
 
   context "when search and filter results are found" do
     it "renders table caption including the search results and total" do
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search and filters\n</span>\n")
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search and filters<br>\n</span>\n")
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
     let(:filters_count) { nil }
 
     it "renders table caption including the search results and total" do
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search\n</span>\n")
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search<br>\n</span>\n")
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
     let(:searched) { nil }
 
     it "renders table caption including the search results and total" do
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching filters\n</span>\n")
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching filters<br>\n</span>\n")
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
     let(:count) { 0 }
 
     it "renders table caption with total count only" do
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>0</strong> users matching search and filters\n</span>\n")
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>0</strong> users matching search and filters<br>\n</span>\n")
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
     let(:count) { 1 }
 
     it "renders table caption with total count only" do
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>1</strong> user matching search and filters\n</span>\n")
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>1</strong> user matching search and filters<br>\n</span>\n")
     end
   end
 end

--- a/spec/components/search_result_caption_component_spec.rb
+++ b/spec/components/search_result_caption_component_spec.rb
@@ -6,19 +6,53 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
   let(:item_label) { "user" }
   let(:total_count) { 3 }
   let(:item) { "schemes" }
+  let(:filters_count) { 1 }
+  let(:result) { render_inline(described_class.new(searched:, count:, item_label:, total_count:, item:, filters_count:)) }
 
-  it "renders table caption including the search results and total" do
-    result = render_inline(described_class.new(searched:, count:, item_label:, total_count:, item:, path:))
-    expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>#{count}</strong> #{item_label} found matching ‘#{searched}’ of <strong>#{total_count}</strong> total #{item}.\n")
+  context "when search and filter results are found" do
+    it "renders table caption including the search results and total" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search and filters\n</span>\n")
+    end
   end
 
-  context "when no search results are found" do
+  context "when search results are found" do
+    let(:filters_count) { nil }
+
+    it "renders table caption including the search results and total" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching search\n</span>\n")
+    end
+  end
+
+  context "when filter results are found" do
     let(:searched) { nil }
 
-    it "renders table caption with total count only" do
-      result = render_inline(described_class.new(searched:, count:, item_label:, total_count:, item:, path:))
+    it "renders table caption including the search results and total" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>2</strong> users matching filters\n</span>\n")
+    end
+  end
 
-      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>#{count}</strong> total #{item}\n</span>\n")
+  context "when no search/filter is applied" do
+    let(:searched) { nil }
+    let(:filters_count) { nil }
+
+    it "renders table caption with total count only" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>#{count}</strong> matching #{item}\n</span>\n")
+    end
+  end
+
+  context "when nothing is found" do
+    let(:count) { 0 }
+
+    it "renders table caption with total count only" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>0</strong> users matching search and filters\n</span>\n")
+    end
+  end
+
+  context "when 1 record is found" do
+    let(:count) { 1 }
+
+    it "renders table caption with total count only" do
+      expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>1</strong> user matching search and filters\n</span>\n")
     end
   end
 end

--- a/spec/components/search_result_caption_component_spec.rb
+++ b/spec/components/search_result_caption_component_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe SearchResultCaptionComponent, type: :component do
   let(:item_label) { "user" }
   let(:total_count) { 3 }
   let(:item) { "schemes" }
-  let(:path) { "path" }
 
   it "renders table caption including the search results and total" do
     result = render_inline(described_class.new(searched:, count:, item_label:, total_count:, item:, path:))
-    expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>#{count}</strong> #{item_label} found matching ‘#{searched}’ of <strong>#{total_count}</strong> total #{item}. <a class=\"govuk-link\" href=\"path\">Clear search</a>\n</span>\n")
+    expect(result.to_html).to eq("<span class=\"govuk-!-margin-right-4\">\n    <strong>#{count}</strong> #{item_label} found matching ‘#{searched}’ of <strong>#{total_count}</strong> total #{item}.\n")
   end
 
   context "when no search results are found" do

--- a/spec/features/lettings_log_spec.rb
+++ b/spec/features/lettings_log_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Lettings Log Features" do
       context "when no filters are selected" do
         it "displays the filters component with no clear button" do
           expect(page).to have_content("No filters applied")
-          expect(page).not_to have_content("Clear")
+          expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=lettings_logs")
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe "Lettings Log Features" do
 
         it "displays the filters component with a correct count and clear button" do
           expect(page).to have_content("5 filters applied")
-          expect(page).to have_content("Clear")
+          expect(page).to have_link("Clear", href: "/clear-filters?filter_type=lettings_logs")
         end
 
         context "when clearing the filters" do
@@ -107,7 +107,7 @@ RSpec.describe "Lettings Log Features" do
 
           it "clears the filters and displays the filter component as before" do
             expect(page).to have_content("No filters applied")
-            expect(page).not_to have_content("Clear")
+            expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=lettings_logs")
           end
         end
       end

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "User Features" do
       end
 
       it "has correct page details" do
-        expect(page).to have_content("#{number_of_lettings_logs} total logs")
+        expect(page).to have_content("#{number_of_lettings_logs} matching logs")
         organisation.lettings_logs.map(&:id).each do |lettings_log_id|
           expect(page).to have_link lettings_log_id.to_s, href: "/lettings-logs/#{lettings_log_id}"
         end
@@ -237,7 +237,7 @@ RSpec.describe "User Features" do
       end
 
       it "can filter sales logs" do
-        expect(page).to have_content("#{number_of_sales_logs} total logs")
+        expect(page).to have_content("#{number_of_sales_logs} matching logs")
         organisation.sales_logs.map(&:id).each do |sales_log_id|
           expect(page).to have_link sales_log_id.to_s, href: "/sales-logs/#{sales_log_id}"
         end

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Sales Log Features" do
       context "when no filters are selected" do
         it "displays the filters component with no clear button" do
           expect(page).to have_content("No filters applied")
-          expect(page).not_to have_content("Clear")
+          expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=sales_logs")
         end
       end
 
@@ -122,7 +122,7 @@ RSpec.describe "Sales Log Features" do
 
         it "displays the filters component with a correct count and clear button" do
           expect(page).to have_content("3 filters applied")
-          expect(page).to have_content("Clear")
+          expect(page).to have_link("Clear", href: "/clear-filters?filter_type=sales_logs")
         end
 
         context "when clearing the filters" do
@@ -132,7 +132,7 @@ RSpec.describe "Sales Log Features" do
 
           it "clears the filters and displays the filter component as before" do
             expect(page).to have_content("No filters applied")
-            expect(page).not_to have_content("Clear")
+            expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=sales_logs")
           end
         end
       end

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -572,7 +572,7 @@ RSpec.describe "Schemes scheme Features" do
 
           it "displays information about a single location" do
             expect(page).to have_content "Locations"
-            expect(page).to have_content "#{scheme.locations.count} total location"
+            expect(page).to have_content "#{scheme.locations.count} matching location"
           end
 
           it "displays information about the first created location" do
@@ -585,7 +585,7 @@ RSpec.describe "Schemes scheme Features" do
             fill_in_and_save_second_location
             click_button "Save and return to locations"
             expect(page).to have_content "Locations"
-            expect(page).to have_content "#{scheme.locations.count} total location"
+            expect(page).to have_content "#{scheme.locations.count} matching location"
           end
 
           it "displays information about newly created location" do

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Schemes scheme Features" do
           context "when no filters are selected" do
             it "displays the filters component with no clear button" do
               expect(page).to have_content("No filters applied")
-              expect(page).not_to have_content("Clear")
+              expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=schemes")
             end
           end
 
@@ -81,7 +81,7 @@ RSpec.describe "Schemes scheme Features" do
 
             it "displays the filters component with a correct count and clear button" do
               expect(page).to have_content("2 filters applied")
-              expect(page).to have_content("Clear")
+              expect(page).to have_link("Clear", href: "/clear-filters?filter_type=schemes")
             end
 
             context "when clearing the filters" do
@@ -91,7 +91,7 @@ RSpec.describe "Schemes scheme Features" do
 
               it "clears the filters and displays the filter component as before" do
                 expect(page).to have_content("No filters applied")
-                expect(page).not_to have_content("Clear")
+                expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=schemes")
               end
             end
           end
@@ -292,7 +292,7 @@ RSpec.describe "Schemes scheme Features" do
               context "when no filters are selected" do
                 it "displays the filters component with no clear button" do
                   expect(page).to have_content("No filters applied")
-                  expect(page).not_to have_content("Clear")
+                  expect(page).not_to have_link("Clear", href: /\/clear-filters\?filter_type=scheme_locations/)
                 end
               end
 
@@ -305,7 +305,7 @@ RSpec.describe "Schemes scheme Features" do
 
                 it "displays the filters component with a correct count and clear button" do
                   expect(page).to have_content("2 filters applied")
-                  expect(page).to have_content("Clear")
+                  expect(page).to have_link("Clear", href: /\/clear-filters\?filter_type=scheme_locations/)
                 end
 
                 context "when clearing the filters" do
@@ -315,7 +315,7 @@ RSpec.describe "Schemes scheme Features" do
 
                   it "clears the filters and displays the filter component as before" do
                     expect(page).to have_content("No filters applied")
-                    expect(page).not_to have_content("Clear")
+                    expect(page).not_to have_link("Clear", href: /\/clear-filters\?filter_type=scheme_locations/)
                   end
                 end
               end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "User Features" do
         context "when no filters are selected" do
           it "displays the filters component with no clear button" do
             expect(page).to have_content("No filters applied")
-            expect(page).not_to have_content("Clear")
+            expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=users")
           end
         end
 
@@ -246,7 +246,7 @@ RSpec.describe "User Features" do
 
           it "displays the filters component with a correct count and clear button" do
             expect(page).to have_content("2 filters applied")
-            expect(page).to have_content("Clear")
+            expect(page).to have_link("Clear", href: "/clear-filters?filter_type=users")
           end
 
           context "when clearing the filters" do
@@ -256,7 +256,7 @@ RSpec.describe "User Features" do
 
             it "clears the filters and displays the filter component as before" do
               expect(page).to have_content("No filters applied")
-              expect(page).not_to have_content("Clear")
+              expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=users")
             end
           end
         end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -774,7 +774,7 @@ RSpec.describe LettingsLogsController, type: :request do
           end
 
           it "shows the total log count" do
-            expect(CGI.unescape_html(response.body)).to match("<strong>1</strong> total logs")
+            expect(CGI.unescape_html(response.body)).to match("<strong>1</strong> matching logs")
           end
 
           it "does not show the pagination links" do
@@ -868,7 +868,7 @@ RSpec.describe LettingsLogsController, type: :request do
             end
 
             it "shows the total log count" do
-              expect(CGI.unescape_html(response.body)).to match("<strong>26</strong> total logs")
+              expect(CGI.unescape_html(response.body)).to match("<strong>26</strong> matching logs")
             end
 
             it "has pagination links" do

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         it "updates the table caption" do
-          expect(page).to have_content("1 location found matching ‘#{search_param}’")
+          expect(page).to have_content("1 location matching search")
         end
 
         it "has search in the title" do
@@ -402,7 +402,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         it "updates the table caption" do
-          expect(page).to have_content("1 location found matching ‘#{search_param}’")
+          expect(page).to have_content("1 location matching search")
         end
 
         it "has search in the title" do

--- a/spec/requests/organisation_relationships_controller_spec.rb
+++ b/spec/requests/organisation_relationships_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           end
 
           it "shows the pagination count" do
-            expect(page).to have_content("1 total stock owners")
+            expect(page).to have_content("1 matching stock owners")
           end
 
           context "when adding a stock owner" do
@@ -113,7 +113,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           end
 
           it "shows the pagination count" do
-            expect(page).to have_content("1 total agents")
+            expect(page).to have_content("1 matching agents")
           end
         end
 
@@ -285,7 +285,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           end
 
           it "shows the pagination count" do
-            expect(page).to have_content("1 total stock owners")
+            expect(page).to have_content("1 matching stock owners")
           end
         end
 
@@ -421,7 +421,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
           end
 
           it "shows the pagination count" do
-            expect(page).to have_content("1 total agents")
+            expect(page).to have_content("1 matching agents")
           end
         end
 
@@ -587,7 +587,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
 
         it "shows the pagination count" do
-          expect(page).to have_content("1 total stock owners")
+          expect(page).to have_content("1 matching stock owners")
         end
 
         context "when adding a stock owner" do
@@ -637,7 +637,7 @@ RSpec.describe OrganisationRelationshipsController, type: :request do
         end
 
         it "shows the pagination count" do
-          expect(page).to have_content("1 total agents")
+          expect(page).to have_content("1 matching agents")
         end
 
         it "shows remove link(s)" do

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -784,6 +784,11 @@ RSpec.describe OrganisationsController, type: :request do
               expect(page).to have_title("#{organisation.name} (1 logs matching ‘#{log_to_search.id}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
             end
 
+            it "has search term in the search box" do
+              get "/organisations/#{organisation.id}/lettings-logs?search=#{log_to_search.id}", headers: headers, params: {}
+              expect(page).to have_field("search", with: log_to_search.id.to_s)
+            end
+
             it "shows lettings logs matching the id" do
               get "/organisations/#{organisation.id}/lettings-logs?search=#{log_to_search.id}", headers: headers, params: {}
               expect(page).to have_link(log_to_search.id.to_s)

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "updates the table caption" do
-            expect(page).to have_content("1 scheme found matching ‘#{search_param}’")
+            expect(page).to have_content("1 scheme matching search")
           end
 
           it "has search in the title" do
@@ -171,7 +171,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "updates the table caption" do
-            expect(page).to have_content("1 scheme found matching ‘#{search_param}’")
+            expect(page).to have_content("1 scheme matching search")
           end
 
           it "has search in the title" do
@@ -332,7 +332,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "shows the pagination count" do
-            expect(page).to have_content("#{user.organisation.users.count} total users")
+            expect(page).to have_content("#{user.organisation.users.count} matching users")
           end
         end
 
@@ -716,7 +716,7 @@ RSpec.describe OrganisationsController, type: :request do
           total_number_of_orgs = Organisation.all.count
           expect(page).to have_link organisation.name, href: "organisations/#{organisation.id}/lettings-logs"
           expect(page).to have_link unauthorised_organisation.name, href: "organisations/#{unauthorised_organisation.id}/lettings-logs"
-          expect(page).to have_content("#{total_number_of_orgs} total organisations")
+          expect(page).to have_content("#{total_number_of_orgs} matching organisations")
         end
 
         it "shows a search bar" do
@@ -745,7 +745,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "only shows logs for that organisation" do
-            expect(page).to have_content("#{total_number_of_org1_logs} total logs")
+            expect(page).to have_content("#{total_number_of_org1_logs} matching logs")
 
             organisation.lettings_logs.visible.map(&:id).each do |lettings_log_id|
               expect(page).to have_link lettings_log_id.to_s, href: "/lettings-logs/#{lettings_log_id}"
@@ -899,7 +899,7 @@ RSpec.describe OrganisationsController, type: :request do
           end
 
           it "only shows logs for that organisation" do
-            expect(page).to have_content("#{number_of_org1_sales_logs} total logs")
+            expect(page).to have_content("#{number_of_org1_sales_logs} matching logs")
             organisation.sales_logs.map(&:id).each do |sales_log_id|
               expect(page).to have_link sales_log_id.to_s, href: "/sales-logs/#{sales_log_id}"
             end
@@ -1033,7 +1033,7 @@ RSpec.describe OrganisationsController, type: :request do
               end
 
               it "updates the table caption" do
-                expect(page).to have_content("1 user found matching ‘#{search_param}’ of #{org_user_count} total users.")
+                expect(page).to have_content("1 user matching search")
               end
 
               context "when we need case insensitive search" do
@@ -1053,7 +1053,7 @@ RSpec.describe OrganisationsController, type: :request do
                 end
 
                 it "updates the table caption" do
-                  expect(page).to have_content("1 user found matching ‘#{search_param}’ of #{org_user_count} total users.")
+                  expect(page).to have_content("1 user matching search")
                 end
               end
             end
@@ -1075,13 +1075,13 @@ RSpec.describe OrganisationsController, type: :request do
               end
 
               it "updates the table caption" do
-                expect(page).to have_content("1 user found matching ‘#{search_param}’ of #{org_user_count} total users.")
+                expect(page).to have_content("1 user matching search")
               end
 
               context "when our search term matches an email and a name" do
                 let!(:matching_user) { create(:user, organisation:, name: "Foobar", email: "some@example.com") }
                 let!(:another_matching_user) { create(:user, organisation:, name: "Joe", email: "foobar@example.com") }
-                let!(:org_user_count) { User.where(organisation:).count }
+                let(:org_user_count) { User.where(organisation:).count }
                 let(:search_param) { "Foobar" }
 
                 before do
@@ -1103,7 +1103,7 @@ RSpec.describe OrganisationsController, type: :request do
                 end
 
                 it "updates the table caption" do
-                  expect(page).to have_content("2 users found matching ‘#{search_param}’ of #{org_user_count} total users.")
+                  expect(page).to have_content("2 users matching search")
                 end
               end
             end
@@ -1160,7 +1160,7 @@ RSpec.describe OrganisationsController, type: :request do
             end
 
             it "shows the total organisations count" do
-              expect(CGI.unescape_html(response.body)).to match("<strong>#{total_organisations_count}</strong> total organisations")
+              expect(CGI.unescape_html(response.body)).to match("<strong>#{total_organisations_count}</strong> matching organisations")
             end
 
             it "has pagination links" do
@@ -1194,7 +1194,7 @@ RSpec.describe OrganisationsController, type: :request do
             end
 
             it "updates the table caption" do
-              expect(page).to have_content("1 organisations found matching ‘#{search_param}’")
+              expect(page).to have_content("1 organisations matching search")
             end
 
             it "has search in the title" do
@@ -1210,7 +1210,7 @@ RSpec.describe OrganisationsController, type: :request do
               end
 
               it "updates the table caption" do
-                expect(page).to have_content("2 organisations found matching ‘#{search_param}’")
+                expect(page).to have_content("2 organisations matching search")
               end
 
               it "has search in the title" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe SalesLogsController, type: :request do
           end
 
           it "shows the total log count" do
-            expect(CGI.unescape_html(response.body)).to match("<strong>1</strong> total logs")
+            expect(CGI.unescape_html(response.body)).to match("<strong>1</strong> matching logs")
           end
 
           it "does not show the pagination links" do
@@ -708,7 +708,7 @@ RSpec.describe SalesLogsController, type: :request do
             end
 
             it "shows the total log count" do
-              expect(CGI.unescape_html(response.body)).to match("<strong>26</strong> total logs")
+              expect(CGI.unescape_html(response.body)).to match("<strong>26</strong> matching logs")
             end
 
             it "has pagination links" do

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe SchemesController, type: :request do
       end
 
       it "shows the total organisations count" do
-        expect(CGI.unescape_html(response.body)).to match("<strong>#{schemes.count}</strong> total schemes")
+        expect(CGI.unescape_html(response.body)).to match("<strong>#{schemes.count}</strong> matching schemes")
       end
 
       context "when paginating over 20 results" do
@@ -250,7 +250,7 @@ RSpec.describe SchemesController, type: :request do
           end
 
           it "shows the total schemes count" do
-            expect(CGI.unescape_html(response.body)).to match("<strong>#{total_schemes_count}</strong> total schemes")
+            expect(CGI.unescape_html(response.body)).to match("<strong>#{total_schemes_count}</strong> matching schemes")
           end
 
           it "shows which schemes are being shown on the current page" do
@@ -275,7 +275,7 @@ RSpec.describe SchemesController, type: :request do
           end
 
           it "shows the total schemes count" do
-            expect(CGI.unescape_html(response.body)).to match("<strong>#{total_schemes_count}</strong> total schemes")
+            expect(CGI.unescape_html(response.body)).to match("<strong>#{total_schemes_count}</strong> matching schemes")
           end
 
           it "has pagination links" do
@@ -321,7 +321,7 @@ RSpec.describe SchemesController, type: :request do
         end
 
         it "updates the table caption" do
-          expect(page).to have_content("1 scheme found matching ‘#{search_param}’")
+          expect(page).to have_content("1 scheme matching search")
         end
 
         it "has search in the title" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe UsersController, type: :request do
           end
 
           it "updates the table caption" do
-            expect(page).to have_content("1 user found matching ‘filter’ of 4 total users.")
+            expect(page).to have_content("1 user matching search")
           end
         end
 
@@ -466,7 +466,7 @@ RSpec.describe UsersController, type: :request do
             end
 
             it "updates the table caption" do
-              expect(page).to have_content("2 users found matching ‘joe’ of 4 total users.")
+              expect(page).to have_content("2 users matching search")
             end
           end
         end
@@ -1136,7 +1136,7 @@ RSpec.describe UsersController, type: :request do
       end
 
       it "shows the pagination count" do
-        expect(page).to have_content("4 total users")
+        expect(page).to have_content("4 matching users")
       end
 
       it "shows the download csv link" do
@@ -1164,7 +1164,7 @@ RSpec.describe UsersController, type: :request do
             end
 
             it "updates the table caption" do
-              expect(page).to have_content("1 user found matching ‘#{search_param}’ of 4 total users.")
+              expect(page).to have_content("1 user matching search")
             end
 
             it "includes the search term in the CSV download link" do
@@ -1207,7 +1207,7 @@ RSpec.describe UsersController, type: :request do
             end
 
             it "updates the table caption" do
-              expect(page).to have_content("2 users found matching ‘joe’ of 4 total users.")
+              expect(page).to have_content("2 users matching search")
             end
           end
         end


### PR DESCRIPTION
- [x] Maintain search after filtering
previously whenever we'd filter after a search has been applied, that search would clear. Now we pass through the search parameters if they exist to maintain both search and filter query
- [x] Move clear search link and change it into a button
<img width="822" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/db775467-c269-49a3-b861-9565856765d1">

- [x] Update search/filter caption content
- [x] Move download links to the next line if search or filter is applied
<img width="834" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/5b9f8f2e-4256-4bb0-9548-2e321909bd84">

