### PR TITLE
CLDC-2636 Fix enter address instead bug

### DIFF
--- a/app/models/form/lettings/pages/address.rb
+++ b/app/models/form/lettings/pages/address.rb
@@ -16,9 +16,9 @@ class Form::Lettings::Pages::Address < ::Form::Page
   end
 
   def routed_to?(log, _current_user = nil)
-    return false if log.uprn_known.nil?
+    return true if log.uprn_known.nil?
     return false if log.is_supported_housing?
 
-    log.uprn_confirmed != 1 || log.uprn_known.zero?
+    log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end
 end

--- a/app/models/form/lettings/pages/address.rb
+++ b/app/models/form/lettings/pages/address.rb
@@ -16,9 +16,8 @@ class Form::Lettings::Pages::Address < ::Form::Page
   end
 
   def routed_to?(log, _current_user = nil)
-    return true if log.uprn_known.nil?
     return false if log.is_supported_housing?
 
-    log.uprn_known.zero? || log.uprn_confirmed&.zero?
+    log.uprn_known.nil? || log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end
 end

--- a/app/models/form/sales/pages/address.rb
+++ b/app/models/form/sales/pages/address.rb
@@ -16,8 +16,6 @@ class Form::Sales::Pages::Address < ::Form::Page
   end
 
   def routed_to?(log, _current_user = nil)
-    return true if log.uprn_known.nil?
-
-    log.uprn_known.zero? || log.uprn_confirmed&.zero?
+    log.uprn_known.nil? || log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end
 end

--- a/app/models/form/sales/pages/address.rb
+++ b/app/models/form/sales/pages/address.rb
@@ -16,7 +16,7 @@ class Form::Sales::Pages::Address < ::Form::Page
   end
 
   def routed_to?(log, _current_user = nil)
-    return false if log.uprn_known.nil?
+    return true if log.uprn_known.nil?
 
     log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end

--- a/app/models/form/sales/pages/uprn.rb
+++ b/app/models/form/sales/pages/uprn.rb
@@ -11,7 +11,7 @@ class Form::Sales::Pages::Uprn < ::Form::Page
     ]
   end
 
-  def routed_to?(log, _current_user)
+  def routed_to?(_log, _current_user)
     true
   end
 

--- a/app/models/form/sales/pages/uprn.rb
+++ b/app/models/form/sales/pages/uprn.rb
@@ -11,6 +11,10 @@ class Form::Sales::Pages::Uprn < ::Form::Page
     ]
   end
 
+  def routed_to?(log, _current_user)
+    true
+  end
+
   def skip_text
     "Enter address instead"
   end

--- a/spec/factories/lettings_log.rb
+++ b/spec/factories/lettings_log.rb
@@ -3,7 +3,10 @@ FactoryBot.define do
     created_by { FactoryBot.create(:user) }
     owning_organisation { created_by.organisation }
     managing_organisation { created_by.organisation }
+    created_at { Time.zone.today }
+    updated_at { Time.zone.today }
     trait :setup_completed do
+      startdate_today
       renewal { 0 }
       needstype { 1 }
       rent_type { 1 }
@@ -206,7 +209,5 @@ FactoryBot.define do
       illness_type_9 { false }
       illness_type_10 { false }
     end
-    created_at { Time.zone.today }
-    updated_at { Time.zone.today }
   end
 end

--- a/spec/models/form/lettings/pages/address_spec.rb
+++ b/spec/models/form/lettings/pages/address_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Lettings::Pages::Address, type: :model do
 
     context "when uprn_confirmed != 1" do
       let(:log) do
-        create(:lettings_log, uprn_known: 1, uprn_confirmed: 0)
+        create(:lettings_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 0)
       end
 
       it "returns true" do
@@ -62,10 +62,10 @@ RSpec.describe Form::Lettings::Pages::Address, type: :model do
 
     context "when uprn_confirmed == 1 && uprn_known != 0" do
       let(:log) do
-        create(:lettings_log, uprn_known: 1, uprn_confirmed: 1, uprn: "123456789")
+        create(:lettings_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1)
       end
 
-      it "returns true" do
+      it "returns false" do
         expect(page.routed_to?(log)).to eq(false)
       end
     end

--- a/spec/models/form/lettings/pages/address_spec.rb
+++ b/spec/models/form/lettings/pages/address_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Form::Lettings::Pages::Address, type: :model do
     context "when uprn_known == nil" do
       let(:log) { create(:lettings_log, uprn_known: nil) }
 
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
+      it "returns true" do
+        expect(page.routed_to?(log)).to eq(true)
       end
     end
 

--- a/spec/models/form/sales/pages/address_spec.rb
+++ b/spec/models/form/sales/pages/address_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Form::Sales::Pages::Address, type: :model do
         create(:sales_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1)
       end
 
-      it "returns true" do
+      it "returns false" do
         expect(page.routed_to?(log)).to eq(false)
       end
     end

--- a/spec/models/form/sales/pages/address_spec.rb
+++ b/spec/models/form/sales/pages/address_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Form::Sales::Pages::Address, type: :model do
     context "when uprn_known == nil" do
       let(:log) { create(:sales_log, uprn_known: nil) }
 
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
+      it "returns true" do
+        expect(page.routed_to?(log)).to eq(true)
       end
     end
 


### PR DESCRIPTION
The link on the "enter address instead" button was correct, but we weren't routing the address page if the `uprn_known` hadn't been answered, which was causing it to redirect to the log tasklist. This PR fixes this routing.

ticket: https://dluhcdigital.atlassian.net/browse/CLDC-2636