### PR TITLE
CLDC-2253 Add collection resources

### DIFF
--- a/app/frontend/styles/_document-list.scss
+++ b/app/frontend/styles/_document-list.scss
@@ -12,7 +12,7 @@
 }
 
 .app-document-list__item-title {
-  @include govuk-font($size: 16, $weight: "bold");
+  @include govuk-font($size: 16);
   margin: 0 0 govuk-spacing(1);
 }
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,6 @@
 <p class="govuk-body-l"><%= "Welcome back, #{@current_user.name}" %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "layouts/collection_resources" %>
+  </div>
+</div>

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -5,7 +5,7 @@
   <h2 class="govuk-heading-m">Collection resources</h2>
 <% end %>
 <p class="govuk-body">Use the 2023 to 2024 forms for lettings that start and sales that complete between 1 April 2023 and 31 March 2024.</p>
-<%= govuk_tabs(title: "Monday’s child nursery rhyme") do |c| %>
+<%= govuk_tabs(title: "Collection resources") do |c| %>
   <% if FormHandler.instance.lettings_form_for_start_year(2023) && FormHandler.instance.lettings_form_for_start_year(2023).edit_end_date > Time.zone.today %>
     <% c.with_tab(label: "Lettings 2023/24") do %>
       <%= render DocumentListComponent.new(items: [

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -15,12 +15,12 @@
         metadata: file_type_size_and_pages("2023_24_lettings_paper_form.pdf", number_of_pages: 8),
       },
       {
-        name: "Download the lettings log for tenants (2023 to 2024) – New question ordering",
+        name: "Download the lettings bulk upload template (2023 to 2024) – New question ordering",
         href: download_23_24_lettings_bulk_upload_template_path,
         metadata: file_type_size_and_pages("bulk-upload-lettings-template-2023-24.xlsx"),
       },
       {
-        name: "Download the lettings bulk upload template (2023 to 2024)",
+        name: "Download the lettings bulk upload template (2023 to 2024) – Legacy version",
         href: download_23_24_lettings_bulk_upload_legacy_template_path,
         metadata: file_type_size_and_pages("bulk-upload-lettings-legacy-template-2023-24.xlsx"),
       },
@@ -39,12 +39,12 @@
           metadata: file_type_size_and_pages("2023_24_sales_paper_form.pdf", number_of_pages: 8),
         },
         {
-          name: "Download the sales log for buyers (2023 to 2024) – New question ordering",
+          name: "Download the sales bulk upload template (2023 to 2024) – New question ordering",
           href: download_23_24_sales_bulk_upload_template_path,
           metadata: file_type_size_and_pages("bulk-upload-sales-template-2023-24.xlsx"),
         },
         {
-          name: "Download the sales bulk upload template (2023 to 2024)",
+          name: "Download the sales bulk upload template (2023 to 2024) – Legacy version",
           href: download_23_24_sales_bulk_upload_legacy_template_path,
           metadata: file_type_size_and_pages("bulk-upload-sales-legacy-template-2023-24.xlsx"),
         },

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -1,94 +1,54 @@
-<div class="app-card">
-  <h2 class="govuk-heading-m">Collection resources</h2>
-  <p class="govuk-body-s">For lettings starting during 1 April 2023 to 31 March 2024 and sales completing during the same period, use the 2023/24 forms.</p>
-
+<h2 class="govuk-heading-m">Collection resources</h2>
+<p class="govuk-body-s">Use the 2023 to 2024 forms for lettings that start and sales that complete between 1 April 2023 and 31 March 2024.</p>
+<%= govuk_tabs(title: "Monday’s child nursery rhyme") do |c| %>
   <% if FormHandler.instance.lettings_form_for_start_year(2023) && FormHandler.instance.lettings_form_for_start_year(2023).edit_end_date > Time.zone.today %>
