### PR TITLE
CLDC-2739 Clear filter for a specific organisation

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,11 @@ class SessionsController < ApplicationController
     session[session_name_for(params[:filter_type])] = "{}"
     path_params = params[:path_params].presence || {}
 
-    redirect_to send("#{params[:filter_type]}_path", scheme_id: path_params[:scheme_id], search: path_params[:search])
+    if path_params[:organisation_id].present?
+      redirect_to send("#{params[:filter_type]}_organisation_path", id: path_params[:organisation_id], scheme_id: path_params[:scheme_id], search: path_params[:search])
+    else
+      redirect_to send("#{params[:filter_type]}_path", scheme_id: path_params[:scheme_id], search: path_params[:search])
+    end
   end
 
 private

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -139,6 +139,10 @@ module FiltersHelper
     request.path.include?("/lettings-logs")
   end
 
+  def specific_organisation_path?
+    request.path.include?("/organisations")
+  end
+
   def applied_filters_count(filter_type)
     filters_count(applied_filters(filter_type))
   end

--- a/app/views/logs/_log_filters.html.erb
+++ b/app/views/logs/_log_filters.html.erb
@@ -12,7 +12,7 @@
               <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"], organisation_id: @organisation&.id }.compact) %>
           </p>
         </div>
         <% if bulk_upload_options(@bulk_upload).present? %>

--- a/app/views/schemes/_scheme_filters.html.erb
+++ b/app/views/schemes/_scheme_filters.html.erb
@@ -5,13 +5,13 @@
     </div>
 
     <div class="app-filter__content">
-      <%= form_with url: schemes_path, html: { method: :get } do |f| %>
+      <%= form_with url: specific_organisation_path? ? schemes_organisation_path(@organisation) : schemes_path, html: { method: :get } do |f| %>
         <div class="govuk-grid-row" style="white-space: nowrap">
           <p class="govuk-grid-column-one-half">
             <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"], organisation_id: @organisation&.id }.compact) %>
           </p>
         </div>
 

--- a/app/views/users/_user_filters.html.erb
+++ b/app/views/users/_user_filters.html.erb
@@ -5,13 +5,13 @@
     </div>
 
     <div class="app-filter__content">
-      <%= form_with url: users_path, html: { method: :get } do |f| %>
+      <%= form_with url: specific_organisation_path? ? users_organisation_path(@organisation) : users_path, html: { method: :get } do |f| %>
         <div class="govuk-grid-row" style="white-space: nowrap">
           <p class="govuk-grid-column-one-half">
             <%= filters_applied_text(@filter_type) %>
           </p>
           <p class="govuk-!-text-align-right govuk-grid-column-one-half">
-            <%= reset_filters_link(@filter_type, { search: request.params["search"] }.compact) %>
+            <%= reset_filters_link(@filter_type, { search: request.params["search"], organisation_id: @organisation&.id }.compact) %>
           </p>
         </div>
 

--- a/spec/features/schemes_spec.rb
+++ b/spec/features/schemes_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Schemes scheme Features" do
 
             it "displays the filters component with a correct count and clear button" do
               expect(page).to have_content("2 filters applied")
-              expect(page).to have_link("Clear", href: "/clear-filters?filter_type=schemes")
+              expect(page).to have_link("Clear", href: /clear-filters\?filter_type=schemes/)
             end
 
             context "when clearing the filters" do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe "User Features" do
         context "when no filters are selected" do
           it "displays the filters component with no clear button" do
             expect(page).to have_content("No filters applied")
-            expect(page).not_to have_link("Clear", href: "/clear-filters?filter_type=users")
+            expect(page).not_to have_link("Clear", href: /clear-filters\?filter_type=users/)
           end
         end
 
@@ -265,7 +265,7 @@ RSpec.describe "User Features" do
 
           it "displays the filters component with a correct count and clear button" do
             expect(page).to have_content("2 filters applied")
-            expect(page).to have_link("Clear", href: "/clear-filters?filter_type=users")
+            expect(page).to have_link("Clear", href: /clear-filters\?filter_type=users/)
           end
 
           context "when clearing the filters" do

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -1440,6 +1440,16 @@ RSpec.describe OrganisationsController, type: :request do
             }.to enqueue_job(EmailCsvJob).with(user, nil, {}, false, organisation, codes_only_export_type)
           end
         end
+
+        context "when filters are applied" do
+          before do
+            get lettings_logs_organisation_path(organisation, status: %w[completed])
+          end
+
+          it "has clear filters link" do
+            expect(page).to have_link("Clear", href: clear_filters_path(filter_type: "lettings_logs", path_params: { organisation_id: organisation.id }))
+          end
+        end
       end
 
       context "when they view the sales logs tab" do


### PR DESCRIPTION
When signed in as a support user on either of the logs pages in a specific organisation, the clear filters link in the filters panel redirects back to the general logs page, not the specific org logs page.
This PR should fix that for logs, schemes and users.

Update the form url on filter for users and schemes, because the filters were being applied to all orgs instead of a specific one when accessing org as support.