### PR TITLE
CLDC-2999 Deactivate locations on merged orgs

### DIFF
--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -70,7 +70,10 @@ private
 
       new_scheme = Scheme.create!(scheme.attributes.except("id", "owning_organisation_id", "old_id", "old_visible_id").merge(owning_organisation: @absorbing_organisation))
       scheme.locations.each do |location|
-        new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id", "old_id", "old_visible_id")) unless location.deactivated?
+        next if location.deactivated?
+
+        new_scheme.locations << Location.new(location.attributes.except("id", "scheme_id", "old_id", "old_visible_id"))
+        LocationDeactivationPeriod.create!(location:, deactivation_date: @merge_date)
       end
       @merged_schemes[merging_organisation.name] << { name: new_scheme.service_name, code: new_scheme.id }
       SchemeDeactivationPeriod.create!(scheme:, deactivation_date: @merge_date)

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -167,6 +167,8 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to be_nil
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+          expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
+          expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
         end
 
         it "moves relevant logs and assigns the new scheme" do
@@ -193,6 +195,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merging_organisation.reload
           expect(absorbing_organisation.owned_schemes.count).to eq(0)
           expect(scheme.scheme_deactivation_periods.count).to eq(0)
+          expect(scheme.locations.first.location_deactivation_periods.count).to eq(0)
           expect(owned_lettings_log.owning_organisation).to eq(merging_organisation)
           expect(owned_lettings_log_no_location.owning_organisation).to eq(merging_organisation)
         end
@@ -333,6 +336,8 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
             expect(scheme.scheme_deactivation_periods.count).to eq(1)
             expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+            expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
+            expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
           end
 
           it "moves relevant logs and assigns the new scheme" do
@@ -359,6 +364,7 @@ RSpec.describe Merge::MergeOrganisationsService do
             merging_organisation.reload
             expect(absorbing_organisation.owned_schemes.count).to eq(0)
             expect(scheme.scheme_deactivation_periods.count).to eq(0)
+            expect(scheme.locations.first.location_deactivation_periods.count).to eq(0)
             expect(owned_lettings_log.owning_organisation).to eq(merging_organisation)
             expect(owned_lettings_log_no_location.owning_organisation).to eq(merging_organisation)
           end
