### PR TITLE
CLDC-2988 Update routing for address pages

### DIFF
--- a/app/models/form/lettings/pages/address.rb
+++ b/app/models/form/lettings/pages/address.rb
@@ -3,6 +3,11 @@ class Form::Lettings::Pages::Address < ::Form::Page
     super
     @id = "address"
     @header = "Q12 - What is the property's address?"
+    @depends_on = [
+      { "is_supported_housing?" => false, "uprn_known" => nil },
+      { "is_supported_housing?" => false, "uprn_known" => 0 },
+      { "is_supported_housing?" => false, "uprn_confirmed" => 0 },
+    ]
   end
 
   def questions
@@ -13,11 +18,5 @@ class Form::Lettings::Pages::Address < ::Form::Page
       Form::Lettings::Questions::County.new(nil, nil, self),
       Form::Lettings::Questions::PostcodeForFullAddress.new(nil, nil, self),
     ]
-  end
-
-  def routed_to?(log, _current_user = nil)
-    return false if log.is_supported_housing?
-
-    log.uprn_known.nil? || log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end
 end

--- a/app/models/form/lettings/pages/uprn.rb
+++ b/app/models/form/lettings/pages/uprn.rb
@@ -2,6 +2,7 @@ class Form::Lettings::Pages::Uprn < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "uprn"
+    @depends_on = [{ "is_supported_housing?" => false }]
   end
 
   def questions
@@ -9,10 +10,6 @@ class Form::Lettings::Pages::Uprn < ::Form::Page
       Form::Lettings::Questions::UprnKnown.new(nil, nil, self),
       Form::Lettings::Questions::Uprn.new(nil, nil, self),
     ]
-  end
-
-  def routed_to?(log, _current_user = nil)
-    !log.is_supported_housing?
   end
 
   def skip_text

--- a/app/models/form/sales/pages/address.rb
+++ b/app/models/form/sales/pages/address.rb
@@ -3,6 +3,11 @@ class Form::Sales::Pages::Address < ::Form::Page
     super
     @id = "address"
     @header = "Q15 - What is the property's address?"
+    @depends_on = [
+      { "uprn_known" => nil },
+      { "uprn_known" => 0 },
+      { "uprn_confirmed" => 0 },
+    ]
   end
 
   def questions
@@ -13,9 +18,5 @@ class Form::Sales::Pages::Address < ::Form::Page
       Form::Sales::Questions::County.new(nil, nil, self),
       Form::Sales::Questions::PostcodeForFullAddress.new(nil, nil, self),
     ]
-  end
-
-  def routed_to?(log, _current_user = nil)
-    log.uprn_known.nil? || log.uprn_known.zero? || log.uprn_confirmed&.zero?
   end
 end

--- a/app/models/form/sales/pages/uprn.rb
+++ b/app/models/form/sales/pages/uprn.rb
@@ -11,10 +11,6 @@ class Form::Sales::Pages::Uprn < ::Form::Page
     ]
   end
 
-  def routed_to?(_log, _current_user)
-    true
-  end
-
   def skip_text
     "Enter address instead"
   end

--- a/spec/lib/tasks/correct_address_from_csv_spec.rb
+++ b/spec/lib/tasks/correct_address_from_csv_spec.rb
@@ -21,22 +21,6 @@ RSpec.describe "data_import" do
       .to_return(status: 200, body: "{\"status\":404,\"error\":\"Postcode not found\"}", headers: {})
     WebMock.stub_request(:get, /api\.postcodes\.io\/postcodes\/B11BB/)
       .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Westminster","codes":{"admin_district":"E08000035"}}}', headers: {})
-
-    body = {
-      results: [
-        {
-          DPA: {
-            "POSTCODE": "LS16 6FT",
-            "POST_TOWN": "Westminster",
-            "PO_BOX_NUMBER": "Wrong Address Line1",
-            "DOUBLE_DEPENDENT_LOCALITY": "Double Dependent Locality",
-          },
-        },
-      ],
-    }.to_json
-
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key&uprn=1")
-     .to_return(status: 200, body:, headers: {})
   end
 
   describe ":import_lettings_addresses_from_csv", type: :task do
@@ -73,19 +57,22 @@ RSpec.describe "data_import" do
       end
 
       let!(:lettings_logs) do
