### PR TITLE
CLDC-2969 Move dpo user when merging

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -50,7 +50,7 @@ class Log < ApplicationRecord
   scope :imported_2023_with_old_form_id, -> { imported.filter_by_year(2023).has_old_form_id }
   scope :imported_2023, -> { imported.filter_by_year(2023) }
 
-  attr_accessor :skip_update_status, :skip_update_uprn_confirmed
+  attr_accessor :skip_update_status, :skip_update_uprn_confirmed, :skip_dpo_validation
 
   def process_uprn_change!
     if uprn.present?

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -83,6 +83,8 @@ module Validations::SetupValidations
   end
 
   def validate_managing_organisation_data_sharing_agremeent_signed(record)
+    return if record.skip_dpo_validation
+
     if record.managing_organisation_id_changed? && record.managing_organisation.present? && !record.managing_organisation.data_protection_confirmed?
       record.errors.add :managing_organisation_id, I18n.t("validations.setup.managing_organisation.data_sharing_agreement_not_signed")
     end

--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -121,6 +121,8 @@ module Validations::SharedValidations
   end
 
   def validate_owning_organisation_data_sharing_agremeent_signed(record)
+    return if record.skip_dpo_validation
+
     if record.owning_organisation_id_changed? && record.owning_organisation.present? && !record.owning_organisation.data_protection_confirmed?
       record.errors.add :owning_organisation_id, I18n.t("validations.setup.owning_organisation.data_sharing_agreement_not_signed")
     end

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -88,18 +88,21 @@ private
         lettings_log.location = location_to_set if location_to_set.present?
       end
       lettings_log.owning_organisation = @absorbing_organisation
-      lettings_log.save!(validate: false)
+      lettings_log.skip_dpo_validation = true
+      lettings_log.save!
     end
     merging_organisation.managed_lettings_logs.after_date(@merge_date.to_time).each do |lettings_log|
       lettings_log.managing_organisation = @absorbing_organisation
-      lettings_log.save!(validate: false)
+      lettings_log.skip_dpo_validation = true
+      lettings_log.save!
     end
   end
 
   def merge_sales_logs(merging_organisation)
     merging_organisation.sales_logs.after_date(@merge_date.to_time).each do |sales_log|
       sales_log.owning_organisation = @absorbing_organisation
-      sales_log.save!(validate: false)
+      sales_log.skip_dpo_validation = true
+      sales_log.save!
     end
   end
 

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -59,8 +59,9 @@ private
   end
 
   def merge_users(merging_organisation)
-    @merged_users[merging_organisation.name] = merging_organisation.users.map { |user| { name: user.name, email: user.email } }
-    merging_organisation.users.update_all(organisation_id: @absorbing_organisation.id)
+    users_to_merge = users_to_merge(merging_organisation)
+    @merged_users[merging_organisation.name] = users_to_merge.map { |user| { name: user.name, email: user.email } }
+    users_to_merge.update_all(organisation_id: @absorbing_organisation.id)
   end
 
   def merge_schemes_and_locations(merging_organisation)
@@ -131,5 +132,26 @@ private
 
   def child_relationship_exists_on_absorbing_organisation?(child_organisation_relationship)
     child_organisation_relationship.child_organisation == @absorbing_organisation || @merging_organisations.include?(child_organisation_relationship.child_organisation) || @absorbing_organisation.child_organisation_relationships.where(child_organisation: child_organisation_relationship.child_organisation).exists?
