### PR TITLE
CLCD-2836 Use available from date for absorbing organisations validations

### DIFF
--- a/app/models/validations/sales/setup_validations.rb
+++ b/app/models/validations/sales/setup_validations.rb
@@ -37,7 +37,7 @@ module Validations::Sales::SetupValidations
     if absorbing_owning_organisation_inactive?(record)
       record.errors.add :saledate, I18n.t("validations.setup.saledate.invalid_absorbing_organisations_saledate",
                                           owning_organisation: record.owning_organisation.name,
-                                          owning_organisation_available_from: record.owning_organisation.created_at.to_formatted_s(:govuk_date))
+                                          owning_organisation_available_from: record.owning_organisation.available_from.to_formatted_s(:govuk_date))
     end
   end
 
@@ -50,10 +50,10 @@ module Validations::Sales::SetupValidations
                                                           owning_organisation: record.owning_organisation.name,
                                                           owning_organisation_merge_date: record.owning_organisation.merge_date.to_formatted_s(:govuk_date),
                                                           owning_absorbing_organisation: record.owning_organisation.absorbing_organisation.name)
-      elsif record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.created_at.to_date > record.saledate.to_date
+      elsif record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.available_from.present? && record.owning_organisation.available_from.to_date > record.saledate.to_date
         record.errors.add :owning_organisation_id, I18n.t("validations.setup.owning_organisation.inactive_absorbing_organisation_sales",
                                                           owning_organisation: record.owning_organisation.name,
-                                                          owning_organisation_available_from: record.owning_organisation.created_at.to_formatted_s(:govuk_date))
+                                                          owning_organisation_available_from: record.owning_organisation.available_from.to_formatted_s(:govuk_date))
       end
     end
   end
@@ -104,6 +104,6 @@ private
   end
 
   def absorbing_owning_organisation_inactive?(record)
-    record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.created_at.to_date > record.saledate.to_date
+    record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.available_from.present? && record.owning_organisation.available_from.to_date > record.saledate.to_date
   end
 end

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -61,10 +61,10 @@ module Validations::SetupValidations
                                                           owning_organisation: record.owning_organisation.name,
                                                           owning_organisation_merge_date: record.owning_organisation.merge_date.to_formatted_s(:govuk_date),
                                                           owning_absorbing_organisation: record.owning_organisation.absorbing_organisation.name)
-      elsif owning_organisation&.absorbed_organisations.present? && owning_organisation.created_at.to_date > record.startdate.to_date
+      elsif owning_organisation&.absorbed_organisations.present? && owning_organisation.available_from.present? && owning_organisation.available_from.to_date > record.startdate.to_date
         record.errors.add :owning_organisation_id, I18n.t("validations.setup.owning_organisation.inactive_absorbing_organisation",
                                                           owning_organisation: record.owning_organisation.name,
-                                                          owning_organisation_available_from: record.owning_organisation.created_at.to_formatted_s(:govuk_date))
+                                                          owning_organisation_available_from: record.owning_organisation.available_from.to_formatted_s(:govuk_date))
       end
     end
 
@@ -74,10 +74,10 @@ module Validations::SetupValidations
                                                             managing_organisation: record.managing_organisation.name,
                                                             managing_organisation_merge_date: record.managing_organisation.merge_date.to_formatted_s(:govuk_date),
                                                             managing_absorbing_organisation: record.managing_organisation.absorbing_organisation.name)
-      elsif managing_organisation&.absorbed_organisations.present? && managing_organisation.created_at.to_date > record.startdate.to_date
+      elsif managing_organisation&.absorbed_organisations.present? && managing_organisation.available_from.present? && managing_organisation.available_from.to_date > record.startdate.to_date
         record.errors.add :managing_organisation_id, I18n.t("validations.setup.managing_organisation.inactive_absorbing_organisation",
                                                             managing_organisation: record.managing_organisation.name,
-                                                            managing_organisation_available_from: record.managing_organisation.created_at.to_formatted_s(:govuk_date))
+                                                            managing_organisation_available_from: record.managing_organisation.available_from.to_formatted_s(:govuk_date))
       end
     end
   end
@@ -221,11 +221,11 @@ private
   end
 
   def absorbing_owning_organisation_inactive?(record)
-    record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.created_at.to_date > record.startdate.to_date
+    record.owning_organisation&.absorbed_organisations.present? && record.owning_organisation.available_from.present? && record.owning_organisation.available_from.to_date > record.startdate.to_date
   end
 
   def absorbing_managing_organisation_inactive?(record)