-        create_list(:lettings_log,
-                    3,
-                    uprn_known: 1,
-                    uprn: "1",
-                    uprn_confirmed: nil,
-                    address_line1: "wrong address line1",
-                    address_line2: "wrong address 2",
-                    town_or_city: "wrong town",
-                    county: "wrong city",
-                    postcode_known: 1,
-                    postcode_full: "A1 1AA",
-                    la: "E06000064",
-                    is_la_inferred: true)
+        logs = build_list(:lettings_log,
+                          3,
+                          :setup_completed,
+                          uprn_known: 1,
+                          uprn: "121",
+                          uprn_confirmed: nil,
+                          address_line1: "wrong address line1",
+                          address_line2: "wrong address 2",
+                          town_or_city: "wrong town",
+                          county: "wrong city",
+                          postcode_known: 1,
+                          postcode_full: "A1 1AA",
+                          la: "E06000064",
+                          is_la_inferred: true)
+        logs.each { |log| log.save!(validate: false) }
+        logs
       end
 
       before do
@@ -135,7 +122,7 @@ RSpec.describe "data_import" do
           task.invoke(addresses_csv_path)
           lettings_logs[1].reload
           expect(lettings_logs[1].uprn_known).to eq(1)
-          expect(lettings_logs[1].uprn).to eq("1")
+          expect(lettings_logs[1].uprn).to eq("121")
           expect(lettings_logs[1].uprn_confirmed).to eq(nil)
           expect(lettings_logs[1].address_line1).to eq("wrong address line1")
           expect(lettings_logs[1].address_line2).to eq("wrong address 2")
@@ -150,7 +137,7 @@ RSpec.describe "data_import" do
           task.invoke(addresses_csv_path)
           lettings_logs[2].reload
           expect(lettings_logs[2].uprn_known).to eq(1)
-          expect(lettings_logs[2].uprn).to eq("1")
+          expect(lettings_logs[2].uprn).to eq("121")
           expect(lettings_logs[2].uprn_confirmed).to eq(nil)
           expect(lettings_logs[2].address_line1).to eq("wrong address line1")
           expect(lettings_logs[2].address_line2).to eq("wrong address 2")
@@ -231,7 +218,7 @@ RSpec.describe "data_import" do
           task.invoke(all_addresses_csv_path)
           lettings_logs[1].reload
           expect(lettings_logs[1].uprn_known).to eq(1)
-          expect(lettings_logs[1].uprn).to eq("1")
+          expect(lettings_logs[1].uprn).to eq("121")
           expect(lettings_logs[1].uprn_confirmed).to eq(nil)
           expect(lettings_logs[1].address_line1).to eq("wrong address line1")
           expect(lettings_logs[1].address_line2).to eq("wrong address 2")
@@ -246,7 +233,7 @@ RSpec.describe "data_import" do
           task.invoke(all_addresses_csv_path)
           lettings_logs[2].reload
           expect(lettings_logs[2].uprn_known).to eq(1)
-          expect(lettings_logs[2].uprn).to eq("1")
+          expect(lettings_logs[2].uprn).to eq("121")
           expect(lettings_logs[2].uprn_confirmed).to eq(nil)
           expect(lettings_logs[2].address_line1).to eq("wrong address line1")
           expect(lettings_logs[2].address_line2).to eq("wrong address 2")
@@ -323,7 +310,7 @@ RSpec.describe "data_import" do
                is_la_inferred: true)
       end
 
-      let!(:sales_logs) { create_list(:sales_log, 3, :completed, uprn_known: 1, uprn: "1", la: "E06000064", is_la_inferred: true) }
+      let!(:sales_logs) { create_list(:sales_log, 3, :completed, uprn_known: 1, uprn: "121", la: "E06000064", is_la_inferred: true) }
 
       before do
         allow(storage_service).to receive(:get_file_io)
@@ -372,7 +359,7 @@ RSpec.describe "data_import" do
           task.invoke(addresses_csv_path)
           sales_logs[1].reload
           expect(sales_logs[1].uprn_known).to eq(1)
-          expect(sales_logs[1].uprn).to eq("1")
+          expect(sales_logs[1].uprn).to eq("121")
           expect(sales_logs[1].uprn_confirmed).to eq(nil)
           expect(sales_logs[1].address_line1).to eq("Wrong Address Line1")
           expect(sales_logs[1].address_line2).to eq("Double Dependent Locality")
