### PR TITLE
CLDC-3049 Add frequency to ecstat error

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -27,6 +27,7 @@ module Validations::FinancialValidations
     if record.ecstat1 && record.weekly_net_income
       if record.weekly_net_income > record.applicable_income_range.hard_max
         hard_max = format_as_currency(record.applicable_income_range.hard_max)
+        frequency = record.form.get_question("incfreq", record).label_from_value(record.incfreq).downcase
         record.errors.add(
           :earnings,
           :over_hard_max,
@@ -35,7 +36,7 @@ module Validations::FinancialValidations
         record.errors.add(
           :ecstat1,
           :over_hard_max,
-          message: I18n.t("validations.financial.ecstat.over_hard_max", hard_max:),
+          message: I18n.t("validations.financial.ecstat.over_hard_max", earnings: format_as_currency(record.earnings), frequency:),
         )
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,7 +371,7 @@ en:
         less_than_shortfall: "Enter an amount that is more than the shortfall in basic rent"
         out_of_range: "Enter a value for the %{charge_name} between £0 and %{maximum_per_period} paid %{frequency}. %{maximum_per_period} is the max limit for rent and charges paid %{frequency} for %{letting_type} lettings owned by a %{provider_type}."
       ecstat:
-        over_hard_max: "Net income of %{hard_max} per week is too high given the tenant’s working situation"
+        over_hard_max: "Net income of %{earnings} %{frequency} is too high given the tenant’s working situation"
       brent:
         below_hard_min: "Rent is below the absolute minimum expected for a property of this type. Please check the rent, rent period, local authority and (if general needs) number of bedrooms"
         above_hard_max: "Rent is higher than the absolute maximum expected for a property of this type. Please check the rent, rent period, local authority and (if general needs) number of bedrooms"

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -203,6 +203,8 @@ RSpec.describe Validations::FinancialValidations do
         financial_validator.validate_net_income(record)
         expect(record.errors["earnings"])
           .to eq(["Net income cannot be greater than £1,230.00 per week given the tenant’s working situation"])
+        expect(record.errors["ecstat1"])
+          .to eq(["Net income of £5,000.00 weekly is too high given the tenant’s working situation"])
       end
     end
 


### PR DESCRIPTION
Error message for income was wrong.
Before we were using the weekly max amount:
<img width="1361" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/7d74d0a6-2ca1-4bbe-8a9f-9949eeab635b">

Now we're using the actual amount the user has input, with the correct income frequency:
<img width="1228" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/b5847c63-602e-407c-a8fe-ffdbca5210e8">