-    record.managing_organisation&.absorbed_organisations.present? && record.managing_organisation.created_at.to_date > record.startdate.to_date
+    record.managing_organisation&.absorbed_organisations.present? && record.managing_organisation.available_from.present? && record.managing_organisation.available_from.to_date > record.startdate.to_date
   end
 
   def organisations_belong_to_same_merge?(organisation_a, organisation_b)

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -194,20 +194,20 @@ private
     if absorbing_owning_organisation_inactive?(record) && absorbing_managing_organisation_inactive?(record)
       record.errors.add :startdate, I18n.t("validations.setup.startdate.invalid_absorbing_organisations_start_date.different_organisations",
                                            owning_organisation: record.owning_organisation.name,
-                                           owning_organisation_active_from: record.owning_organisation.created_at.to_formatted_s(:govuk_date),
+                                           owning_organisation_active_from: record.owning_organisation.available_from.to_formatted_s(:govuk_date),
                                            managing_organisation: record.managing_organisation.name,
-                                           managing_organisation_active_from: record.managing_organisation.created_at.to_formatted_s(:govuk_date))
+                                           managing_organisation_active_from: record.managing_organisation.available_from.to_formatted_s(:govuk_date))
     else
       if absorbing_owning_organisation_inactive?(record)
         record.errors.add :startdate, I18n.t("validations.setup.startdate.invalid_absorbing_organisations_start_date.owning_organisation",
                                              owning_organisation: record.owning_organisation.name,
-                                             owning_organisation_available_from: record.owning_organisation.created_at.to_formatted_s(:govuk_date))
+                                             owning_organisation_available_from: record.owning_organisation.available_from.to_formatted_s(:govuk_date))
       end
 
       if absorbing_managing_organisation_inactive?(record)
         record.errors.add :startdate, I18n.t("validations.setup.startdate.invalid_absorbing_organisations_start_date.managing_organisation",
                                              managing_organisation: record.managing_organisation.name,
-                                             managing_organisation_available_from: record.managing_organisation.created_at.to_formatted_s(:govuk_date))
+                                             managing_organisation_available_from: record.managing_organisation.available_from.to_formatted_s(:govuk_date))
       end
     end
   end

--- a/db/migrate/20231023142854_add_available_from_to_org.rb
+++ b/db/migrate/20231023142854_add_available_from_to_org.rb
@@ -1,0 +1,5 @@
+class AddAvailableFromToOrg < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :available_from, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_093443) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_142854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -440,6 +440,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_093443) do
     t.string "old_visible_id"
     t.datetime "merge_date"
     t.bigint "absorbing_organisation_id"
+    t.datetime "available_from"
     t.index ["absorbing_organisation_id"], name: "index_organisations_on_absorbing_organisation_id"
     t.index ["old_visible_id"], name: "index_organisations_on_old_visible_id", unique: true
   end

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -147,14 +147,14 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning organisation is no longer active" do
-        it "does not allow startate after organisation has been merged" do
+        it "does not allow startdate after organisation has been merged" do
           record.startdate = Time.zone.local(2023, 3, 1)
           record.owning_organisation_id = merged_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning organisation was active. Merged org became inactive on 2 February 2023 and was replaced by Absorbing org.")
         end
 
-        it "allows startate before organisation has been merged" do
+        it "allows startdate before organisation has been merged" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = merged_organisation.id
           setup_validator.validate_startdate_setup(record)
@@ -163,21 +163,21 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has become available" do
+        it "does not allow startdate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has become available" do
+        it "allows startdate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           record.startdate = Time.zone.local(2023, 1, 1)
           absorbing_organisation.update!(available_from: nil)
           record.owning_organisation_id = absorbing_organisation.id
@@ -187,14 +187,14 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and managing organisation is no longer active during the startdate" do
-        it "does not allow startate after organisation has been merged" do
+        it "does not allow startdate after organisation has been merged" do
           record.startdate = Time.zone.local(2023, 3, 1)
           record.managing_organisation_id = merged_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the managing organisation was active. Merged org became inactive on 2 February 2023 and was replaced by Absorbing org.")
         end
 
-        it "allows startate before organisation has been merged" do
+        it "allows startdate before organisation has been merged" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = merged_organisation.id
           setup_validator.validate_startdate_setup(record)
@@ -203,21 +203,21 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and managing organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has become available'" do
+        it "does not allow startdate before absorbing organisation has become available'" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the managing organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has become available" do
+        it "allows startdate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           record.startdate = Time.zone.local(2023, 1, 1)
           absorbing_organisation.update!(available_from: nil)
           record.managing_organisation_id = absorbing_organisation.id
@@ -227,7 +227,7 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning and managing organisation is no longer active during the startdate" do
-        it "does not allow startate after organisation has been merged" do
+        it "does not allow startdate after organisation has been merged" do
           record.startdate = Time.zone.local(2023, 3, 1)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation.id
@@ -235,7 +235,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisation was active. Merged org became inactive on 2 February 2023 and was replaced by Absorbing org.")
         end
 
