### PR TITLE
CLDC-3029 Clear not routed answers twice

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -192,54 +192,64 @@ class Form
 
   def reset_checkbox_questions_if_not_routed(log)
     checkbox_questions = routed_and_not_routed_questions_by_type(log, type: "checkbox")
-    checkbox_questions[:not_routed].each do |not_routed_question|
-      valid_options = checkbox_questions[:routed]
-                                        .select { |q| q.id == not_routed_question.id }
-                                        .flat_map { |q| q.answer_options.keys }
-      not_routed_question.answer_options.each_key do |invalid_option|
-        if !log.respond_to?(invalid_option) || valid_options.include?(invalid_option) || log.public_send(invalid_option).nil?
-          next
-        else
-          clear_attribute(log, invalid_option)
-        end
-      end
-    end
+    checkbox_clearing_pass(log, checkbox_questions[:routed], checkbox_questions[:not_routed])
+
+    checkbox_questions_recalculated = routed_and_not_routed_questions_by_type(log, type: "checkbox")
+    newly_not_routed_checkbox_questions = checkbox_questions_recalculated[:not_routed].reject { |question| checkbox_questions[:not_routed].include?(question) }
+    checkbox_clearing_pass(log, checkbox_questions_recalculated[:routed], newly_not_routed_checkbox_questions)
   end
 
   def reset_radio_questions_if_not_routed_or_invalid_answers(log)
     radio_questions = routed_and_not_routed_questions_by_type(log, type: "radio")
-    valid_radio_options = radio_questions[:routed]
-                                         .group_by(&:id)
-                                         .transform_values! { |q_array| q_array.flat_map { |q| q.answer_options.keys } }
-    radio_questions[:not_routed].each do |not_routed_question|
-      question_id = not_routed_question.id
-      if !log.respond_to?(question_id) || log.public_send(question_id).nil? || valid_radio_options.key?(question_id)
-        next
-      else
-        clear_attribute(log, question_id)
-      end
-    end
-    valid_radio_options.each do |question_id, valid_options|
-      if !log.respond_to?(question_id) || valid_options.include?(log.public_send(question_id).to_s)
-        next
-      else
-        clear_attribute(log, question_id)
-      end
-    end
+    radio_clearing_pass(log, radio_questions[:routed], radio_questions[:not_routed])
+
+    radio_questions_recalculated = routed_and_not_routed_questions_by_type(log, type: "radio")
+    newly_not_routed_radio_questions = radio_questions_recalculated[:not_routed].reject { |question| radio_questions[:not_routed].include?(question) }
+    radio_clearing_pass(log, radio_questions_recalculated[:routed], newly_not_routed_radio_questions)
+
   end
 
   def reset_free_user_input_questions_if_not_routed(log)
     non_radio_checkbox_questions = routed_and_not_routed_questions_by_type(log)
-    enabled_question_ids = non_radio_checkbox_questions[:routed].map(&:id)
-    non_radio_checkbox_questions[:not_routed].each do |not_routed_question|
-      question_id = not_routed_question.id
-      if log.public_send(question_id).nil? || enabled_question_ids.include?(question_id)
-        next
-      else
-        clear_attribute(log, question_id)
+    free_user_input_clearing_pass(log, non_radio_checkbox_questions[:routed], non_radio_checkbox_questions[:not_routed])
+
+    non_radio_checkbox_questions_recalculated = routed_and_not_routed_questions_by_type(log)
+    newly_not_routed_non_radio_checkbox_questions = non_radio_checkbox_questions_recalculated[:not_routed].reject { |question| non_radio_checkbox_questions[:not_routed].include?(question) }
+    free_user_input_clearing_pass(log, non_radio_checkbox_questions_recalculated[:routed], newly_not_routed_non_radio_checkbox_questions)
+  end
+
+  def checkbox_clearing_pass(log, routed_questions, not_routed_questions)
+    not_routed_questions.each do |not_routed_question|
+      valid_options = routed_questions
+                        .select { |q| q.id == not_routed_question.id }
+                        .flat_map { |q| q.answer_options.keys }
+      not_routed_question.answer_options.each_key do |invalid_option|
+        clear_attribute(log, invalid_option) if log.respond_to?(invalid_option) && valid_options.exclude?(invalid_option) && log.public_send(invalid_option).present?
       end
     end
   end
