### PR TITLE
CLDC-2863: Create 'redirect to new service' page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,10 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :render_not_authorized
 
-  before_action :check_maintenance
+  before_action :check_maintenance_status
   before_action :set_paper_trail_whodunnit
 
-  def check_maintenance
+  def check_maintenance_status
     if FeatureToggle.service_unavailable? && !%w[service-unavailable accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
       redirect_to service_unavailable_path
     elsif !FeatureToggle.service_unavailable? && request.fullpath.split("?")[0].delete("/") == "service-unavailable"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,15 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
 
   def check_maintenance_status
-    if FeatureToggle.service_unavailable? && !%w[service-unavailable accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
-      redirect_to service_unavailable_path
-    elsif !FeatureToggle.service_unavailable? && request.fullpath.split("?")[0].delete("/") == "service-unavailable"
+    if FeatureToggle.service_moved?
+      unless %w[service-moved accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
+        redirect_to service_moved_path
+      end
+    elsif FeatureToggle.service_unavailable?
+      unless %w[service-unavailable accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
+        redirect_to service_unavailable_path
+      end
+    elsif %w[service-moved service-unavailable].include?(request.fullpath.split("?")[0].delete("/"))
       redirect_back(fallback_location: root_path)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,9 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
 
   def check_maintenance
-    if FeatureToggle.maintenance_mode_enabled? && !%w[service-unavailable accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
+    if FeatureToggle.service_unavailable? && !%w[service-unavailable accessibility-statement privacy-notice cookies].include?(request.fullpath.split("?")[0].delete("/"))
       redirect_to service_unavailable_path
-    elsif !FeatureToggle.maintenance_mode_enabled? && request.fullpath.split("?")[0].delete("/") == "service-unavailable"
+    elsif !FeatureToggle.service_unavailable? && request.fullpath.split("?")[0].delete("/") == "service-unavailable"
       redirect_back(fallback_location: root_path)
     end
   end

--- a/app/controllers/maintenance_controller.rb
+++ b/app/controllers/maintenance_controller.rb
@@ -1,4 +1,10 @@
 class MaintenanceController < ApplicationController
+  def service_moved
+    if current_user
+      sign_out
+    end
+  end
+
   def service_unavailable
     if current_user
       sign_out

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -38,7 +38,7 @@ class FeatureToggle
     !Rails.env.production?
   end
 
-  def self.maintenance_mode_enabled?
+  def self.service_unavailable?
     false
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -41,4 +41,8 @@ class FeatureToggle
   def self.service_unavailable?
     false
   end
+
+  def self.service_moved?
+    false
+  end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -43,6 +43,6 @@ class FeatureToggle
   end
 
   def self.service_moved?
-    true
+    false
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -43,6 +43,6 @@ class FeatureToggle
   end
 
   def self.service_moved?
-    false
+    true
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,7 +91,7 @@
       navigation_classes: "govuk-header__navigation--end",
     ) do |component|
       component.product_name(name: t("service_name"))
-      unless FeatureToggle.service_unavailable?
+      unless FeatureToggle.service_moved? || FeatureToggle.service_unavailable?
         if current_user.nil?
           component.navigation_item(text: "Sign in", href: user_session_path)
         else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,7 +91,7 @@
       navigation_classes: "govuk-header__navigation--end",
     ) do |component|
       component.product_name(name: t("service_name"))
-      unless FeatureToggle.maintenance_mode_enabled?
+      unless FeatureToggle.service_unavailable?
         if current_user.nil?
           component.navigation_item(text: "Sign in", href: user_session_path)
         else

--- a/app/views/maintenance/service_moved.html.erb
+++ b/app/views/maintenance/service_moved.html.erb
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-l govuk-!-width-two-thirds">
+  The URL for this service has changed.
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <p class="govuk-body">Submit social housing lettings and sales data (CORE) can now be found at <%= govuk_link_to "https://submit-social-housing-data.levellingup.gov.uk", "https://submit-social-housing-data.levellingup.gov.uk" %>. If you have bookmarked this page, you need to update it.</p>
+  </div>
+</div>

--- a/app/views/maintenance/service_moved.html.erb
+++ b/app/views/maintenance/service_moved.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-width-two-thirds">
-  The URL for this service has changed.
+  The URL for this service has changed
 </h1>
 
 <div class="govuk-grid-row">

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -33,7 +33,7 @@ Redis.silence_deprecations = true
 Sidekiq.configure_server do |config|
   config.on(:startup) do
     Sidekiq::Cron::Job.all.each(&:destroy)
-    unless FeatureToggle.maintenance_mode_enabled?
+    unless FeatureToggle.service_unavailable?
       Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/sidekiq_cron_schedule.yml")
     end
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -33,7 +33,7 @@ Redis.silence_deprecations = true
 Sidekiq.configure_server do |config|
   config.on(:startup) do
     Sidekiq::Cron::Job.all.each(&:destroy)
-    unless FeatureToggle.service_unavailable?
+    unless FeatureToggle.service_moved? || FeatureToggle.service_unavailable?
       Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/sidekiq_cron_schedule.yml")
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get "/accessibility-statement", to: "content#accessibility_statement"
   get "/privacy-notice", to: "content#privacy_notice"
   get "/data-sharing-agreement", to: "content#data_sharing_agreement"
+  get "/service-moved", to: "maintenance#service_moved"
   get "/service-unavailable", to: "maintenance#service_unavailable"
 
   get "/download-23-24-lettings-form", to: "start#download_23_24_lettings_form"

--- a/spec/controllers/maintenance_controller_spec.rb
+++ b/spec/controllers/maintenance_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MaintenanceController do
   let(:user) { FactoryBot.create(:user) }
 
   describe "GET #service_unavailable" do
-    context "when maintenance mode is enabled" do
+    context "when the service is unavailable" do
       it "logs the user out" do
         allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
         sign_in user
@@ -14,7 +14,7 @@ RSpec.describe MaintenanceController do
       end
     end
 
-    context "when maintenance mode is disabled" do
+    context "when the service is available" do
       it "doesn't log the user out" do
         allow(FeatureToggle).to receive(:service_unavailable?).and_return(false)
         sign_in user

--- a/spec/controllers/maintenance_controller_spec.rb
+++ b/spec/controllers/maintenance_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MaintenanceController do
   describe "GET #service_unavailable" do
     context "when maintenance mode is enabled" do
       it "logs the user out" do
-        allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+        allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
         sign_in user
         expect(controller).to be_user_signed_in
         get :service_unavailable
@@ -16,7 +16,7 @@ RSpec.describe MaintenanceController do
 
     context "when maintenance mode is disabled" do
       it "doesn't log the user out" do
-        allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(false)
+        allow(FeatureToggle).to receive(:service_unavailable?).and_return(false)
         sign_in user
         expect(controller).to be_user_signed_in
         get :service_unavailable

--- a/spec/controllers/maintenance_controller_spec.rb
+++ b/spec/controllers/maintenance_controller_spec.rb
@@ -3,6 +3,28 @@ require "rails_helper"
 RSpec.describe MaintenanceController do
   let(:user) { FactoryBot.create(:user) }
 
+  describe "GET #service_moved" do
+    context "when the service has moved" do
+      it "logs the user out" do
+        allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+        sign_in user
+        expect(controller).to be_user_signed_in
+        get :service_moved
+        expect(controller).not_to be_user_signed_in
+      end
+    end
+
+    context "when the service hasn't moved" do
+      it "doesn't log the user out" do
+        allow(FeatureToggle).to receive(:service_moved?).and_return(false)
+        sign_in user
+        expect(controller).to be_user_signed_in
+        get :service_moved
+        expect(controller).to be_user_signed_in
+      end
+    end
+  end
+
   describe "GET #service_unavailable" do
     context "when the service is unavailable" do
       it "logs the user out" do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -151,6 +151,13 @@ RSpec.describe "User Features" do
       visit("/lettings-logs")
       expect(page).not_to have_link("Sign in")
     end
+
+    it "does not show 'Sign in' link when both the service_moved? and service_unavailable? feature toggles are on" do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
+      visit("/lettings-logs")
+      expect(page).not_to have_link("Sign in")
+    end
   end
 
   context "when the user is trying to log in with incorrect credentials" do
@@ -345,6 +352,14 @@ RSpec.describe "User Features" do
       end
 
       it "does not show 'Your account' or 'Sign out' links when the service is unavailable" do
+        allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
+        visit("/lettings-logs")
+        expect(page).not_to have_link("Your account")
+        expect(page).not_to have_link("Sign out")
+      end
+
+      it "does not show 'Your account' or 'Sign out' links when both the service_moved? and service_unavailable? feature toggles are on" do
+        allow(FeatureToggle).to receive(:service_moved?).and_return(true)
         allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
         visit("/lettings-logs")
         expect(page).not_to have_link("Your account")

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe "User Features" do
       expect(page).to have_content("Sign in to your account to submit CORE data")
     end
 
+    it "does not show 'Sign in' link when the service has moved" do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+      visit("/lettings-logs")
+      expect(page).not_to have_link("Sign in")
+    end
+
     it "does not show 'Sign in' link when the service is unavailable" do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
       visit("/lettings-logs")
@@ -329,6 +335,13 @@ RSpec.describe "User Features" do
         visit("/account")
         expect(page).to have_selector('[data-qa="change-data-protection-officer"]')
         expect(page).to have_selector('[data-qa="change-key-contact"]')
+      end
+
+      it "does not show 'Your account' or 'Sign out' links when the service has moved" do
+        allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+        visit("/lettings-logs")
+        expect(page).not_to have_link("Your account")
+        expect(page).not_to have_link("Sign out")
       end
 
       it "does not show 'Your account' or 'Sign out' links when the service is unavailable" do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "User Features" do
     end
 
     it "does not show 'Sign in' link if maintenance mode is enabled" do
-      allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
       visit("/lettings-logs")
       expect(page).not_to have_link("Sign in")
     end
@@ -332,7 +332,7 @@ RSpec.describe "User Features" do
       end
 
       it "does not show 'Your account' or 'Sign out' links if maintenance mode is enabled" do
-        allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+        allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
         visit("/lettings-logs")
         expect(page).not_to have_link("Your account")
         expect(page).not_to have_link("Sign out")

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "User Features" do
       expect(page).to have_content("Sign in to your account to submit CORE data")
     end
 
-    it "does not show 'Sign in' link if maintenance mode is enabled" do
+    it "does not show 'Sign in' link when the service is unavailable" do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
       visit("/lettings-logs")
       expect(page).not_to have_link("Sign in")
@@ -331,7 +331,7 @@ RSpec.describe "User Features" do
         expect(page).to have_selector('[data-qa="change-key-contact"]')
       end
 
-      it "does not show 'Your account' or 'Sign out' links if maintenance mode is enabled" do
+      it "does not show 'Your account' or 'Sign out' links when the service is unavailable" do
         allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
         visit("/lettings-logs")
         expect(page).not_to have_link("Your account")

--- a/spec/requests/content_controller_spec.rb
+++ b/spec/requests/content_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ContentController, type: :request do
   let(:headers) { { "Accept" => "text/html" } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
 
-  describe "when maintenance mode is disabled" do
+  describe "when the service is available" do
     describe "render privacy notice content page" do
       before do
         get "/privacy-notice", headers:, params: {}
@@ -48,7 +48,7 @@ RSpec.describe ContentController, type: :request do
     end
   end
 
-  describe "when maintenance mode is enabled" do
+  describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end

--- a/spec/requests/content_controller_spec.rb
+++ b/spec/requests/content_controller_spec.rb
@@ -48,6 +48,40 @@ RSpec.describe ContentController, type: :request do
     end
   end
 
+  describe "when the service has moved" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+    end
+
+    describe "render privacy notice content page" do
+      before do
+        get "/privacy-notice", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Privacy notice")
+      end
+    end
+
+    describe "render accessibility statement content page" do
+      before do
+        get "/accessibility-statement", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Accessibility statement")
+      end
+    end
+  end
+
   describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)

--- a/spec/requests/content_controller_spec.rb
+++ b/spec/requests/content_controller_spec.rb
@@ -115,4 +115,39 @@ RSpec.describe ContentController, type: :request do
       end
     end
   end
+
+  describe "when both the service_moved? and service_unavailable? feature toggles are on" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
+    end
+
+    describe "render privacy notice content page" do
+      before do
+        get "/privacy-notice", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Privacy notice")
+      end
+    end
+
+    describe "render accessibility statement content page" do
+      before do
+        get "/accessibility-statement", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Accessibility statement")
+      end
+    end
+  end
 end

--- a/spec/requests/content_controller_spec.rb
+++ b/spec/requests/content_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ContentController, type: :request do
 
   describe "when maintenance mode is enabled" do
     before do
-      allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end
 
     describe "render privacy notice content page" do

--- a/spec/requests/cookies_controller_spec.rb
+++ b/spec/requests/cookies_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CookiesController, type: :request do
 
   describe "when maintenance mode is enabled" do
     before do
-      allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end
 
     describe "render cookies page" do

--- a/spec/requests/cookies_controller_spec.rb
+++ b/spec/requests/cookies_controller_spec.rb
@@ -59,4 +59,25 @@ RSpec.describe CookiesController, type: :request do
       end
     end
   end
+
+  describe "when both the service_moved? and service_unavailable? feature toggles are on" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
+    end
+
+    describe "render cookies page" do
+      before do
+        get "/cookies", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Cookies")
+      end
+    end
+  end
 end

--- a/spec/requests/cookies_controller_spec.rb
+++ b/spec/requests/cookies_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CookiesController, type: :request do
   let(:headers) { { "Accept" => "text/html" } }
   let(:page) { Capybara::Node::Simple.new(response.body) }
 
-  describe "when maintenance mode is disabled" do
+  describe "when the service is available" do
     describe "render cookies page" do
       before do
         get "/cookies", headers:, params: {}
@@ -20,7 +20,7 @@ RSpec.describe CookiesController, type: :request do
     end
   end
 
-  describe "when maintenance mode is enabled" do
+  describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end

--- a/spec/requests/cookies_controller_spec.rb
+++ b/spec/requests/cookies_controller_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe CookiesController, type: :request do
     end
   end
 
+  describe "when the service has moved" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+    end
+
+    describe "render cookies page" do
+      before do
+        get "/cookies", headers:, params: {}
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the page" do
+        expect(page).to have_title("Cookies")
+      end
+    end
+  end
+
   describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)

--- a/spec/requests/maintenance_controller_spec.rb
+++ b/spec/requests/maintenance_controller_spec.rb
@@ -84,6 +84,45 @@ RSpec.describe MaintenanceController, type: :request do
     end
   end
 
+  describe "when both the service_moved? and service_unavailable? feature toggles are on" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
+    end
+
+    context "when a user visits a page other than the service moved page" do
+      before do
+        get "/service-unavailable"
+      end
+
+      it "redirects the user to the service moved page" do
+        expect(response).to redirect_to(service_moved_path)
+        follow_redirect!
+        expect(page).to have_content("The URL for this service has changed.")
+      end
+
+      it "the cookie banner is visible" do
+        follow_redirect!
+        expect(page).to have_content("We’d like to use analytics cookies so we can understand how you use the service and make improvements.")
+      end
+    end
+
+    context "when a user visits the service moved page" do
+      before do
+        get "/service-moved"
+      end
+
+      it "keeps the user on the service moved page" do
+        expect(response).not_to redirect_to(service_moved_path)
+        expect(page).to have_content("The URL for this service has changed.")
+      end
+
+      it "the cookie banner is visible" do
+        expect(page).to have_content("We’d like to use analytics cookies so we can understand how you use the service and make improvements.")
+      end
+    end
+  end
+
   describe "when the service is available" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(false)

--- a/spec/requests/maintenance_controller_spec.rb
+++ b/spec/requests/maintenance_controller_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe MaintenanceController, type: :request do
     sign_in user
   end
 
-  describe "when maintenance mode is enabled" do
+  describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end
 
-    context "when a user visits a page other than the maintenance page" do
+    context "when a user visits a page other than the service unavailable page" do
       before do
         get "/lettings-logs"
       end
 
-      it "redirects the user to the maintenance page" do
+      it "redirects the user to the service unavailable page" do
         expect(response).to redirect_to(service_unavailable_path)
         follow_redirect!
         expect(page).to have_content("Sorry, the service is unavailable")
@@ -30,12 +30,12 @@ RSpec.describe MaintenanceController, type: :request do
       end
     end
 
-    context "when a user visits the maintenance page" do
+    context "when a user visits the service unavailable page" do
       before do
         get "/service-unavailable"
       end
 
-      it "keeps the user on the maintenance page" do
+      it "keeps the user on the service unavailable page" do
         expect(response).not_to redirect_to(service_unavailable_path)
         expect(page).to have_content("Sorry, the service is unavailable")
       end
@@ -46,17 +46,17 @@ RSpec.describe MaintenanceController, type: :request do
     end
   end
 
-  describe "when maintenance mode is disabled" do
+  describe "when the service is available" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(false)
     end
 
-    context "when a user visits a page other than the maintenance page" do
+    context "when a user visits a page other than the service unavailable page" do
       before do
         get "/lettings-logs"
       end
 
-      it "doesn't redirect the user to the maintenance page" do
+      it "doesn't redirect the user to the service unavailable page" do
         expect(response).not_to redirect_to(service_unavailable_path)
         expect(page).to have_content("Create a new lettings log")
       end
@@ -66,7 +66,7 @@ RSpec.describe MaintenanceController, type: :request do
       end
     end
 
-    context "when a user visits the maintenance page" do
+    context "when a user visits the service unavailable page" do
       before do
         get "/service-unavailable"
       end

--- a/spec/requests/maintenance_controller_spec.rb
+++ b/spec/requests/maintenance_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe MaintenanceController, type: :request do
       it "redirects the user to the service moved page" do
         expect(response).to redirect_to(service_moved_path)
         follow_redirect!
-        expect(page).to have_content("The URL for this service has changed.")
+        expect(page).to have_content("The URL for this service has changed")
       end
 
       it "the cookie banner is visible" do
@@ -37,7 +37,7 @@ RSpec.describe MaintenanceController, type: :request do
 
       it "keeps the user on the service moved page" do
         expect(response).not_to redirect_to(service_moved_path)
-        expect(page).to have_content("The URL for this service has changed.")
+        expect(page).to have_content("The URL for this service has changed")
       end
 
       it "the cookie banner is visible" do
@@ -98,7 +98,7 @@ RSpec.describe MaintenanceController, type: :request do
       it "redirects the user to the service moved page" do
         expect(response).to redirect_to(service_moved_path)
         follow_redirect!
-        expect(page).to have_content("The URL for this service has changed.")
+        expect(page).to have_content("The URL for this service has changed")
       end
 
       it "the cookie banner is visible" do
@@ -114,7 +114,7 @@ RSpec.describe MaintenanceController, type: :request do
 
       it "keeps the user on the service moved page" do
         expect(response).not_to redirect_to(service_moved_path)
-        expect(page).to have_content("The URL for this service has changed.")
+        expect(page).to have_content("The URL for this service has changed")
       end
 
       it "the cookie banner is visible" do

--- a/spec/requests/maintenance_controller_spec.rb
+++ b/spec/requests/maintenance_controller_spec.rb
@@ -8,6 +8,44 @@ RSpec.describe MaintenanceController, type: :request do
     sign_in user
   end
 
+  describe "when the service has moved" do
+    before do
+      allow(FeatureToggle).to receive(:service_moved?).and_return(true)
+    end
+
+    context "when a user visits a page other than the service moved page" do
+      before do
+        get "/service-unavailable"
+      end
+
+      it "redirects the user to the service moved page" do
+        expect(response).to redirect_to(service_moved_path)
+        follow_redirect!
+        expect(page).to have_content("The URL for this service has changed.")
+      end
+
+      it "the cookie banner is visible" do
+        follow_redirect!
+        expect(page).to have_content("We’d like to use analytics cookies so we can understand how you use the service and make improvements.")
+      end
+    end
+
+    context "when a user visits the service moved page" do
+      before do
+        get "/service-moved"
+      end
+
+      it "keeps the user on the service moved page" do
+        expect(response).not_to redirect_to(service_moved_path)
+        expect(page).to have_content("The URL for this service has changed.")
+      end
+
+      it "the cookie banner is visible" do
+        expect(page).to have_content("We’d like to use analytics cookies so we can understand how you use the service and make improvements.")
+      end
+    end
+  end
+
   describe "when the service is unavailable" do
     before do
       allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)

--- a/spec/requests/maintenance_controller_spec.rb
+++ b/spec/requests/maintenance_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MaintenanceController, type: :request do
 
   describe "when maintenance mode is enabled" do
     before do
-      allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(true)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(true)
     end
 
     context "when a user visits a page other than the maintenance page" do
@@ -48,7 +48,7 @@ RSpec.describe MaintenanceController, type: :request do
 
   describe "when maintenance mode is disabled" do
     before do
-      allow(FeatureToggle).to receive(:maintenance_mode_enabled?).and_return(false)
+      allow(FeatureToggle).to receive(:service_unavailable?).and_return(false)
     end
 
     context "when a user visits a page other than the maintenance page" do


### PR DESCRIPTION
Ticket: https://dluhcdigital.atlassian.net/browse/CLDC-2863

Previously I created a "Sorry, the service is unavailable" page for when we are doing the switchover. Once the switchover is complete and we are ready for users to use the app in the new AWS infra, we will present a new "The URL for this service has changed." page (i.e. a 'redirect' page) to users when they try to visit the app in the PaaS infra. This PR creates that new page.

It might be worth looking at the PR in two stages - the first of which is the first 3 commits in which I refactored the "Sorry, the service is unavailable" page code. Basically I just renamed `maintenance_mode` to `service_unavailable` as I thought that was more clear, and it also was cleaner when adding code for the new redirect page (the second stage of this work - described next).

The code for the new redirect page is almost identical to the `service_unavailable` code, but instead it's called `service_moved`. (Hence hiding the initial refactor commits when reviewing this part might make things cleaner.) The only important difference is that if both feature toggles are turned on at the same time then the `service_moved` feature has priority. This is because on switchover day we will be turning on `service_unavailable` first and then `service_moved` later, so I wanted to prepare for the case where we forget to turn off `service_unavailable`.

Of course I added tests for when the `service_moved` feature is on, but because it's possible for both feature toggles to be on at the same time I added tests for this possibility as well.

Thanks in advance!