### PR TITLE
CLDC-2938 Add sales managing org

### DIFF
--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -33,6 +33,8 @@ class SalesLog < Log
   before_validation :set_derived_fields!
   before_validation :process_uprn_change!, if: :should_process_uprn_change?
 
+  belongs_to :managing_organisation, class_name: "Organisation", optional: true
+
   scope :filter_by_year, ->(year) { where(saledate: Time.zone.local(year.to_i, 4, 1)...Time.zone.local(year.to_i + 1, 4, 1)) }
   scope :filter_by_purchaser_code, ->(purchid) { where("purchid ILIKE ?", "%#{purchid}%") }
   scope :search_by, lambda { |param|

--- a/db/migrate/20231121131725_add_sales_managing_organisation.rb
+++ b/db/migrate/20231121131725_add_sales_managing_organisation.rb
@@ -1,0 +1,7 @@
+class AddSalesManagingOrganisation < ActiveRecord::Migration[7.0]
+  def change
+    change_table :sales_logs, bulk: true do |t|
+      t.references :managing_organisation, class_name: "Organisation"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_142854) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_21_131725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -624,8 +624,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_142854) do
     t.integer "creation_method", default: 1
     t.integer "old_form_id"
     t.datetime "values_updated_at"
+    t.bigint "managing_organisation_id"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
+    t.index ["managing_organisation_id"], name: "index_sales_logs_on_managing_organisation_id"
     t.index ["old_id"], name: "index_sales_logs_on_old_id", unique: true
     t.index ["owning_organisation_id"], name: "index_sales_logs_on_owning_organisation_id"
     t.index ["updated_by_id"], name: "index_sales_logs_on_updated_by_id"

--- a/lib/tasks/set_sales_managing_organisation.rake
+++ b/lib/tasks/set_sales_managing_organisation.rake
@@ -1,0 +1,4 @@
+desc "Set sales managing organisation id to owning organisation id"
+task set_sales_managing_organisation: :environment do
+  SalesLog.where.not(owning_organisation_id: nil).update_all("managing_organisation_id = owning_organisation_id")
+end

--- a/spec/lib/tasks/set_sales_managing_organisation_spec.rb
+++ b/spec/lib/tasks/set_sales_managing_organisation_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "set_sales_managing_organisation" do
+  describe ":set_sales_managing_organisation", type: :task do
+    subject(:task) { Rake::Task["set_sales_managing_organisation"] }
+
+    before do
+      Rake.application.rake_require("tasks/set_sales_managing_organisation")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let!(:sales_log) { create(:sales_log, :completed, managing_organisation_id: nil) }
+
+      it "updates sales log managing_organisation_id with owning_organisation_id" do
+        expect(sales_log.managing_organisation_id).to eq(nil)
+        expect(sales_log.status).to eq("completed")
+        task.invoke
+        sales_log.reload
+        expect(sales_log.managing_organisation_id).to eq(sales_log.owning_organisation_id)
+        expect(sales_log.status).to eq("completed")
+      end
+
+      it "does not update sales log managing_organisation_id if owning_organisation_id is nil" do
+        sales_log.update!(owning_organisation_id: nil)
+        expect(sales_log.status).to eq("in_progress")
+        expect(sales_log.managing_organisation_id).to eq(nil)
+        task.invoke
+        sales_log.reload
+        expect(sales_log.managing_organisation_id).to eq(nil)
+        expect(sales_log.status).to eq("in_progress")
+      end
+
+      it "skips validations" do
+        sales_log.saledate = Time.zone.local(2021, 3, 3)
+        sales_log.save!(validate: false)
+        expect(sales_log.managing_organisation_id).to eq(nil)
+        expect(sales_log.status).to eq("in_progress")
+        task.invoke
+        sales_log.reload
+        expect(sales_log.managing_organisation_id).to eq(sales_log.owning_organisation_id)
+        expect(sales_log.status).to eq("in_progress")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to start collecting managing organisation IDs for Sales logs as sometimes they are actually reported by organisations different from the owning organisation.
This PR adds the column and the task that copies owning organisation ID over to managing organisation ID.
This needs to be released and executed before we add the new managing organisation question to the set up section.