### PR TITLE
Fix: Make declaration not use a separate check answers card in 2024

### DIFF
--- a/app/models/form/lettings/questions/declaration.rb
+++ b/app/models/form/lettings/questions/declaration.rb
@@ -5,7 +5,7 @@ class Form::Lettings::Questions::Declaration < ::Form::Question
     @check_answer_label = "Tenant has seen the privacy notice"
     @header = "Declaration"
     @type = "checkbox"
-    @check_answers_card_number = 0
+    @check_answers_card_number = 0 unless form.start_year_after_2024?
     @top_guidance_partial = form.start_year_after_2024? ? "privacy_notice_tenant_2024" : "privacy_notice_tenant"
     @question_number = 30
   end

--- a/spec/models/form/lettings/questions/declaration_spec.rb
+++ b/spec/models/form/lettings/questions/declaration_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe Form::Lettings::Questions::Declaration, type: :model do
     it "uses the expected top guidance partial" do
       expect(question.top_guidance_partial).to eq("privacy_notice_tenant")
     end
+
+    it "has check_answers_card_number = 0" do
+      expect(question.check_answers_card_number).to eq(0)
+    end
   end
 
   context "when the form year is >= 2024" do
@@ -72,6 +76,10 @@ RSpec.describe Form::Lettings::Questions::Declaration, type: :model do
 
     it "uses the expected top guidance partial" do
       expect(question.top_guidance_partial).to eq("privacy_notice_tenant_2024")
+    end
+
+    it "has check_answers_card_number nil" do
+      expect(question.check_answers_card_number).to be_nil
     end
   end
 


### PR DESCRIPTION
Now it's in the setup section, it shouldn't have the card number - there's no reason to pull it out on its own separate from the other setup questions.