### PR TITLE
CLDC-2864: Allow PaaS-only deployments

### DIFF
--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -1,4 +1,4 @@
-name: Staging CI/CD Pipeline
+name: PaaS-only Production CI/CD Pipeline
 
 on:
   workflow_dispatch:

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -259,15 +259,3 @@ jobs:
           cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE $CSV_DOWNLOAD_PAAS_INSTANCE
           cf set-env $APP_NAME SENTRY_DSN $SENTRY_DSN
           cf push $APP_NAME --strategy rolling
-
-  aws_deploy:
-    name: AWS Deploy
-    needs: [lint, test, feature_test, audit]
-    uses: ./.github/workflows/aws_deploy.yml
-    with:
-      aws_account_id: 977287343304
-      aws_resource_prefix: core-prod
-      environment: production
-      release_tag: ${{ needs.test.outputs.releasetag }}
-    permissions:
-      id-token: write

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -174,7 +174,6 @@ jobs:
     concurrency: staging
     runs-on: ubuntu-latest
     environment: staging
-    if: github.ref == 'refs/heads/main'
     needs: [lint, test, feature_test, audit]
 
     steps:

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -1,0 +1,273 @@
+name: Production CI/CD Pipeline
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+env:
+  REPO_URL: communitiesuk/submit-social-housing-lettings-and-sales-data
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    outputs:
+      releasetag: ${{ steps.latestrelease.outputs.releasetag }}
+
+    services:
+      postgres:
+        image: postgres:13.5
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: data_collector
+        ports:
+          - 5432:5432
+        # Needed because the Postgres container does not provide a health check
+        # tmpfs makes database faster by using RAM
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      GEMFILE_RUBY_VERSION: 3.1.1
+      DB_HOST: localhost
+      DB_DATABASE: data_collector
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      PARALLEL_TEST_PROCESSORS: 4
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "releasetag=$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Create database
+        run: |
+          bundle exec rake parallel:setup
+
+      - name: Compile Assets
+        run: |
+          bundle exec rake assets:precompile
+
+      - name: Run tests
+        run: |
+          bundle exec rake parallel:spec['spec\/(?!features)']
+
+  feature_test:
+    name: Feature Tests
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13.5
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: data_collector
+        ports:
+          - 5432:5432
+        # Needed because the Postgres container does not provide a health check
+        # tmpfs makes database faster by using RAM
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      GEMFILE_RUBY_VERSION: 3.1.1
+      DB_HOST: localhost
+      DB_DATABASE: data_collector
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Create database
+        run: |
+          bundle exec rake db:prepare
+
+      - name: Compile assets
+        run: |
+          bundle exec rake assets:precompile
+
+      - name: Run tests
+        run: |
+          bundle exec rspec spec/features --fail-fast
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Rubocop
+        run: |
+          bundle exec rubocop
+
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Audit
+        run: |
+          bundle exec bundler-audit
+
+  deploy:
+    name: Deploy
+    concurrency: "production"
+    runs-on: ubuntu-latest
+    environment: "production"
+    needs: [lint, test, feature_test, audit]
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Install Cloud Foundry CLI
+        run: |
+          wget --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15" -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf8-cli
+
+      - name: Deploy
+        env:
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_API_ENDPOINT: ${{ secrets.CF_API_ENDPOINT }}
+          CF_SPACE: ${{ secrets.CF_SPACE }}
+          CF_ORG: ${{ secrets.CF_ORG }}
+          APP_NAME: dluhc-core-production
+          GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
+          APP_HOST: ${{ secrets.APP_HOST }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          OS_DATA_KEY: ${{ secrets.OS_DATA_KEY }}
+          IMPORT_PAAS_INSTANCE: ${{ secrets.IMPORT_PAAS_INSTANCE }}
+          EXPORT_PAAS_INSTANCE: ${{ secrets.EXPORT_PAAS_INSTANCE }}
+          S3_CONFIG: ${{ secrets.S3_CONFIG }}
+          CSV_DOWNLOAD_PAAS_INSTANCE: ${{ secrets.CSV_DOWNLOAD_PAAS_INSTANCE }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          cf api $CF_API_ENDPOINT
+          cf auth
+          cf target -o $CF_ORG -s $CF_SPACE
+          cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
+          cf set-env $APP_NAME APP_HOST $APP_HOST
+          cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
+          cf set-env $APP_NAME OS_DATA_KEY $OS_DATA_KEY
+          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE $IMPORT_PAAS_INSTANCE
+          cf set-env $APP_NAME EXPORT_PAAS_INSTANCE $EXPORT_PAAS_INSTANCE
+          cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
+          cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE $CSV_DOWNLOAD_PAAS_INSTANCE
+          cf set-env $APP_NAME SENTRY_DSN $SENTRY_DSN
+          cf push $APP_NAME --strategy rolling
+
+  aws_deploy:
+    name: AWS Deploy
+    needs: [lint, test, feature_test, audit]
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws_account_id: 977287343304
+      aws_resource_prefix: core-prod
+      environment: production
+      release_tag: ${{ needs.test.outputs.releasetag }}
+    permissions:
+      id-token: write

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -194,8 +194,6 @@ jobs:
           CF_API_ENDPOINT: ${{ secrets.CF_API_ENDPOINT }}
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_ORG: ${{ secrets.CF_ORG }}
-          API_USER: ${{ secrets.API_USER }}
-          API_KEY: ${{ secrets.API_KEY }}
           APP_NAME: dluhc-core-production
           GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
           APP_HOST: ${{ secrets.APP_HOST }}
@@ -210,8 +208,6 @@ jobs:
           cf api $CF_API_ENDPOINT
           cf auth
           cf target -o $CF_ORG -s $CF_SPACE
-          cf set-env $APP_NAME API_USER $API_USER
-          cf set-env $APP_NAME API_KEY $API_KEY
           cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
           cf set-env $APP_NAME APP_HOST $APP_HOST
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -1,8 +1,8 @@
 name: Production CI/CD Pipeline
 
 on:
-  release:
-    types: [released]
+  # release:
+  #   types: [released]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -171,9 +171,9 @@ jobs:
 
   deploy:
     name: Deploy
-    concurrency: staging
+    concurrency: "production"
     runs-on: ubuntu-latest
-    environment: staging
+    environment: "production"
     needs: [lint, test, feature_test, audit]
 
     steps:
@@ -196,7 +196,7 @@ jobs:
           CF_ORG: ${{ secrets.CF_ORG }}
           API_USER: ${{ secrets.API_USER }}
           API_KEY: ${{ secrets.API_KEY }}
-          APP_NAME: dluhc-core-staging
+          APP_NAME: dluhc-core-production
           GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
           APP_HOST: ${{ secrets.APP_HOST }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -1,13 +1,6 @@
 name: Staging CI/CD Pipeline
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -217,4 +217,4 @@ jobs:
           cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
           cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE $CSV_DOWNLOAD_PAAS_INSTANCE
           cf set-env $APP_NAME SENTRY_DSN $SENTRY_DSN
-          cf push $APP_NAME --strategy rolling -t 180
+          cf push $APP_NAME --strategy rolling

--- a/.github/workflows/paas_only_production_pipeline.yml
+++ b/.github/workflows/paas_only_production_pipeline.yml
@@ -1,12 +1,14 @@
-name: Production CI/CD Pipeline
+name: Staging CI/CD Pipeline
 
 on:
-  # release:
-  #   types: [released]
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
   workflow_dispatch:
-
-env:
-  REPO_URL: communitiesuk/submit-social-housing-lettings-and-sales-data
 
 defaults:
   run:
@@ -14,10 +16,8 @@ defaults:
 
 jobs:
   test:
-    name: Test
+    name: Tests
     runs-on: ubuntu-latest
-    outputs:
-      releasetag: ${{ steps.latestrelease.outputs.releasetag }}
 
     services:
       postgres:
@@ -36,6 +36,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
     env:
       RAILS_ENV: test
       GEMFILE_RUBY_VERSION: 3.1.1
@@ -47,26 +48,15 @@ jobs:
       PARALLEL_TEST_PROCESSORS: 4
 
     steps:
-      - name: Get latest release with tag
-        id: latestrelease
-        run: |
-          echo "releasetag=$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
-
-      - name: Confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Checkout tag
+      - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Set up node
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           cache: yarn
@@ -76,7 +66,7 @@ jobs:
         run: |
           bundle exec rake parallel:setup
 
-      - name: Compile Assets
+      - name: Compile assets
         run: |
           bundle exec rake assets:precompile
 
@@ -86,7 +76,6 @@ jobs:
 
   feature_test:
     name: Feature Tests
-    if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
 
     services:
@@ -148,47 +137,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get latest release with tag
-        id: latestrelease
-        run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-
-      - name: Confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Checkout tag
+      - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Rubocop
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Install packages and symlink local dependencies
         run: |
-          bundle exec rubocop
+          yarn install --immutable --immutable-cache --check-cache
+
+      - name: Lint
+        run: |
+          bundle exec rake lint
 
   audit:
     name: Audit dependencies
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get latest release with tag
-        id: latestrelease
-        run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-
-      - name: Confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Checkout tag
+      - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -201,25 +178,15 @@ jobs:
 
   deploy:
     name: Deploy
-    concurrency: "production"
+    concurrency: staging
     runs-on: ubuntu-latest
-    environment: "production"
+    environment: staging
+    if: github.ref == 'refs/heads/main'
     needs: [lint, test, feature_test, audit]
 
     steps:
-      - name: Get latest release with tag
-        id: latestrelease
-        run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-
-      - name: Confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Checkout tag
+      - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Install Cloud Foundry CLI
         run: |
@@ -235,7 +202,9 @@ jobs:
           CF_API_ENDPOINT: ${{ secrets.CF_API_ENDPOINT }}
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_ORG: ${{ secrets.CF_ORG }}
-          APP_NAME: dluhc-core-production
+          API_USER: ${{ secrets.API_USER }}
+          API_KEY: ${{ secrets.API_KEY }}
+          APP_NAME: dluhc-core-staging
           GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
           APP_HOST: ${{ secrets.APP_HOST }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
@@ -249,6 +218,8 @@ jobs:
           cf api $CF_API_ENDPOINT
           cf auth
           cf target -o $CF_ORG -s $CF_SPACE
+          cf set-env $APP_NAME API_USER $API_USER
+          cf set-env $APP_NAME API_KEY $API_KEY
           cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
           cf set-env $APP_NAME APP_HOST $APP_HOST
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
@@ -258,4 +229,4 @@ jobs:
           cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
           cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE $CSV_DOWNLOAD_PAAS_INSTANCE
           cf set-env $APP_NAME SENTRY_DSN $SENTRY_DSN
-          cf push $APP_NAME --strategy rolling
+          cf push $APP_NAME --strategy rolling -t 180


### PR DESCRIPTION
Basically all I've done is duplicate the staging pipeline and tinker with it a bit. To be precise, here are the non-trivial changes that I've made:

- Only allowed the pipeline to be manually triggered
- Changed all 'staging' parameters/strings to 'production' 
- Stop enforcing that the deploy job can only happen on main
- Removed the `API_USER` and `API_KEY` env vars (to match prod)
- Removed the 180s timeout from the `cf push` command (to match prod)

Here's how I think the GitHub actions stuff should go on switchover day:

1. Disable the normal prod pipeline via the GitHub UI.
2. Create a new branch in which we turn on maintenance mode for the production environment.
3. Enable the PaaS-only pipeline via the GitHub UI. (Does it also need to be updated to only run on the new branch created? Or can we choose which branch to trigger it on via the UI?)
4. Trigger the PaaS-only pipeline via the GitHub UI. This will turn on maintenance mode for the PaaS production app.
5. Later on (I'm ignoring various non-GitHub actions steps here) we push a commit to the branch which updates some more feature flag logic to turn on redirect mode (i.e. instead of the 'service unavailable' page we will now show the 'redirect' page) for the production environment. This hasn't been built yet, but that doesn't matter for the sake of this plan.
6. Trigger the PaaS-only pipeline via the GitHub UI again. This will turn on redirect mode for the PaaS production app.
7. On another new branch, update the regular prod pipeline so that it only deploys to the AWS infra (and then merge it to main via a PR). Then re-enable it via the GitHub UI.