### PR TITLE
CLDC-3195 Download schemes per organisation (fix)

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -33,7 +33,7 @@ class OrganisationsController < ApplicationController
     organisation_schemes = Scheme.where(owning_organisation: [@organisation] + @organisation.parent_organisations)
     unpaginated_filtered_schemes = filter_manager.filtered_schemes(organisation_schemes, search_term, session_filters)
 
-    render "schemes/download_csv", locals: { search_term:, post_path: email_csv_schemes_path, download_type: params[:download_type], schemes: unpaginated_filtered_schemes }
+    render "schemes/download_csv", locals: { search_term:, post_path: schemes_email_csv_organisation_path, download_type: params[:download_type], schemes: unpaginated_filtered_schemes }
   end
 
   def email_schemes_csv

--- a/app/jobs/scheme_email_csv_job.rb
+++ b/app/jobs/scheme_email_csv_job.rb
@@ -6,7 +6,11 @@ class SchemeEmailCsvJob < ApplicationJob
   EXPIRATION_TIME = 24.hours.to_i
 
   def perform(user, search_term = nil, filters = {}, all_orgs = false, organisation = nil, download_type = "combined") # rubocop:disable Style/OptionalBooleanParameter - sidekiq can't serialise named params
-    unfiltered_schemes = organisation.present? && user.support? ? Scheme.where(owning_organisation_id: organisation.id) : user.schemes
+    unfiltered_schemes = if organisation.present? && user.support?
+                           Scheme.where(owning_organisation: [organisation] + organisation.parent_organisations)
+                         else
+                           Scheme.where(owning_organisation: [user.organisation] + user.organisation.parent_organisations)
+                         end
     filtered_schemes = FilterManager.filter_schemes(unfiltered_schemes, search_term, filters, all_orgs, user)
     csv_string = Csv::SchemeCsvService.new(download_type:).prepare_csv(filtered_schemes)
 

--- a/app/jobs/scheme_email_csv_job.rb
+++ b/app/jobs/scheme_email_csv_job.rb
@@ -9,7 +9,7 @@ class SchemeEmailCsvJob < ApplicationJob
     unfiltered_schemes = if organisation.present? && user.support?
                            Scheme.where(owning_organisation: [organisation] + organisation.parent_organisations)
                          else
-                           Scheme.where(owning_organisation: [user.organisation] + user.organisation.parent_organisations)
+                           user.schemes
                          end
     filtered_schemes = FilterManager.filter_schemes(unfiltered_schemes, search_term, filters, all_orgs, user)
     csv_string = Csv::SchemeCsvService.new(download_type:).prepare_csv(filtered_schemes)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,7 +113,7 @@ class User < ApplicationRecord
     if support?
       Scheme.all
     else
-      Scheme.filter_by_owning_organisation(organisation.absorbed_organisations + [organisation])
+      Scheme.filter_by_owning_organisation(organisation.absorbed_organisations + [organisation] + organisation.parent_organisations)
     end
   end
 

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -327,6 +327,19 @@ RSpec.describe "User Features" do
       end
     end
 
+    context "when viewing schemes for specific organisation" do
+      before do
+        create(:scheme, owning_organisation: organisation)
+        visit("/organisations/#{org_id}/schemes")
+      end
+
+      it "allows downloading schemes csv for the specific org" do
+        click_link("Download schemes (CSV)")
+        click_button("Send email")
+        expect(page).to have_current_path("/organisations/#{org_id}/schemes/csv-confirmation")
+      end
+    end
+
     context "and the organisation does not hold housing stock" do
       before do
         organisation.update!(holds_own_stock: false)

--- a/spec/jobs/scheme_email_csv_job_spec.rb
+++ b/spec/jobs/scheme_email_csv_job_spec.rb
@@ -6,41 +6,52 @@ describe SchemeEmailCsvJob do
   test_url = :test_url
 
   let(:job) { described_class.new }
+  let(:storage_service) { instance_double(Storage::S3Service, write_file: nil, get_presigned_url: test_url) }
+  let(:mailer) { instance_double(CsvDownloadMailer, send_csv_download_mail: nil) }
   let(:user) { FactoryBot.create(:user) }
-  let(:storage_service) { instance_double(Storage::S3Service) }
-  let(:mailer) { instance_double(CsvDownloadMailer) }
-  let(:scheme_csv_service) { instance_double(Csv::SchemeCsvService) }
-  let(:search_term) { "meaning" }
-  let(:filters) { { "owning_organisation" => organisation.id, "status" => %w[active] } }
-  let(:all_orgs) { false }
-  let(:organisation) { build(:organisation) }
-  let(:download_type) { "combined" }
-  let(:schemes) { build_list(:scheme, 5, owning_organisation: organisation) }
-  let(:locations) { build_list(:location, 5, scheme: schemes.first) }
 
   before do
     allow(Storage::S3Service).to receive(:new).and_return(storage_service)