@@ -387,7 +374,7 @@ RSpec.describe "data_import" do
           task.invoke(addresses_csv_path)
           sales_logs[2].reload
           expect(sales_logs[2].uprn_known).to eq(1)
-          expect(sales_logs[2].uprn).to eq("1")
+          expect(sales_logs[2].uprn).to eq("121")
           expect(sales_logs[2].uprn_confirmed).to eq(nil)
           expect(sales_logs[2].address_line1).to eq("Wrong Address Line1")
           expect(sales_logs[2].address_line2).to eq("Double Dependent Locality")
@@ -468,7 +455,7 @@ RSpec.describe "data_import" do
           task.invoke(all_addresses_csv_path)
           sales_logs[1].reload
           expect(sales_logs[1].uprn_known).to eq(1)
-          expect(sales_logs[1].uprn).to eq("1")
+          expect(sales_logs[1].uprn).to eq("121")
           expect(sales_logs[1].uprn_confirmed).to eq(nil)
           expect(sales_logs[1].address_line1).to eq("Wrong Address Line1")
           expect(sales_logs[1].address_line2).to eq("Double Dependent Locality")
@@ -483,7 +470,7 @@ RSpec.describe "data_import" do
           task.invoke(all_addresses_csv_path)
           sales_logs[2].reload
           expect(sales_logs[2].uprn_known).to eq(1)
-          expect(sales_logs[2].uprn).to eq("1")
+          expect(sales_logs[2].uprn).to eq("121")
           expect(sales_logs[2].uprn_confirmed).to eq(nil)
           expect(sales_logs[2].address_line1).to eq("Wrong Address Line1")
           expect(sales_logs[2].address_line2).to eq("Double Dependent Locality")

--- a/spec/lib/tasks/send_missing_addresses_csv_spec.rb
+++ b/spec/lib/tasks/send_missing_addresses_csv_spec.rb
@@ -17,36 +17,6 @@ RSpec.describe "correct_addresses" do
       Rake.application.rake_require("tasks/send_missing_addresses_csv")
       Rake::Task.define_task(:environment)
       task.reenable
-
-      body_1 = {
-        results: [
-          {
-            DPA: {
-              "POSTCODE": "BS1 1AD",
-              "POST_TOWN": "Bristol",
-              "ORGANISATION_NAME": "Some place",
-            },
-          },
-        ],
-      }.to_json
-
-      body_2 = {
-        results: [
-          {
-            DPA: {
-              "POSTCODE": "EC1N 2TD",
-              "POST_TOWN": "Newcastle",
-              "ORGANISATION_NAME": "Some place",
-            },
-          },
-        ],
-      }.to_json
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123")
-      .to_return(status: 200, body: body_1, headers: {})
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=12")
-      .to_return(status: 200, body: body_2, headers: {})
     end
 
     context "when the rake task is run" do
