### PR TITLE
CLDC-3064 Set correct merged managing organisation

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -108,6 +108,8 @@ private
           result["managing_organisation_id"] = owning_organisation.id
         elsif owning_organisation&.absorbing_organisation == current_user.organisation
           result["managing_organisation_id"] = owning_organisation.id
+        elsif @log.managing_organisation&.absorbing_organisation == current_user.organisation && owning_organisation == current_user.organisation
+          result["managing_organisation_id"] = owning_organisation.id
         end
       end
 

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -770,6 +770,34 @@ RSpec.describe FormController, type: :request do
           end
         end
 
+        context "when owning organisation changes from merged organisation to absorbing user organisation" do
+          let(:params) do
+            {
+              id: lettings_log.id,
+              lettings_log: {
+                page: "stock_owner",
+                owning_organisation_id: organisation.id,
+              },
+            }
+          end
+          let(:merged_org) { create(:organisation) }
+
+          before do
+            merged_org.update!(merge_date: Time.zone.today, absorbing_organisation: organisation)
+            organisation.reload
+            lettings_log.update!(owning_organisation: merged_org, managing_organisation: merged_org, created_by: user)
+            lettings_log.reload
+          end
+
+          it "sets managing organisation to owning organisation" do
+            post "/lettings-logs/#{lettings_log.id}/stock-owner", params: params
+            follow_redirect!
+            lettings_log.reload
+            expect(lettings_log.owning_organisation).to eq(organisation)
+            expect(lettings_log.managing_organisation).to eq(organisation)
+          end
+        end
+
         context "when the question was accessed from a duplicate logs screen" do
           let(:lettings_log) { create(:lettings_log, :duplicate, created_by: user) }
           let(:duplicate_log) { create(:lettings_log, :duplicate, created_by: user) }


### PR DESCRIPTION
In situations where owning organisation was getting changed from merged organisation to absorbed organisation we weren't changing the managing organisation and if the managing organisation question was not routed to (owning org has no managing agents) it would often create an invalid state that cannot be fixed.