+
+  def radio_clearing_pass(log, routed_questions, not_routed_questions)
+    valid_radio_options = routed_questions
+                            .group_by(&:id)
+                            .transform_values! { |q_array| q_array.flat_map { |q| q.answer_options.keys } }
+    not_routed_questions.each do |not_routed_question|
+      question_id = not_routed_question.id
+      clear_attribute(log, question_id) if log.respond_to?(question_id) && log.public_send(question_id).present? && !valid_radio_options.key?(question_id)
+    end
+    valid_radio_options.each do |question_id, valid_options|
+      clear_attribute(log, question_id) if log.respond_to?(question_id) && valid_options.exclude?(log.public_send(question_id).to_s)
+    end
+  end
+
+  def free_user_input_clearing_pass(log, routed_questions, not_routed_questions)
+    enabled_question_ids = routed_questions.map(&:id)
+    not_routed_questions.each do |not_routed_question|
+      question_id = not_routed_question.id
+      clear_attribute(log, question_id) if log.public_send(question_id).present? && enabled_question_ids.exclude?(question_id)
+    end
+  end
+
 
   def routed_and_not_routed_questions_by_type(log, type: nil, current_user: nil)
     questions_by_type = if type

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -192,32 +192,32 @@ class Form
 
   def reset_checkbox_questions_if_not_routed(log)
     checkbox_questions = routed_and_not_routed_questions_by_type(log, type: "checkbox")
-    checkbox_clearing_pass(log, checkbox_questions[:routed], checkbox_questions[:not_routed])
+    clear_checkbox_attributes(log, checkbox_questions[:routed], checkbox_questions[:not_routed])
 
     checkbox_questions_recalculated = routed_and_not_routed_questions_by_type(log, type: "checkbox")
     newly_not_routed_checkbox_questions = checkbox_questions_recalculated[:not_routed].reject { |question| checkbox_questions[:not_routed].include?(question) }
-    checkbox_clearing_pass(log, checkbox_questions_recalculated[:routed], newly_not_routed_checkbox_questions)
+    clear_checkbox_attributes(log, checkbox_questions_recalculated[:routed], newly_not_routed_checkbox_questions)
   end
 
   def reset_radio_questions_if_not_routed_or_invalid_answers(log)
     radio_questions = routed_and_not_routed_questions_by_type(log, type: "radio")
-    radio_clearing_pass(log, radio_questions[:routed], radio_questions[:not_routed])
+    clear_radio_attributes(log, radio_questions[:routed], radio_questions[:not_routed])
 
     radio_questions_recalculated = routed_and_not_routed_questions_by_type(log, type: "radio")
     newly_not_routed_radio_questions = radio_questions_recalculated[:not_routed].reject { |question| radio_questions[:not_routed].include?(question) }
-    radio_clearing_pass(log, radio_questions_recalculated[:routed], newly_not_routed_radio_questions)
+    clear_radio_attributes(log, radio_questions_recalculated[:routed], newly_not_routed_radio_questions)
   end
 
   def reset_free_user_input_questions_if_not_routed(log)
-    non_radio_checkbox_questions = routed_and_not_routed_questions_by_type(log)
-    free_user_input_clearing_pass(log, non_radio_checkbox_questions[:routed], non_radio_checkbox_questions[:not_routed])
+    non_radio_or_checkbox_questions = routed_and_not_routed_questions_by_type(log)
+    clear_free_user_input_attributes(log, non_radio_or_checkbox_questions[:routed], non_radio_or_checkbox_questions[:not_routed])
 
-    non_radio_checkbox_questions_recalculated = routed_and_not_routed_questions_by_type(log)
-    newly_not_routed_non_radio_checkbox_questions = non_radio_checkbox_questions_recalculated[:not_routed].reject { |question| non_radio_checkbox_questions[:not_routed].include?(question) }
-    free_user_input_clearing_pass(log, non_radio_checkbox_questions_recalculated[:routed], newly_not_routed_non_radio_checkbox_questions)
+    non_radio_or_checkbox_questions_recalculated = routed_and_not_routed_questions_by_type(log)
+    newly_not_routed_non_radio_or_checkbox_questions = non_radio_or_checkbox_questions_recalculated[:not_routed].reject { |question| non_radio_or_checkbox_questions[:not_routed].include?(question) }
+    clear_free_user_input_attributes(log, non_radio_or_checkbox_questions_recalculated[:routed], newly_not_routed_non_radio_or_checkbox_questions)
   end
 