@@ -62,7 +32,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:lettings_log, 7, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_1", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 7, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_1", owning_organisation: organisation, managing_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -81,7 +51,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -96,9 +66,11 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org has less than 5 missing addresses" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:lettings_log, 3, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
-          create_list(:lettings_log, 2, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 3, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
+          create_list(:lettings_log, 2, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job with organisations that is missing less addresses than threshold amount" do
@@ -112,7 +84,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:lettings_log, 7, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, needstype: 1, old_form_id: "form_1", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 7, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, needstype: 1, old_form_id: "form_1", owning_organisation: organisation, managing_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -131,7 +103,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -146,9 +118,11 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org has less than 5 missing town or city" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:lettings_log, 3, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "address", town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
-          create_list(:lettings_log, 2, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "address", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 3, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "address", town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
+          create_list(:lettings_log, 2, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: "address", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job with organisations that is missing less town or city data than threshold amount" do
@@ -162,7 +136,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:lettings_log, 7, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "123", town_or_city: "Bristol", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 7, :imported, :setup_completed, startdate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "123", town_or_city: "Bristol", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -181,7 +155,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, :setup_completed, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -200,8 +174,8 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 3, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "123", town_or_city: "Bristol", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
-          create_list(:lettings_log, 2, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", tenancycode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 3, :imported, :setup_completed, startdate: Time.zone.local(2023, 9, 9), uprn: "123", town_or_city: "Bristol", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
+          create_list(:lettings_log, 2, :imported, :setup_completed, startdate: Time.zone.local(2023, 9, 9), uprn: "12", tenancycode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -216,8 +190,10 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org is included in skip_uprn_issue_organisations list" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job" do
@@ -230,8 +206,8 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, needstype: 1, old_form_id: "form_2", owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
+          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job" do
@@ -244,7 +220,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:lettings_log, 5, :imported, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: organisation.users.first)
+          create_list(:lettings_log, 5, :imported, :setup_completed, startdate: Time.zone.local(2023, 9, 9), uprn: "12", propcode: "12", needstype: 1, owning_organisation: organisation, managing_organisation: organisation, created_by: data_provider)
         end
 
         it "does enqueues the job with correct skip_uprn_issue_organisations" do
@@ -262,36 +238,6 @@ RSpec.describe "correct_addresses" do
       Rake.application.rake_require("tasks/send_missing_addresses_csv")
       Rake::Task.define_task(:environment)
       task.reenable
-
-      body_1 = {
-        results: [
-          {
-            DPA: {
-              "POSTCODE": "BS1 1AD",
-              "POST_TOWN": "Bristol",
-              "ORGANISATION_NAME": "Some place",
-            },
-          },
-        ],
-      }.to_json
-
-      body_2 = {
-        results: [
-          {
-            DPA: {
-              "POSTCODE": "EC1N 2TD",
-              "POST_TOWN": "Newcastle",
-              "ORGANISATION_NAME": "Some place",
-            },
-          },
-        ],
-      }.to_json
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123")
-      .to_return(status: 200, body: body_1, headers: {})
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=12")
-      .to_return(status: 200, body: body_2, headers: {})
     end
 
     context "when the rake task is run" do
@@ -307,7 +253,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_1", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_1", owning_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -326,7 +272,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -341,9 +287,11 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org has less than 5 missing addresses" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: organisation.users.first)
-          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: data_provider)
+          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: nil, owning_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job with organisations that is missing less addresses than threshold amount" do
@@ -357,7 +305,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, old_form_id: "form_1", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, old_form_id: "form_1", owning_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -376,7 +324,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "exists", town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -391,9 +339,11 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org has less than 5 missing town or city" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "address", town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: organisation.users.first)
-          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "address", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "address", town_or_city: nil, old_form_id: "form_2", owning_organisation: organisation, created_by: data_provider)
+          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), address_line1: "address", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job with organisations that is missing less town or city data than threshold amount" do
@@ -407,7 +357,7 @@ RSpec.describe "correct_addresses" do
 
         before do
           create(:user, :data_provider, organisation:, email: "data_provider1@example.com")
-          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "123", town_or_city: "Bristol", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 7, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "123", town_or_city: "Bristol", owning_organisation: organisation, created_by: data_coordinator)
         end
 
         it "enqueues the job with correct organisations" do
@@ -426,7 +376,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -445,8 +395,8 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "123", town_or_city: "Bristol", owning_organisation: organisation, created_by: organisation.users.first)
-          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 3, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "123", town_or_city: "Bristol", owning_organisation: organisation, created_by: data_provider)
+          create_list(:sales_log, 2, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "enqueues the job with correct organisations" do
@@ -461,8 +411,10 @@ RSpec.describe "correct_addresses" do
       end
 
       context "when org is included in skip_uprn_issue_organisations list" do
+        let!(:data_provider) { create(:user, :data_provider, organisation:, email: "data_provider3@example.com") }
+
         before do
-          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "does not enqueue the job" do
@@ -475,7 +427,7 @@ RSpec.describe "correct_addresses" do
         let!(:data_provider2) { create(:user, :data_provider, organisation:, email: "data_provider4@example.com") }
 
         before do
-          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: organisation.users.first)
+          create_list(:sales_log, 5, :completed, :imported, saledate: Time.zone.local(2023, 9, 9), uprn_known: 1, uprn: "12", purchid: "12", owning_organisation: organisation, created_by: data_provider)
         end
 
         it "does enqueues the job with correct skip_uprn_issue_organisations" do

