### PR TITLE
CLDC-2865: Remove PaaS deployment from prod pipeline

### DIFF
--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -209,67 +209,6 @@ jobs:
         run: |
           bundle exec bundler-audit
 
-  deploy:
-    name: Deploy
-    concurrency: "production"
-    runs-on: ubuntu-latest
-    environment: "production"
-    needs: [lint, test, feature_test, audit]
-
-    steps:
-      - name: Get latest release with tag
-        id: latestrelease
-        run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-
-      - name: Confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Checkout tag
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
-
-      - name: Install Cloud Foundry CLI
-        run: |
-          wget --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15" -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          sudo apt-get update
-          sudo apt-get install cf8-cli
-
-      - name: Deploy
-        env:
-          CF_USERNAME: ${{ secrets.CF_USERNAME }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-          CF_API_ENDPOINT: ${{ secrets.CF_API_ENDPOINT }}
-          CF_SPACE: ${{ secrets.CF_SPACE }}
-          CF_ORG: ${{ secrets.CF_ORG }}
-          APP_NAME: dluhc-core-production
-          GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
-          APP_HOST: ${{ secrets.APP_HOST }}
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          OS_DATA_KEY: ${{ secrets.OS_DATA_KEY }}
-          IMPORT_PAAS_INSTANCE: ${{ secrets.IMPORT_PAAS_INSTANCE }}
-          EXPORT_PAAS_INSTANCE: ${{ secrets.EXPORT_PAAS_INSTANCE }}
-          S3_CONFIG: ${{ secrets.S3_CONFIG }}
-          CSV_DOWNLOAD_PAAS_INSTANCE: ${{ secrets.CSV_DOWNLOAD_PAAS_INSTANCE }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: |
-          cf api $CF_API_ENDPOINT
-          cf auth
-          cf target -o $CF_ORG -s $CF_SPACE
-          cf set-env $APP_NAME GOVUK_NOTIFY_API_KEY $GOVUK_NOTIFY_API_KEY
-          cf set-env $APP_NAME APP_HOST $APP_HOST
-          cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
-          cf set-env $APP_NAME OS_DATA_KEY $OS_DATA_KEY
-          cf set-env $APP_NAME IMPORT_PAAS_INSTANCE $IMPORT_PAAS_INSTANCE
-          cf set-env $APP_NAME EXPORT_PAAS_INSTANCE $EXPORT_PAAS_INSTANCE
-          cf set-env $APP_NAME S3_CONFIG $S3_CONFIG
-          cf set-env $APP_NAME CSV_DOWNLOAD_PAAS_INSTANCE $CSV_DOWNLOAD_PAAS_INSTANCE
-          cf set-env $APP_NAME SENTRY_DSN $SENTRY_DSN
-          cf push $APP_NAME --strategy rolling
-
   aws_deploy:
     name: AWS Deploy
     needs: [lint, test, feature_test, audit]


### PR DESCRIPTION
- Remove the PaaS Deployment stage from the Production Pipeline in preparation for AWS migration. This PR will only be merged once the migration to AWS has been completed successfully.