### PR TITLE
CLDC-2071 Add intermediate rent error to BU

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -329,6 +329,14 @@ class BulkUpload::Lettings::Year2023::RowParser
             },
             on: :after_log
 
+  validates :field_11,
+            presence: {
+              if: proc { renttype == :intermediate },
+              message: I18n.t("validations.not_answered", question: "intermediate rent type"),
+              category: :setup,
+            },
+            on: :after_log
+
   validates :field_15,
             presence: {
               if: proc { supported_housing? && log_uses_old_scheme_id? },
@@ -349,14 +357,6 @@ class BulkUpload::Lettings::Year2023::RowParser
             presence: {
               if: proc { supported_housing? && log_uses_new_scheme_id? },
               message: I18n.t("validations.not_answered", question: "location code"),
-              category: :setup,
-            },
-            on: :after_log
-
-  validates :field_11,
-            presence: {
-              if: proc { renttype == :intermediate },
-              message: I18n.t("validations.not_answered", question: "intermediate rent type"),
               category: :setup,
             },
             on: :after_log

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -353,6 +353,14 @@ class BulkUpload::Lettings::Year2023::RowParser
             },
             on: :after_log
 
+  validates :field_11,
+            presence: {
+              if: proc { renttype == :intermediate },
+              message: I18n.t("validations.not_answered", question: "intermediate rent type"),
+              category: :setup,
+            },
+            on: :after_log
+
   validates :field_46, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 1 must be a number or the letter R" }, on: :after_log
   validates :field_52, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 2 must be a number or the letter R" }, allow_blank: true, on: :after_log
   validates :field_56, format: { with: /\A\d{1,3}\z|\AR\z/, message: "Age of person 3 must be a number or the letter R" }, allow_blank: true, on: :after_log

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -809,6 +809,15 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
+      context "when intermediate rent and field_11 (Which type of Intermediate Rent) is not given" do
+        let(:attributes) { { bulk_upload:, field_5: "9", field_11: nil } }
+
+        it "adds error on field_11" do
+          expect(parser.errors[:field_5]).to be_present
+          expect(parser.errors[:field_11]).to eq(["You must answer intermediate rent type"])
+        end
+      end
+
       context "when bulk upload is for general needs" do
         context "when general needs option selected" do
           let(:attributes) { { bulk_upload:, field_5: "1", field_4: "1" } }

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -818,6 +818,14 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
+      context "when intermediate rent other and field_12 is not given" do
+        let(:attributes) { { bulk_upload:, field_5: "9", field_11: "3", field_12: nil } }
+
+        it "adds error on field_12" do
+          expect(parser.errors[:field_12]).to eq(["You must answer product name"])
+        end
+      end
+
       context "when bulk upload is for general needs" do
         context "when general needs option selected" do
           let(:attributes) { { bulk_upload:, field_5: "1", field_4: "1" } }


### PR DESCRIPTION
For intermediate rent logs, we also need answers to field 11 and conditionally field 12, but if field 11 is not given we currently only add an error on field 5 with `You must answer rent type` which doesn't really make sense. This PR adds an error to field 11 in this situation.