### PR TITLE
CLDC-2960 Display missing stock owners banner

### DIFF
--- a/app/components/create_log_actions_component.rb
+++ b/app/components/create_log_actions_component.rb
@@ -14,6 +14,7 @@ class CreateLogActionsComponent < ViewComponent::Base
   def display_actions?
     return false if bulk_upload.present?
     return true if user.support?
+    return false if !user.organisation.holds_own_stock? && user.organisation.stock_owners.empty? && user.organisation.absorbed_organisations.empty?
 
     user.organisation.data_protection_confirmed?
   end

--- a/app/components/data_protection_confirmation_banner_component.rb
+++ b/app/components/data_protection_confirmation_banner_component.rb
@@ -3,8 +3,6 @@ class DataProtectionConfirmationBannerComponent < ViewComponent::Base
 
   attr_reader :user, :organisation
 
-  HELPDESK_URL = "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11".freeze
-
   def initialize(user:, organisation: nil)
     @user = user
     @organisation = organisation
@@ -58,7 +56,7 @@ private
   end
 
   def link_href
-    dpo_required? ? HELPDESK_URL : data_sharing_agreement_organisation_path(org_or_user_org)
+    dpo_required? ? GlobalConstants::HELPDESK_URL : data_sharing_agreement_organisation_path(org_or_user_org)
   end
 
   def dpo_required?

--- a/app/components/missing_stock_owners_banner_component.html.erb
+++ b/app/components/missing_stock_owners_banner_component.html.erb
@@ -1,0 +1,8 @@
+<% if display_banner? %>
+  <%= govuk_notification_banner(title_text: "Important") do %>
+    <p class="govuk-notification-banner__heading govuk-!-width-full" style="max-width: fit-content">
+      <%= header_text %>
+    <p>
+    <%= banner_text %>
+  <% end %>
+<% end %>

--- a/app/components/missing_stock_owners_banner_component.html.erb
+++ b/app/components/missing_stock_owners_banner_component.html.erb
@@ -3,6 +3,8 @@
     <p class="govuk-notification-banner__heading govuk-!-width-full" style="max-width: fit-content">
       <%= header_text %>
     <p>
-    <%= banner_text %>
+    <p style="max-width: fit-content">
+      <%= banner_text %>
+    </p>
   <% end %>
 <% end %>

--- a/app/components/missing_stock_owners_banner_component.rb
+++ b/app/components/missing_stock_owners_banner_component.rb
@@ -28,7 +28,7 @@ class MissingStockOwnersBannerComponent < ViewComponent::Base
     if user.data_coordinator? || user.support?
       "If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
     else
-      "Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.</br>
+      "Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.</br></br>
       If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
     end
   end

--- a/app/components/missing_stock_owners_banner_component.rb
+++ b/app/components/missing_stock_owners_banner_component.rb
@@ -1,0 +1,64 @@
+class MissingStockOwnersBannerComponent < ViewComponent::Base
+  include Rails.application.routes.url_helpers
+
+  attr_reader :user, :organisation
+
+  HELPDESK_URL = "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11".freeze
+
+  def initialize(user:)
+    @user = user
+    @organisation = user.organisation
+
+    super
+  end
+
+  def display_banner?
+    return false if user.support?
+    return false if DataProtectionConfirmationBannerComponent.new(user:, organisation:).display_banner?
+
+    !organisation.holds_own_stock? && organisation.stock_owners.empty? && organisation.absorbed_organisations.empty?
+  end
+
+  def header_text
+    if user.data_coordinator?
+      "Your organisation does not own stock. You must #{add_stock_owner_link} before you can create logs.".html_safe
+    else
+      "Your organisation does not own stock. You must add a stock owner before you can create logs.".html_safe
+    end
+  end
+
+  def banner_text
+    if user.data_coordinator?
+      "If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
+    else
+      "If your organisation does own stock, #{contact_helpdesk_link} to update your details.</br>
+      Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.".html_safe
+    end
+  end
+
+private
+
+  def add_stock_owner_link
+    govuk_link_to(
+      "add a stock owner",
+      stock_owners_add_organisation_path(id: organisation.id),
+      class: "govuk-notification-banner__link govuk-!-font-weight-bold",
+    )
+  end
+
+  def contact_helpdesk_link
+    govuk_link_to(
+      "contact the helpdesk",
+      HELPDESK_URL,
+      class: "govuk-notification-banner__link govuk-!-font-weight-bold",
+    )
+  end
+
+  def users_link
+    govuk_link_to(
+      "users page",
+      users_path,
+      class: "govuk-notification-banner__link govuk-!-font-weight-bold",
+    )
+  end
+end

