### PR TITLE
CLDC-2865: Add an AWS production only pipeline

### DIFF
--- a/.github/workflows/aws_only_production_pipeline.yml
+++ b/.github/workflows/aws_only_production_pipeline.yml
@@ -1,0 +1,222 @@
+name: AWS-only Production CI/CD Pipeline
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+env:
+  REPO_URL: communitiesuk/submit-social-housing-lettings-and-sales-data
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    outputs:
+      releasetag: ${{ steps.latestrelease.outputs.releasetag }}
+
+    services:
+      postgres:
+        image: postgres:13.5
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: data_collector
+        ports:
+          - 5432:5432
+        # Needed because the Postgres container does not provide a health check
+        # tmpfs makes database faster by using RAM
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      GEMFILE_RUBY_VERSION: 3.1.1
+      DB_HOST: localhost
+      DB_DATABASE: data_collector
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      PARALLEL_TEST_PROCESSORS: 4
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "releasetag=$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Create database
+        run: |
+          bundle exec rake parallel:setup
+
+      - name: Compile Assets
+        run: |
+          bundle exec rake assets:precompile
+
+      - name: Run tests
+        run: |
+          bundle exec rake parallel:spec['spec\/(?!features)']
+
+  feature_test:
+    name: Feature Tests
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13.5
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: data_collector
+        ports:
+          - 5432:5432
+        # Needed because the Postgres container does not provide a health check
+        # tmpfs makes database faster by using RAM
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      GEMFILE_RUBY_VERSION: 3.1.1
+      DB_HOST: localhost
+      DB_DATABASE: data_collector
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Create database
+        run: |
+          bundle exec rake db:prepare
+
+      - name: Compile assets
+        run: |
+          bundle exec rake assets:precompile
+
+      - name: Run tests
+        run: |
+          bundle exec rspec spec/features --fail-fast
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+
+      - name: Install packages and symlink local dependencies
+        run: |
+          yarn install --immutable --immutable-cache --check-cache
+
+      - name: Lint
+        run: |
+          bundle exec rake lint
+
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest release with tag
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/${REPO_URL}/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: Confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Audit
+        run: |
+          bundle exec bundler-audit
+
+  aws_deploy:
+    name: AWS Deploy
+    needs: [lint, test, feature_test, audit]
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws_account_id: 977287343304
+      aws_resource_prefix: core-prod
+      environment: production
+      release_tag: ${{ needs.test.outputs.releasetag }}
+    permissions:
+      id-token: write


### PR DESCRIPTION
- A pipeline we need to use in order to bump up the Sidekiq task CPU / Memory temporarily as part of the AWS migration
- This will only deploy to AWS Prod