### PR TITLE
CLDC-3179 Update routing for previous postcode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: compilation tools for bundle
 # yarn: node package manager
 # postgresql-dev: postgres driver and libraries
-RUN apk add --no-cache build-base=0.5-r3 nodejs-current=20.8.1-r0 yarn=1.22.19-r0 postgresql13-dev=13.13-r0 git=2.40.1-r0 bash=5.2.15-r5
+RUN apk add --no-cache build-base=0.5-r3 nodejs-current=20.8.1-r0 yarn=1.22.19-r0 postgresql13-dev=13.14-r0 git=2.40.1-r0 bash=5.2.15-r5
 
 # Bundler version should be the same version as what the Gemfile.lock was bundled with
 RUN gem install bundler:2.3.14 --no-document

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -38,6 +38,10 @@ module DerivedVariables::SalesLogVariables
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?
 
+    if saledate && form.start_year_after_2024? && discounted_ownership_sale?
+      self.ppostcode_full = postcode_full
+    end
+
     set_encoded_derived_values!(DEPENDENCIES)
   end
 

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -40,6 +40,10 @@ module DerivedVariables::SalesLogVariables
 
     if saledate && form.start_year_after_2024? && discounted_ownership_sale?
       self.ppostcode_full = postcode_full
+      self.ppcodenk = 0 if postcode_full.present?
+      self.prevloc = la
+      self.is_previous_la_inferred = is_la_inferred
+      self.previous_la_known = la_known
     end
 
     set_encoded_derived_values!(DEPENDENCIES)

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -17,7 +17,7 @@ module DerivedVariables::SalesLogVariables
       self.hoyear = hodate.year
     end
     self.deposit = value if outright_sale? && mortgage_not_used?
-    
+
     if saledate && form.start_year_after_2024? && discounted_ownership_sale?
       self.ppostcode_full = postcode_full
       self.ppcodenk = 0 if postcode_full.present?

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -17,6 +17,15 @@ module DerivedVariables::SalesLogVariables
       self.hoyear = hodate.year
     end
     self.deposit = value if outright_sale? && mortgage_not_used?
+    
+    if saledate && form.start_year_after_2024? && discounted_ownership_sale?
+      self.ppostcode_full = postcode_full
+      self.ppcodenk = 0 if postcode_full.present?
+      self.prevloc = la
+      self.is_previous_la_inferred = is_la_inferred
+      self.previous_la_known = la_known
+    end
+
     self.pcode1, self.pcode2 = postcode_full.split if postcode_full.present?
     self.ppostc1, self.ppostc2 = ppostcode_full.split if ppostcode_full.present?
     self.totchild = total_child
@@ -37,14 +46,6 @@ module DerivedVariables::SalesLogVariables
 
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?
-
-    if saledate && form.start_year_after_2024? && discounted_ownership_sale?
-      self.ppostcode_full = postcode_full
-      self.ppcodenk = 0 if postcode_full.present?
-      self.prevloc = la
-      self.is_previous_la_inferred = is_la_inferred
-      self.previous_la_known = la_known
-    end
 
     set_encoded_derived_values!(DEPENDENCIES)
   end

--- a/app/models/form/sales/pages/last_accommodation.rb
+++ b/app/models/form/sales/pages/last_accommodation.rb
@@ -10,4 +10,10 @@ class Form::Sales::Pages::LastAccommodation < ::Form::Page
       Form::Sales::Questions::PreviousPostcode.new(nil, nil, self),
     ]
   end
+
+  def routed_to?(log, _user)
+    return false if log.form.start_year_after_2024? && log.discounted_ownership_sale?
+
+    super
+  end
 end

--- a/app/models/form/sales/pages/last_accommodation_la.rb
+++ b/app/models/form/sales/pages/last_accommodation_la.rb
@@ -13,4 +13,10 @@ class Form::Sales::Pages::LastAccommodationLa < ::Form::Page
       Form::Sales::Questions::Prevloc.new(nil, nil, self),
     ]
   end
+
+  def routed_to?(log, _user)
+    return false if log.form.start_year_after_2024? && log.discounted_ownership_sale?
+
+    super
+  end
 end

--- a/app/models/validations/sales/household_validations.rb
+++ b/app/models/validations/sales/household_validations.rb
@@ -11,15 +11,6 @@ module Validations::Sales::HouseholdValidations
     shared_validate_partner_count(record, 6)
   end
 
