### PR TITLE
CLDC-2895 Add safe navigation operator to entity name updates

### DIFF
--- a/lib/tasks/squish_names.rake
+++ b/lib/tasks/squish_names.rake
@@ -1,19 +1,19 @@
 desc "Squish names of locations, schemes, users, and organisations"
 task squish_names: :environment do
   Location.find_each do |location|
-    location.name.squish!
+    location.name&.squish!
     location.save!
   end
   Scheme.find_each do |scheme|
-    scheme.service_name.squish!
+    scheme.service_name&.squish!
     scheme.save!
   end
   User.find_each do |user|
-    user.name.squish!
+    user.name&.squish!
     user.save!
   end
   Organisation.find_each do |organisation|
-    organisation.name.squish!
+    organisation.name&.squish!
     organisation.save!
   end
 end


### PR DESCRIPTION
The rake task failed on staging because names can be nil if that question hasn't been answered yet.