### PR TITLE
CLDC-3025 Fix leading zeroes bug in bulk upload

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -110,7 +110,7 @@ class Location < ApplicationRecord
   def self.find_by_id_on_multiple_fields(id)
     return if id.nil?
 
-    where(id:).or(where("ltrim(old_visible_id, '0') = ?", id.to_s)).first
+    where(id:).or(where("ltrim(old_visible_id, '0') = ?", id.to_i.to_s)).first
   end
 
   def postcode=(postcode)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -110,7 +110,7 @@ class Location < ApplicationRecord
   def self.find_by_id_on_multiple_fields(id)
     return if id.nil?
 
-    where(id:).or(where(old_visible_id: id)).first
+    where(id:).or(where("ltrim(old_visible_id, '0') = ?", id.to_s)).first
   end
 
   def postcode=(postcode)

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -169,9 +169,9 @@ class Scheme < ApplicationRecord
     if scheme_id.start_with?("S")
       where(id: scheme_id[1..]).first
     elsif location_id.present?
-      joins(:locations).where("ltrim(schemes.old_visible_id, '0') = ? AND ltrim(locations.old_visible_id, '0') = ?", scheme_id.to_s, location_id.to_s).first || where("ltrim(schemes.old_visible_id, '0') = ?", scheme_id.to_s).first
+      joins(:locations).where("ltrim(schemes.old_visible_id, '0') = ? AND ltrim(locations.old_visible_id, '0') = ?", scheme_id.to_i.to_s, location_id.to_i.to_s).first || where("ltrim(schemes.old_visible_id, '0') = ?", scheme_id.to_i.to_s).first
     else
-      where("ltrim(old_visible_id, '0') = ?", scheme_id.to_s).first
+      where("ltrim(old_visible_id, '0') = ?", scheme_id.to_i.to_s).first
     end
   end
 

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -169,9 +169,9 @@ class Scheme < ApplicationRecord
     if scheme_id.start_with?("S")
       where(id: scheme_id[1..]).first
     elsif location_id.present?
-      joins(:locations).where("schemes.old_visible_id = ? AND locations.old_visible_id = ?", scheme_id.to_s, location_id.to_s).first || where(old_visible_id: scheme_id).first
+      joins(:locations).where("ltrim(schemes.old_visible_id, '0') = ? AND ltrim(locations.old_visible_id, '0') = ?", scheme_id.to_s, location_id.to_s).first || where("ltrim(schemes.old_visible_id, '0') = ?", scheme_id.to_s).first
     else
-      where(old_visible_id: scheme_id).first
+      where("ltrim(old_visible_id, '0') = ?", scheme_id.to_s).first
     end
   end
 

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1403,6 +1403,19 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
             expect(parser.log.location).to eql(location)
           end
         end
+
+        context "when the user provides an id with leading zeroes" do
+          let(:attributes) { { bulk_upload:, field_4: scheme.old_visible_id, field_5: "00123", field_111: owning_org.old_visible_id, field_113: owning_org.old_visible_id } }
+
+          before do
+            location.old_visible_id = "123"
+            location.save!
+          end
+
+          it "assigns the correct location" do
+            expect(parser.log.location).to eql(location)
+          end
+        end
       end
     end
 
@@ -1427,6 +1440,19 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
           before do
             scheme.old_visible_id = "010"
+            scheme.save!
+          end
+
+          it "assigns the correct scheme" do
+            expect(parser.log.scheme).to eql(scheme)
+          end
+        end
+
+        context "when the user provides an id with leading zeroes" do
+          let(:attributes) { { bulk_upload:, field_4: "010", field_5: location.old_visible_id, field_111: owning_org.old_visible_id, field_113: owning_org.old_visible_id } }
+
+          before do
+            scheme.old_visible_id = "10"
             scheme.save!
           end
 

--- a/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2022/row_parser_spec.rb
@@ -1390,6 +1390,19 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
         it "assigns the correct location" do
           expect(parser.log.location).to eql(location)
         end