-  def validate_previous_postcode(record)
-    return unless record.postcode_full && record.ppostcode_full && record.discounted_ownership_sale?
-
-    unless record.postcode_full == record.ppostcode_full
-      record.errors.add :postcode_full, :postcodes_not_matching, message: I18n.t("validations.household.postcode.discounted_ownership")
-      record.errors.add :ppostcode_full, :postcodes_not_matching, message: I18n.t("validations.household.postcode.discounted_ownership")
-    end
-  end
-
   def validate_buyers_living_in_property(record)
     return unless record.form.start_date.year >= 2023
 

--- a/app/models/validations/sales/property_validations.rb
+++ b/app/models/validations/sales/property_validations.rb
@@ -1,5 +1,6 @@
 module Validations::Sales::PropertyValidations
   def validate_postcodes_match_if_discounted_ownership(record)
+    return unless record.saledate && !record.form.start_year_after_2024?
     return unless record.ppostcode_full.present? && record.postcode_full.present?
 
     if record.discounted_ownership_sale? && record.ppostcode_full != record.postcode_full

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe SalesLog, type: :model do
       end
 
       before do
-        WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/CA101AA/)
+        WebMock.stub_request(:get, /api\.postcodes\.io\/postcodes\/CA101AA/)
                .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Cumberland","codes":{"admin_district":"E06000064"}}}', headers: {})
 
         Timecop.freeze(2023, 5, 1)
@@ -687,7 +687,7 @@ RSpec.describe SalesLog, type: :model do
       end
 
       before do
-        WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/CA101AA/)
+        WebMock.stub_request(:get, /api\.postcodes\.io\/postcodes\/CA101AA/)
         .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Eden","codes":{"admin_district":"E07000030"}}}', headers: {})
 
         Timecop.freeze(2023, 5, 2)
@@ -724,7 +724,7 @@ RSpec.describe SalesLog, type: :model do
       end
 
       before do
-        WebMock.stub_request(:get, /api.postcodes.io\/postcodes\/CA101AA/)
+        WebMock.stub_request(:get, /api\.postcodes\.io\/postcodes\/CA101AA/)
         .to_return(status: 200, body: '{"status":200,"result":{"admin_district":"Eden","codes":{"admin_district":"E07000030"}}}', headers: {})
 
         Timecop.freeze(2024, 5, 2)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -704,11 +704,12 @@ RSpec.describe SalesLog, type: :model do
         expect(record_from_db["la"]).to eq("E06000064")
       end
 
-      it "does not set previous postcode for discounted sale" do
-        address_sales_log_23_24.update!(ownershipsch: 2, ppostcode_full: nil)
+      it "does not set previous postcode or previous la for discounted sale" do
+        address_sales_log_23_24.update!(ownershipsch: 2, ppostcode_full: nil, prevloc: nil)
         record_from_db = described_class.find(address_sales_log_23_24.id)
         expect(address_sales_log_23_24.ppostcode_full).to eq(nil)
         expect(record_from_db["ppostcode_full"]).to eq(nil)
+        expect(record_from_db["prevloc"]).to eq(nil)
       end
     end
 
@@ -719,6 +720,8 @@ RSpec.describe SalesLog, type: :model do
           created_by: created_by_user,
           ppcodenk: 1,
           postcode_full: "CA10 1AA",
+          ppostcode_full: nil,
+          prevloc: nil,
           saledate: Time.zone.local(2024, 5, 2),
         })
       end
@@ -740,6 +743,7 @@ RSpec.describe SalesLog, type: :model do
         record_from_db = described_class.find(address_sales_log_24_25.id)
         expect(address_sales_log_24_25.ppostcode_full).to eq("CA10 1AA")
         expect(record_from_db["ppostcode_full"]).to eq("CA10 1AA")
+        expect(record_from_db["prevloc"]).to eq("E06000064")
       end
 
       it "does not set previous postcode for non discounted sale" do
@@ -747,6 +751,7 @@ RSpec.describe SalesLog, type: :model do
         record_from_db = described_class.find(address_sales_log_24_25.id)
         expect(address_sales_log_24_25.ppostcode_full).to eq(nil)
         expect(record_from_db["ppostcode_full"]).to eq(nil)
