### PR TITLE
CLDC-3172 Update routing for staircase transactions

### DIFF
--- a/app/models/form/sales/pages/buyer_previous.rb
+++ b/app/models/form/sales/pages/buyer_previous.rb
@@ -12,7 +12,7 @@ class Form::Sales::Pages::BuyerPrevious < ::Form::Page
   end
 
   def routed_to?(log, _current_user)
-    return false if log.staircase == 1 && log.form.start_year_after_2024?
+    return false if log.is_staircase? && log.form.start_year_after_2024?
 
     super
   end

--- a/app/models/form/sales/pages/buyer_previous.rb
+++ b/app/models/form/sales/pages/buyer_previous.rb
@@ -10,4 +10,10 @@ class Form::Sales::Pages::BuyerPrevious < ::Form::Page
       Form::Sales::Questions::BuyerPrevious.new(nil, nil, self, joint_purchase: @joint_purchase),
     ]
   end
+
+  def routed_to?(log, _current_user)
+    return false if log.staircase == 1 && log.form.start_year_after_2024?
+
+    super
+  end
 end

--- a/app/models/form/sales/pages/la_nominations.rb
+++ b/app/models/form/sales/pages/la_nominations.rb
@@ -9,4 +9,10 @@ class Form::Sales::Pages::LaNominations < ::Form::Page
       Form::Sales::Questions::LaNominations.new(nil, nil, self),
     ]
   end
+
+  def routed_to?(log, _current_user)
+    return false if log.staircase == 1 && log.form.start_year_after_2024?
+
+    super
+  end
 end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -477,7 +477,7 @@ class SalesLog < Log
   def nationality2_uk_or_prefers_not_to_say?
     nationality_all_buyer2_group&.zero? || nationality_all_buyer2_group == 826
   end
-  
+
   def is_staircase?
     staircase == 1
   end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -477,4 +477,8 @@ class SalesLog < Log
   def nationality2_uk_or_prefers_not_to_say?
     nationality_all_buyer2_group&.zero? || nationality_all_buyer2_group == 826
   end
+  
+  def is_staircase?
+    staircase == 1
+  end
 end

--- a/spec/models/form/sales/pages/buyer_previous_spec.rb
+++ b/spec/models/form/sales/pages/buyer_previous_spec.rb
@@ -3,10 +3,20 @@ require "rails_helper"
 RSpec.describe Form::Sales::Pages::BuyerPrevious, type: :model do
   subject(:page) { described_class.new(page_id, page_definition, subsection, joint_purchase:) }
 
+  let(:log) { create(:sales_log, :completed) }
+
   let(:page_id) { "example" }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form) }
   let(:joint_purchase) { false }
+
+  before do
+    allow(subsection).to receive(:depends_on).and_return(nil)
+    allow(subsection).to receive(:enabled?).and_return(true)
+    allow(subsection).to receive(:form).and_return(form)
+    allow(form).to receive(:depends_on_met).and_return(true)
+  end
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -39,6 +49,53 @@ RSpec.describe Form::Sales::Pages::BuyerPrevious, type: :model do
   context "when sales is not a joint purchase" do
     it "has the correct depends on" do
       expect(page.depends_on).to eq([{ "joint_purchase?" => false }])
+    end
+  end
+
+  context "with 23/24 log" do
+    before do
+      Timecop.freeze(Time.zone.local(2023, 4, 2))
+      Singleton.__init__(FormHandler)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "has correct routed to" do
+      log.staircase = 1
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+  end
+
+  context "with 24/25 log" do
+    before do
+      Timecop.freeze(Time.zone.local(2024, 4, 2))
+      Singleton.__init__(FormHandler)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "has correct routed to when staircase is yes" do
+      log.staircase = 1
+      expect(page.routed_to?(log, nil)).to eq(false)
+    end
+
+    it "has correct routed to when staircase is nil" do
+      log.staircase = nil
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+
+    it "has correct routed to when staircase is no" do
+      log.staircase = 2
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+
+    it "has correct routed to when staircase is don't know" do
+      log.staircase = 3
+      expect(page.routed_to?(log, nil)).to eq(true)
     end
   end
 end

--- a/spec/models/form/sales/pages/la_nominations_spec.rb
+++ b/spec/models/form/sales/pages/la_nominations_spec.rb
@@ -3,9 +3,15 @@ require "rails_helper"
 RSpec.describe Form::Sales::Pages::LaNominations, type: :model do
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
+  let(:log) { create(:sales_log, :completed) }
+
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
+
+  before do
+    allow(subsection).to receive(:depends_on).and_return(nil)
+  end
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -25,5 +31,52 @@ RSpec.describe Form::Sales::Pages::LaNominations, type: :model do
 
   it "has the correct description" do
     expect(page.description).to be_nil
+  end
+
+  context "with 23/24 log" do
+    before do
+      Timecop.freeze(Time.zone.local(2023, 4, 2))
+      Singleton.__init__(FormHandler)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "has correct routed to" do
+      log.staircase = 1
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+  end
+
+  context "with 24/25 log" do
+    before do
+      Timecop.freeze(Time.zone.local(2024, 4, 2))
+      Singleton.__init__(FormHandler)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "has correct routed to when staircase is yes" do
+      log.staircase = 1
+      expect(page.routed_to?(log, nil)).to eq(false)
+    end
+
+    it "has correct routed to when staircase is nil" do
+      log.staircase = nil
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+
+    it "has correct routed to when staircase is no" do
+      log.staircase = 2
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
+
+    it "has correct routed to when staircase is don't know" do
+      log.staircase = 3
+      expect(page.routed_to?(log, nil)).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
If staircase is yes, we don't want to route to questions 83-87. I've only added the routing changes to questions 83 and 84, because the rest of them already have a condition that depends on 84 being answered