-    <h3 class="govuk-heading-s">Lettings 2023/24</h3>
-    <%= render DocumentListComponent.new(items: [
+    <% c.with_tab(label: "Lettings 2023/24") do %>
+      <%= render DocumentListComponent.new(items: [
       {
-        name: "Lettings log for tenants (2023/24)",
+        name: "Download the lettings log for tenants (2023 to 2024)",
         href: download_23_24_lettings_form_path,
         metadata: file_type_size_and_pages("2023_24_lettings_paper_form.pdf", number_of_pages: 8),
       },
       {
-        name: "Lettings bulk upload template (2023/24) – New question ordering",
+        name: "Download the lettings log for tenants (2023 to 2024) – New question ordering",
         href: download_23_24_lettings_bulk_upload_template_path,
         metadata: file_type_size_and_pages("bulk-upload-lettings-template-2023-24.xlsx"),
       },
       {
-        name: "Lettings bulk upload template (2023/24)",
+        name: "Download the lettings bulk upload template (2023 to 2024)",
         href: download_23_24_lettings_bulk_upload_legacy_template_path,
         metadata: file_type_size_and_pages("bulk-upload-lettings-legacy-template-2023-24.xlsx"),
       },
       {
-        name: "Lettings bulk upload specification (2023/24)",
+        name: "Download the lettings bulk upload specification (2023 to 2024)",
         href: download_23_24_lettings_bulk_upload_specification_path,
         metadata: file_type_size_and_pages("bulk-upload-lettings-specification-2023-24.xlsx"),
       },
-    ]) %>
-
-    <h3 class="govuk-heading-s">Sales 2023/24</h3>
-    <%= render DocumentListComponent.new(items: [
-      {
-        name: "Sales log for buyers (2023/24)",
-        href: download_23_24_sales_form_path,
-        metadata: file_type_size_and_pages("2023_24_sales_paper_form.pdf", number_of_pages: 8),
-      },
-      {
-        name: "Sales bulk upload template (2023/24) – New question ordering",
-        href: download_23_24_sales_bulk_upload_template_path,
-        metadata: file_type_size_and_pages("bulk-upload-sales-template-2023-24.xlsx"),
-      },
-      {
-        name: "Sales bulk upload template (2023/24)",
-        href: download_23_24_sales_bulk_upload_legacy_template_path,
-        metadata: file_type_size_and_pages("bulk-upload-sales-legacy-template-2023-24.xlsx"),
-      },
-      {
-        name: "Sales bulk upload specification (2023/24)",
-        href: download_23_24_sales_bulk_upload_specification_path,
-        metadata: file_type_size_and_pages("bulk-upload-sales-specification-2023-24.xlsx"),
-      },
-    ]) %>
+      ]) %>
+    <% end %>
+    <% c.with_tab(label: "Sales 2023/24") do %>
+      <%= render DocumentListComponent.new(items: [
+        {
+          name: "Download the sales log for buyers (2023 to 2024)",
+          href: download_23_24_sales_form_path,
+          metadata: file_type_size_and_pages("2023_24_sales_paper_form.pdf", number_of_pages: 8),
+        },
+        {
+          name: "Download the sales log for buyers (2023 to 2024) – New question ordering",
+          href: download_23_24_sales_bulk_upload_template_path,
+          metadata: file_type_size_and_pages("bulk-upload-sales-template-2023-24.xlsx"),
+        },
+        {
+          name: "Download the sales bulk upload template (2023 to 2024)",
+          href: download_23_24_sales_bulk_upload_legacy_template_path,
+          metadata: file_type_size_and_pages("bulk-upload-sales-legacy-template-2023-24.xlsx"),
+        },
+        {
+          name: "Download the sales bulk upload specification (2023 to 2024)",
+          href: download_23_24_sales_bulk_upload_specification_path,
+          metadata: file_type_size_and_pages("bulk-upload-sales-specification-2023-24.xlsx"),
+        },
+      ]) %>
+    <% end %>
   <% end %>
-
-  <% if FormHandler.instance.lettings_form_for_start_year(2022) && FormHandler.instance.lettings_form_for_start_year(2022).edit_end_date > Time.zone.today %>
-    <h3 class="govuk-heading-s">Lettings 2022/23</h3>
-    <%= render DocumentListComponent.new(items: [
-      {
-        name: "Lettings log for tenants (2022/23)",
-        href: download_22_23_lettings_form_path,
-        metadata: file_type_size_and_pages("2022_23_lettings_paper_form.pdf", number_of_pages: 4),
-      },
-      {
-        name: "Lettings bulk upload template (2022/23)",
-        href: download_22_23_lettings_bulk_upload_template_path,
-        metadata: file_type_size_and_pages("bulk-upload-lettings-template-2022-23.xlsx"),
-      },
-      {
-        name: "Lettings bulk upload specification (2022/23)",
-        href: download_22_23_lettings_bulk_upload_specification_path,
-        metadata: file_type_size_and_pages("bulk-upload-lettings-specification-2022-23.xlsx"),
-      },
-    ]) %>
-
-    <h3 class="govuk-heading-s">Sales 2022/23</h3>
-    <%= render DocumentListComponent.new(items: [
-      {
-        name: "Sales log for buyers (2022/23)",
-        href: download_22_23_sales_form_path,
-        metadata: file_type_size_and_pages("2022_23_sales_paper_form.pdf", number_of_pages: 5),
-      },
-      {
-        name: "Sales bulk upload template (2022/23)",
-        href: download_22_23_sales_bulk_upload_template_path,
-        metadata: file_type_size_and_pages("bulk-upload-sales-template-2022-23.xlsx"),
-      },
-      {
-        name: "Sales bulk upload specification (2022/23)",
-        href: download_22_23_sales_bulk_upload_specification_path,
-        metadata: file_type_size_and_pages("bulk-upload-sales-template-2022-23.xlsx"),
-      },
-    ]) %>
-  <% end %>
-</div>
+<% end %>

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -1,10 +1,8 @@
-<h2 class="govuk-heading-m">Collection resources</h2>
 <% if current_user %>
