### PR TITLE
CLDC-3026 Only display 1 set of save buttons

### DIFF
--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -63,18 +63,20 @@
       <%= f.hidden_field :interruption_page_referrer_type, value: @interruption_page_referrer_type %>
 
       <div class="govuk-button-group">
-      <% if accessed_from_duplicate_logs?(request.query_parameters["referrer"]) %>
-        <%= f.govuk_submit "Save changes" %>
-        <%= govuk_link_to "Cancel", send("#{@log.class.name.underscore}_duplicate_logs_path", @log, original_log_id: request.query_parameters["original_log_id"]) %>
-      <% elsif returning_to_question_page?(@page, request.query_parameters["referrer"]) %>
-        <%= f.govuk_submit "Save changes" %>
-        <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>
-      <% else %>
-        <%= f.govuk_submit "Save and continue" %>
-          <%= govuk_link_to(
-            (@page.skip_text || "Skip for now"),
-            (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
-          ) %>
+      <% if !@page.interruption_screen? %>
+        <% if accessed_from_duplicate_logs?(request.query_parameters["referrer"]) %>
+          <%= f.govuk_submit "Save changes" %>
+          <%= govuk_link_to "Cancel", send("#{@log.class.name.underscore}_duplicate_logs_path", @log, original_log_id: request.query_parameters["original_log_id"]) %>
+        <% elsif returning_to_question_page?(@page, request.query_parameters["referrer"]) %>
+          <%= f.govuk_submit "Save changes" %>
+          <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>
+        <% else %>
+          <%= f.govuk_submit "Save and continue" %>
+            <%= govuk_link_to(
+              (@page.skip_text || "Skip for now"),
+              (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
+            ) %>
+        <% end %>
       <% end %>
       </div>
     </div>

--- a/spec/features/form/validations_spec.rb
+++ b/spec/features/form/validations_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe "validations" do
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-value-check")
         expect(page).to have_content("You told us the lead tenant’s income is £750.00 weekly.")
         expect(page).to have_content("This is higher than we would expect for their working situation.")
+        expect(page).not_to have_button("Save changes")
         click_button("Confirm and continue")
         expect(page).to have_current_path("/lettings-logs/#{lettings_log.id}/net-income-uc-proportion")
       end


### PR DESCRIPTION
Interruption screen has it's own set of Confirm and continue buttons, so we shouldn't be displaying a duplicate set