### PR TITLE
CLDC-2995 Add renttype_detail column

### DIFF
--- a/db/migrate/20240109153031_add_renttype_detail.rb
+++ b/db/migrate/20240109153031_add_renttype_detail.rb
@@ -1,0 +1,5 @@
+class AddRenttypeDetail < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lettings_logs, :renttype_detail, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_18_105226) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_09_153031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -302,6 +302,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_18_105226) do
     t.integer "supcharg_value_check"
     t.integer "scharge_value_check"
     t.integer "pscharge_value_check"
+    t.integer "renttype_detail"
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"

--- a/lib/tasks/set_renttype_detail.rake
+++ b/lib/tasks/set_renttype_detail.rake
@@ -1,0 +1,9 @@
+desc "Set lettings renttype_detail depending on rent_type"
+task set_renttype_detail: :environment do
+  LettingsLog.where(rent_type: 0).update_all(renttype_detail: 1)
+  LettingsLog.where(rent_type: 1).update_all(renttype_detail: 2)
+  LettingsLog.where(rent_type: 2).update_all(renttype_detail: 3)
+  LettingsLog.where(rent_type: 3).update_all(renttype_detail: 4)
+  LettingsLog.where(rent_type: 4).update_all(renttype_detail: 5)
+  LettingsLog.where(rent_type: 5).update_all(renttype_detail: 6)
+end

--- a/spec/lib/tasks/set_renttype_detail_spec.rb
+++ b/spec/lib/tasks/set_renttype_detail_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "set_renttype_detail" do
+  describe ":set_renttype_detail", type: :task do
+    subject(:task) { Rake::Task["set_renttype_detail"] }
+
+    before do
+      Rake.application.rake_require("tasks/set_renttype_detail")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run and rent_type is 0" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 0) }
+
+      it "sets lettings log renttype_detail to 1" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(1)
+      end
+    end
+
+    context "when the rake task is run and rent_type is 1" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 1) }
+
+      it "sets lettings log renttype_detail to 2" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(2)
+      end
+    end
+
+    context "when the rake task is run and rent_type is 2" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 2) }
+
+      it "sets lettings log renttype_detail to 3" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(3)
+      end
+    end
+
+    context "when the rake task is run and rent_type is 3" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 3) }
+
+      it "sets lettings log renttype_detail to 4" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(4)
+      end
+    end
+
+    context "when the rake task is run and rent_type is 4" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 4) }
+
+      it "sets lettings log renttype_detail to 5" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(5)
+      end
+    end
+
+    context "when the rake task is run and rent_type is 5" do
+      let!(:lettings_log) { create(:lettings_log, :completed, rent_type: 5, irproduct_other: "sum") }
+
+      it "sets lettings log renttype_detail to 6" do
+        expect(lettings_log.renttype_detail).to eq(nil)
+        expected_updated_at = lettings_log.updated_at
+        task.invoke
+        lettings_log.reload
+        expect(lettings_log.values_updated_at).to eq(nil)
+        expect(lettings_log.updated_at).to eq(expected_updated_at)
+        expect(lettings_log.renttype_detail).to eq(6)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We aim to replace `rent_type` column with `renttype_detail` as we want to start exporting it. 
We also want to be change the mapping for this column and will be introducing it in the 2024/25 bulk upload forms.

Given that the numbering from `rent_type` is not externally used anywhere other than the csv_exports and as it will be changing in 2024/25 it might be a good idea to replace it with `renttype_detail` and it's values across the service instead of having 2 columns and exporting/mapping different values.

This will mean that any CSVs exported before this change will have different `rent_type_detail`(what `rent_type` is currently getting exported as) value to the `renttype_detail` values after this change.

This PR needs to get merged first and `renttype_detail` set right before we replace `rent_type` occurrences with `renttype_detail` and update relevant label value mappings.


