### PR TITLE
CLDC-3127 Amend renewal question wording for 2024

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -323,4 +323,8 @@ class Form
   def sales_or_start_year_after_2022?(type, start_year)
     type == "sales" || (start_year && start_year.to_i > 2022)
   end
+
+  def start_year_after_2024?
+    start_date && start_date.year >= 2024
+  end
 end

--- a/app/models/form/lettings/questions/renewal.rb
+++ b/app/models/form/lettings/questions/renewal.rb
@@ -3,15 +3,32 @@ class Form::Lettings::Questions::Renewal < ::Form::Question
     super
     @id = "renewal"
     @check_answer_label = "Property renewal"
-    @header = "Is this letting a renewal?"
+    @header = header_text
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
-    @hint_text = "A renewal is a letting to the same tenant in the same property. If the property was previously being used as temporary accommodation, then answer 'no'"
+    @hint_text = hint_text
     @question_number = 4
   end
 
   ANSWER_OPTIONS = {
     "1" => { "value" => "Yes" },
     "0" => { "value" => "No" },
-  }.freeze
+  }
+  .freeze
+
+  def header_text
+    if form.start_date && form.start_date.year >= 2024
+      "Is this letting a renewal of social housing to the same tenant in the same property?"
+    else
+      "Is this letting a renewal?"
+    end
+  end
+
+  def hint_text
+    if form.start_date && form.start_date.year >= 2024
+      "If the property was previously being used as temporary accommodation, then answer 'no'"
+    else
+      "A renewal is a letting to the same tenant in the same property. If the property was previously being used as temporary accommodation, then answer 'no'"
+    end
+  end
 end

--- a/app/models/form/lettings/questions/renewal.rb
+++ b/app/models/form/lettings/questions/renewal.rb
@@ -17,7 +17,7 @@ class Form::Lettings::Questions::Renewal < ::Form::Question
   .freeze
 
   def header_text
-    if form.start_date && form.start_date.year >= 2024
+    if form.start_year_after_2024?
       "Is this letting a renewal of social housing to the same tenant in the same property?"
     else
       "Is this letting a renewal?"
@@ -25,7 +25,7 @@ class Form::Lettings::Questions::Renewal < ::Form::Question
   end
 
   def hint_text
-    if form.start_date && form.start_date.year >= 2024
+    if form.start_year_after_2024?
       "If the property was previously being used as temporary accommodation, then answer 'no'"
     else
       "A renewal is a letting to the same tenant in the same property. If the property was previously being used as temporary accommodation, then answer 'no'"

--- a/app/models/validations/setup_validations.rb
+++ b/app/models/validations/setup_validations.rb
@@ -3,7 +3,7 @@ module Validations::SetupValidations
   include CollectionTimeHelper
 
   def validate_startdate_setup(record)
-    return unless record.startdate && date_valid?("startdate", record)
+    return unless record.startdate && date_valid?("startdate", record) && FeatureToggle.startdate_collection_window_validation_enabled?
 
     first_collection_start_date = if record.startdate_was.present?
                                     editable_collection_start_date

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,7 +1,11 @@
 class FeatureToggle
   # Disable check on preview apps to allow for testing of future forms
   def self.saledate_collection_window_validation_enabled?
-    true
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
+  end
+
+  def self.startdate_collection_window_validation_enabled?
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
   def self.startdate_two_week_validation_enabled?
@@ -9,7 +13,7 @@ class FeatureToggle
   end
 
   def self.saledate_two_week_validation_enabled?
-    Rails.env.production? || Rails.env.test? || Rails.env.staging? || Rails.env.review?
+    Rails.env.production? || Rails.env.test? || Rails.env.staging?
   end
 
   def self.bulk_upload_duplicate_log_check_enabled?

--- a/spec/models/form/lettings/pages/renewal_spec.rb
+++ b/spec/models/form/lettings/pages/renewal_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Form::Lettings::Pages::Renewal, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form) }
+
+  before do
+    allow(form).to receive(:start_year_after_2024?).and_return(false)
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/lettings/questions/renewal_spec.rb
+++ b/spec/models/form/lettings/questions/renewal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Form::Lettings::Questions::Renewal, type: :model do
   let(:form) { instance_double(Form) }
 
   before do
-    allow(form).to receive(:start_date).and_return(Time.zone.local(2023, 4, 1))
+    allow(form).to receive(:start_year_after_2024?).and_return(false)
     allow(page).to receive(:subsection).and_return(subsection)
     allow(subsection).to receive(:form).and_return(form)
   end
@@ -52,7 +52,7 @@ RSpec.describe Form::Lettings::Questions::Renewal, type: :model do
 
   context "with collection year on or after 2024" do
     before do
-      allow(form).to receive(:start_date).and_return(Time.zone.local(2024, 4, 1))
+      allow(form).to receive(:start_year_after_2024?).and_return(true)
     end
 
     it "has the correct header" do

--- a/spec/models/form/lettings/questions/renewal_spec.rb
+++ b/spec/models/form/lettings/questions/renewal_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Form::Lettings::Questions::Renewal, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form) }
+
+  before do
+    allow(form).to receive(:start_date).and_return(Time.zone.local(2023, 4, 1))
+    allow(page).to receive(:subsection).and_return(subsection)
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -40,5 +48,19 @@ RSpec.describe Form::Lettings::Questions::Renewal, type: :model do
 
   it "is not marked as derived" do
     expect(question.derived?).to be false
+  end
+
+  context "with collection year on or after 2024" do
+    before do
+      allow(form).to receive(:start_date).and_return(Time.zone.local(2024, 4, 1))
+    end
+
+    it "has the correct header" do
+      expect(question.header).to eq("Is this letting a renewal of social housing to the same tenant in the same property?")
+    end
+
+    it "has the correct hint_text" do
+      expect(question.hint_text).to eq("If the property was previously being used as temporary accommodation, then answer 'no'")
+    end
   end
 end

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -546,6 +546,16 @@ RSpec.describe LettingsLogsController, type: :request do
           end
 
           context "with bulk_upload_id filter" do
+            before do
+              Timecop.freeze(2023, 4, 1)
+              Singleton.__init__(FormHandler)
+            end
+
+            after do
+              Timecop.unfreeze
+              Singleton.__init__(FormHandler)
+            end
+
             context "with bulk upload that belongs to current user" do
               let(:organisation) { create(:organisation) }
 


### PR DESCRIPTION
Amend renewal question header and hint text for 2024 and disable collection year validations on review apps only so that these changes could be tested
