### PR TITLE
CLDC-3004 Do not reset created by for merged orgs

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -559,6 +559,7 @@ class LettingsLog < Log
     return unless updated_by&.support?
     return if owning_organisation.blank? || managing_organisation.blank? || created_by.blank?
     return if created_by&.organisation == managing_organisation || created_by&.organisation == owning_organisation
+    return if created_by&.organisation == owning_organisation.absorbing_organisation || created_by&.organisation == managing_organisation.absorbing_organisation
 
     update!(created_by: nil)
   end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -318,6 +318,7 @@ class SalesLog < Log
     return unless updated_by&.support?
     return if owning_organisation.blank? || created_by.blank?
     return if created_by&.organisation == owning_organisation
+    return if created_by&.organisation == owning_organisation.absorbing_organisation
 
     update!(created_by: nil)
   end

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -214,6 +214,33 @@ RSpec.describe FormController, type: :request do
       end
     end
 
+    context "with valid absorbed managing organisation" do
+      let(:params) do
+        {
+          id: lettings_log.id,
+          lettings_log: {
+            page: "stock_owner",
+            owning_organisation_id: stock_owner.id,
+          },
+        }
+      end
+      let(:merged_org) { create(:organisation) }
+
+      before do
+        merged_org.update!(merge_date: Time.zone.today, absorbing_organisation: organisation)
+        lettings_log.update!(owning_organisation: merged_org, created_by: user, managing_organisation: merged_org)
+        lettings_log.reload
+      end
+
+      it "does not reset created by" do
+        post "/lettings-logs/#{lettings_log.id}/stock-owner", params: params
+        expect(response).to redirect_to("/lettings-logs/#{lettings_log.id}/managing-organisation")
+        follow_redirect!
+        lettings_log.reload
+        expect(lettings_log.created_by).to eq(user)
+      end
+    end
+
     context "with only adding the stock owner" do
       let(:params) do
         {

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -189,6 +189,62 @@ RSpec.describe FormController, type: :request do
       end
     end
 
+    context "when submitting a sales log with valid owning organisation" do
+      let(:sales_log) { create(:sales_log) }
+      let(:created_by) { managing_organisation.users.first }
+      let(:params) do
+        {
+          id: sales_log.id,
+          sales_log: {
+            page: "organisation",
+            owning_organisation_id: managing_organisation.id,
+          },
+        }
+      end
+
+      before do
+        sales_log.update!(owning_organisation: managing_organisation, created_by:)
+        sales_log.reload
+      end
+
+      it "does not reset created by" do
+        post "/sales-logs/#{sales_log.id}/organisation", params: params
+        expect(response).to redirect_to("/sales-logs/#{sales_log.id}/created-by")
+        follow_redirect!
+        sales_log.reload
+        expect(sales_log.created_by).to eq(created_by)
+      end
+    end
+
+    context "when submitting a sales log with valid merged owning organisation" do
+      let(:sales_log) { create(:sales_log) }
+      let(:created_by) { managing_organisation.users.first }
+      let(:merged_organisation) { create(:organisation) }
+      let(:params) do
+        {
+          id: sales_log.id,
+          sales_log: {
+            page: "organisation",
+            owning_organisation_id: merged_organisation.id,
+          },
+        }
+      end
+
+      before do
+        merged_organisation.update!(merge_date: Time.zone.today, absorbing_organisation: managing_organisation)
+        sales_log.update!(owning_organisation: managing_organisation, created_by:)
+        sales_log.reload
+      end
+
+      it "does not reset created by" do
+        post "/sales-logs/#{sales_log.id}/organisation", params: params
+        expect(response).to redirect_to("/sales-logs/#{sales_log.id}/created-by")
+        follow_redirect!
+        sales_log.reload
+        expect(sales_log.created_by).to eq(created_by)
+      end
+    end
+
     context "with valid managing organisation" do
       let(:params) do
         {


### PR DESCRIPTION
When support user selects a log owner for merged organisation it would get reset, because that user no longer belongs to the merged organisation.
This PR does not reset create by user if they belong to the absorbing organisation of owning or managing org.