### PR TITLE
CLDC-3034 Ignore household charge in general needs bulk uploads

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1187,7 +1187,7 @@ private
     attributes["tcharge"] = field_132
     attributes["chcharge"] = field_127
     attributes["is_carehome"] = field_127.present? ? 1 : 0
-    attributes["household_charge"] = field_125
+    attributes["household_charge"] = supported_housing? ? field_125 : nil
     attributes["hbrentshortfall"] = field_133
     attributes["tshortfall_known"] = tshortfall_known
     attributes["tshortfall"] = field_134

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -2241,7 +2241,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "sets correct value from mapping" do
           expect(parser.log.household_charge).to eq(nil)
         end
-
       end
 
       context "when log is supported housing" do

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -2235,10 +2235,22 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#household_charge" do
-      let(:attributes) { { bulk_upload:, field_125: "1" } }
+      context "when log is general needs" do
+        let(:attributes) { { bulk_upload:, field_4: 1, field_125: "1" } }
 
-      it "sets correct value from mapping" do
-        expect(parser.log.household_charge).to eq(1)
+        it "sets correct value from mapping" do
+          expect(parser.log.household_charge).to eq(nil)
+        end
+
+      end
+
+      context "when log is supported housing" do
+        let(:attributes) { { bulk_upload:, field_4: 2, field_125: "1" } }
+
+        it "sets correct value from mapping" do
+          expect(parser.log.household_charge).to eq(1)
+        end
+
       end
     end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -2235,10 +2235,21 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#household_charge" do
-      let(:attributes) { { bulk_upload:, field_125: "1" } }
+      context "when log is general needs" do
+        let(:attributes) { { bulk_upload:, field_4: 1, field_125: "1" } }
 
-      it "sets correct value from mapping" do
-        expect(parser.log.household_charge).to eq(1)
+        it "sets correct value from mapping" do
+          expect(parser.log.household_charge).to eq(nil)
+        end
+
+      end
+
+      context "when log is supported housing" do
+        let(:attributes) { { bulk_upload:, field_4: 2, field_125: "1" } }
+
+        it "sets correct value from mapping" do
+          expect(parser.log.household_charge).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
General needs logs should ignore the household charge in bulk upload. The template specifies field_125 (household_charge) is supported housing only, but if a user entered it we could get in situations where later data was cleared because it was "not routed to" because field_125 was present, even though field_125 would later be cleared. A more robust solution would involve a deeper dive into the order we are clearing and checking routing of questions, but this fixes the issue (and I'm not aware of any other questions in which this issue can arise other than here).