### PR TITLE
CLDC-2865: Update Postgres version in Dockerfile to the latest compatible version (as required by Alpine)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: compilation tools for bundle
 # yarn: node package manager
 # postgresql-dev: postgres driver and libraries
-RUN apk add --no-cache build-base=0.5-r3 yarn=1.22.19-r0 postgresql13-dev=13.12-r0 git=2.40.1-r0 bash=5.2.15-r5
+RUN apk add --no-cache build-base=0.5-r3 yarn=1.22.19-r0 postgresql13-dev=13.13-r0 git=2.40.1-r0 bash=5.2.15-r5
 
 # Bundler version should be the same version as what the Gemfile.lock was bundled with
 RUN gem install bundler:2.3.14 --no-document


### PR DESCRIPTION
For `Alpine 3.18`, the package `postgresql13-dev` was updated from version `13.12-r0` to `13.13-r0` (on 15th Nov around 8.15pm). Alpine enforces this version must be installed; and so we therefore had to update our Dockerfile accordingly.

See link [here](https://pkgs.alpinelinux.org/packages?name=postgresql13-dev&branch=v3.18&repo=&arch=&maintainer=) for more info about the alpine package