### PR TITLE
CLDC-1753 Update accessible autocomplete

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -103,7 +103,7 @@ private
       end
 
       if question.id == "owning_organisation_id"
-        owning_organisation = Organisation.find(result["owning_organisation_id"])
+        owning_organisation = result["owning_organisation_id"].present? ? Organisation.find(result["owning_organisation_id"]) : nil
         if current_user.support? && @log.managing_organisation.blank? && owning_organisation&.managing_agents&.empty?
           result["managing_organisation_id"] = owning_organisation.id
         elsif owning_organisation&.absorbing_organisation == current_user.organisation

--- a/app/frontend/controllers/accessible_autocomplete_controller.js
+++ b/app/frontend/controllers/accessible_autocomplete_controller.js
@@ -32,5 +32,12 @@ export default class extends Controller {
         if (selectedOption) selectedOption.selected = true
       }
     })
+
+    const parentElement = selectEl.parentElement
+    const inputElement = parentElement.querySelector('[role=combobox]')
+
+    inputElement.addEventListener("input", () => { 
+      selectOptions.forEach((option) => option.selected = false)
+    } )
   }
 }

--- a/app/frontend/controllers/accessible_autocomplete_controller.js
+++ b/app/frontend/controllers/accessible_autocomplete_controller.js
@@ -36,8 +36,8 @@ export default class extends Controller {
     const parentElement = selectEl.parentElement
     const inputElement = parentElement.querySelector('[role=combobox]')
 
-    inputElement.addEventListener("input", () => { 
-      selectOptions.forEach((option) => option.selected = false)
-    } )
+    inputElement.addEventListener('input', () => {
+      selectOptions.forEach((option) => { option.selected = false })
+    })
   }
 }

--- a/app/views/form/_select_question.html.erb
+++ b/app/views/form/_select_question.html.erb
@@ -13,8 +13,7 @@
         data-synonyms="<%= answer_option_synonyms(answer.resource) %>"
         data-append="<%= answer_option_append(answer.resource) %>"
         data-hint="<%= answer_option_hint(answer.resource) %>"
-        <%= question.answer_selected?(@log, answer) ? "selected" : "" %>
-        <%= answer.id == "" ? "disabled" : "" %>><%= answer.name || answer.resource %></option>
+        <%= question.answer_selected?(@log, answer) ? "selected" : "" %>><%= answer.name || answer.resource %></option>
     <% end %>
   <% end %>
 

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -63,10 +63,6 @@ RSpec.describe "Accessible Autocomplete" do
       click_link(text: "Back")
       expect(page).to have_selector("input", class: "autocomplete__input", count: 1)
     end
-
-    it "has a disabled null option" do
-      expect(page).to have_select("lettings-log-prevloc-field", disabled_options: ["Select an option"])
-    end
   end
 
   context "when searching schemes" do


### PR DESCRIPTION
The search input element is separate from select element so if a selected (persisted) option is deleted in the search element it would not previously apply in the select element.
Now whenever we get any input action on search element, we immediately unselect the selected option. We still can't unselect a value if it was previously selected, but we'd get an "You must select .." error until a valid value is selected if value is required.
