### PR TITLE
CLDC-2953 Clear conditional values with errors

### DIFF
--- a/app/frontend/controllers/conditional_question_controller.js
+++ b/app/frontend/controllers/conditional_question_controller.js
@@ -14,7 +14,10 @@ export default class extends Controller {
 
       Object.entries(conditionalFor).forEach(([targetQuestion, conditions]) => {
         if (!conditions.map(String).includes(String(selectedValue))) {
-          const textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field`)
+          let textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field`)
+          if (textNumericInput == null) {
+            textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field-error`)
+          }
           if (textNumericInput == null) {
             const dateInputs = [1, 2, 3].map((idx) => {
               return document.getElementById(`${type.replaceAll('-', '_')}_${targetQuestion}_${idx}i`)

--- a/app/frontend/controllers/conditional_question_controller.js
+++ b/app/frontend/controllers/conditional_question_controller.js
@@ -14,28 +14,28 @@ export default class extends Controller {
 
       Object.entries(conditionalFor).forEach(([targetQuestion, conditions]) => {
         if (!conditions.map(String).includes(String(selectedValue))) {
-          let textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field`)
-          if (textNumericInput == null) {
-            textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field-error`)
-          }
-          if (textNumericInput == null) {
-            const dateInputs = [1, 2, 3].map((idx) => {
-              return document.getElementById(`${type.replaceAll('-', '_')}_${targetQuestion}_${idx}i`)
-            })
-            this.clearDateInputs(dateInputs)
-          } else {
-            this.clearTextNumericInput(textNumericInput)
-          }
+          const textNumericInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field`)
+          const errorInput = document.getElementById(`${type}-${targetQuestion.replaceAll('_', '-')}-field-error`)
+          const dateInputs = [1, 2, 3].map((idx) => {
+            return document.getElementById(`lettings_log_mrcdate_${idx}i`)
+          })
+          this.clearTextInput(textNumericInput)
+          this.clearTextInput(errorInput)
+          this.clearDateInputs(dateInputs)
         }
       })
     }
   }
 
-  clearTextNumericInput (input) {
-    input.value = ''
+  clearTextInput (input) {
+    if (input != null) {
+      input.value = ''
+    }
   }
 
   clearDateInputs (inputs) {
-    inputs.forEach((input) => { input.value = '' })
+    inputs.forEach((input) => {
+      this.clearTextInput(input)
+    })
   }
 }

--- a/spec/features/form/conditional_questions_spec.rb
+++ b/spec/features/form/conditional_questions_spec.rb
@@ -33,12 +33,15 @@ RSpec.describe "Form Conditional Questions" do
 
   before do
     sign_in user
-    allow(sales_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
-    allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
-    allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
   end
 
   context "with a page where some questions are only conditionally shown, depending on how you answer the first question" do
+    before do
+      allow(sales_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+      allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+      allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
+    end
+
     it "initially hides conditional questions" do
       visit("/lettings-logs/#{id}/armed-forces")
       expect(page).not_to have_selector("#armed_forces_injured_div")
@@ -57,6 +60,12 @@ RSpec.describe "Form Conditional Questions" do
   end
 
   context "when a conditional question has a saved answer", js: true do
+    before do
+      allow(sales_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+      allow(lettings_log.form).to receive(:new_logs_end_date).and_return(Time.zone.today + 1.day)
+      allow(FormHandler.instance).to receive(:current_lettings_form).and_return(fake_2021_2022_form)
+    end
+
     it "is displayed correctly" do
       lettings_log.update!(postcode_known: 1, postcode_full: "NW1 6RT")
       visit("/lettings-logs/#{id}/property-postcode")
@@ -71,6 +80,35 @@ RSpec.describe "Form Conditional Questions" do
       choose("sales-log-age1-known-1-field", allow_label_click: true)
       choose("sales-log-age1-known-0-field", allow_label_click: true)
       expect(page).to have_field("sales-log-age1-field", with: "")
+    end
+  end
+
+  context "when a conditional question has an error" do
+    let(:lettings_log) do
+      FactoryBot.create(
+        :lettings_log,
+        :completed,
+        created_by: user,
+      )
+    end
+
+    before do
+      FormHandler.instance.use_real_forms!
+    end
+
+    it "shows conditional questions if the required answer is selected and hides it again when a different answer option is selected", js: true do
+      visit("/lettings-logs/#{id}/lead-tenant-age")
+      choose("lettings-log-age1-known-0-field", allow_label_click: true)
+      fill_in("lettings-log-age1-field", with: "200")
+      click_button("Save and continue")
+      expect(page).not_to have_field("lettings-log-age1-field")
+      expect(page).to have_field("lettings-log-age1-field-error")
+      choose("lettings-log-age1-known-1-field", allow_label_click: true)
+      expect(page).not_to have_field("lettings-log-age1-field")
+      expect(page).not_to have_field("lettings-log-age1-field-error")
+      choose("lettings-log-age1-known-0-field", allow_label_click: true)
+      expect(page).not_to have_field("lettings-log-age1-field")
+      expect(page).to have_field("lettings-log-age1-field-error", with: "")
     end
   end
 end


### PR DESCRIPTION
on conditional questions we use js to clear the values if an option that hides a question is selected. We do that by getting the input field by id and clearing it's value, however if there is an error on this field from the previous input, the field id is different and the values don't get cleared. 
This PR clears both input value versions if there are any values in them.