@@ -676,6 +682,8 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(new_absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to be_nil
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+          expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
+          expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
         end
 
         it "moves relevant logs and assigns the new scheme" do
@@ -702,6 +710,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           merging_organisation.reload
           expect(new_absorbing_organisation.owned_schemes.count).to eq(0)
           expect(scheme.scheme_deactivation_periods.count).to eq(0)
+          expect(scheme.locations.first.location_deactivation_periods.count).to eq(0)
           expect(owned_lettings_log.owning_organisation).to eq(merging_organisation)
           expect(owned_lettings_log_no_location.owning_organisation).to eq(merging_organisation)
         end
@@ -842,6 +851,8 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(new_absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
             expect(scheme.scheme_deactivation_periods.count).to eq(1)
             expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+            expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
+            expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
           end
 
           it "moves relevant logs and assigns the new scheme" do
@@ -868,6 +879,7 @@ RSpec.describe Merge::MergeOrganisationsService do
             merging_organisation.reload
             expect(new_absorbing_organisation.owned_schemes.count).to eq(0)
             expect(scheme.scheme_deactivation_periods.count).to eq(0)
+            expect(scheme.locations.first.location_deactivation_periods.count).to eq(0)
             expect(owned_lettings_log.owning_organisation).to eq(merging_organisation)
             expect(owned_lettings_log_no_location.owning_organisation).to eq(merging_organisation)
           end

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -154,21 +154,47 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
           expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
           expect(Rails.logger).to receive(:info).with(/\t#{scheme.service_name} \(S/)
+          expect(Rails.logger).to receive(:info).with(/\t#{deactivated_scheme.service_name} \(S/)
           merge_organisations_service.call
 
           absorbing_organisation.reload
-          expect(absorbing_organisation.owned_schemes.count).to eq(1)
-          expect(absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
-          expect(absorbing_organisation.owned_schemes.first.old_id).to be_nil
-          expect(absorbing_organisation.owned_schemes.first.old_visible_id).to be_nil
-          expect(absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
-          expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
-          expect(absorbing_organisation.owned_schemes.first.locations.first.old_id).to be_nil
-          expect(absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to be_nil
+          deactivated_scheme.reload
+          deactivated_location.reload
+          expect(absorbing_organisation.owned_schemes.count).to eq(2)
+
+          # moves active schemes and locations to absorbing organisation
+          absorbed_active_scheme = absorbing_organisation.owned_schemes.find_by(service_name: scheme.service_name)
+          absorbed_active_location = absorbed_active_scheme.locations.find_by(postcode: location.postcode)
+          expect(absorbed_active_scheme.service_name).to eq(scheme.service_name)
+          expect(absorbed_active_scheme.old_id).to be_nil
+          expect(absorbed_active_scheme.old_visible_id).to be_nil
+          expect(absorbed_active_scheme.locations.count).to eq(2)
+          expect(absorbed_active_location.postcode).to eq(location.postcode)
+          expect(absorbed_active_location.old_id).to be_nil
+          expect(absorbed_active_location.old_visible_id).to be_nil
+
+          # deactivates active schemes and locations on merging organisation
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
-          expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
-          expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+          expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.count).to eq(1)
+          expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+
+          # does not deactivate inactive locations on merging organisation again
+          expect(scheme.locations.find_by(postcode: deactivated_location.postcode).location_deactivation_periods.count).to eq(1)
+
+          # moves inactive schemes and their locations to absorbing organisation
+          absorbed_inactive_scheme = absorbing_organisation.owned_schemes.find_by(service_name: deactivated_scheme.service_name)
+          expect(absorbed_inactive_scheme.scheme_deactivation_periods.count).to eq(1)
+          expect(absorbed_inactive_scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivated_scheme.scheme_deactivation_periods.first.deactivation_date)
+          expect(absorbed_inactive_scheme.locations.count).to eq(1)
+          expect(absorbed_inactive_scheme.locations.first.location_deactivation_periods.count).to eq(0)
+          expect(deactivated_scheme.scheme_deactivation_periods.count).to eq(1)
+
+          # moves inactive locations of active schemes to absorbing organisation
+          absorbed_inactive_location = absorbed_active_scheme.locations.find_by(postcode: deactivated_location.postcode)
+          expect(absorbed_active_scheme.scheme_deactivation_periods.count).to eq(0)
+          expect(absorbed_inactive_location.location_deactivation_periods.count).to eq(1)
+          expect(absorbed_inactive_location.location_deactivation_periods.first.deactivation_date).to eq(deactivated_location.location_deactivation_periods.first.deactivation_date)
         end
 
         it "moves relevant logs and assigns the new scheme" do
@@ -327,17 +353,47 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
             expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
             expect(Rails.logger).to receive(:info).with(/\t#{scheme.service_name} \(S/)
+            expect(Rails.logger).to receive(:info).with(/\t#{deactivated_scheme.service_name} \(S/)
             merge_organisations_service.call
 
             absorbing_organisation.reload
-            expect(absorbing_organisation.owned_schemes.count).to eq(1)
-            expect(absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
-            expect(absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
-            expect(absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
+            deactivated_scheme.reload
+            deactivated_location.reload
+            expect(absorbing_organisation.owned_schemes.count).to eq(2)
+
+            # moves active schemes and locations to absorbing organisation
+            absorbed_active_scheme = absorbing_organisation.owned_schemes.find_by(service_name: scheme.service_name)
+            absorbed_active_location = absorbed_active_scheme.locations.find_by(postcode: location.postcode)
+            expect(absorbed_active_scheme.service_name).to eq(scheme.service_name)
+            expect(absorbed_active_scheme.old_id).to be_nil
+            expect(absorbed_active_scheme.old_visible_id).to be_nil
+            expect(absorbed_active_scheme.locations.count).to eq(2)
+            expect(absorbed_active_location.postcode).to eq(location.postcode)
+            expect(absorbed_active_location.old_id).to be_nil
+            expect(absorbed_active_location.old_visible_id).to be_nil
+
+            # deactivates active schemes and locations on merging organisation
             expect(scheme.scheme_deactivation_periods.count).to eq(1)
             expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
-            expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
-            expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+            expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.count).to eq(1)
+            expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+
+            # does not deactivate inactive locations on merging organisation again
+            expect(scheme.locations.find_by(postcode: deactivated_location.postcode).location_deactivation_periods.count).to eq(1)
+
+            # moves inactive schemes and their locations to absorbing organisation
+            absorbed_inactive_scheme = absorbing_organisation.owned_schemes.find_by(service_name: deactivated_scheme.service_name)
+            expect(absorbed_inactive_scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(absorbed_inactive_scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivated_scheme.scheme_deactivation_periods.first.deactivation_date)
+            expect(absorbed_inactive_scheme.locations.count).to eq(1)
+            expect(absorbed_inactive_scheme.locations.first.location_deactivation_periods.count).to eq(0)
+            expect(deactivated_scheme.scheme_deactivation_periods.count).to eq(1)
+
+            # moves inactive locations of active schemes to absorbing organisation
+            absorbed_inactive_location = absorbed_active_scheme.locations.find_by(postcode: deactivated_location.postcode)
+            expect(absorbed_active_scheme.scheme_deactivation_periods.count).to eq(0)
+            expect(absorbed_inactive_location.location_deactivation_periods.count).to eq(1)
+            expect(absorbed_inactive_location.location_deactivation_periods.first.deactivation_date).to eq(deactivated_location.location_deactivation_periods.first.deactivation_date)
           end
 
           it "moves relevant logs and assigns the new scheme" do
@@ -669,21 +725,47 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
           expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
           expect(Rails.logger).to receive(:info).with(/\t#{scheme.service_name} \(S/)
+          expect(Rails.logger).to receive(:info).with(/\t#{deactivated_scheme.service_name} \(S/)
           merge_organisations_service.call
 
           new_absorbing_organisation.reload
-          expect(new_absorbing_organisation.owned_schemes.count).to eq(1)
-          expect(new_absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
-          expect(new_absorbing_organisation.owned_schemes.first.old_id).to be_nil
-          expect(new_absorbing_organisation.owned_schemes.first.old_visible_id).to be_nil
-          expect(new_absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
-          expect(new_absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
-          expect(new_absorbing_organisation.owned_schemes.first.locations.first.old_id).to be_nil
-          expect(new_absorbing_organisation.owned_schemes.first.locations.first.old_visible_id).to be_nil
+          deactivated_scheme.reload
+          deactivated_location.reload
+          expect(new_absorbing_organisation.owned_schemes.count).to eq(2)
+
+          # moves active schemes and locations to absorbing organisation
+          absorbed_active_scheme = new_absorbing_organisation.owned_schemes.find_by(service_name: scheme.service_name)
+          absorbed_active_location = absorbed_active_scheme.locations.find_by(postcode: location.postcode)
+          expect(absorbed_active_scheme.service_name).to eq(scheme.service_name)
+          expect(absorbed_active_scheme.old_id).to be_nil
+          expect(absorbed_active_scheme.old_visible_id).to be_nil
+          expect(absorbed_active_scheme.locations.count).to eq(2)
+          expect(absorbed_active_location.postcode).to eq(location.postcode)
+          expect(absorbed_active_location.old_id).to be_nil
+          expect(absorbed_active_location.old_visible_id).to be_nil
+
+          # deactivates active schemes and locations on merging organisation
           expect(scheme.scheme_deactivation_periods.count).to eq(1)
           expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
-          expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
-          expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+          expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.count).to eq(1)
+          expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.today)
+
+          # does not deactivate inactive locations on merging organisation again
+          expect(scheme.locations.find_by(postcode: deactivated_location.postcode).location_deactivation_periods.count).to eq(1)
+
+          # moves inactive schemes and their locations to absorbing organisation
+          absorbed_inactive_scheme = new_absorbing_organisation.owned_schemes.find_by(service_name: deactivated_scheme.service_name)
+          expect(absorbed_inactive_scheme.scheme_deactivation_periods.count).to eq(1)
+          expect(absorbed_inactive_scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivated_scheme.scheme_deactivation_periods.first.deactivation_date)
+          expect(absorbed_inactive_scheme.locations.count).to eq(1)
+          expect(absorbed_inactive_scheme.locations.first.location_deactivation_periods.count).to eq(0)
+          expect(deactivated_scheme.scheme_deactivation_periods.count).to eq(1)
+
+          # moves inactive locations of active schemes to absorbing organisation
+          absorbed_inactive_location = absorbed_active_scheme.locations.find_by(postcode: deactivated_location.postcode)
+          expect(absorbed_active_scheme.scheme_deactivation_periods.count).to eq(0)
+          expect(absorbed_inactive_location.location_deactivation_periods.count).to eq(1)
+          expect(absorbed_inactive_location.location_deactivation_periods.first.deactivation_date).to eq(deactivated_location.location_deactivation_periods.first.deactivation_date)
         end
 
         it "moves relevant logs and assigns the new scheme" do
@@ -842,17 +924,47 @@ RSpec.describe Merge::MergeOrganisationsService do
             expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
             expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
             expect(Rails.logger).to receive(:info).with(/\t#{scheme.service_name} \(S/)
+            expect(Rails.logger).to receive(:info).with(/\t#{deactivated_scheme.service_name} \(S/)
             merge_organisations_service.call
 
             new_absorbing_organisation.reload
-            expect(new_absorbing_organisation.owned_schemes.count).to eq(1)
-            expect(new_absorbing_organisation.owned_schemes.first.service_name).to eq(scheme.service_name)
-            expect(new_absorbing_organisation.owned_schemes.first.locations.count).to eq(1)
-            expect(new_absorbing_organisation.owned_schemes.first.locations.first.postcode).to eq(location.postcode)
+            deactivated_scheme.reload
+            deactivated_location.reload
+            expect(new_absorbing_organisation.owned_schemes.count).to eq(2)
+
+            # moves active schemes and locations to absorbing organisation
+            absorbed_active_scheme = new_absorbing_organisation.owned_schemes.find_by(service_name: scheme.service_name)
+            absorbed_active_location = absorbed_active_scheme.locations.find_by(postcode: location.postcode)
+            expect(absorbed_active_scheme.service_name).to eq(scheme.service_name)
+            expect(absorbed_active_scheme.old_id).to be_nil
+            expect(absorbed_active_scheme.old_visible_id).to be_nil
+            expect(absorbed_active_scheme.locations.count).to eq(2)
+            expect(absorbed_active_location.postcode).to eq(location.postcode)
+            expect(absorbed_active_location.old_id).to be_nil
+            expect(absorbed_active_location.old_visible_id).to be_nil
+
+            # deactivates active schemes and locations on merging organisation
             expect(scheme.scheme_deactivation_periods.count).to eq(1)
             expect(scheme.scheme_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
-            expect(scheme.locations.first.location_deactivation_periods.count).to eq(1)
-            expect(scheme.locations.first.location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+            expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.count).to eq(1)
+            expect(scheme.locations.find_by(postcode: location.postcode).location_deactivation_periods.first.deactivation_date.to_date).to eq(Time.zone.yesterday)
+
+            # does not deactivate inactive locations on merging organisation again
+            expect(scheme.locations.find_by(postcode: deactivated_location.postcode).location_deactivation_periods.count).to eq(1)
+
+            # moves inactive schemes and their locations to absorbing organisation
+            absorbed_inactive_scheme = new_absorbing_organisation.owned_schemes.find_by(service_name: deactivated_scheme.service_name)
+            expect(absorbed_inactive_scheme.scheme_deactivation_periods.count).to eq(1)
+            expect(absorbed_inactive_scheme.scheme_deactivation_periods.first.deactivation_date).to eq(deactivated_scheme.scheme_deactivation_periods.first.deactivation_date)
+            expect(absorbed_inactive_scheme.locations.count).to eq(1)
+            expect(absorbed_inactive_scheme.locations.first.location_deactivation_periods.count).to eq(0)
+            expect(deactivated_scheme.scheme_deactivation_periods.count).to eq(1)
+
+            # moves inactive locations of active schemes to absorbing organisation
+            absorbed_inactive_location = absorbed_active_scheme.locations.find_by(postcode: deactivated_location.postcode)
+            expect(absorbed_active_scheme.scheme_deactivation_periods.count).to eq(0)
+            expect(absorbed_inactive_location.location_deactivation_periods.count).to eq(1)
+            expect(absorbed_inactive_location.location_deactivation_periods.first.deactivation_date).to eq(deactivated_location.location_deactivation_periods.first.deactivation_date)
           end
 
           it "moves relevant logs and assigns the new scheme" do


### PR DESCRIPTION
Deactivate the locations on merged organisations after they get copied over to the absorbing organisation
This PR also includes copying deactivated schemes and locations over to the absorbing organisation (CLDC-3003). We're also now copying the state by duplicating all of the scheme/location deactivation periods