--- a/spec/models/form/lettings/pages/address_spec.rb
+++ b/spec/models/form/lettings/pages/address_spec.rb
@@ -28,46 +28,6 @@ RSpec.describe Form::Lettings::Pages::Address, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
-  end
-
-  describe "has correct routed_to?" do
-    context "when uprn_known == nil" do
-      let(:log) { create(:lettings_log, uprn_known: nil) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_confirmed != 1" do
-      let(:log) do
-        create(:lettings_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 0)
-      end
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_known == 0" do
-      let(:log) do
-        create(:lettings_log, uprn_known: 0, uprn_confirmed: 0)
-      end
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_confirmed == 1 && uprn_known != 0" do
-      let(:log) do
-        create(:lettings_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1)
-      end
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
+    expect(page.depends_on).to eq([{ "is_supported_housing?" => false, "uprn_known" => nil }, { "is_supported_housing?" => false, "uprn_known" => 0 }, { "is_supported_housing?" => false, "uprn_confirmed" => 0 }])
   end
 end

--- a/spec/models/form/lettings/pages/uprn_confirmation_spec.rb
+++ b/spec/models/form/lettings/pages/uprn_confirmation_spec.rb
@@ -30,30 +30,4 @@ RSpec.describe Form::Lettings::Pages::UprnConfirmation, type: :model do
   it "has correct depends_on" do
     expect(page.depends_on).to be_nil
   end
-
-  describe "has correct routed_to?" do
-    context "when uprn present && uprn_known == 1 " do
-      let(:log) { create(:lettings_log, uprn_known: 1, uprn: "123456789") }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn = nil" do
-      let(:log) { create(:lettings_log, uprn_known: 1, uprn: nil) }
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
-
-    context "when uprn_known == 0" do
-      let(:log) { create(:lettings_log, uprn_known: 0, uprn: "123456789") }
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
-  end
 end

--- a/spec/models/form/lettings/pages/uprn_spec.rb
+++ b/spec/models/form/lettings/pages/uprn_spec.rb
@@ -28,29 +28,11 @@ RSpec.describe Form::Lettings::Pages::Uprn, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
+    expect(page.depends_on).to eq([{ "is_supported_housing?" => false }])
   end
 
   it "has correct skip_text" do
     expect(page.skip_text).to eq("Enter address instead")
-  end
-
-  describe "has correct routed_to?" do
-    context "when uprn_known == 1" do
-      let(:log) { create(:lettings_log, uprn_known: 1) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when needstype == 2" do
-      let(:log) { create(:lettings_log, uprn_known: 1, needstype: 2) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
   end
 
   describe "has correct skip_href" do

--- a/spec/models/form/lettings/questions/uprn_confirmation_spec.rb
+++ b/spec/models/form/lettings/questions/uprn_confirmation_spec.rb
@@ -7,25 +7,6 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
 
-  before do
-    body = {
-      results: [
-        {
-          DPA: {
-            "POSTCODE": "AA1 1AA",
-            "POST_TOWN": "Test Town",
-            "ORGANISATION_NAME": "1, Test Street",
-          },
-        },
-      ],
-    }.to_json
-
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1234")
-    .to_return(status: 200, body:, headers: {})
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
-    .to_return(status: 200, body:, headers: {})
-  end
-
   it "has correct page" do
     expect(question.page).to eq(page)
   end
@@ -69,12 +50,12 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
 
     context "when address is present" do
       it "returns formatted value" do
-        log = create(:lettings_log, :setup_completed, address_line1: "1, Test Street", town_or_city: "Test Town", postcode_full: "AA1 1AA", uprn: "1234", uprn_known: 1)
+        log = create(:lettings_log, :setup_completed, address_line1: "1, Test Street", town_or_city: "Test Town", postcode_full: "AA1 1AA", uprn: "1", uprn_known: 1)
 
         expect(question.notification_banner(log)).to eq(
           {
             heading: "1, Test Street\nAA1 1AA\nTest Town",
-            title: "UPRN: 1234",
+            title: "UPRN: 1",
           },
         )
       end

--- a/spec/models/form/lettings/questions/uprn_spec.rb
+++ b/spec/models/form/lettings/questions/uprn_spec.rb
@@ -7,23 +7,6 @@ RSpec.describe Form::Lettings::Questions::Uprn, type: :model do
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
 
-  before do
-    body = {
-      results: [
-        {
-          DPA: {
-            "POSTCODE": "AA1 1AA",
-            "POST_TOWN": "Test Town",
-            "ORGANISATION_NAME": "1, Test Street",
-          },
-        },
-      ],
-    }.to_json
-
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
-    .to_return(status: 200, body:, headers: {})
-  end
-
   it "has correct page" do
     expect(question.page).to eq(page)
   end

--- a/spec/models/form/lettings/questions/uprn_spec.rb
+++ b/spec/models/form/lettings/questions/uprn_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe Form::Lettings::Questions::Uprn, type: :model do
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
 
+  before do
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "AA1 1AA",
+            "POST_TOWN": "Test Town",
+            "ORGANISATION_NAME": "1, Test Street",
+          },
+        },
+      ],
+    }.to_json
+
+    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
+    .to_return(status: 200, body:, headers: {})
+  end
+
   it "has correct page" do
     expect(question.page).to eq(page)
   end
