### PR TITLE
CLDC-3067 Surface organisation and date errors in summary

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -435,12 +435,14 @@ class BulkUpload::Lettings::Year2023::RowParser
       fields = field_mapping_for_errors[error.attribute] || []
 
       fields.each do |field|
-        unless errors.include?(field)
-          if error.attribute == :owning_organisation_id || error.attribute == :managing_organisation_id || error.attribute == :startdate
-            errors.add(field, error.message, category: :setup)
-          else
-            errors.add(field, error.message)
-          end
+        next if errors.include?(field)
+
+        question = log.form.get_question(error.attribute, log)
+
+        if question.present? && setup_question?(question)
+          errors.add(field, error.message, category: :setup)
+        else
+          errors.add(field, error.message)
         end
       end
     end

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -436,7 +436,11 @@ class BulkUpload::Lettings::Year2023::RowParser
 
       fields.each do |field|
         unless errors.include?(field)
-          errors.add(field, error.message)
+          if error.attribute == :owning_organisation_id || error.attribute == :managing_organisation_id || error.attribute == :startdate
+            errors.add(field, error.message, category: :setup)
+          else
+            errors.add(field, error.message)
+          end
         end
       end
     end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -513,7 +513,7 @@ class BulkUpload::Sales::Year2023::RowParser
 
         question = log.form.get_question(error.attribute, log)
 
-        if setup_question?(question)
+        if question.present? && setup_question?(question)
           errors.add(field, error.message, category: :setup)
         else
           errors.add(field, error.message)

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -510,7 +510,11 @@ class BulkUpload::Sales::Year2023::RowParser
 
       fields.each do |field|
         unless errors.include?(field)
-          errors.add(field, error.message)
+          if error.attribute == :owning_organisation_id || error.attribute == :managing_organisation_id || error.attribute == :saledate
+            errors.add(field, error.message, category: :setup)
+          else
+            errors.add(field, error.message)
+          end
         end
       end
     end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -509,12 +509,14 @@ class BulkUpload::Sales::Year2023::RowParser
       fields = field_mapping_for_errors[error.attribute] || []
 
       fields.each do |field|
-        unless errors.include?(field)
-          if error.attribute == :owning_organisation_id || error.attribute == :managing_organisation_id || error.attribute == :saledate
-            errors.add(field, error.message, category: :setup)
-          else
-            errors.add(field, error.message)
-          end
+        next if errors.include?(field)
+
+        question = log.form.get_question(error.attribute, log)
+
+        if setup_question?(question)
+          errors.add(field, error.message, category: :setup)
+        else
+          errors.add(field, error.message)
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1406,6 +1406,29 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           expect(parser.errors.where(:field_3)).not_to be_present
         end
       end
+
+      context "when user's org has absorbed owning organisation before the startdate" do
+        let(:merged_org) { create(:organisation, :with_old_visible_id, holds_own_stock: true) }
+
+        let(:attributes) { setup_section_params.merge({ field_1: merged_org.old_visible_id, field_2: merged_org.old_visible_id, field_3: user.email }) }
+
+        before do
+          merged_org.update!(absorbing_organisation: user.organisation, merge_date: Time.zone.today - 5.years)
+          merged_org.reload
+          user.organisation.reload
+        end
+
+        it "is not permitted" do
+          parser = described_class.new(attributes)
+
+          parser.valid?
+          expect(parser.errors[:field_1]).to include(/The owning organisation must be active on the tenancy start date/)
+          expect(parser.errors[:field_2]).to include(/The managing organisation must be active on the tenancy start date/)
+          expect(parser.errors[:field_7]).to include(/Enter a date when the owning and managing organisation was active/)
+          expect(parser.errors[:field_8]).to include(/Enter a date when the owning and managing organisation was active/)
+          expect(parser.errors[:field_9]).to include(/Enter a date when the owning and managing organisation was active/)
+        end
+      end
     end
 
     describe "#field_2" do # managing org


### PR DESCRIPTION
Inactive merged organisation errors were not shown in the summary (they were shown in the full report correctly), this PR adds any organisation or startdate errors as setup errors, so that they're shown in the summary:
<img width="1155" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/7107c238-cfdd-4a26-b907-a22fac859b25">
