### PR TITLE
Govuk components 5.0 footer hotfix

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_footer do |footer| %>
-  <%= footer.meta do %>
+  <%= footer.with_meta do %>
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
       <h2 class="govuk-heading-m">Get help with this service</h2>
       <div class="govuk-grid-row">


### PR DESCRIPTION
Footer component was using the old slot syntax so not displaying links correctly, this PR fixes this.