--- a/app/components/missing_stock_owners_banner_component.rb
+++ b/app/components/missing_stock_owners_banner_component.rb
@@ -3,8 +3,6 @@ class MissingStockOwnersBannerComponent < ViewComponent::Base
 
   attr_reader :user, :organisation
 
-  HELPDESK_URL = "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11".freeze
-
   def initialize(user:)
     @user = user
     @organisation = user.organisation
@@ -49,7 +47,7 @@ private
   def contact_helpdesk_link
     govuk_link_to(
       "contact the helpdesk",
-      HELPDESK_URL,
+      GlobalConstants::HELPDESK_URL,
       class: "govuk-notification-banner__link govuk-!-font-weight-bold",
     )
   end

--- a/app/components/missing_stock_owners_banner_component.rb
+++ b/app/components/missing_stock_owners_banner_component.rb
@@ -3,22 +3,21 @@ class MissingStockOwnersBannerComponent < ViewComponent::Base
 
   attr_reader :user, :organisation
 
-  def initialize(user:)
+  def initialize(user:, organisation: nil)
     @user = user
-    @organisation = user.organisation
+    @organisation = organisation || user.organisation
 
     super
   end
 
   def display_banner?
-    return false if user.support?
     return false if DataProtectionConfirmationBannerComponent.new(user:, organisation:).display_banner?
 
     !organisation.holds_own_stock? && organisation.stock_owners.empty? && organisation.absorbed_organisations.empty?
   end
 
   def header_text
-    if user.data_coordinator?
+    if user.data_coordinator? || user.support?
       "Your organisation does not own stock. You must #{add_stock_owner_link} before you can create logs.".html_safe
     else
       "Your organisation does not own stock. You must add a stock owner before you can create logs.".html_safe
@@ -26,7 +25,7 @@ class MissingStockOwnersBannerComponent < ViewComponent::Base
   end
 
   def banner_text
-    if user.data_coordinator?
+    if user.data_coordinator? || user.support?
       "If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
     else
       "Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.</br>

--- a/app/components/missing_stock_owners_banner_component.rb
+++ b/app/components/missing_stock_owners_banner_component.rb
@@ -29,8 +29,8 @@ class MissingStockOwnersBannerComponent < ViewComponent::Base
     if user.data_coordinator?
       "If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
     else
-      "If your organisation does own stock, #{contact_helpdesk_link} to update your details.</br>
-      Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.".html_safe
+      "Ask a data coordinator to add a stock owner. Find your data coordinators on the #{users_link}.</br>
+      If your organisation does own stock, #{contact_helpdesk_link} to update your details.".html_safe
     end
   end
 

--- a/app/constants/global_constants.rb
+++ b/app/constants/global_constants.rb
@@ -1,0 +1,3 @@
+module GlobalConstants
+  HELPDESK_URL = "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11".freeze
+end

--- a/app/mailers/csv_download_mailer.rb
+++ b/app/mailers/csv_download_mailer.rb
@@ -29,8 +29,6 @@ class CsvDownloadMailer < NotifyMailer
 
 private
 
