### PR TITLE
Make linting consistent in staging and prod pipelines

### DIFF
--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -167,9 +167,19 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Rubocop
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Install packages and symlink local dependencies
         run: |
-          bundle exec rubocop
+          yarn install --immutable --immutable-cache --check-cache
+
+      - name: Lint
+        run: |
+          bundle exec rake lint
 
   audit:
     name: Audit dependencies


### PR DESCRIPTION
The prod pipeline was using `bundle exec rubocop`, but the staging pipeline was using `bundle exec rake lint` (which includes `bundle exec rubocop` along with some other linting commands). Discussed with @natdeanlewissoftwire and agreed it would make sense for prod to be updated to match staging.