### PR TITLE
CLDC-2975 Correctly map  location and scheme errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -738,7 +738,7 @@ private
         fields.each do |field|
           if errors.select { |e| fields.include?(e.attribute) }.none?
             question_text = question.error_display_label.presence || "this question"
-            errors.add(field, I18n.t("validations.not_answered", question: question_text.downcase), category: :setup)
+            errors.add(field, I18n.t("validations.not_answered", question: question_text.downcase), category: :setup) if field.present?
           end
         end
       else
@@ -883,7 +883,9 @@ private
       owning_organisation_id: [:field_1],
       managing_organisation_id: [:field_2],
       renewal: [:field_6],
+      scheme_id: [scheme_field],
       scheme: [scheme_field],
+      location_id: [location_field],
       location: [location_field],
       created_by: [:field_3],
       needstype: [:field_4],


### PR DESCRIPTION
Some of the errors on the model get added to scheme_id/location_id instead of scheme/location so not all of them were coming through