### PR TITLE
CLDC- 2268 Validate using correct deactivation periods

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -131,8 +131,8 @@ class Location < ApplicationRecord
     location_deactivation_periods.deactivations_without_reactivation.first
   end
 
-  def recent_deactivation
-    location_deactivation_periods.order("created_at").last
+  def last_deactivation_before(date)
+    location_deactivation_periods.where("deactivation_date <= ?", date).order("created_at").last
   end
 
   def status
@@ -143,7 +143,7 @@ class Location < ApplicationRecord
     return :incomplete unless confirmed
     return :deactivated if open_deactivation&.deactivation_date.present? && date >= open_deactivation.deactivation_date
     return :deactivating_soon if open_deactivation&.deactivation_date.present? && date < open_deactivation.deactivation_date
-    return :reactivating_soon if recent_deactivation&.reactivation_date.present? && date < recent_deactivation.reactivation_date
+    return :reactivating_soon if last_deactivation_before(date)&.reactivation_date.present? && date < last_deactivation_before(date).reactivation_date
     return :activating_soon if startdate.present? && date < startdate
 
     :active

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -267,8 +267,8 @@ class Scheme < ApplicationRecord
     scheme_deactivation_periods.deactivations_without_reactivation.first
   end
 
-  def recent_deactivation
-    scheme_deactivation_periods.order("created_at").last
+  def last_deactivation_before(date)
+    scheme_deactivation_periods.where("deactivation_date <= ?", date).order("created_at").last
   end
 
   def status
@@ -279,7 +279,7 @@ class Scheme < ApplicationRecord
     return :incomplete unless confirmed && locations.confirmed.any?
     return :deactivated if open_deactivation&.deactivation_date.present? && date >= open_deactivation.deactivation_date
     return :deactivating_soon if open_deactivation&.deactivation_date.present? && date < open_deactivation.deactivation_date
-    return :reactivating_soon if recent_deactivation&.reactivation_date.present? && date < recent_deactivation.reactivation_date
+    return :reactivating_soon if last_deactivation_before(date)&.reactivation_date.present? && date < last_deactivation_before(date).reactivation_date
 
     :active
   end

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -90,7 +90,7 @@ module Validations::SharedValidations
     status = resource.status_at(date)
     return unless %i[reactivating_soon activating_soon deactivated].include?(status)
 
-    closest_reactivation = resource.recent_deactivation
+    closest_reactivation = resource.last_deactivation_before(date)
     open_deactivation = resource.open_deactivation
 
     date = case status

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -930,6 +930,29 @@ RSpec.describe Location, type: :model do
     end
   end
 
+  describe "status_at" do
+    let(:location) { FactoryBot.build(:location, startdate: Time.zone.local(2022, 4, 1)) }
+
+    before do
+      Timecop.freeze(2022, 6, 7)
+    end
+
+    after do
+      Timecop.unfreeze
+    end
+
+    context "when there have been previous deactivations" do
+      before do
+        FactoryBot.create(:location_deactivation_period, deactivation_date: Time.zone.local(2022, 5, 4), reactivation_date: Time.zone.local(2022, 6, 5), location:)
+        location.save!
+      end
+
+      it "returns active if the location has no relevant deactivation records" do
+        expect(location.status_at(Time.zone.local(2022, 4, 4))).to eq(:active)
+      end
+    end
+  end
+
   describe "filter by status" do
     let!(:incomplete_location) { FactoryBot.create(:location, :incomplete, startdate: Time.zone.local(2022, 4, 1)) }
     let!(:incomplete_location_with_nil_confirmed) { FactoryBot.create(:location, :incomplete, startdate: Time.zone.local(2022, 4, 1), confirmed: nil) }

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -290,6 +290,29 @@ RSpec.describe Scheme, type: :model do
     end
   end
 
+  describe "status_at" do
+    let(:scheme) { FactoryBot.build(:scheme) }
+
+    before do
+      FactoryBot.create(:location, scheme:)
+      Timecop.freeze(2022, 6, 7)
+    end
+
+    after do
+      Timecop.unfreeze
+    end
+
+    context "when there have been previous deactivations" do
+      before do
+        FactoryBot.create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2022, 6, 4), reactivation_date: Time.zone.local(2022, 6, 5), scheme:)
+      end
+
+      it "returns active if the scheme has no relevant deactivation records" do
+        expect(scheme.status_at(Time.zone.local(2022, 5, 5))).to eq(:active)
+      end
+    end
+  end
+
   describe "available_from" do
     context "when the scheme was created at the start of the 2022/23 collection window" do
       let(:scheme) { FactoryBot.build(:scheme, created_at: Time.zone.local(2022, 4, 6)) }


### PR DESCRIPTION
We validate whether the scheme/location is active during the tenancy startdate using status_at(date) method.
This method has sometimes been incorrectly returning reactivating_soon status instead of active, therefore preventing some schemes/locations from being selected.
This would happen because we always looked at the most recent deactivation to determine reactivating_soon status, but depending on the status, the most recent deactivation might not have been relevant.

For example, if the tenancy startdate is 18th November 2022 and the last deactivation that has been reactivated happened 20th November 2022 - 22nd August 2023, we would look at this deactivation, see that the scheme/location reactivates in August 2023 and mark it as reactivating_soon.

Now we only look at deactivations that happened before the given date and find the most recent one of those to determine reactivating soon status.