-        it "allows startate before organisation has been merged" do
+        it "allows startdate before organisation has been merged" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation.id
@@ -245,7 +245,7 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning and managing organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has become available" do
+        it "does not allow startdate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
@@ -253,7 +253,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has become available" do
+        it "allows startdate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
@@ -261,7 +261,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           record.startdate = Time.zone.local(2023, 1, 1)
           absorbing_organisation.update!(available_from: nil)
           record.managing_organisation_id = absorbing_organisation.id
@@ -272,7 +272,7 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning and managing organisations are no longer active during the startdate" do
-        it "does not allow startate after organisation have been merged" do
+        it "does not allow startdate after organisation have been merged" do
           record.startdate = Time.zone.local(2023, 2, 2)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation_2.id
@@ -280,7 +280,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisations were active. Merged org 2 and Merged org became inactive on 2 February 2023 and were replaced by Absorbing org.")
         end
 
-        it "allows startate before organisations have been merged" do
+        it "allows startdate before organisations have been merged" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation_2.id
@@ -294,7 +294,7 @@ RSpec.describe Validations::SetupValidations do
           merged_organisation_2.update!(absorbing_organisation: absorbing_organisation_2, merge_date: Time.zone.local(2023, 2, 2))
         end
 
-        it "does not allow startate after organisations have been merged" do
+        it "does not allow startdate after organisations have been merged" do
           record.startdate = Time.zone.local(2023, 3, 1)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation_2.id
@@ -302,7 +302,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisations were active. Merged org 2 became inactive on 2 February 2023 and was replaced by Absorbing org 2. Merged org became inactive on 2 February 2023 and was replaced by Absorbing org.")
         end
 
-        it "allows startate before organisations have been merged" do
+        it "allows startdate before organisations have been merged" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = merged_organisation.id
           record.owning_organisation_id = merged_organisation_2.id
@@ -316,7 +316,7 @@ RSpec.describe Validations::SetupValidations do
           merged_organisation_2.update!(absorbing_organisation: absorbing_organisation_2, merge_date: Time.zone.local(2023, 2, 2))
         end
 
-        it "does not allow startate before absorbing organisation has become available" do
+        it "does not allow startdate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation_2.id
@@ -324,7 +324,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisations were active. Absorbing org 2 became active on 1 February 2023, and Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has become available" do
+        it "allows startdate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
@@ -332,7 +332,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           absorbing_organisation.update!(available_from: nil)
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
@@ -798,7 +798,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["owning_organisation_id"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           absorbing_organisation.update!(available_from: nil)
           record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = absorbing_organisation.id
@@ -838,7 +838,7 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["managing_organisation_id"]).to be_empty
         end
 
-        it "allows startate if organisation does not have available from date" do
+        it "allows startdate if organisation does not have available from date" do
           absorbing_organisation.update!(available_from: nil)
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe Validations::SetupValidations do
         Timecop.return
       end
 
-      let(:absorbing_organisation) { create(:organisation, created_at: Time.zone.local(2023, 2, 1, 4, 5, 6), name: "Absorbing org") }
-      let(:absorbing_organisation_2) { create(:organisation, created_at: Time.zone.local(2023, 2, 1), name: "Absorbing org 2") }
+      let(:absorbing_organisation) { create(:organisation, created_at: Time.zone.local(2023, 2, 1, 4, 5, 6), available_from: Time.zone.local(2023, 2, 1, 4, 5, 6), name: "Absorbing org") }
+      let(:absorbing_organisation_2) { create(:organisation, created_at: Time.zone.local(2023, 2, 1), available_from: Time.zone.local(2023, 2, 1), name: "Absorbing org 2") }
       let(:merged_organisation) { create(:organisation, name: "Merged org") }
       let(:merged_organisation_2) { create(:organisation, name: "Merged org 2") }
 
