### PR TITLE
CLDC-2608: Add documentation for the app API

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,6 +1,6 @@
 ---
 has_children: true
-nav_order: 9
+nav_order: 10
 ---
 
 # Architecture decisions

--- a/docs/app_api.md
+++ b/docs/app_api.md
@@ -1,0 +1,15 @@
+---
+nav_order: 8
+---
+
+# Using the App API
+
+In order to use the app as an API, you will need to configure requests to the API as so:
+
+* Configure your request with Basic Auth. Set the username to be the same as `API_USER` and password as the `API_KEY` (`API_USER` and `API_KEY` are environment variables that should be set for the application)
+* Check the endpoint you are calling is an action that is `create`, `show` or `update`
+* Check you are setting the following request headers:
+  * `Content-Type = application/json`
+  * `Action = application/json` N.B. If you use `*/*` instead, the request won't be recognised as an API request`
+
+Currently only the logs controller is configured to accept and authenticate API requests, when the above API environment variables are set.

--- a/docs/documentation_website.md
+++ b/docs/documentation_website.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 10
+nav_order: 11
 ---
 
 # This documentation website

--- a/docs/form/index.md
+++ b/docs/form/index.md
@@ -1,6 +1,6 @@
 ---
 has_children: true
-nav_order: 8
+nav_order: 9
 ---
 
 # Generating forms

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 2
+nav_order: 3
 ---
 
 # Local development


### PR DESCRIPTION
Added some documentation for the App API, as part of CLDC-2608 in the PaaS -> AWS migration work. 

This ticket was originally for deploying the prod env in AWS, before we realised some API env vars weren't being set in PaaS Prod. We investigated the API and how it can receive requests (although there isn't much of an API except for some stuff on the logs controller).

The docs aim to capture this learning to save hassle in future 😀