### PR TITLE
CLDC-2637 Make bulk upload error count dynamic

### DIFF
--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -116,6 +116,14 @@ class BulkUpload < ApplicationRecord
     bulk_upload_errors.distinct.count("row")
   end
 
+  def remaining_logs_with_errors_count
+    logs.filter_by_status("in_progress").count
+  end
+
+  def remaining_errors_count
+    logs.filter_by_status("in_progress").map(&:missing_answers_count).sum(0)
+  end
+
 private
 
   def generate_identifier

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -203,6 +203,12 @@ class Log < ApplicationRecord
     }.compact
   end
 
+  def missing_answers_count
+    form.questions.count do |question|
+      !optional_fields.include?(question.id) && question.displayed_to_user?(self) && question.unanswered?(self) && !question.is_derived_or_has_inferred_check_answers_value?(self)
+    end
+  end
+
 private
 
   # Handle logs that are older than previous collection start date

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -48,7 +48,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body-l">
-          You have uploaded <%= pluralize(@bulk_upload.logs.count, "log") %>. There are errors in <%= pluralize(@bulk_upload.logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.bulk_upload_errors.count, "error") %> in total. Select the log to fix the errors.
+          You have uploaded <%= pluralize(@bulk_upload.logs.count, "log") %>. There are errors in <%= pluralize(@bulk_upload.remaining_logs_with_errors_count, "log") %>, and <%= pluralize(@bulk_upload.remaining_errors_count, "error") %> in total. Select the log to fix the errors.
         </p>
 
         <p class="govuk-body">

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe LettingsLogsController, type: :request do
               let(:user) { create(:user, organisation:) }
               let(:bulk_upload) { create(:bulk_upload, :lettings, user:) }
 
-              let!(:included_log) { create(:lettings_log, :in_progress, bulk_upload:, owning_organisation: organisation) }
+              let!(:included_log) { create(:lettings_log, :completed, age1: nil, bulk_upload:, owning_organisation: organisation) }
               let!(:excluded_log) { create(:lettings_log, :in_progress, owning_organisation: organisation, tenancycode: "fake_code") }
 
               before do
@@ -600,6 +600,12 @@ RSpec.describe LettingsLogsController, type: :request do
               it "displays card with help info" do
                 get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 1 error in total. Select the log to fix the errors.")
+              end
+
+              it "displays dynamic error number" do
+                included_log.update!(age2: nil)
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 2 errors in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe SalesLogsController, type: :request do
               let(:user) { create(:user, organisation:) }
               let(:bulk_upload) { create(:bulk_upload, :sales, user:) }
 
-              let!(:included_log) { create(:sales_log, :in_progress, purchid: "included_id", bulk_upload:, owning_organisation: organisation) }
+              let!(:included_log) { create(:sales_log, :completed, age1: nil, purchid: "included_id", bulk_upload:, owning_organisation: organisation) }
               let!(:excluded_log) { create(:sales_log, :in_progress, purchid: "excluded_id", owning_organisation: organisation) }
 
               before do
@@ -497,6 +497,12 @@ RSpec.describe SalesLogsController, type: :request do
               it "displays card with help info" do
                 get "/sales-logs?bulk_upload_id[]=#{bulk_upload.id}"
                 expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 1 error in total. Select the log to fix the errors.")
+              end
+
+              it "displays dynamic error number" do
+                included_log.update!(age2: nil)
+                get "/lettings-logs?bulk_upload_id[]=#{bulk_upload.id}"
+                expect(page).to have_content("You have uploaded 1 log. There are errors in 1 log, and 2 errors in total. Select the log to fix the errors.")
               end
 
               it "displays meta info about the bulk upload" do


### PR DESCRIPTION
Base bulk upload error count on the number of logs and questions that are still to be answered for that bulk upload as opposed to the initial bulk upload error count.