@@ -56,6 +73,7 @@ RSpec.describe Form::Lettings::Questions::Uprn, type: :model do
       let(:log) do
         create(
           :lettings_log,
+          :completed,
           address_line1: "1, Test Street",
           town_or_city: "Test Town",
           county: "Test County",
@@ -77,11 +95,11 @@ RSpec.describe Form::Lettings::Questions::Uprn, type: :model do
 
       context "when uprn known" do
         let(:uprn_known) { 1 }
-        let(:uprn) { 123_456_789 }
+        let(:uprn) { 1 }
 
         it "returns formatted value" do
           expect(question.get_extra_check_answer_value(log)).to eq(
-            "\n\n1, Test Street\nTest Town\nTest County\nAA1 1AA\nWestminster",
+            "\n\n1, Test Street\nTest Town\nAA1 1AA\nWestminster",
           )
         end
       end

--- a/spec/models/form/sales/pages/address_spec.rb
+++ b/spec/models/form/sales/pages/address_spec.rb
@@ -28,47 +28,6 @@ RSpec.describe Form::Sales::Pages::Address, type: :model do
   end
 
   it "has correct depends_on" do
-    expect(page.depends_on).to be_nil
-  end
-
-  describe "has correct routed_to?" do
-    context "when uprn_known == nil" do
-      let(:log) { create(:sales_log, uprn_known: nil) }
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_confirmed != 1" do
-      let(:log) do
-        create(:sales_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 0)
-      end
-
-      it "returns true" do
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_known == 0" do
-      let(:log) do
-        create(:sales_log, uprn_confirmed: 0)
-      end
-
-      it "returns true" do
-        log.uprn_known = 0
-        expect(page.routed_to?(log)).to eq(true)
-      end
-    end
-
-    context "when uprn_confirmed == 1 && uprn_known != 0" do
-      let(:log) do
-        create(:sales_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1)
-      end
-
-      it "returns false" do
-        expect(page.routed_to?(log)).to eq(false)
-      end
-    end
+    expect(page.depends_on).to eq([{ "uprn_known" => nil }, { "uprn_known" => 0 }, { "uprn_confirmed" => 0 }])
   end
 end

--- a/spec/models/form/sales/questions/uprn_spec.rb
+++ b/spec/models/form/sales/questions/uprn_spec.rb
@@ -7,23 +7,6 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
 
-  before do
-    body = {
-      results: [
-        {
-          DPA: {
-            "POSTCODE": "AA1 1AA",
-            "POST_TOWN": "Test Town",
-            "ORGANISATION_NAME": "1, Test Street",
-          },
-        },
-      ],
-    }.to_json
-
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
-    .to_return(status: 200, body:, headers: {})
-  end
-
   it "has correct page" do
     expect(question.page).to eq(page)
   end

--- a/spec/models/form/sales/questions/uprn_spec.rb
+++ b/spec/models/form/sales/questions/uprn_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
 
+  before do
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "AA1 1AA",
+            "POST_TOWN": "Test Town",
+            "ORGANISATION_NAME": "1, Test Street",
+          },
+        },
+      ],
+    }.to_json
+
+    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
+    .to_return(status: 200, body:, headers: {})
+  end
+
   it "has correct page" do
     expect(question.page).to eq(page)
   end