-    allow(storage_service).to receive(:write_file)
-    allow(storage_service).to receive(:get_presigned_url).and_return(test_url)
-
-    allow(Csv::SchemeCsvService).to receive(:new).and_return(scheme_csv_service)
-    allow(scheme_csv_service).to receive(:prepare_csv).and_return("")
-
     allow(CsvDownloadMailer).to receive(:new).and_return(mailer)
-    allow(mailer).to receive(:send_csv_download_mail)
   end
 
   context "when exporting" do
+    let(:scheme_csv_service) { instance_double(Csv::SchemeCsvService) }
+    let(:organisation) { user.organisation }
+    let(:download_type) { "combined" }
+    let(:schemes) { create_list(:scheme, 1, owning_organisation: organisation) }
+
     before do
-      allow(FilterManager).to receive(:filter_schemes).and_return(schemes)
+      create_list(:location, 2, scheme: schemes.first)
     end
 
     context "when download type schemes" do
       let(:download_type) { "schemes" }
 
-      it "uses an appropriate filename in S3" do
-        expect(storage_service).to receive(:write_file).with(/schemes-.*\.csv/, anything)
-        job.perform(user)
+      it "uses an appropriate filename in S3 and exports the correct schemes" do
+        expect(storage_service).to receive(:write_file).with(/schemes-.*\.csv/, anything) do |_, content|
+          expect(content).not_to be_nil
+          expect(content).not_to be_nil
+          expect(CSV.parse(content).count).to eq(2)
+        end
+        job.perform(user, nil, {}, nil, nil, download_type)
+      end
+
+      context "and there are stock owner schemes" do
+        let(:parent_organisation) { create(:organisation) }
+
+        before do
+          create(:scheme, owning_organisation: parent_organisation)
+          create(:organisation_relationship, parent_organisation:, child_organisation: organisation)
+        end
+
+        it "exports the correct number of schemes" do
+          expect(storage_service).to receive(:write_file).with(/schemes-.*\.csv/, anything) do |_, content|
+            expect(content).not_to be_nil
+            expect(CSV.parse(content).count).to eq(3)
+          end
+          job.perform(user, nil, {}, nil, nil, download_type)
+        end
       end
     end
 
@@ -49,7 +60,7 @@ describe SchemeEmailCsvJob do
 
       it "uses an appropriate filename in S3" do
         expect(storage_service).to receive(:write_file).with(/locations-.*\.csv/, anything)
-        job.perform(user)
+        job.perform(user, nil, {}, nil, nil, download_type)
       end
     end
 
@@ -58,7 +69,7 @@ describe SchemeEmailCsvJob do
 
       it "uses an appropriate filename in S3" do
         expect(storage_service).to receive(:write_file).with(/schemes-and-locations.*\.csv/, anything)
-        job.perform(user)
+        job.perform(user, nil, {}, nil, nil, download_type)
       end
     end
 
@@ -67,12 +78,27 @@ describe SchemeEmailCsvJob do
       job.perform(user, nil, {}, nil, organisation, "combined")
     end
 
-    it "calls the filter manager with the arguments provided" do
-      expect(FilterManager).to receive(:filter_schemes).with(a_kind_of(ActiveRecord::Relation), search_term, filters, all_orgs, user)
-      job.perform(user, search_term, filters, all_orgs, organisation, "combined")
+    context "when resources are filtered" do
+      let(:search_term) { "meaning" }
+      let(:filters) { { "owning_organisation" => organisation.id, "status" => %w[active] } }
+      let(:all_orgs) { false }
+
+      before do
+        allow(Csv::SchemeCsvService).to receive(:new).and_return(scheme_csv_service)
+        allow(scheme_csv_service).to receive(:prepare_csv).and_return("")
+        allow(FilterManager).to receive(:filter_schemes).and_return(schemes)
+      end
+
+      it "calls the filter manager with the arguments provided" do
+        expect(FilterManager).to receive(:filter_schemes).with(a_kind_of(ActiveRecord::Relation), search_term, filters, all_orgs, user)
+        job.perform(user, search_term, filters, all_orgs, organisation, "combined")
+      end
     end
 
     it "creates a SchemeCsvService with the correct download type" do
+      allow(Csv::SchemeCsvService).to receive(:new).and_return(scheme_csv_service)
+      allow(scheme_csv_service).to receive(:prepare_csv).and_return("")
+
       expect(Csv::SchemeCsvService).to receive(:new).with(download_type: "schemes")
       job.perform(user, nil, {}, nil, nil, "schemes")
       expect(Csv::SchemeCsvService).to receive(:new).with(download_type: "locations")
@@ -82,6 +108,9 @@ describe SchemeEmailCsvJob do
     end
 
     it "passes the schemes returned by the filter manager to the csv service" do
+      allow(Csv::SchemeCsvService).to receive(:new).and_return(scheme_csv_service)
+      allow(scheme_csv_service).to receive(:prepare_csv).and_return("")
+
       expect(scheme_csv_service).to receive(:prepare_csv).with(schemes)
       job.perform(user, nil, {}, nil, nil, "combined")
     end


### PR DESCRIPTION
For a specific organisation we were routing to the schemes controller send csv email instead of organisation schemes send csv email, so support users would get all the schemes downloaded from the organisation schemes page.