### PR TITLE
CLDC-3119 Dynamically display discount in the error message

### DIFF
--- a/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
+++ b/app/models/form/sales/pages/shared_ownership_deposit_value_check.rb
@@ -11,6 +11,10 @@ class Form::Sales::Pages::SharedOwnershipDepositValueCheck < ::Form::Page
       "translation" => "soft_validations.shared_ownership_deposit.title_text",
       "arguments" => [
         {
+          "key" => "mortgage_deposit_and_discount_error_fields",
+          "i18n_template" => "mortgage_deposit_and_discount_error_fields",
+        },
+        {
           "key" => "field_formatted_as_currency",
           "arguments_for_key" => "mortgage_deposit_and_discount_total",
           "i18n_template" => "mortgage_deposit_and_discount_total",

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -272,6 +272,14 @@ class SalesLog < Log
     mortgage_amount + deposit_amount + cashdis_amount
   end
 
+  def mortgage_deposit_and_discount_error_fields
+    [
+      "mortgage",
+      "deposit",
+      cashdis.present? ? "discount" : nil,
+    ].compact.to_sentence
+  end
+
   def mortgage_and_deposit_total
     return unless mortgage && deposit
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -657,7 +657,7 @@ Make sure these answers are correct."
       title_text: "You told us that the property has been vacant for more than 2 years."
       hint_text: "This is higher than we would expect."
     shared_ownership_deposit:
-      title_text: "You told us that the mortgage, deposit and discount add up to %{mortgage_deposit_and_discount_total}"
+      title_text: "You told us that the %{mortgage_deposit_and_discount_error_fields} add up to %{mortgage_deposit_and_discount_total}"
     old_persons_shared_ownership:
       title_text: "You told us the buyer is using the Older Persons Shared Ownership scheme."
       hint_text: "At least one buyer must be aged 65 years and over to use this scheme."

--- a/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
+++ b/spec/models/form/sales/pages/shared_ownership_deposit_value_check_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Form::Sales::Pages::SharedOwnershipDepositValueCheck, type: :mode
   it "has the correct title_text" do
     expect(page.title_text).to eq({
       "translation" => "soft_validations.shared_ownership_deposit.title_text",
-      "arguments" => [{ "arguments_for_key" => "mortgage_deposit_and_discount_total", "i18n_template" => "mortgage_deposit_and_discount_total", "key" => "field_formatted_as_currency" }],
+      "arguments" => [
+        { "i18n_template" => "mortgage_deposit_and_discount_error_fields", "key" => "mortgage_deposit_and_discount_error_fields" },
+        { "arguments_for_key" => "mortgage_deposit_and_discount_total", "i18n_template" => "mortgage_deposit_and_discount_total", "key" => "field_formatted_as_currency" },
+      ],
     })
   end
 


### PR DESCRIPTION
This shared ownership soft validation triggers if MORTGAGE + DEPOSIT + CASHDIS are not equal VALUE * EQUITY/100 . If cash discount is not used we consider it to be £0 and still trigger this validation, but the error message does not make sense in that case.

Now if cash discount exists we keep the validation as:
`You told us that the mortgage, deposit and discount add up to xx`

And if cash discount is not given, the validation message is:
`You told us that the mortgage and deposit add up to xx`