-  def checkbox_clearing_pass(log, routed_questions, not_routed_questions)
+  def clear_checkbox_attributes(log, routed_questions, not_routed_questions)
     not_routed_questions.each do |not_routed_question|
       valid_options = routed_questions
                         .select { |q| q.id == not_routed_question.id }
@@ -228,7 +228,7 @@ class Form
     end
   end
 
-  def radio_clearing_pass(log, routed_questions, not_routed_questions)
+  def clear_radio_attributes(log, routed_questions, not_routed_questions)
     valid_radio_options = routed_questions
                             .group_by(&:id)
                             .transform_values! { |q_array| q_array.flat_map { |q| q.answer_options.keys } }
@@ -241,7 +241,7 @@ class Form
     end
   end
 
-  def free_user_input_clearing_pass(log, routed_questions, not_routed_questions)
+  def clear_free_user_input_attributes(log, routed_questions, not_routed_questions)
     enabled_question_ids = routed_questions.map(&:id)
     not_routed_questions.each do |not_routed_question|
       question_id = not_routed_question.id

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -206,7 +206,6 @@ class Form
     radio_questions_recalculated = routed_and_not_routed_questions_by_type(log, type: "radio")
     newly_not_routed_radio_questions = radio_questions_recalculated[:not_routed].reject { |question| radio_questions[:not_routed].include?(question) }
     radio_clearing_pass(log, radio_questions_recalculated[:routed], newly_not_routed_radio_questions)
-
   end
 
   def reset_free_user_input_questions_if_not_routed(log)
@@ -249,7 +248,6 @@ class Form
       clear_attribute(log, question_id) if log.public_send(question_id).present? && enabled_question_ids.exclude?(question_id)
     end
   end
-
 
   def routed_and_not_routed_questions_by_type(log, type: nil, current_user: nil)
     questions_by_type = if type

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -238,7 +238,9 @@ private
   def reset_invalidated_dependent_fields!
     return unless form
 
-    form.reset_not_routed_questions_and_invalid_answers(self)
+    2.times do
+      form.reset_not_routed_questions_and_invalid_answers(self)
+    end
     reset_created_by!
   end
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -238,9 +238,7 @@ private
   def reset_invalidated_dependent_fields!
     return unless form
 
-    2.times do
-      form.reset_not_routed_questions_and_invalid_answers(self)
-    end
+    form.reset_not_routed_questions_and_invalid_answers(self)
     reset_created_by!
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -328,6 +328,28 @@ RSpec.describe Form, type: :model do
       end
     end
 
+    context "when a value is changed such that a radio and free input questions are no longer routed to" do
+      let(:log) { FactoryBot.create(:lettings_log, :completed, startdate: now) }
+
+      it "all attributes relating to that checkbox question are cleared" do
+        expect(log.hhmemb).to be 2
+        expect(log.details_known_2).to be 0
+        expect(log.sex2).to eq("M")
+        expect(log.relat2).to eq("P")
+        expect(log.age2_known).to be 0
+        expect(log.age2).to be 32
+        expect(log.ecstat2).to be 6
+
+        log.update!(hhmemb: 1)
+        expect(log.details_known_2).to be nil
+        expect(log.sex2).to be nil
+        expect(log.relat2).to be nil
+        expect(log.age2_known).to be nil
+        expect(log.age2).to be nil
+        expect(log.ecstat2).to be nil
+      end
+    end
+
     context "when an attribute is derived, but no questions for that attribute are routed to" do
       let(:log) { FactoryBot.create(:sales_log, :outright_sale_setup_complete, value: 200_000) }
 


### PR DESCRIPTION
We clear not routed answers a second time after recalculating routing to catch newly not-routed questions.
We found this bug because when the household was reduced in size, the details known question was cleared but not the details as they were newly not-routed to only after the details known question had been cleared.

ticket: https://dluhcdigital.atlassian.net/browse/CLDC-3029