### PR TITLE
CLDC-3235 Update how we display create new logs actions

### DIFF
--- a/app/components/create_log_actions_component.rb
+++ b/app/components/create_log_actions_component.rb
@@ -15,7 +15,7 @@ class CreateLogActionsComponent < ViewComponent::Base
     return false if bulk_upload.present?
     return true if user.support?
 
-    user.organisation.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
+    user.organisation.data_protection_confirmed? && user.organisation.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
   end
 
   def create_button_href

--- a/app/components/create_log_actions_component.rb
+++ b/app/components/create_log_actions_component.rb
@@ -14,9 +14,8 @@ class CreateLogActionsComponent < ViewComponent::Base
   def display_actions?
     return false if bulk_upload.present?
     return true if user.support?
-    return false if !user.organisation.holds_own_stock? && user.organisation.stock_owners.empty? && user.organisation.absorbed_organisations.empty?
 
-    user.organisation.data_protection_confirmed?
+    organisation_or_stock_owner_signed_dsa_and_holds_own_stock?(user.organisation)
   end
 
   def create_button_href
@@ -53,5 +52,13 @@ class CreateLogActionsComponent < ViewComponent::Base
     when "sales"
       bulk_upload_sales_log_path(id: "start")
     end
+  end
+
+  def organisation_or_stock_owner_signed_dsa_and_holds_own_stock?(organisation)
+    return true if organisation.data_protection_confirmed? && organisation.holds_own_stock?
+    return true if organisation.stock_owners.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
+    return true if organisation.absorbed_organisations.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
+
+    false
   end
 end

--- a/app/components/create_log_actions_component.rb
+++ b/app/components/create_log_actions_component.rb
@@ -15,7 +15,7 @@ class CreateLogActionsComponent < ViewComponent::Base
     return false if bulk_upload.present?
     return true if user.support?
 
-    organisation_or_stock_owner_signed_dsa_and_holds_own_stock?(user.organisation)
+    user.organisation.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
   end
 
   def create_button_href
@@ -52,13 +52,5 @@ class CreateLogActionsComponent < ViewComponent::Base
     when "sales"
       bulk_upload_sales_log_path(id: "start")
     end
-  end
-
-  def organisation_or_stock_owner_signed_dsa_and_holds_own_stock?(organisation)
-    return true if organisation.data_protection_confirmed? && organisation.holds_own_stock?
-    return true if organisation.stock_owners.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
-    return true if organisation.absorbed_organisations.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
-
-    false
   end
 end

--- a/app/components/data_protection_confirmation_banner_component.rb
+++ b/app/components/data_protection_confirmation_banner_component.rb
@@ -13,13 +13,16 @@ class DataProtectionConfirmationBannerComponent < ViewComponent::Base
   def display_banner?
     return false if user.support? && organisation.blank?
     return true if org_without_dpo?
+    return false if !org_or_user_org.holds_own_stock? && org_or_user_org.stock_owners.empty? && org_or_user_org.absorbed_organisations.empty?
 
-    !org_or_user_org.data_protection_confirmed?
+    !org_or_user_org.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
   end
 
   def header_text
     if org_without_dpo?
       "To create logs your organisation must state a data protection officer. They must sign the Data Sharing Agreement."
+    elsif !org_or_user_org.holds_own_stock?
+      "Your organisation does not own stock. To create logs your stock owner(s) must accept the Data Sharing Agreement on CORE."
     elsif user.is_dpo?
       "Your organisation must accept the Data Sharing Agreement before you can create any logs."
     else
@@ -28,7 +31,7 @@ class DataProtectionConfirmationBannerComponent < ViewComponent::Base
   end
 
   def banner_text
