### PR TITLE
CLDC-2832 Merge testing prep

### DIFF
--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -68,7 +68,7 @@ private
     merging_organisation.owned_schemes.each do |scheme|
       next if scheme.deactivated?
 
-      new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id").merge(owning_organisation: @absorbing_organisation))
+      new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id", "old_id").merge(owning_organisation: @absorbing_organisation))
       scheme.locations.each do |location|
         new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id", "old_id")) unless location.deactivated?
       end

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -70,7 +70,7 @@ private
 
       new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id").merge(owning_organisation: @absorbing_organisation))
       scheme.locations.each do |location|
-        new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id")) unless location.deactivated?
+        new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id", "old_id")) unless location.deactivated?
       end
       @merged_schemes[merging_organisation.name] << { name: new_scheme.service_name, code: new_scheme.id }
       SchemeDeactivationPeriod.create!(scheme:, deactivation_date: @merge_date)

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Merge::MergeOrganisationsService do
       end
 
       context "and merging organisation schemes and locations" do
-        let!(:scheme) { create(:scheme, owning_organisation: merging_organisation) }
-        let!(:location) { create(:location, scheme:) }
+        let!(:scheme) { create(:scheme, owning_organisation: merging_organisation, old_id: "scheme_old_id", old_visible_id: "scheme_old_visible_id") }
+        let!(:location) { create(:location, scheme:, old_id: "location_old_id", old_visible_id: "location_old_visible_id") }
         let!(:deactivated_location) { create(:location, scheme:) }
         let!(:deactivated_scheme) { create(:scheme, owning_organisation: merging_organisation) }
         let!(:owned_lettings_log) { create(:lettings_log, :sh, scheme:, location:, startdate: Time.zone.tomorrow, owning_organisation: merging_organisation) }
@@ -160,8 +160,12 @@ RSpec.describe Merge::MergeOrganisationsService do
           absorbing_organisation.reload
           expect(absorbing_organisation.owned_schemes.count).to eq(1)
           expect(absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
+          expect(absorbing_organisation.owned_schemes.first.old_id).to be_nil
+          expect(absorbing_organisation.owned_schemes.first.old_visible_id).to eq(scheme.old_visible_id)
           expect(absorbing_organisation.owned_schemes.first.locations.count).to eq(2)
           expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
+          expect(absorbing_organisation.owned_schemes.first.locations.first.old_id).to be_nil
+          expect(absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to eq(location.old_visible_id)
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
         end


### PR DESCRIPTION
Fix to the merge orgs task so I can get everything set up in advance of the mobbing session.

New behaviour:

Don't copy across `old_id` to new schemes and locations in absorbing orgs after a merge as `old_id` for locations (and schemes after a pending tech debt ticket) must be unique. We now just leave the `old_id` on the pre-merge absorbed org scheme.

I've left `old_visible_id` in the post-merge objects as this is used in bulk uploads, and users may use it to refer to a location/scheme that has since been merged.