@@ -56,9 +73,9 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
       let(:log) do
         create(
           :sales_log,
+          :completed,
           address_line1: "1, Test Street",
           town_or_city: "Test Town",
-          county: "Test County",
           postcode_full: "AA1 1AA",
           la: "E09000003",
           uprn_known:,
@@ -77,11 +94,11 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
 
       context "when uprn known" do
         let(:uprn_known) { 1 }
-        let(:uprn) { 123_456_789 }
+        let(:uprn) { 1 }
 
         it "returns formatted value" do
           expect(question.get_extra_check_answer_value(log)).to eq(
-            "\n\n1, Test Street\nTest Town\nTest County\nAA1 1AA\nWestminster",
+            "\n\n1, Test Street\nTest Town\nAA1 1AA\nWestminster",
           )
         end
       end

--- a/spec/request_helper.rb
+++ b/spec/request_helper.rb
@@ -19,6 +19,70 @@ module RequestHelper
       .to_return(status: 200, body: "", headers: {})
     WebMock.stub_request(:post, /api.notifications.service.gov.uk\/v2\/notifications\/sms/)
       .to_return(status: 200, body: "", headers: {})
+
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "AA1 1AA",
+            "POST_TOWN": "Test Town",
+            "ORGANISATION_NAME": "1, Test Street",
+          },
+        },
+      ],
+    }.to_json
+
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1")
+    .to_return(status: 200, body:, headers: {})
+
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "LS16 6FT",
+            "POST_TOWN": "Westminster",
+            "PO_BOX_NUMBER": "Wrong Address Line1",
+            "DOUBLE_DEPENDENT_LOCALITY": "Double Dependent Locality",
+          },
+        },
+      ],
+    }.to_json
+
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key&uprn=121")
+     .to_return(status: 200, body:, headers: {})
+
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "BS1 1AD",
+            "POST_TOWN": "Bristol",
+            "ORGANISATION_NAME": "Some place",
+          },
+        },
+      ],
+    }.to_json
+
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123")
+    .to_return(status: 200, body:, headers: {})
+
+    body = {
+      results: [
+        {
+          DPA: {
+            "POSTCODE": "EC1N 2TD",
+            "POST_TOWN": "Newcastle",
+            "ORGANISATION_NAME": "Some place",
+          },
+        },
+      ],
+    }.to_json
+
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=12")
+    .to_return(status: 200, body:, headers: {})
+
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=1234567890123")
+    .to_return(status: 404, body: "", headers: {})
   end
 
   def self.real_http_requests

--- a/spec/requests/duplicate_logs_controller_spec.rb
+++ b/spec/requests/duplicate_logs_controller_spec.rb
@@ -29,24 +29,6 @@ RSpec.describe DuplicateLogsController, type: :request do
     end
 
     context "when user is signed in" do
-      before do
-        body = {
-          results: [
-            {
-              DPA: {
-                "POSTCODE": "LS16 6FT",
-                "POST_TOWN": "Westminster",
-                "PO_BOX_NUMBER": "321",
-                "DOUBLE_DEPENDENT_LOCALITY": "Double Dependent Locality",
-              },
-            },
-          ],
-        }.to_json
-
-        stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=123")
-          .to_return(status: 200, body:, headers: {})
-      end
-
       context "when user is support" do
         let(:support_user_org) { create(:organisation) }
         let(:user) { create(:user, :support, organisation: support_user_org) }

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       field_16: "2",
       field_17: "1",
       field_18: "1",
-      field_19: "100023336956",
+      field_19: "12",
       field_24: "CR0",
       field_25: "4BB",
       field_26: "E09000008",
@@ -186,43 +186,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
     before do
       stub_request(:get, /api.postcodes.io/)
       .to_return(status: 200, body: "{\"status\":200,\"result\":{\"admin_district\":\"Manchester\", \"codes\":{\"admin_district\": \"E08000003\"}}}", headers: {})