@@ -163,15 +163,23 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has been created" do
+        it "does not allow startate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has been created" do
+        it "allows startate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
+          record.owning_organisation_id = absorbing_organisation.id
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          record.startdate = Time.zone.local(2023, 1, 1)
+          absorbing_organisation.update!(available_from: nil)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to be_empty
@@ -195,15 +203,23 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and managing organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has been created" do
+        it "does not allow startate before absorbing organisation has become available'" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to include(match "Enter a date when the managing organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has been created" do
+        it "allows startate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
+          record.managing_organisation_id = absorbing_organisation.id
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          record.startdate = Time.zone.local(2023, 1, 1)
+          absorbing_organisation.update!(available_from: nil)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
           expect(record.errors["startdate"]).to be_empty
@@ -229,7 +245,7 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning and managing organisation is not yet active during the startdate" do
-        it "does not allow startate before absorbing organisation has been created" do
+        it "does not allow startate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
@@ -237,8 +253,17 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisation was active. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has been created" do
+        it "allows startate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 1)
+          record.managing_organisation_id = absorbing_organisation.id
+          record.owning_organisation_id = absorbing_organisation.id
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          record.startdate = Time.zone.local(2023, 1, 1)
+          absorbing_organisation.update!(available_from: nil)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
@@ -291,7 +316,7 @@ RSpec.describe Validations::SetupValidations do
           merged_organisation_2.update!(absorbing_organisation: absorbing_organisation_2, merge_date: Time.zone.local(2023, 2, 2))
         end
 
-        it "does not allow startate before absorbing organisation has been created" do
+        it "does not allow startate before absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation_2.id
@@ -299,8 +324,17 @@ RSpec.describe Validations::SetupValidations do
           expect(record.errors["startdate"]).to include(match "Enter a date when the owning and managing organisations were active. Absorbing org 2 became active on 1 February 2023, and Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows startate after absorbing organisation has been created" do
+        it "allows startate after absorbing organisation has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
+          record.managing_organisation_id = absorbing_organisation.id
+          record.owning_organisation_id = absorbing_organisation.id
+          setup_validator.validate_startdate_setup(record)
+          expect(record.errors["startdate"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          absorbing_organisation.update!(available_from: nil)
+          record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_startdate_setup(record)
@@ -723,7 +757,7 @@ RSpec.describe Validations::SetupValidations do
     end
 
     context "when organisations are merged" do
-      let(:absorbing_organisation) { create(:organisation, created_at: Time.zone.local(2023, 2, 1, 4, 5, 6), name: "Absorbing org") }
+      let(:absorbing_organisation) { create(:organisation, created_at: Time.zone.local(2023, 2, 1, 4, 5, 6), available_from: Time.zone.local(2023, 2, 1, 4, 5, 6), name: "Absorbing org") }
       let(:merged_organisation) { create(:organisation, name: "Merged org") }
 
       around do |example|
@@ -750,15 +784,23 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "and owning organisation is not yet active during the startdate" do
-        it "does not allow absorbing organisation before it had been created" do
+        it "does not allow absorbing organisation before it has become available'" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_organisation(record)
           expect(record.errors["owning_organisation_id"]).to include(match "The owning organisation must be active on the tenancy start date. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows absorbing organisation after it has been created" do
+        it "allows absorbing organisation after it has become available" do
           record.startdate = Time.zone.local(2023, 2, 2)
+          record.owning_organisation_id = absorbing_organisation.id
+          setup_validator.validate_organisation(record)
+          expect(record.errors["owning_organisation_id"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          absorbing_organisation.update!(available_from: nil)
+          record.startdate = Time.zone.local(2023, 1, 1)
           record.owning_organisation_id = absorbing_organisation.id
           setup_validator.validate_organisation(record)
           expect(record.errors["owning_organisation_id"]).to be_empty
@@ -782,15 +824,23 @@ RSpec.describe Validations::SetupValidations do
       end
 
       context "when managing organisation is not yet active during the startdate" do
-        it "does not allow absorbing organisation before it had been created" do
+        it "does not allow absorbing organisation before it has become available" do
           record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_organisation(record)
           expect(record.errors["managing_organisation_id"]).to include(match "The managing organisation must be active on the tenancy start date. Absorbing org became active on 1 February 2023.")
         end
 
-        it "allows absorbing organisation after it has been created" do
+        it "allows absorbing organisation after it has become available'" do
           record.startdate = Time.zone.local(2023, 2, 2)
+          record.managing_organisation_id = absorbing_organisation.id
+          setup_validator.validate_organisation(record)
+          expect(record.errors["managing_organisation_id"]).to be_empty
+        end
+
+        it "allows startate if organisation does not have available from date" do
+          absorbing_organisation.update!(available_from: nil)
+          record.startdate = Time.zone.local(2023, 1, 1)
           record.managing_organisation_id = absorbing_organisation.id
           setup_validator.validate_organisation(record)
           expect(record.errors["managing_organisation_id"]).to be_empty


### PR DESCRIPTION
If an organisation has absorbed other organisations we run some validations on the start date for logs.
Up until now we only expected the merges to form a new organisation, so logs could be created for any merged organisations before the merge date and only for the new organisation after the creation of the new (absorbing) organisation date (which we intended to be the same as merge date).

These validations would also work if a set of organisations merged into an existing organisation if the created_at date for that organisation represented the date from which the organisation was available. Currently that's not the case and created_at date represents the date the organisation has been created on our system.

This PR adds available_from date to organisation which will used for validations on start date for absorbing organisation logs. We will not run date validations for an absorbing organisation unless this date is provided