### PR TITLE
CLDC-2778 Set different hint texts for tenancy length

### DIFF
--- a/app/models/form/lettings/pages/tenancy_length.rb
+++ b/app/models/form/lettings/pages/tenancy_length.rb
@@ -2,7 +2,7 @@ class Form::Lettings::Pages::TenancyLength < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "tenancy_length"
-    @depends_on = [{ "tenancy_type_fixed_term?" => true }]
+    @depends_on = [{ "tenancy_type_fixed_term?" => true, "needstype" => 2 }]
   end
 
   def questions

--- a/app/models/form/lettings/pages/tenancy_length_affordable_rent.rb
+++ b/app/models/form/lettings/pages/tenancy_length_affordable_rent.rb
@@ -1,0 +1,11 @@
+class Form::Lettings::Pages::TenancyLengthAffordableRent < ::Form::Page
+  def initialize(id, hsh, subsection)
+    super
+    @id = "tenancy_length_affordable_rent"
+    @depends_on = [{ "tenancy_type_fixed_term?" => true, "affordable_or_social_rent?" => true, "needstype" => 1 }]
+  end
+
+  def questions
+    @questions ||= [Form::Lettings::Questions::TenancyLengthAffordableRent.new(nil, nil, self)]
+  end
+end

--- a/app/models/form/lettings/pages/tenancy_length_intermediate_rent.rb
+++ b/app/models/form/lettings/pages/tenancy_length_intermediate_rent.rb
@@ -1,0 +1,11 @@
+class Form::Lettings::Pages::TenancyLengthIntermediateRent < ::Form::Page
+  def initialize(id, hsh, subsection)
+    super
+    @id = "tenancy_length_intermediate_rent"
+    @depends_on = [{ "tenancy_type_fixed_term?" => true, "affordable_or_social_rent?" => false, "needstype" => 1 }]
+  end
+
+  def questions
+    @questions ||= [Form::Lettings::Questions::TenancyLengthIntermediateRent.new(nil, nil, self)]
+  end
+end

--- a/app/models/form/lettings/questions/tenancy_length_affordable_rent.rb
+++ b/app/models/form/lettings/questions/tenancy_length_affordable_rent.rb
@@ -1,4 +1,4 @@
-class Form::Lettings::Questions::TenancyLength < ::Form::Question
+class Form::Lettings::Questions::TenancyLengthAffordableRent < ::Form::Question
   def initialize(id, hsh, page)
     super
     @id = "tenancylength"
@@ -9,7 +9,7 @@ class Form::Lettings::Questions::TenancyLength < ::Form::Question
     @check_answers_card_number = 0
     @max = 150
     @min = 0
-    @hint_text = "Do not include the starter or introductory period."
+    @hint_text = "Do not include the starter or introductory period.</br>The minimum period is 2 years for social or affordable rent general needs logs and you do not need a log for shorter tenancies."
     @step = 1
     @question_number = 28
   end

--- a/app/models/form/lettings/questions/tenancy_length_intermediate_rent.rb
+++ b/app/models/form/lettings/questions/tenancy_length_intermediate_rent.rb
@@ -1,4 +1,4 @@
-class Form::Lettings::Questions::TenancyLength < ::Form::Question
+class Form::Lettings::Questions::TenancyLengthIntermediateRent < ::Form::Question
   def initialize(id, hsh, page)
     super
     @id = "tenancylength"
@@ -9,7 +9,7 @@ class Form::Lettings::Questions::TenancyLength < ::Form::Question
     @check_answers_card_number = 0
     @max = 150
     @min = 0
-    @hint_text = "Do not include the starter or introductory period."
+    @hint_text = "Do not include the starter or introductory period.</br>The minimum period is 1 year for intermediate rent general needs logs and you do not need a log for shorter tenancies."
     @step = 1
     @question_number = 28
   end

--- a/app/models/form/lettings/subsections/tenancy_information.rb
+++ b/app/models/form/lettings/subsections/tenancy_information.rb
@@ -13,6 +13,8 @@ class Form::Lettings::Subsections::TenancyInformation < ::Form::Subsection
       Form::Lettings::Pages::TenancyType.new(nil, nil, self),
       Form::Lettings::Pages::StarterTenancyType.new(nil, nil, self),
       Form::Lettings::Pages::TenancyLength.new(nil, nil, self),
+      Form::Lettings::Pages::TenancyLengthAffordableRent.new(nil, nil, self),
+      Form::Lettings::Pages::TenancyLengthIntermediateRent.new(nil, nil, self),
       Form::Lettings::Pages::ShelteredAccommodation.new(nil, nil, self),
     ].compact
   end

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -627,6 +627,10 @@ class LettingsLog < Log
     letting_allocation_unknown
   end
 
+  def affordable_or_social_rent?
+    renttype == 1 || renttype == 2
+  end
+
 private
 
   def reset_invalid_unresolved_log_fields!

--- a/spec/models/form/lettings/pages/tenancy_length_spec.rb
+++ b/spec/models/form/lettings/pages/tenancy_length_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe Form::Lettings::Pages::TenancyLength, type: :model do
   end
 
   it "has the correct depends_on" do
-    expect(page.depends_on).to eq [{ "tenancy_type_fixed_term?" => true }]
+    expect(page.depends_on).to eq [{ "tenancy_type_fixed_term?" => true, "needstype" => 2 }]
   end
 end

--- a/spec/models/form/lettings/questions/tenancy_length_spec.rb
+++ b/spec/models/form/lettings/questions/tenancy_length_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Form::Lettings::Questions::TenancyLength, type: :model do
   end
 
   it "has the correct hint_text" do
-    expect(question.hint_text).to eq("Don’t include the starter or introductory period.")
+    expect(question.hint_text).to eq("Do not include the starter or introductory period.")
   end
 
   it "has the correct minimum and maximum" do

--- a/spec/models/form/lettings/subsections/tenancy_information_spec.rb
+++ b/spec/models/form/lettings/subsections/tenancy_information_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Form::Lettings::Subsections::TenancyInformation, type: :model do
 
   it "has correct pages" do
     expect(tenancy_information.pages.map(&:id)).to eq(
-      %w[joint starter_tenancy tenancy_type starter_tenancy_type tenancy_length sheltered_accommodation],
+      %w[joint starter_tenancy tenancy_type starter_tenancy_type tenancy_length tenancy_length_affordable_rent tenancy_length_intermediate_rent sheltered_accommodation],
     )
   end
 


### PR DESCRIPTION
- For supported housing - stays the same 
<img width="1283" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/01f4ab1c-e116-4ed4-9720-53a3dfd0773e">

- For GN affordable or social rent:
<img width="1298" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/a6e6ee6b-995d-4ca5-93b2-7d9fb36354e8">

- For GN intermediate rent:
<img width="1384" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/66a2272e-4cda-443b-a89c-3c555d755107">