-
-      body = {
-        results: [
-          {
-            DPA: {
-              "POSTCODE": "EC1N 2TD",
-              "POST_TOWN": "Newcastle",
-              "ORGANISATION_NAME": "Some place",
-            },
-          },
-        ],
-      }.to_json
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=100023336956")
-        .to_return(status: 200, body:, headers: {})
-
-      body = {
-        header: {
-          uri: "https://api.os.uk/search/places/v1/uprn?uprn=2",
-          query: "uprn=2",
-          offset: 0,
-          totalresults: 0,
-          format: "JSON",
-          dataset: "DPA",
-          lr: "EN,CY",
-          maxresults: 100,
-          epoch: "101",
-          lastupdate: "2023-05-11",
-          output_srs: "EPSG:27700",
-        },
-      }.to_json
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=2")
-        .to_return(status: 200, body:, headers: {})
-
-      stub_request(:get, "https://api.os.uk/search/places/v1/uprn?key=OS_DATA_KEY&uprn=3")
-        .to_return(status: 404, body:, headers: {})
 
       parser.valid?
     end
@@ -744,14 +707,14 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
     describe "#field_19" do # UPRN
       context "when UPRN known and lookup found" do
-        let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }
+        let(:attributes) { setup_section_params.merge({ field_19: "12" }) }
 
         it "is valid" do
           expect(parser.errors[:field_19]).to be_blank
         end
 
         it "sets UPRN and UPRN known" do
-          expect(parser.log.uprn).to eq("100023336956")
+          expect(parser.log.uprn).to eq("12")
           expect(parser.log.uprn_known).to eq(1)
           expect(parser.log.uprn_confirmed).to eq(1)
         end
@@ -774,7 +737,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
 
       context "when UPRN entered but no lookup found" do
-        let(:attributes) { setup_section_params.merge({ field_19: "2" }) }
+        let(:attributes) { setup_section_params.merge({ field_19: "1234567890123" }) }
 
         it "is not valid" do
           expect(parser.errors[:field_19]).to be_present
@@ -789,7 +752,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       describe "##{data[:field]} (#{data[:name]})" do
         context "when UPRN present" do
           context "when UPRN valid" do
-            let(:attributes) { setup_section_params.merge({ field_19: "100023336956", data[:field] => nil }) }
+            let(:attributes) { setup_section_params.merge({ field_19: "12", data[:field] => nil }) }
 
             it "can be blank" do
               expect(parser.errors[data[:field]]).to be_blank
@@ -797,7 +760,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           end
 
           context "when UPRN invalid" do
-            let(:attributes) { setup_section_params.merge({ field_19: "3", data[:field] => nil }) }
+            let(:attributes) { setup_section_params.merge({ field_19: "1234567890123", data[:field] => nil }) }
 
             it "cannot be blank" do
               expect(parser.errors[data[:field]]).to be_present
@@ -949,16 +912,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
   describe "#log" do
     describe "#uprn" do
-      let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }
+      let(:attributes) { setup_section_params.merge({ field_19: "12" }) }
 
       it "is correctly set" do
-        expect(parser.log.uprn).to eql("100023336956")
+        expect(parser.log.uprn).to eql("12")
       end
     end
 
     describe "#uprn_known" do
       context "when uprn known" do
-        let(:attributes) { setup_section_params.merge({ field_19: "100023336956" }) }
+        let(:attributes) { setup_section_params.merge({ field_19: "12" }) }
 
         it "is correctly set" do
           expect(parser.log.uprn_known).to be(1)

--- a/spec/shared/shared_log_examples.rb
+++ b/spec/shared/shared_log_examples.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples "shared log examples" do |log_type|
   describe "#process_uprn_change!" do
     context "when UPRN set to a value" do
       let(:log) do
-        create(
+        log = build(
           log_type,
           uprn: "123456789",
           uprn_confirmed: 1,
@@ -59,6 +59,8 @@ RSpec.shared_examples "shared log examples" do |log_type|
           county: "county",
           postcode_full: nil,
         )
+        log.save!(validate: false)
+        log
       end
 
       it "updates log fields" do


### PR DESCRIPTION
We had defined custom `routed_to?` methods for address fields, which meant that it was possible to navigate to those questions without completing the setup section.
This PR translates the conditions from those `routed_to?` methods to `depends_on` and executes parent `routed_to?` method instead.

Given that we clear the questions we're not routing to a lot of the tests had to be updated too. This was mostly done by filling out the setup section for test logs where appropriate.

This PR also extracts some web stubs for UPRNs to `request_helper.rb`. There are some changes to the UPRN numbers in the tests, these are so that we could reuse the mocks.