+        expect(record_from_db["prevloc"]).to eq(nil)
       end
     end
 

--- a/spec/models/validations/sales/household_validations_spec.rb
+++ b/spec/models/validations/sales/household_validations_spec.rb
@@ -154,64 +154,6 @@ RSpec.describe Validations::Sales::HouseholdValidations do
     end
   end
 
-  describe "previous postcode validations" do
-    let(:record) { build(:sales_log) }
-
-    context "with a discounted sale" do
-      before do
-        record.ownershipsch = 2
-      end
-
-      it "adds an error when previous and current postcodes are not the same" do
-        record.postcode_full = "SO32 3PT"
-        record.ppostcode_full = "DN6 7FB"
-        household_validator.validate_previous_postcode(record)
-        expect(record.errors["postcode_full"])
-          .to include(match I18n.t("validations.household.postcode.discounted_ownership"))
-        expect(record.errors["ppostcode_full"])
-          .to include(match I18n.t("validations.household.postcode.discounted_ownership"))
-      end
-
-      it "allows same postcodes" do
-        record.postcode_full = "SO32 3PT"
-        record.ppostcode_full = "SO32 3PT"
-        household_validator.validate_previous_postcode(record)
-        expect(record.errors["postcode_full"]).to be_empty
-        expect(record.errors["ppostcode_full"]).to be_empty
-      end
-
-      it "does not add an error when postcode is missing" do
-        record.postcode_full = nil
-        record.ppostcode_full = "SO32 3PT"
-        household_validator.validate_previous_postcode(record)
-        expect(record.errors["postcode_full"]).to be_empty
-        expect(record.errors["ppostcode_full"]).to be_empty
-      end
-
-      it "does not add an error when previous postcode is missing" do
-        record.postcode_full = "SO32 3PT"
-        record.ppostcode_full = nil
-        household_validator.validate_previous_postcode(record)
-        expect(record.errors["postcode_full"]).to be_empty
-        expect(record.errors["ppostcode_full"]).to be_empty
-      end
-    end
-
-    context "without a discounted sale" do
-      before do
-        record.ownershipsch = 1
-      end
-
-      it "allows different postcodes" do
-        record.postcode_full = "SO32 3PT"
-        record.ppostcode_full = "DN6 7FB"
-        household_validator.validate_previous_postcode(record)
-        expect(record.errors["postcode_full"]).to be_empty
-        expect(record.errors["ppostcode_full"]).to be_empty
-      end
-    end
-  end
-
   describe "validating fields about buyers living in the property" do
     let(:sales_log) { FactoryBot.create(:sales_log, :outright_sale_setup_complete, noint: 1, companybuy: 2, buylivein:, jointpur:, jointmore:, buy1livein:) }
 

--- a/spec/models/validations/sales/property_validations_spec.rb
+++ b/spec/models/validations/sales/property_validations_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Validations::Sales::PropertyValidations do
     end
 
     context "when ownership scheme is discounted ownership" do
-      let(:record) { build(:sales_log, ownershipsch: 2) }
+      let(:record) { build(:sales_log, ownershipsch: 2, saledate: Time.zone.local(2023, 4, 5)) }
 
       it "when ppostcode_full is not present no error is added" do
         record.postcode_full = "SW1A 1AA"
@@ -53,6 +53,16 @@ RSpec.describe Validations::Sales::PropertyValidations do
         expect(record.errors["postcode_full"]).to include(match I18n.t("validations.property.postcode.must_match_previous"))
         expect(record.errors["ppostcode_full"]).to include(match I18n.t("validations.property.postcode.must_match_previous"))
         expect(record.errors["ownershipsch"]).to include(match I18n.t("validations.property.postcode.must_match_previous"))
+      end
+
+      it "does not add error for 2024 log" do
+        record.postcode_full = "SW1A 1AA"
+        record.ppostcode_full = "SW1A 0AA"
+        record.saledate = Time.zone.local(2024, 4, 5)
+        property_validator.validate_postcodes_match_if_discounted_ownership(record)
+        expect(record.errors["postcode_full"]).to be_empty
+        expect(record.errors["ppostcode_full"]).to be_empty
+        expect(record.errors["ownershipsch"]).to be_empty
       end
     end
   end


### PR DESCRIPTION
There's a validation for this, but for 2024 we want to infer previous postcode to be the same as current for discounted sales only