### PR TITLE
CLDC-3215 Add charges bu errors

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -382,6 +382,7 @@ class BulkUpload::Lettings::Year2024::RowParser
   validate :validate_uprn_exists_if_any_key_address_fields_are_blank, on: :after_log, unless: -> { supported_housing? }
 
   validate :validate_incomplete_soft_validations, on: :after_log
+  validate :validate_all_charges_given, on: :after_log, if: proc { is_carehome.zero? }
 
   def self.question_for_field(field)
     QUESTIONS[field]
@@ -810,6 +811,19 @@ private
     end
   end
 
+  def validate_all_charges_given
+    return if supported_housing? && field_125 == 1
+
+    { field_125: "basic rent",
+      field_126: "service charge",
+      field_127: "personal service charge",
+      field_128: "support charge" }.each do |field, charge|
+      if public_send(field.to_sym).blank?
+        errors.add(field, I18n.t("validations.financial.charges.missing_charges", question: charge))
+      end
+    end
+  end
+
   def setup_question?(question)
     log.form.setup_sections[0].subsections[0].questions.include?(question)
   end
@@ -1152,7 +1166,7 @@ private
     attributes["pscharge"] = field_127
     attributes["supcharg"] = field_128
     attributes["chcharge"] = field_124
-    attributes["is_carehome"] = field_124.present? ? 1 : 0
+    attributes["is_carehome"] = is_carehome
     attributes["household_charge"] = supported_housing? ? field_122 : nil
     attributes["hbrentshortfall"] = field_129
     attributes["tshortfall_known"] = tshortfall_known
@@ -1478,5 +1492,9 @@ private
     return 826 if nationality_value == 826
 
     12
+  end
+
+  def is_carehome
+    field_124.present? ? 1 : 0
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,6 +416,7 @@ en:
           above_hard_max: "Rent is higher than the absolute maximum expected for a property of this type based on this period"
       charges:
         complete_1_of_3: "Answer either the ‘household rent and charges’ question or ‘is this accommodation a care home‘, or select ‘no’ for ‘does the household pay rent or charges for the accommodation?’"
+        missing_charges: "Please enter the %{question}. If there is no %{question}, please enter '0'."
       tcharge:
         under_10: "Enter a total charge that is at least £10.00 per week"
       rent_period:

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -2294,18 +2294,75 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#chcharge" do
-      let(:attributes) { { bulk_upload:, field_127: "123.45" } }
+      let(:attributes) { { bulk_upload:, field_127: "123.45", field_131: "123.45", field_130: "123.45", field_129: "123.45", field_128: "123.45" } }
 
       it "sets value given" do
         expect(parser.log.chcharge).to eq(123.45)
       end
+
+      it "sets is care home to yes" do
+        expect(parser.log.is_carehome).to eq(1)
+      end
+
+      it "clears any other given charges" do
+        parser.log.save!
+        expect(parser.log.tcharge).to be_nil
+        expect(parser.log.brent).to be_nil
+        expect(parser.log.supcharg).to be_nil
+        expect(parser.log.pscharge).to be_nil
+        expect(parser.log.scharge).to be_nil
+      end
     end
 
     describe "#tcharge" do
-      let(:attributes) { { bulk_upload:, field_132: "123.45" } }
+      let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: "123.45", field_128: "123.45", field_129: "123.45", field_130: "123.45", field_131: "123.45" } }
 
       it "sets value given" do
         expect(parser.log.tcharge).to eq(123.45)
+      end
+
+      context "when other charges are not given" do
+        context "and it is carehome" do
+          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: "123.45", field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
+
+          it "does not set charges values" do
+            parser.log.save!
+            expect(parser.log.tcharge).to be_nil
+            expect(parser.log.brent).to be_nil
+            expect(parser.log.supcharg).to be_nil
+            expect(parser.log.pscharge).to be_nil
+            expect(parser.log.scharge).to be_nil
+          end
+
+          it "does not add errors to missing charges" do
+            parser.valid?
+            expect(parser.errors[:field_128]).to be_empty
+            expect(parser.errors[:field_129]).to be_empty
+            expect(parser.errors[:field_130]).to be_empty
+            expect(parser.errors[:field_131]).to be_empty
+          end
+        end
+
+        context "and it is not carehome" do
+          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: nil, field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
+
+          it "does not set charges values" do
+            parser.log.save!
+            expect(parser.log.tcharge).to be_nil
+            expect(parser.log.brent).to be_nil
+            expect(parser.log.supcharg).to be_nil
+            expect(parser.log.pscharge).to be_nil
+            expect(parser.log.scharge).to be_nil
+          end
+
+          it "adds an error to all missing charges" do
+            parser.valid?
+            expect(parser.errors[:field_128]).to eql(["Please enter the basic rent. If there is no basic rent, please enter '0'."])
+            expect(parser.errors[:field_129]).to eql(["Please enter the service charge. If there is no service charge, please enter '0'."])
+            expect(parser.errors[:field_130]).to eql(["Please enter the personal service charge. If there is no personal service charge, please enter '0'."])
+            expect(parser.errors[:field_131]).to eql(["Please enter the support charge. If there is no support charge, please enter '0'."])
+          end
+        end
       end
     end
 
@@ -2314,6 +2371,50 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
       it "sets value given" do
         expect(parser.log.supcharg).to eq(123.45)
+      end
+
+      context "when other charges are not given" do
+        context "and it is carehome" do
+          let(:attributes) { { bulk_upload:, field_132: nil, field_127: "123.45", field_128: nil, field_129: nil, field_130: nil, field_131: "123.45" } }
+
+          it "does not set charges values" do
+            parser.log.save!
+            expect(parser.log.tcharge).to be_nil
+            expect(parser.log.brent).to be_nil
+            expect(parser.log.supcharg).to be_nil
+            expect(parser.log.pscharge).to be_nil
+            expect(parser.log.scharge).to be_nil
+          end
+
+          it "does not add errors to missing charges" do
+            parser.valid?
+            expect(parser.errors[:field_128]).to be_empty
+            expect(parser.errors[:field_129]).to be_empty
+            expect(parser.errors[:field_130]).to be_empty
+            expect(parser.errors[:field_131]).to be_empty
+          end
+        end
+
+        context "and it is not carehome" do
+          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: nil, field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
+
+          it "does not set charges values" do
+            parser.log.save!
+            expect(parser.log.tcharge).to be_nil
+            expect(parser.log.brent).to be_nil
+            expect(parser.log.supcharg).to be_nil
+            expect(parser.log.pscharge).to be_nil
+            expect(parser.log.scharge).to be_nil
+          end
+
+          it "adds an error to all missing charges" do
+            parser.valid?
+            expect(parser.errors[:field_128]).to eql(["Please enter the basic rent. If there is no basic rent, please enter '0'."])
+            expect(parser.errors[:field_129]).to eql(["Please enter the service charge. If there is no service charge, please enter '0'."])
+            expect(parser.errors[:field_130]).to eql(["Please enter the personal service charge. If there is no personal service charge, please enter '0'."])
+            expect(parser.errors[:field_131]).to eql(["Please enter the support charge. If there is no support charge, please enter '0'."])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Previously if not all of the charges were answered in BU template, the remaining charges would get set to 0 which might be wrong. This PR adds a validation for this case:
<img width="1163" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/5744e9f7-aa6f-4336-8347-ed7ab13386ba">
