### PR TITLE
CLDC-3250 Add tolerance to soft validation

### DIFF
--- a/app/models/validations/sales/soft_validations.rb
+++ b/app/models/validations/sales/soft_validations.rb
@@ -89,9 +89,11 @@ module Validations::Sales::SoftValidations
     return unless cashdis || !is_type_discount?
     return unless deposit && value && equity
 
-    cash_discount = cashdis || 0
-    mortgage_value = mortgage || 0
-    mortgage_value + deposit + cash_discount != value * equity / 100
+    !within_tolerance?(mortgage_deposit_and_discount_total, value * equity / 100, 1)
+  end
+
+  def within_tolerance?(expected, actual, tolerance)
+    (expected - actual).abs <= tolerance
   end
 
   def mortgage_plus_deposit_less_than_discounted_value?

--- a/spec/models/validations/sales/soft_validations_spec.rb
+++ b/spec/models/validations/sales/soft_validations_spec.rb
@@ -415,6 +415,17 @@ RSpec.describe Validations::Sales::SoftValidations do
           .not_to be_shared_ownership_deposit_invalid
       end
 
+      it "returns false if MORTGAGE + DEPOSIT + CASHDIS are within 1£ of VALUE * EQUITY/100" do
+        record.mortgage = 500
+        record.deposit = 500
+        record.cashdis = 500
+        record.value = 3001
+        record.equity = 50
+
+        expect(record)
+          .not_to be_shared_ownership_deposit_invalid
+      end
+
       it "returns false if mortgage is used and no mortgage is given" do
         record.mortgage = nil
         record.deposit = 1000
@@ -471,6 +482,18 @@ RSpec.describe Validations::Sales::SoftValidations do
 
         expect(record)
           .to be_shared_ownership_deposit_invalid
+      end
+
+      it "returns false if no cashdis not routed to and MORTGAGE + DEPOSIT are within 1£ of VALUE * EQUITY/100" do
+        record.mortgage = 500
+        record.deposit = 500
+        record.type = 2
+        record.cashdis = nil
+        record.value = 1999
+        record.equity = 50
+
+        expect(record)
+          .not_to be_shared_ownership_deposit_invalid
       end
 
       it "returns false if no value is given" do


### PR DESCRIPTION
This soft validation sometimes shows up without a sensible way to fix it, because we enforce fields like mortgage, purchase price etc to be whole numbers. However when we do calculations with them (like getting a percentage) those expected numbers might become decimals.
The examples in the tests illustrate these cases better.

This PR adds a tolerance of £1 to this soft validation (there might potentially be other validations like this that we want to update)