### PR TITLE
CLDC-2957 Clear filters on completed bulk upload link

### DIFF
--- a/app/mailers/bulk_upload_mailer.rb
+++ b/app/mailers/bulk_upload_mailer.rb
@@ -50,9 +50,9 @@ class BulkUploadMailer < NotifyMailer
 
   def send_bulk_upload_complete_mail(user:, bulk_upload:)
     url = if bulk_upload.lettings?
-            lettings_logs_url("[years][]" => "", "[status][]" => "", user: :all, organisation_select: :all)
+            clear_filters_url(filter_type: "lettings_logs")
           else
-            sales_logs_url("[years][]" => "", "[status][]" => "", user: :all)
+            clear_filters_url(filter_type: "sales_logs")
           end
 
     n_logs = pluralize(bulk_upload.logs.count, "log")

--- a/spec/mailers/bulk_upload_mailer_spec.rb
+++ b/spec/mailers/bulk_upload_mailer_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe BulkUploadMailer do
           log_type: "lettings",
           upload_timestamp: bulk_upload.created_at.to_fs(:govuk_date_and_time),
           success_description: "The lettings 2022/23 data you uploaded has been checked. The 0 logs you uploaded are now complete.",
-          logs_link: lettings_logs_url("[years][]" => "", "[status][]" => "", user: :all, organisation_select: :all),
+          logs_link: clear_filters_url(filter_type: "lettings_logs"),
         },
       )
 


### PR DESCRIPTION
We were previously clearing the filters in completed bu email by setting them to defaults in the url, but in some cases where the user doesn't see the organisation filter they'd be stuck with 1 filter applied, but the filter not showing up.