### PR TITLE
CLDC-3005 Display labels and filters for merged orgs

### DIFF
--- a/app/components/lettings_log_summary_component.html.erb
+++ b/app/components/lettings_log_summary_component.html.erb
@@ -34,7 +34,7 @@
           <% end %>
         </p>
       <% end %>
-      <% if current_user.support? || current_user.organisation.has_managing_agents? %>
+      <% if current_user.support? || current_user.organisation.has_managing_agents? || current_user.organisation.has_recent_absorbed_organisations? %>
         <dl class="app-metadata">
           <% if log.owning_organisation %>
             <div class="app-metadata__item">

--- a/app/components/sales_log_summary_component.html.erb
+++ b/app/components/sales_log_summary_component.html.erb
@@ -24,7 +24,7 @@
           Sale completed <time datetime="<%= log.saledate.iso8601 %>"><%= log.saledate.to_formatted_s(:govuk_date) %></time>
         <% end %>
       </p>
-      <% if current_user.support? || current_user.organisation.has_managing_agents? %>
+      <% if current_user.support? || current_user.organisation.has_managing_agents? || current_user.organisation.has_recent_absorbed_organisations? %>
         <dl class="app-metadata">
           <% if log.owning_organisation %>
             <div class="app-metadata__item">

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -124,11 +124,11 @@ module FiltersHelper
   end
 
   def non_support_with_multiple_owning_orgs?
-    current_user.organisation.stock_owners.count > 1 && user_lettings_path?
+    current_user.organisation.stock_owners.count > 1 && user_lettings_path? || current_user.organisation.has_recent_absorbed_organisations?
   end
 
   def non_support_with_multiple_managing_orgs?
-    current_user.organisation.managing_agents.count > 1 && user_lettings_path?
+    current_user.organisation.managing_agents.count > 1 && user_lettings_path? || current_user.organisation.has_recent_absorbed_organisations?
   end
 
   def user_lettings_path?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -146,4 +146,8 @@ class Organisation < ApplicationRecord
 
     absorbed_organisations.merged_during_open_collection_period.group_by(&:merge_date)
   end
+
+  def has_recent_absorbed_organisations?
+    absorbed_organisations&.merged_during_open_collection_period.present?
+  end
 end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -277,6 +277,20 @@ RSpec.describe LettingsLogsController, type: :request do
             expect(page).not_to have_link "Delete logs"
           end
         end
+
+        context "and organisation has absorbed organisations" do
+          let(:merged_organisation) { FactoryBot.create(:organisation) }
+
+          before do
+            merged_organisation.update!(absorbing_organisation: organisation, merge_date: Time.zone.yesterday)
+          end
+
+          it "shows organisation labels" do
+            get "/lettings-logs", headers:, params: {}
+            expect(page).to have_content("Owned by")
+            expect(page).to have_content("Managed by")
+          end
+        end
       end
 
       context "when the user is a customer support user" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe SalesLogsController, type: :request do
           sign_in user
         end
 
-        it "does not have organisation values" do
+        it "does not show organisation labels" do
           get "/sales-logs", headers: headers, params: {}
           expect(page).not_to have_content("Owned by")
           expect(page).not_to have_content("Managed by")
@@ -572,7 +572,7 @@ RSpec.describe SalesLogsController, type: :request do
             merged_organisation.update!(absorbing_organisation: organisation, merge_date: Time.zone.yesterday)
           end
 
-          it "has organisation values" do
+          it "shows organisation labels" do
             get "/sales-logs", headers: headers, params: {}
             expect(page).to have_content("Owned by")
             expect(page).not_to have_content("Managed by")

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -559,6 +559,26 @@ RSpec.describe SalesLogsController, type: :request do
           sign_in user
         end
 
+        it "does not have organisation values" do
+          get "/sales-logs", headers: headers, params: {}
+          expect(page).not_to have_content("Owned by")
+          expect(page).not_to have_content("Managed by")
+        end
+
+        context "and organisation has absorbed organisations" do
+          let(:merged_organisation) { FactoryBot.create(:organisation) }
+
+          before do
+            merged_organisation.update!(absorbing_organisation: organisation, merge_date: Time.zone.yesterday)
+          end
+
+          it "has organisation values" do
+            get "/sales-logs", headers: headers, params: {}
+            expect(page).to have_content("Owned by")
+            expect(page).not_to have_content("Managed by")
+          end
+        end
+
         it "does not have organisation columns" do
           get "/sales-logs", headers: headers, params: {}
           expect(page).not_to have_content("Owning organisation")


### PR DESCRIPTION
We've previously only displayed owned by and managed by labels and filters for logs if they have managing agents, but we also want to do it if they have absorbed organisations.