-    if org_without_dpo? || user.is_dpo?
+    if org_without_dpo? || user.is_dpo? || !org_or_user_org.holds_own_stock?
       govuk_link_to(
         link_text,
         link_href,
@@ -50,13 +53,21 @@ private
   def link_text
     if dpo_required?
       "Contact helpdesk to assign a data protection officer"
+    elsif !org_or_user_org.holds_own_stock?
+      "View or add stock owners"
     else
       "Read the Data Sharing Agreement"
     end
   end
 
   def link_href
-    dpo_required? ? GlobalConstants::HELPDESK_URL : data_sharing_agreement_organisation_path(org_or_user_org)
+    if dpo_required?
+      GlobalConstants::HELPDESK_URL
+    elsif !org_or_user_org.holds_own_stock?
+      stock_owners_organisation_path(org_or_user_org)
+    else
+      data_sharing_agreement_organisation_path(org_or_user_org)
+    end
   end
 
   def dpo_required?

--- a/app/components/data_protection_confirmation_banner_component.rb
+++ b/app/components/data_protection_confirmation_banner_component.rb
@@ -15,13 +15,13 @@ class DataProtectionConfirmationBannerComponent < ViewComponent::Base
     return true if org_without_dpo?
     return false if !org_or_user_org.holds_own_stock? && org_or_user_org.stock_owners.empty? && org_or_user_org.absorbed_organisations.empty?
 
-    !org_or_user_org.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
+    !org_or_user_org.data_protection_confirmed? || !org_or_user_org.organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
   end
 
   def header_text
     if org_without_dpo?
       "To create logs your organisation must state a data protection officer. They must sign the Data Sharing Agreement."
-    elsif !org_or_user_org.holds_own_stock?
+    elsif !org_or_user_org.holds_own_stock? && org_or_user_org.data_protection_confirmed?
       "Your organisation does not own stock. To create logs your stock owner(s) must accept the Data Sharing Agreement on CORE."
     elsif user.is_dpo?
       "Your organisation must accept the Data Sharing Agreement before you can create any logs."
@@ -53,7 +53,7 @@ private
   def link_text
     if dpo_required?
       "Contact helpdesk to assign a data protection officer"
-    elsif !org_or_user_org.holds_own_stock?
+    elsif !org_or_user_org.holds_own_stock? && org_or_user_org.data_protection_confirmed?
       "View or add stock owners"
     else
       "Read the Data Sharing Agreement"
@@ -63,7 +63,7 @@ private
   def link_href
     if dpo_required?
       GlobalConstants::HELPDESK_URL
-    elsif !org_or_user_org.holds_own_stock?
+    elsif !org_or_user_org.holds_own_stock? && org_or_user_org.data_protection_confirmed?
       stock_owners_organisation_path(org_or_user_org)
     else
       data_sharing_agreement_organisation_path(org_or_user_org)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -159,4 +159,12 @@ class Organisation < ApplicationRecord
   def has_recent_absorbed_organisations?
     absorbed_organisations&.merged_during_open_collection_period.present?
   end
+
+  def organisation_or_stock_owner_signed_dsa_and_holds_own_stock?
+    return true if data_protection_confirmed? && holds_own_stock?
+    return true if stock_owners.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
+    return true if absorbed_organisations.any? { |stock_owner| stock_owner.data_protection_confirmed? && stock_owner.holds_own_stock? }
+
+    false
+  end
 end

--- a/spec/components/create_log_actions_component_spec.rb
+++ b/spec/components/create_log_actions_component_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CreateLogActionsComponent, type: :component do
             user.organisation.update!(holds_own_stock: false)
           end
 
-          context "and stock owners that have signed data sharing agreement" do
+          context "and has signed DSA and stock owners have signed DSA" do
             before do
               parent_organisation = create(:organisation)
               create(:organisation_relationship, child_organisation: user.organisation, parent_organisation:)
@@ -128,6 +128,18 @@ RSpec.describe CreateLogActionsComponent, type: :component do
 
             it "renders actions" do
               expect(component.display_actions?).to eq(true)
+            end
+          end
+
+          context "and hasn't signed DSA and and stock owners have signed DSA" do
+            before do
+              user.organisation.data_protection_confirmation.update!(confirmed: false)
+              parent_organisation = create(:organisation)
+              create(:organisation_relationship, child_organisation: user.organisation, parent_organisation:)
+            end
+
+            it "renders actions" do
+              expect(component.display_actions?).to eq(false)
             end
           end
 

--- a/spec/components/create_log_actions_component_spec.rb
+++ b/spec/components/create_log_actions_component_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CreateLogActionsComponent, type: :component do
       end
 
       context "when has data sharing agremeent" do
-        let(:user) { create(:user, :support) }
+        let(:user) { create(:user) }
 
         it "renders actions" do
           expect(component.display_actions?).to eq(true)
@@ -112,6 +112,34 @@ RSpec.describe CreateLogActionsComponent, type: :component do
           it "returns create button href" do
             render
             expect(component.create_button_href).to eq("/sales-logs")
+          end
+        end
+
+        context "when organisation doesn't own stock" do
+          before do
+            user.organisation.update!(holds_own_stock: false)
+          end
+
+          context "and stock owners that have signed data sharing agreement" do
+            before do
+              parent_organisation = create(:organisation)
+              create(:organisation_relationship, child_organisation: user.organisation, parent_organisation:)
+            end
+
+            it "renders actions" do
+              expect(component.display_actions?).to eq(true)
+            end
+          end
+
+          context "and no stock owners have signed data sharing agreement" do
+            before do
+              parent_organisation = create(:organisation, :without_dpc)
+              create(:organisation_relationship, child_organisation: user.organisation, parent_organisation:)
+            end
+
+            it "does not render actions" do
+              expect(component.display_actions?).to eq(false)
+            end
           end
         end
       end


### PR DESCRIPTION
There was previously a situation where organisation doesn't own their stock but have multiple stock owners and none of those stock owners have their DSAs signed. In this case in the owning organisation question we should already be showing the errors, that the selected organisation hasn’t signed the DSA.
 
However, there is an edge case where organisation doesn’t own stock, organisation has 1 stock owner and that stock owner doesn’t have their DSA signed. In this situation we’re not showing the owning organisation question and default to the stock owner as the owning organisation and that fails (internally, without any useful message for the user) and doesn’t set the owning organisation.

This PR should prevent that by hiding the `create a new log` actions
<img width="938" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/a0cbe136-fec2-4d80-b10f-5c81b7940428">