+
+        context "when location had leading zeroes in its id in Old CORE" do
+          let(:attributes) { { bulk_upload:, field_4: scheme.old_visible_id, field_5: "123", field_111: owning_org.old_visible_id, field_113: owning_org.old_visible_id } }
+
+          before do
+            location.old_visible_id = "00123"
+            location.save!
+          end
+
+          it "assigns the correct location" do
+            expect(parser.log.location).to eql(location)
+          end
+        end
       end
     end
 
@@ -1407,6 +1420,19 @@ RSpec.describe BulkUpload::Lettings::Year2022::RowParser do
 
         it "assigns the correct scheme" do
           expect(parser.log.scheme).to eql(scheme)
+        end
+
+        context "when scheme had leading zeroes in its id in Old CORE" do
+          let(:attributes) { { bulk_upload:, field_4: "10", field_5: location.old_visible_id, field_111: owning_org.old_visible_id, field_113: owning_org.old_visible_id } }
+
+          before do
+            scheme.old_visible_id = "010"
+            scheme.save!
+          end
+
+          it "assigns the correct scheme" do
+            expect(parser.log.scheme).to eql(scheme)
+          end
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1759,7 +1759,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
             expect(parser.log.location).to eql(location)
           end
         end
-
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1746,6 +1746,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
             expect(parser.log.location).to eql(location)
           end
         end
+
+        context "when the user provides an id with leading zeroes" do
+          let(:attributes) { { bulk_upload:, field_15: scheme.old_visible_id, field_16: "00123", field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id } }
+
+          before do
+            location.old_visible_id = "123"
+            location.save!
+          end
+
+          it "assigns the correct location" do
+            expect(parser.log.location).to eql(location)
+          end
+        end
+
       end
     end
 
@@ -1770,6 +1784,19 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
           before do
             scheme.old_visible_id = "010"
+            scheme.save!
+          end
+
+          it "assigns the correct scheme" do
+            expect(parser.log.scheme).to eql(scheme)
+          end
+        end
+
+        context "when the user provides an id with leading zeroes" do
+          let(:attributes) { { bulk_upload:, field_15: "010", field_16: location.old_visible_id, field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id } }
+
+          before do
+            scheme.old_visible_id = "10"
             scheme.save!
           end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1733,6 +1733,20 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "assigns the correct location" do
           expect(parser.log.location).to eql(location)
         end
+
+        context "when location had leading zeroes in its id in Old CORE" do
+          let(:attributes) { { bulk_upload:, field_15: scheme.old_visible_id, field_16: "123", field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id } }
+
+          before do
+            location.old_visible_id = "00123"
+            location.save!
+          end
+
+          it "assigns the correct location" do
+            expect(parser.log.location).to eql(location)
+          end
+        end
+
       end
     end
 
@@ -1750,6 +1764,19 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
         it "assigns the correct scheme" do
           expect(parser.log.scheme).to eql(scheme)
+        end
+
+        context "when scheme had leading zeroes in its id in Old CORE" do
+          let(:attributes) { { bulk_upload:, field_15: "10", field_16: location.old_visible_id, field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id } }
+
+          before do
+            scheme.old_visible_id = "010"
+            scheme.save!
+          end
+
+          it "assigns the correct scheme" do
+            expect(parser.log.scheme).to eql(scheme)
+          end
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1746,7 +1746,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
             expect(parser.log.location).to eql(location)
           end
         end
-
       end
     end
 


### PR DESCRIPTION
Some schemes and locaitons have leading 0s in their `old_visible_id`s  because they did on Old CORE. This means when users type e.g. 1 in a bulk upload form scheme field, it won’t find a scheme with id “001” when it should.

This PR removes leading zeroes when we match by `old_visible_id` in bulk upload to address this, this is not necessary for organisation `old_visible_id`s as they do not have leading zeroes in any cases (I've checked)

ticket: https://dluhcdigital.atlassian.net/browse/CLDC-3025