-  HELPDESK_URL = "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11".freeze
-
   def issue_explanation(issue_types, log_type)
     [
       "We have found #{multiple_issue_types?(issue_types) ? 'these issues' : 'this issue'} in your logs imported to the new version of CORE:\n",
@@ -43,7 +41,7 @@ private
   def how_to_fix(issue_types, link, log_type)
     [
       "You need to:\n\n",
-      "- download [this spreadsheet for #{log_type} logs](#{link}). This link will expire in one week. To request another link, [contact the CORE helpdesk](#{HELPDESK_URL}).\n",
+      "- download [this spreadsheet for #{log_type} logs](#{link}). This link will expire in one week. To request another link, [contact the CORE helpdesk](#{GlobalConstants::HELPDESK_URL}).\n",
       issue_types.include?("missing_address") || issue_types.include?("missing_town") ? "- fill in the missing address data\n" : "",
       uprn_issues_only(issue_types) ? "- check that the address data is correct\n" : "- check that the existing address data is correct\n",
       has_uprn_issues(issue_types) ? "- correct any address errors\n" : "",

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,6 +5,6 @@
     <h1 class="govuk-heading-l"><%= content_for(:title) %></h1>
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-    <p class="govuk-body"><%= govuk_link_to "Get help", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11" %> if the web address is correct and not working.</p>
+    <p class="govuk-body"><%= govuk_link_to "Get help", GlobalConstants::HELPDESK_URL %> if the web address is correct and not working.</p>
   </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -6,7 +6,7 @@
         <div class="govuk-grid-column-one-third-from-desktop">
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Online helpdesk</h3>
           <p class="govuk-body govuk-!-font-size-16">
-            <%= govuk_link_to("CORE helpdesk (opens in a new tab)", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", class: "govuk-footer__link", rel: "noreferrer noopener", target: "_blank") %>
+            <%= govuk_link_to("CORE helpdesk (opens in a new tab)", GlobalConstants::HELPDESK_URL, class: "govuk-footer__link", rel: "noreferrer noopener", target: "_blank") %>
           </p>
         </div>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -3,16 +3,18 @@
 
 <% content_for :title, title %>
 
-<%= render DataProtectionConfirmationBannerComponent.new(
+<% dpo_confirmation_banner = DataProtectionConfirmationBannerComponent.new(
   user: current_user,
   organisation: @organisation,
 ) %>
+<%= render dpo_confirmation_banner %>
 
-<%= render MissingStockOwnersBannerComponent.new(
+<% missing_stock_owner_banner = MissingStockOwnersBannerComponent.new(
   user: current_user,
 ) %>
+<%= render missing_stock_owner_banner %>
 
-<% if @duplicate_sets_count&.positive? %>
+<% if @duplicate_sets_count&.positive? && !dpo_confirmation_banner.display_banner? && !missing_stock_owner_banner.display_banner? %>
   <%= govuk_notification_banner(title_text: "Important", text: govuk_link_to("Review logs", duplicate_logs_path(referrer: "duplicate_logs_banner"))) do |banner| %>
     <% banner.with_heading(text: I18n.t("notification.duplicate_sets", count: @duplicate_sets_count)) %>
   <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -8,6 +8,10 @@
   organisation: @organisation,
 ) %>
 
+<%= render MissingStockOwnersBannerComponent.new(
+  user: current_user,
+) %>
+
 <% if @duplicate_sets_count&.positive? %>
   <%= govuk_notification_banner(title_text: "Important", text: govuk_link_to("Review logs", duplicate_logs_path(referrer: "duplicate_logs_banner"))) do |banner| %>
     <% banner.with_heading(text: I18n.t("notification.duplicate_sets", count: @duplicate_sets_count)) %>

--- a/app/views/maintenance/service_unavailable.html.erb
+++ b/app/views/maintenance/service_unavailable.html.erb
@@ -6,6 +6,6 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <p class="govuk-body">You will be able to use the service from 9am on Thursday 16 November 2023.</p>
     <p class="govuk-body">Changes from the page you were on have not been saved. Changes on pages where you have selected 'save and continue' have been saved.</p>
-    <p class="govuk-body"><%= govuk_link_to "Contact the helpdesk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11" %> if you need help.</p>
+    <p class="govuk-body"><%= govuk_link_to "Contact the helpdesk", GlobalConstants::HELPDESK_URL %> if you need help.</p>
   </div>
 </div>

--- a/app/views/organisation_relationships/add_managing_agent.html.erb
+++ b/app/views/organisation_relationships/add_managing_agent.html.erb
@@ -31,7 +31,7 @@
       <li>Double check the spelling and try again</li>
       <li>Type the first few letters to see the suggestions</li>
       <li>If you still can't find it,
-        <%= govuk_link_to("contact the DLUHC service desk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %>
+        <%= govuk_link_to("contact the DLUHC service desk", GlobalConstants::HELPDESK_URL, rel: "noreferrer noopener", target: "_blank") %>
       </li>
     </ul>
   <% end %>

--- a/app/views/organisation_relationships/add_stock_owner.html.erb
+++ b/app/views/organisation_relationships/add_stock_owner.html.erb
@@ -31,7 +31,7 @@
       <li>Double check the spelling and try again</li>
       <li>Type the first few letters to see the suggestions</li>
       <li>If you still can't find it,
-        <%= govuk_link_to("contact the DLUHC service desk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %>
+        <%= govuk_link_to("contact the DLUHC service desk", GlobalConstants::HELPDESK_URL, rel: "noreferrer noopener", target: "_blank") %>
       </li>
     </ul>
   <% end %>

--- a/app/views/organisations/logs.html.erb
+++ b/app/views/organisations/logs.html.erb
@@ -17,6 +17,11 @@
   organisation: @organisation,
 ) %>
 
+<%= render MissingStockOwnersBannerComponent.new(
+  user: current_user,
+  organisation: @organisation,
+) %>
+
 <% if @duplicate_sets_count&.positive? %>
   <%= govuk_notification_banner(title_text: "Important", text: govuk_link_to("Review logs", organisation_duplicates_path(@organisation, referrer: "duplicate_logs_banner"))) do |banner| %>
     <% banner.with_heading(text: I18n.t("notification.duplicate_sets", count: @duplicate_sets_count)) %>

--- a/app/views/organisations/logs.html.erb
+++ b/app/views/organisations/logs.html.erb
@@ -12,17 +12,19 @@
   <h2 class="govuk-visually-hidden">Logs</h2>
 <% end %>
 
-<%= render DataProtectionConfirmationBannerComponent.new(
+<% dpo_confirmation_banner = DataProtectionConfirmationBannerComponent.new(
   user: current_user,
   organisation: @organisation,
 ) %>
+<%= render dpo_confirmation_banner %>
 
-<%= render MissingStockOwnersBannerComponent.new(
+<% missing_stock_owner_banner = MissingStockOwnersBannerComponent.new(
   user: current_user,
   organisation: @organisation,
 ) %>
+<%= render missing_stock_owner_banner %>
 
-<% if @duplicate_sets_count&.positive? %>
+<% if @duplicate_sets_count&.positive? && !dpo_confirmation_banner.display_banner? && !missing_stock_owner_banner.display_banner? %>
   <%= govuk_notification_banner(title_text: "Important", text: govuk_link_to("Review logs", organisation_duplicates_path(@organisation, referrer: "duplicate_logs_banner"))) do |banner| %>
     <% banner.with_heading(text: I18n.t("notification.duplicate_sets", count: @duplicate_sets_count)) %>
   <% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -37,7 +37,7 @@
       <%= data_sharing_agreement_row(organisation: @organisation, user: current_user, summary_list:) %>
     <% end %>
     <% if FeatureToggle.merge_organisations_enabled? %>
-      <p>To report a merge or update your organisation details, <%= govuk_link_to "contact the helpdesk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11" %>.</p>
+      <p>To report a merge or update your organisation details, <%= govuk_link_to "contact the helpdesk", GlobalConstants::HELPDESK_URL %>.</p>
     <% end %>
     <%= render partial: "organisations/merged_organisation_details" %>
   </div>

--- a/app/views/schemes/changes.html.erb
+++ b/app/views/schemes/changes.html.erb
@@ -28,6 +28,6 @@
     <p class="govuk-body">If you upload logs in bulk, you can use either the new or old scheme codes in your template.</p>
     <h2 class="govuk-heading-m">If you can’t find a scheme</h2>
     <p class="govuk-body">You should be able to recognise a scheme migrated from old CORE by viewing its details or locations. Try searching for it by postcode.</p>
-    <p class="govuk-body">If you still can’t find a scheme that was migrated from old CORE, either create a new one if you know the details, or <%= govuk_link_to("contact the helpdesk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11", rel: "noreferrer noopener", target: "_blank") %> to report the problem. Only data coordinators can create and edit schemes.</p>
+    <p class="govuk-body">If you still can’t find a scheme that was migrated from old CORE, either create a new one if you know the details, or <%= govuk_link_to("contact the helpdesk", GlobalConstants::HELPDESK_URL, rel: "noreferrer noopener", target: "_blank") %> to report the problem. Only data coordinators can create and edit schemes.</p>
   </div>
 </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -18,7 +18,7 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">Use your account details to sign in.</p>
-    <p class="govuk-body">If you need to set up a new account, speak to your organisation’s CORE data coordinator. If you don’t know who that is, <%= govuk_link_to("contact the helpdesk", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/6/group/11") %>.</p>
+    <p class="govuk-body">If you need to set up a new account, speak to your organisation’s CORE data coordinator. If you don’t know who that is, <%= govuk_link_to("contact the helpdesk", GlobalConstants::HELPDESK_URL) %>.</p>
     <p class="govuk-body">You can <%= govuk_mail_to("dluhc.digital-services@levellingup.gov.uk", "request an account", subject: "CORE: Request a new account") %> if your organisation doesn’t have one.</p>
   </div>
 

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -326,6 +326,25 @@ RSpec.describe LettingsLogsController, type: :request do
             end
           end
         end
+
+        context "and organisation owns stock" do
+          before do
+            organisation.update!(holds_own_stock: true)
+          end
+
+          it "displays button to create a new log" do
+            get "/lettings-logs"
+            expect(page).to have_content("Create a new lettings log")
+          end
+
+          it "does not display the missing stock owners banner" do
+            get "/lettings-logs", headers:, params: {}
+            expect(page).not_to have_css(".govuk-notification-banner")
+            expect(page).not_to have_content("Your organisation does not own stock.")
+            expect(page).not_to have_link("add a stock owner", href: /stock-owners\/add/)
+            expect(page).not_to have_link("users page", href: /users/)
+          end
+        end
       end
 
       context "when the user is a customer support user" do

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -291,6 +291,41 @@ RSpec.describe LettingsLogsController, type: :request do
             expect(page).to have_content("Managed by")
           end
         end
+
+        context "and organisation does not own stock or have valid stock owners" do
+          before do
+            organisation.update!(holds_own_stock: false)
+          end
+
+          it "hides button to create a new log" do
+            get "/lettings-logs"
+            expect(page).not_to have_content("Create a new lettings log")
+          end
+
+          context "with coordinator user" do
+            let(:user) { FactoryBot.create(:user, :data_coordinator) }
+
+            it "displays a banner exlaining why create new logs button is missing" do
+              get "/lettings-logs", headers:, params: {}
+              expect(page).to have_css(".govuk-notification-banner")
+              expect(page).to have_content("Your organisation does not own stock.")
+              expect(page).to have_link("add a stock owner", href: /stock-owners\/add/)
+              expect(page).not_to have_link("users page", href: /users/)
+            end
+          end
+
+          context "with provider user" do
+            let(:user) { FactoryBot.create(:user, :data_provider) }
+
+            it "displays a banner exlaining why create new logs button is missing" do
+              get "/lettings-logs", headers:, params: {}
+              expect(page).to have_css(".govuk-notification-banner")
+              expect(page).to have_content("Your organisation does not own stock.")
+              expect(page).not_to have_link("add a stock owner", href: /stock-owners\/add/)
+              expect(page).to have_link("users page", href: /users/)
+            end
+          end
+        end
       end
 
       context "when the user is a customer support user" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -804,6 +804,30 @@ RSpec.describe SalesLogsController, type: :request do
                 expect(page).not_to have_content "duplicate logs"
               end
             end
+
+            context "and the data sharing agreement banner is shown" do
+              before do
+                user.organisation.data_protection_confirmation.destroy!
+                user.organisation.reload
+              end
+
+              it "displays the correct copy in the banner" do
+                get sales_logs_path
+                expect(page).not_to have_content "duplicate logs"
+              end
+            end
+
+            context "and the missing stock owner banner is shown" do
+              before do
+                user.organisation.update!(holds_own_stock: false)
+                user.organisation.reload
+              end
+
+              it "displays the correct copy in the banner" do
+                get sales_logs_path
+                expect(page).not_to have_content "duplicate logs"
+              end
+            end
           end
 
           context "when there are multiple sets of duplicates" do


### PR DESCRIPTION
Add a banner if the organisation shouldn't be able to create logs
<img width="1306" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/594bad77-f681-4564-98c1-72b82f6c5b93">

Do not display create logs buttons in organisation shouldn't be able to create logs