### PR TITLE
CLDC-3011 Display scheme owner question for absorbing orgs

### DIFF
--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -38,7 +38,8 @@ module SchemesHelper
     all_orgs = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) }
     user_org = [OpenStruct.new(id: current_user.organisation_id, name: current_user.organisation.name)]
     stock_owners = current_user.organisation.stock_owners.map { |org| OpenStruct.new(id: org.id, name: org.name) }
-    current_user.support? ? all_orgs : user_org + stock_owners
+    merged_organisations = current_user.organisation.absorbed_organisations.merged_during_open_collection_period.map { |org| OpenStruct.new(id: org.id, name: org.name) }
+    current_user.support? ? all_orgs : user_org + stock_owners + merged_organisations
   end
 
   def null_option

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -146,4 +146,8 @@ class Organisation < ApplicationRecord
 
     absorbed_organisations.merged_during_open_collection_period.group_by(&:merge_date)
   end
+
+  def has_recent_absorbed_organisations?
+    absorbed_organisations&.merged_during_open_collection_period.present?
+  end
 end

--- a/app/views/schemes/details.html.erb
+++ b/app/views/schemes/details.html.erb
@@ -44,7 +44,7 @@
                                            :description,
                                            legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
 
-      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? %>
+      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? && !current_user.organisation.has_recent_absorbed_organisations? %>
         <%= f.hidden_field :owning_organisation_id, value: current_user.organisation.id %>
       <% else %>
         <%= f.govuk_collection_select :owning_organisation_id,

--- a/app/views/schemes/edit_name.html.erb
+++ b/app/views/schemes/edit_name.html.erb
@@ -25,7 +25,7 @@
                               label: { text: "This scheme contains confidential information" } %>
       <% end %>
 
-      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? %>
+      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? && !current_user.organisation.has_recent_absorbed_organisations? %>
         <%= f.hidden_field :owning_organisation_id, value: current_user.organisation.id %>
       <% else %>
         <%= f.govuk_collection_select :owning_organisation_id,

--- a/app/views/schemes/new.html.erb
+++ b/app/views/schemes/new.html.erb
@@ -44,7 +44,7 @@
                                            :description,
                                            legend: { text: "Is this scheme registered under the Care Standards Act 2000?", size: "m" } %>
 
-      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? %>
+      <% if current_user.data_coordinator? && current_user.organisation.stock_owners.count.zero? && !current_user.organisation.has_recent_absorbed_organisations? %>
         <%= f.hidden_field :owning_organisation_id, value: current_user.organisation.id %>
       <% else %>
               <%= f.govuk_collection_select :owning_organisation_id,

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -2229,12 +2229,14 @@ RSpec.describe SchemesController, type: :request do
           get "/schemes/#{scheme.id}/edit-name"
         end
 
-        it "does not include the owning organisation question" do
-          expect(response).to have_http_status(:ok)
-          expect(page).not_to have_content("Which organisation owns the housing stock for this scheme?")
+        context "and there are no absorbed organisations" do
+          it "does not include the owning organisation question" do
+            expect(response).to have_http_status(:ok)
+            expect(page).not_to have_content("Which organisation owns the housing stock for this scheme?")
+          end
         end
 
-        context "and there are absorbed organisations" do
+        context "and there are organisations absorbed during an open collection period" do
           let(:merged_organisation) { create(:organisation) }
 
           before do
@@ -2245,6 +2247,20 @@ RSpec.describe SchemesController, type: :request do
           it "includes the owning organisation question" do
             expect(response).to have_http_status(:ok)
             expect(page).to have_content("Which organisation owns the housing stock for this scheme?")
+          end
+        end
+
+        context "and there are no recently absorbed organisations" do
+          let(:merged_organisation) { create(:organisation) }
+
+          before do
+            merged_organisation.update!(absorbing_organisation: user.organisation, merge_date: Time.zone.today - 2.years)
+            get "/schemes/#{scheme.id}/edit-name"
+          end
+
+          it "does not include the owning organisation question" do
+            expect(response).to have_http_status(:ok)
+            expect(page).not_to have_content("Which organisation owns the housing stock for this scheme?")
           end
         end
       end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -2224,6 +2224,31 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
+      context "when there are no stock owners" do
+        before do
+          get "/schemes/#{scheme.id}/edit-name"
+        end
+
+        it "does not include the owning organisation question" do
+          expect(response).to have_http_status(:ok)
+          expect(page).not_to have_content("Which organisation owns the housing stock for this scheme?")
+        end
+
+        context "and there are absorbed organisations" do
+          let(:merged_organisation) { create(:organisation) }
+
+          before do
+            merged_organisation.update!(absorbing_organisation: user.organisation, merge_date: Time.zone.today)
+            get "/schemes/#{scheme.id}/edit-name"
+          end
+
+          it "includes the owning organisation question" do
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_content("Which organisation owns the housing stock for this scheme?")
+          end
+        end
+      end
+
       context "when attempting to access secondary-client-group scheme page for another organisation" do
         before do
           get "/schemes/#{another_scheme.id}/edit-name"


### PR DESCRIPTION
When creating new schemes if user's organisation has stock owners we ask "Which organisation owns the housing stock for this scheme?". We also want to ask this question if user's organisation has recently absorbed organisations