-  <p class="govuk-body"><strong>
-    <%= govuk_link_to guidance_path do %>
-      Guidance for submitting social housing lettings and sales data (CORE)
-    <% end %>
-  </strong></p>
+  <h1 class="govuk-heading-l">Collection resources</h1>
+  <p class="govuk-body"><strong><%= govuk_link_to "Guidance for submitting social housing lettings and sales data (CORE)", guidance_path %></strong></p>
+<% else %>
+  <h2 class="govuk-heading-m">Collection resources</h2>
 <% end %>
 <p class="govuk-body">Use the 2023 to 2024 forms for lettings that start and sales that complete between 1 April 2023 and 31 March 2024.</p>
 <%= govuk_tabs(title: "Monday’s child nursery rhyme") do |c| %>

--- a/app/views/layouts/_collection_resources.html.erb
+++ b/app/views/layouts/_collection_resources.html.erb
@@ -1,5 +1,12 @@
 <h2 class="govuk-heading-m">Collection resources</h2>
-<p class="govuk-body-s">Use the 2023 to 2024 forms for lettings that start and sales that complete between 1 April 2023 and 31 March 2024.</p>
+<% if current_user %>
+  <p class="govuk-body"><strong>
+    <%= govuk_link_to guidance_path do %>
+      Guidance for submitting social housing lettings and sales data (CORE)
+    <% end %>
+  </strong></p>
+<% end %>
+<p class="govuk-body">Use the 2023 to 2024 forms for lettings that start and sales that complete between 1 April 2023 and 31 March 2024.</p>
 <%= govuk_tabs(title: "Monday’s child nursery rhyme") do |c| %>
   <% if FormHandler.instance.lettings_form_for_start_year(2023) && FormHandler.instance.lettings_form_for_start_year(2023).edit_end_date > Time.zone.today %>
     <% c.with_tab(label: "Lettings 2023/24") do %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -41,8 +41,4 @@
     <% end %>
     <%= render partial: "organisations/merged_organisation_details" %>
   </div>
-
-  <div class="govuk-grid-column-one-third-from-desktop">
-    <%= render partial: "layouts/collection_resources" %>
-  </div>
 </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -22,8 +22,4 @@
     <p class="govuk-body">You can <%= govuk_mail_to("dluhc.digital-services@levellingup.gov.uk", "request an account", subject: "CORE: Request a new account") %> if your organisation doesn’t have one.</p>
     <p class="govuk-body"><strong><%= govuk_link_to guidance_path do %>Guidance for submitting social housing lettings and sales data (CORE)<% end %></strong><p>
   </div>
-
-  <div class="govuk-grid-column-one-third-from-desktop">
-    <%= render partial: "layouts/collection_resources" %>
-  </div>
 </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -16,6 +16,8 @@
       href: start_path,
     ) %>
 
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">Use your account details to sign in.</p>
     <p class="govuk-body">If you need to set up a new account, speak to your organisation’s CORE data coordinator. If you don’t know who that is, <%= govuk_link_to("contact the helpdesk", GlobalConstants::HELPDESK_URL) %>.</p>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -23,3 +23,10 @@
     <p class="govuk-body"><strong><%= govuk_link_to guidance_path do %>Guidance for submitting social housing lettings and sales data (CORE)<% end %></strong><p>
   </div>
 </div>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "layouts/collection_resources" %>