+  end
+
+  def users_to_merge(merging_organisation)
+    return merging_organisation.users if merging_organisation.data_protection_confirmation.blank?
+    if merging_organisation.data_protection_confirmation.data_protection_officer.email.exclude?("@")
+      return merging_organisation.users.where.not(id: merging_organisation.data_protection_confirmation.data_protection_officer.id)
+    end
+
+    new_dpo = User.new(
+      name: merging_organisation.data_protection_confirmation.data_protection_officer.name,
+      organisation: merging_organisation,
+      is_dpo: true,
+      encrypted_password: SecureRandom.hex(10),
+      email: SecureRandom.uuid,
+      confirmed_at: Time.zone.now,
+      active: false,
+    )
+    new_dpo.save!(validate: false)
+    merging_organisation.data_protection_confirmation.update!(data_protection_officer: new_dpo)
+
+    merging_organisation.users.where.not(id: new_dpo.id)
   end
 end

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -160,11 +160,11 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(absorbing_organisation.owned_schemes.count).to eq(1)
           expect(absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
           expect(absorbing_organisation.owned_schemes.first.old_id).to be_nil
-          expect(absorbing_organisation.owned_schemes.first.old_visible_id).to be_nil
+          expect(absorbing_organisation.owned_schemes.first.old_visible_id).to eq(nil)
           expect(absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
           expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
           expect(absorbing_organisation.owned_schemes.first.locations.first.old_id).to be_nil
-          expect(absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to be_nil
+          expect(absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to eq(nil)
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
         end
@@ -179,7 +179,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).scheme).to eq(absorbing_organisation.owned_schemes.first)
           expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).location).to eq(absorbing_organisation.owned_schemes.first.locations.first)
           expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).scheme).to eq(absorbing_organisation.owned_schemes.first)
-          expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(nil)
+          expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(absorbing_organisation.owned_schemes.first.locations.first)
         end
 
         it "rolls back if there's an error" do
@@ -345,7 +345,7 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).scheme).to eq(absorbing_organisation.owned_schemes.first)
             expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).location).to eq(absorbing_organisation.owned_schemes.first.locations.first)
             expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).scheme).to eq(absorbing_organisation.owned_schemes.first)
-            expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(nil)
+            expect(absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(absorbing_organisation.owned_schemes.first.locations.first)
           end
 
           it "rolls back if there's an error" do
@@ -728,7 +728,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).scheme).to eq(new_absorbing_organisation.owned_schemes.first)
           expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).location).to eq(new_absorbing_organisation.owned_schemes.first.locations.first)
           expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).scheme).to eq(new_absorbing_organisation.owned_schemes.first)
-          expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(nil)
+          expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(new_absorbing_organisation.owned_schemes.first.locations.first)
         end
 
         it "rolls back if there's an error" do
@@ -801,7 +801,7 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(SalesLog.filter_by_owning_organisation(new_absorbing_organisation).first).to eq(sales_log)
           end
 
-          fit "rolls back if there's an error" do
+          it "rolls back if there's an error" do
             allow(Organisation).to receive(:find).with([merging_organisation_ids]).and_return(Organisation.find(merging_organisation_ids))
             allow(Organisation).to receive(:find).with(new_absorbing_organisation.id).and_return(new_absorbing_organisation)
             allow(new_absorbing_organisation).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
@@ -889,12 +889,13 @@ RSpec.describe Merge::MergeOrganisationsService do
 
             new_absorbing_organisation.reload
             merging_organisation.reload
+            owned_lettings_log_no_location.reload
             expect(new_absorbing_organisation.owned_lettings_logs.count).to eq(2)
             expect(new_absorbing_organisation.managed_lettings_logs.count).to eq(1)
             expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).scheme).to eq(new_absorbing_organisation.owned_schemes.first)
             expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log.id).location).to eq(new_absorbing_organisation.owned_schemes.first.locations.first)
             expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).scheme).to eq(new_absorbing_organisation.owned_schemes.first)
-            expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(nil)
+            expect(new_absorbing_organisation.owned_lettings_logs.find(owned_lettings_log_no_location.id).location).to eq(new_absorbing_organisation.owned_schemes.first.locations.first)
           end
 
           it "rolls back if there's an error" do


### PR DESCRIPTION
When merging organisations, we move users to the absorbing organisation. We still want to keep DPO in the merging organisation so that the DSA stays signed.
This PR:
- replaces dpo users with fake users in merging organisation if they have signed the data sharing agreement
- does not move dpo users who have signed data sharing agreement if they have a fake email address

This PR also adds the validation for sales and lettings logs back, but we set a flag to skip dpo validation so that we can move the logs over.