### PR TITLE
CLDC-3068 Update type mismatch error messages

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -675,11 +675,15 @@ private
 
   def validate_lettings_type_matches_bulk_upload
     if [1, 3, 5, 7, 9, 11].include?(field_5) && !general_needs?
-      errors.add(:field_5, I18n.t("validations.setup.lettype.supported_housing_mismatch"))
+      block_log_creation!
+      errors.add(:field_4, I18n.t("validations.setup.needstype.lettype_not_supported_housing"), category: :setup)
+      errors.add(:field_5, I18n.t("validations.setup.lettype.needstype_supported_housing"), category: :setup)
     end
 
     if [2, 4, 6, 8, 10, 12].include?(field_5) && !supported_housing?
-      errors.add(:field_5, I18n.t("validations.setup.lettype.general_needs_mismatch"))
+      block_log_creation!
+      errors.add(:field_4, I18n.t("validations.setup.needstype.lettype_not_general_needs"), category: :setup)
+      errors.add(:field_5, I18n.t("validations.setup.lettype.needstype_general_needs"), category: :setup)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -307,6 +307,11 @@ en:
       lettype:
         general_needs_mismatch: Lettings type must be a general needs type because you selected general needs when uploading the file
         supported_housing_mismatch: Lettings type must be a supported housing type because you selected supported housing when uploading the file
+        needstype_general_needs: This needs type is general needs, but the letting type is supported housing. Change either the needs type or the letting type.
+        needstype_supported_housing: This needs type is supported housing, but the letting type is general needs. Change either the needs type or the letting type.
+      needstype:
+        lettype_not_general_needs: This letting type is supported housing, but the needs type is general needs. Change either the needs type or the letting type.
+        lettype_not_supported_housing: This letting type is general needs, but the needs type is supported housing. Change either the needs type or the letting type.
       location:
         incomplete: "This location is incomplete. Select another location or update this one"
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -831,6 +831,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           let(:attributes) { { bulk_upload:, field_5: "1", field_4: "1" } }
 
           it "is permitted" do
+            expect(parser.errors[:field_4]).to be_blank
             expect(parser.errors[:field_5]).to be_blank
           end
         end
@@ -839,7 +840,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           let(:attributes) { { bulk_upload:, field_5: "2", field_4: "1" } }
 
           it "is not permitted" do
-            expect(parser.errors[:field_5]).to include("Lettings type must be a general needs type because you selected general needs when uploading the file")
+            expect(parser.errors[:field_4]).to include("This letting type is supported housing, but the needs type is general needs. Change either the needs type or the letting type.")
+            expect(parser.errors[:field_5]).to include("This needs type is general needs, but the letting type is supported housing. Change either the needs type or the letting type.")
           end
         end
       end
@@ -851,7 +853,8 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           let(:attributes) { { bulk_upload:, field_5: "1", field_4: "2" } }
 
           it "is not permitted" do
-            expect(parser.errors[:field_5]).to include("Lettings type must be a supported housing type because you selected supported housing when uploading the file")
+            expect(parser.errors[:field_4]).to include("This letting type is general needs, but the needs type is supported housing. Change either the needs type or the letting type.")
+            expect(parser.errors[:field_5]).to include("This needs type is supported housing, but the letting type is general needs. Change either the needs type or the letting type.")
           end
         end
 
@@ -859,6 +862,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           let(:attributes) { { bulk_upload:, field_5: "2", field_4: "2" } }
 
           it "is permitted" do
+            expect(parser.errors[:field_4]).to be_blank
             expect(parser.errors[:field_5]).to be_blank
           end
         end


### PR DESCRIPTION
Update error messages for mismatched let type and needstype and add it to both fields.
<img width="1546" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/10ea7063-8aab-4199-8cab-90efbfc09abf">