+  </div>
+</div>

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -310,42 +310,6 @@ RSpec.describe OrganisationsController, type: :request do
         it "redirects to details" do
           expect(response).to have_http_status(:redirect)
         end
-
-        context "and 2022 collection window is open" do
-          let(:set_time) { allow(Time).to receive(:now).and_return(Time.zone.local(2023, 1, 1)) }
-
-          it "displays correct resources for 2022/23 and 2023/24 collection years" do
-            follow_redirect!
-            expect(page).to have_content("Lettings 2023/24")
-            expect(page).to have_content("Sales 2023/24")
-            expect(page).to have_content("Lettings 2022/23")
-            expect(page).to have_content("Sales 2022/23")
-          end
-        end
-
-        context "and 2022 collection window is closed for editing" do
-          let(:set_time) { allow(Time).to receive(:now).and_return(Time.zone.local(2024, 1, 1)) }
-
-          it "displays correct resources for 2022/23 and 2023/24 collection years" do
-            follow_redirect!
-            expect(page).to have_content("Lettings 2023/24")
-            expect(page).to have_content("Sales 2023/24")
-            expect(page).not_to have_content("Lettings 2022/23")
-            expect(page).not_to have_content("Sales 2022/23")
-          end
-        end
-
-        context "and 2023 collection window is closed for editing" do
-          let(:set_time) { allow(Time).to receive(:now).and_return(Time.zone.local(2025, 1, 1)) }
-
-          it "displays correct resources for 2022/23 and 2023/24 collection years" do
-            follow_redirect!
-            expect(page).not_to have_content("Lettings 2023/24")
-            expect(page).not_to have_content("Sales 2023/24")
-            expect(page).not_to have_content("Lettings 2022/23")
-            expect(page).not_to have_content("Sales 2022/23")
-          end
-        end
       end
 
       context "with an organisation that are not in scope for the user, i.e. that they do not belong to" do

--- a/spec/requests/start_controller_spec.rb
+++ b/spec/requests/start_controller_spec.rb
@@ -20,11 +20,6 @@ RSpec.describe StartController, type: :request do
         expect(path).to include("/")
         expect(page).to have_content("Start now")
       end
-
-      it "does not show guidance link" do
-        get "/", headers: headers, params: {}
-        expect(page).not_to have_content("Guidance for submitting social housing lettings and sales data (CORE)")
-      end
     end
 
     context "when the user is signed in" do

--- a/spec/requests/start_controller_spec.rb
+++ b/spec/requests/start_controller_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe StartController, type: :request do
         expect(path).to include("/")
         expect(page).to have_content("Start now")
       end
+
+      it "does not show guidance link" do
+        get "/", headers: headers, params: {}
+        expect(page).not_to have_content("Guidance for submitting social housing lettings and sales data (CORE)")
+      end
     end
 
     context "when the user is signed in" do
@@ -54,6 +59,11 @@ RSpec.describe StartController, type: :request do
           expect(page).not_to have_content("Lettings 2023/24")
           expect(page).not_to have_content("Sales 2023/24")
         end
+      end
+
+      it "shows guidance link" do
+        get "/", headers: headers, params: {}
+        expect(page).to have_content("Guidance for submitting social housing lettings and sales data (CORE)")
       end
     end
   end

--- a/spec/requests/start_controller_spec.rb
+++ b/spec/requests/start_controller_spec.rb
@@ -31,6 +31,30 @@ RSpec.describe StartController, type: :request do
         get "/", headers:, params: {}
         expect(page).to have_content("Welcome back")
       end
+
+      context "and 2023 collection window is open for editing" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 1, 1))
+        end
+
+        it "displays correct resources for 2022/23 and 2023/24 collection years" do
+          get "/", headers: headers, params: {}
+          expect(page).to have_content("Lettings 2023/24")
+          expect(page).to have_content("Sales 2023/24")
+        end
+      end
+
+      context "and 2023 collection window is closed for editing" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.zone.local(2025, 1, 1))
+        end
+
+        it "displays correct resources for 2022/23 and 2023/24 collection years" do
+          get "/", headers: headers, params: {}
+          expect(page).not_to have_content("Lettings 2023/24")
+          expect(page).not_to have_content("Sales 2023/24")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- Update collection resources
- Add collection resources to the homepage, link to guidance page (https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2121)
- Remove collection resource from org page
- Replace collection resources with the new component on the start page (CLDC-1401)
<img width="1693" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/9ed37e75-0468-498d-a1aa-a19ea3ed4aa2">
