### PR TITLE
CLDC-2478 Allow deleting locations

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -14,8 +14,8 @@ class LocationsController < ApplicationController
   def index
     authorize @scheme
 
-    @pagy, @locations = pagy(filter_manager.filtered_locations(@scheme.locations, search_term, session_filters))
-    @total_count = @scheme.locations.size
+    @pagy, @locations = pagy(filter_manager.filtered_locations(@scheme.locations.visible, search_term, session_filters))
+    @total_count = @scheme.locations.visible.size
     @searched = search_term.presence
     @filter_type = "scheme_locations"
   end
@@ -230,7 +230,10 @@ class LocationsController < ApplicationController
     end
   end
 
-  def delete; end
+  def delete
+    @location.discard!
+    redirect_to scheme_locations_path(@scheme), notice: I18n.t("notification.location_deleted", postcode: @location.postcode)
+  end
 
 private
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -230,6 +230,8 @@ class LocationsController < ApplicationController
     end
   end
 
+  def delete; end
+
 private
 
   def authorize_user

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    organisation_schemes = Scheme.where(owning_organisation: [@organisation] + @organisation.parent_organisations)
+    organisation_schemes = Scheme.visible.where(owning_organisation: [@organisation] + @organisation.parent_organisations)
 
     @pagy, @schemes = pagy(filter_manager.filtered_schemes(organisation_schemes, search_term, session_filters))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -13,11 +13,11 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.all
+    all_visible_schemes = Scheme.visible
 
-    @pagy, @schemes = pagy(filter_manager.filtered_schemes(all_schemes, search_term, session_filters))
+    @pagy, @schemes = pagy(filter_manager.filtered_schemes(all_visible_schemes, search_term, session_filters))
     @searched = search_term.presence
-    @total_count = all_schemes.size
+    @total_count = all_visible_schemes.size
     @filter_type = "schemes"
   end
 
@@ -222,6 +222,11 @@ class SchemesController < ApplicationController
   end
 
   def csv_confirmation; end
+
+  def delete
+    @scheme.discard!
+    redirect_to schemes_organisation_path(@scheme.owning_organisation), notice: I18n.t("notification.scheme_deleted", service_name: @scheme.service_name)
+  end
 
 private
 

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -73,6 +73,10 @@ module LocationsHelper
     return govuk_button_link_to "Reactivate this location", scheme_location_new_reactivation_path(location.scheme, location) if location.deactivated?
   end
 
+  def delete_location_link(location)
+    govuk_button_link_to "Delete this location", scheme_location_delete_confirmation_path(location.scheme, location), warning: true
+  end
+
   def location_creation_success_notice(location)
     if location.confirmed
       "#{location.postcode} #{location.startdate.blank? || location.startdate.before?(Time.zone.now) ? 'has been' : 'will be'} added to this scheme"

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -15,6 +15,10 @@ module SchemesHelper
     return govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(scheme) if scheme.deactivated?
   end
 
+  def delete_scheme_link(scheme)
+    govuk_button_link_to "Delete this scheme", scheme_delete_confirmation_path(scheme), warning: true
+  end
+
   def owning_organisation_options(current_user)
     all_orgs = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) }
     user_org = [OpenStruct.new(id: current_user.organisation_id, name: current_user.organisation.name)]

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -20,7 +20,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
     answer_opts = {}
     return answer_opts unless ActiveRecord::Base.connected?
 
-    Location.started_in_2_weeks.select(:id, :postcode, :name).each_with_object(answer_opts) do |location, hsh|
+    Location.visible.started_in_2_weeks.select(:id, :postcode, :name).each_with_object(answer_opts) do |location, hsh|
       hsh[location.id.to_s] = { "value" => location.postcode, "hint" => location.name }
       hsh
     end
@@ -29,7 +29,7 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     return {} unless lettings_log.scheme
 
-    scheme_location_ids = lettings_log.scheme.locations.confirmed.pluck(:id)
+    scheme_location_ids = lettings_log.scheme.locations.visible.confirmed.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
   end
 

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -19,8 +19,8 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
     answer_opts = { "" => "Select an option" }
     return answer_opts unless ActiveRecord::Base.connected?
 
-    Scheme.select(:id, :service_name, :primary_client_group,
-                  :secondary_client_group).each_with_object(answer_opts) do |scheme, hsh|
+    Scheme.visible.select(:id, :service_name, :primary_client_group,
+                          :secondary_client_group).each_with_object(answer_opts) do |scheme, hsh|
       hsh[scheme.id.to_s] = scheme
       hsh
     end
@@ -29,10 +29,10 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     organisation = lettings_log.owning_organisation || lettings_log.created_by&.organisation
     schemes = if organisation
-                Scheme.includes(:locations).select(:id).where(owning_organisation_id: organisation.id,
-                                                              confirmed: true)
+                Scheme.visible.includes(:locations).select(:id).where(owning_organisation_id: organisation.id,
+                                                                      confirmed: true)
               else
-                Scheme.includes(:locations).select(:id).where(confirmed: true)
+                Scheme.visible.includes(:locations).select(:id).where(confirmed: true)
               end
     filtered_scheme_ids = schemes.joins(:locations).merge(Location.started_in_2_weeks).map(&:id)
     answer_options.select do |k, _v|

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -89,8 +89,7 @@ private
 
   def has_any_logs_in_editable_collection_period
     editable_from_date = FormHandler.instance.earliest_open_for_editing_collection_start_date
-    editable_logs = LettingsLog.where(location_id: location.id).after_date(editable_from_date)
 
-    LettingsLog.where(location_id: location.id, startdate: nil).any? || editable_logs.any?
+    LettingsLog.where(location_id: location.id).after_date(editable_from_date).or(LettingsLog.where(startdate: nil, location_id: location.id)).any?
   end
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -26,6 +26,14 @@ class LocationPolicy
     user.data_coordinator? && scheme_owned_by_user_org_or_stock_owner
   end
 
+  def delete_confirmation?
+    user.support?
+  end
+
+  def delete?
+    user.support?
+  end
+
   %w[
     update_postcode?
     update_local_authority?

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -27,11 +27,11 @@ class LocationPolicy
   end
 
   def delete_confirmation?
-    user.support?
+    delete?
   end
 
   def delete?
-    user.support?
+    user.support? && (location.status == :incomplete || location.status == :deactivated)
   end
 
   %w[

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -26,4 +26,12 @@ class FeatureToggle
   def self.service_moved?
     false
   end
+
+  def self.delete_scheme_enabled?
+    !Rails.env.production?
+  end
+
+  def self.delete_location_enabled?
+    !Rails.env.production?
+  end
 end

--- a/app/views/locations/check_answers.html.erb
+++ b/app/views/locations/check_answers.html.erb
@@ -45,3 +45,7 @@
     <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>
   </div>
 <% end %>
+
+<% if LocationPolicy.new(current_user, @location).delete? %>
+  <%= delete_location_link(@location) %>
+<% end %>

--- a/app/views/locations/check_answers.html.erb
+++ b/app/views/locations/check_answers.html.erb
@@ -42,10 +42,9 @@
 <% if LocationPolicy.new(current_user, @location).create? %>
   <div class="govuk-button-group">
     <%= govuk_button_to "Save and return to locations", scheme_location_confirm_path(@scheme, @location, route: params[:route]), method: :patch %>
+    <% if LocationPolicy.new(current_user, @location).delete? %>
+      <%= delete_location_link(@location) %>
+    <% end %>
     <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>
   </div>
-<% end %>
-
-<% if LocationPolicy.new(current_user, @location).delete? %>
-  <%= delete_location_link(@location) %>
 <% end %>

--- a/app/views/locations/check_answers.html.erb
+++ b/app/views/locations/check_answers.html.erb
@@ -42,7 +42,7 @@
 <% if LocationPolicy.new(current_user, @location).create? %>
   <div class="govuk-button-group">
     <%= govuk_button_to "Save and return to locations", scheme_location_confirm_path(@scheme, @location, route: params[:route]), method: :patch %>
-    <% if LocationPolicy.new(current_user, @location).delete? %>
+    <% if LocationPolicy.new(current_user, @location).delete? && FeatureToggle.delete_location_enabled? %>
       <%= delete_location_link(@location) %>
     <% end %>
     <%= govuk_button_link_to "Cancel", scheme_locations_path(@scheme), secondary: true %>

--- a/app/views/locations/delete_confirmation.html.erb
+++ b/app/views/locations/delete_confirmation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content do %>
+  <% content_for :title, "Are you sure you want to delete this location?" %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-xl">Delete <%= @location.postcode %></span>
+    <h1 class="govuk-heading-xl">
+      <%= content_for(:title) %>
+    </h1>
+
+    <%= govuk_warning_text(text: "You will not be able to undo this action.") %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        "Delete this location",
+        scheme_location_delete_path(@scheme, @location),
+        method: :delete,
+      ) %>
+      <%= govuk_button_link_to "Cancel", scheme_location_path(@scheme, @location), html: { method: :get }, secondary: true %>
+    </div>
+  </div>
+</div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -19,7 +19,12 @@
           <%= summary_list.with_row do |row| %>
             <% row.with_key { attr[:name] } %>
             <% if attr[:attribute].eql?("status") %>
-              <%= row.with_value { status_tag_from_resource(@location) } %>
+              <%= row.with_value do %>
+                <%= details_html({ name: "Status", value: status_tag_from_resource(@location), id: "status" }) %>
+                <% if @location.deactivated? && current_user.support? && !LocationPolicy.new(current_user, @location).delete? %>
+                  <span class="app-!-colour-muted">This location was active in an open or editable collection year, and cannot be deleted.</span>
+                <% end %>
+              <% end %>
             <% elsif attr[:attribute].eql?("postcode") && @location.is_la_inferred %>
               <% row.with_value do %>
                 <%= details_html(attr) %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -45,3 +45,7 @@
 <% if LocationPolicy.new(current_user, @location).deactivate? %>
   <%= toggle_location_link(@location) %>
 <% end %>
+
+<% if LocationPolicy.new(current_user, @location).delete? %>
+  <%= delete_location_link(@location) %>
+<% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -51,6 +51,6 @@
   <%= toggle_location_link(@location) %>
 <% end %>
 
-<% if LocationPolicy.new(current_user, @location).delete? %>
+<% if LocationPolicy.new(current_user, @location).delete? && FeatureToggle.delete_location_enabled? %>
   <%= delete_location_link(@location) %>
 <% end %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -24,7 +24,7 @@
     <%= f.govuk_submit button_label %>
   <% end %>
 
-  <% if SchemePolicy.new(current_user, @scheme).delete? %>
+  <% if SchemePolicy.new(current_user, @scheme).delete? && FeatureToggle.delete_scheme_enabled? %>
     <%= delete_scheme_link(@scheme) %>
   <% end %>
 <% end %>

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -23,4 +23,8 @@
   <% if SchemePolicy.new(current_user, @scheme).create? %>
     <%= f.govuk_submit button_label %>
   <% end %>
+
+  <% if SchemePolicy.new(current_user, @scheme).delete? %>
+    <%= delete_scheme_link(@scheme) %>
+  <% end %>
 <% end %>

--- a/app/views/schemes/delete_confirmation.html.erb
+++ b/app/views/schemes/delete_confirmation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content do %>
+  <% content_for :title, "Are you sure you want to delete this scheme?" %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-xl">Delete <%= @scheme.service_name %></span>
+    <h1 class="govuk-heading-xl">
+      <%= content_for(:title) %>
+    </h1>
+
+    <%= govuk_warning_text(text: "You will not be able to undo this action.") %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        "Delete this scheme",
+        scheme_delete_path(@scheme),
+        method: :delete,
+      ) %>
+      <%= govuk_button_link_to "Cancel", scheme_path(@scheme), html: { method: :get }, secondary: true %>
+    </div>
+  </div>
+</div>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -29,6 +29,9 @@
               <% if @scheme.confirmed? && @scheme.locations.confirmed.none? && LocationPolicy.new(current_user, @scheme.locations.new).create? %>
                 <span class="app-!-colour-muted">Complete this scheme by adding a location using the <%= govuk_link_to("‘locations’ tab", scheme_locations_path(@scheme)) %>.</span>
               <% end %>
+              <% if @scheme.deactivated? && current_user.support? && !SchemePolicy.new(current_user, @scheme).delete? %>
+                  <span class="app-!-colour-muted">This scheme was active in an open or editable collection year, and cannot be deleted.</span>
+              <% end %>
             </dd>
           </div>
         <% elsif attr[:id] != "secondary_client_group" || @scheme.has_other_client_group == "Yes" %>
@@ -48,4 +51,8 @@
 
 <% if SchemePolicy.new(current_user, @scheme).deactivate? %>
   <%= toggle_scheme_link(@scheme) %>
+<% end %>
+
+<% if SchemePolicy.new(current_user, @scheme).delete? %>
+  <%= delete_scheme_link(@scheme) %>
 <% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -53,6 +53,6 @@
   <%= toggle_scheme_link(@scheme) %>
 <% end %>
 
-<% if SchemePolicy.new(current_user, @scheme).delete? %>
+<% if SchemePolicy.new(current_user, @scheme).delete? && FeatureToggle.delete_scheme_enabled? %>
   <%= delete_scheme_link(@scheme) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,7 @@ en:
       one: "There is %{count} set of duplicate logs"
       other: "There are %{count} sets of duplicate logs"
     location_deleted: "%{postcode} has been deleted."
+    scheme_deleted: "%{service_name} has been deleted."
 
   validations:
     organisation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,7 @@ en:
     duplicate_sets:
       one: "There is %{count} set of duplicate logs"
       other: "There are %{count} sets of duplicate logs"
+    location_deleted: "%{postcode} has been deleted."
 
   validations:
     organisation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
       patch "new-deactivation", to: "locations#new_deactivation"
       patch "deactivate", to: "locations#deactivate"
       patch "reactivate", to: "locations#reactivate"
+      get "delete-confirmation", to: "locations#delete_confirmation"
+      delete "delete", to: "locations#delete"
     end
   end
   get "scheme-changes", to: "schemes#changes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
     patch "new-deactivation", to: "schemes#new_deactivation"
     patch "deactivate", to: "schemes#deactivate"
     patch "reactivate", to: "schemes#reactivate"
+    get "delete-confirmation", to: "schemes#delete_confirmation"
+    delete "delete", to: "schemes#delete"
 
     collection do
       get "csv-download", to: "schemes#download_csv"

--- a/db/migrate/20240301125651_add_discarded_at_column.rb
+++ b/db/migrate/20240301125651_add_discarded_at_column.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtColumn < ActiveRecord::Migration[7.0]
+  def change
+    add_column :locations, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20240304100017_add_discarded_at_column_to_schemes.rb
+++ b/db/migrate/20240304100017_add_discarded_at_column_to_schemes.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtColumnToSchemes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schemes, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,6 +374,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_122706) do
     t.string "location_admin_district"
     t.boolean "confirmed"
     t.boolean "is_la_inferred"
+    t.datetime "discarded_at"
     t.index ["old_id"], name: "index_locations_on_old_id", unique: true
     t.index ["scheme_id"], name: "index_locations_on_scheme_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -723,6 +723,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_122706) do
     t.integer "total_units"
     t.boolean "confirmed"
     t.datetime "startdate"
+    t.datetime "discarded_at"
     t.index ["owning_organisation_id"], name: "index_schemes_on_owning_organisation_id"
   end
 

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
         end
       end
 
+      context "and all the locations are deleted" do
+        before do
+          FactoryBot.create(:location, scheme:, discarded_at: Time.utc(2022, 5, 12))
+          FactoryBot.create(:location, scheme:, discarded_at: Time.utc(2022, 5, 12))
+          lettings_log.update!(scheme:)
+        end
+
+        it "the displayed_answer_options is an empty hash" do
+          expect(question.displayed_answer_options(lettings_log)).to eq({})
+        end
+      end
+
       context "and all but one of the locations have a startdate more than 2 weeks in the future" do
         before do
           FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 13))

--- a/spec/models/form/lettings/questions/scheme_id_spec.rb
+++ b/spec/models/form/lettings/questions/scheme_id_spec.rb
@@ -147,6 +147,19 @@ RSpec.describe Form::Lettings::Questions::SchemeId, type: :model do
           expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
         end
       end
+
+      context "when the scheme is deleted" do
+        let(:scheme) { FactoryBot.create(:scheme, owning_organisation: organisation, discarded_at: Time.zone.yesterday) }
+
+        before do
+          FactoryBot.create(:location, startdate: Time.zone.tomorrow, scheme:)
+        end
+
+        it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
+          expected_answer = { "" => "Select an option" }
+          expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+        end
+      end
     end
 
     context "when there are no schemes with locations" do

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -304,6 +304,14 @@ RSpec.describe Scheme, type: :model do
         expect(scheme.status).to eq(:activating_soon)
       end
     end
+
+    context "when scheme has discarded_at value" do
+      let(:scheme) { FactoryBot.create(:scheme, discarded_at: Time.zone.now) }
+
+      it "returns deleted" do
+        expect(scheme.status).to eq(:deleted)
+      end
+    end
   end
 
   describe "status_at" do

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe LocationPolicy do
+  subject(:policy) { described_class }
+
+  let(:data_provider) { FactoryBot.create(:user, :data_provider) }
+  let(:data_coordinator) { FactoryBot.create(:user, :data_coordinator) }
+  let(:support) { FactoryBot.create(:user, :support) }
+
+  permissions :delete? do
+    let(:location) { FactoryBot.create(:location) }
+
+    context "with active location" do
+      it "does not allow deleting a location as a provider" do
+        expect(policy).not_to permit(data_provider, location)
+      end
+
+      it "does not allow allows deleting a location as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, location)
+      end
+
+      it "does not allow deleting a location as a support user" do
+        expect(policy).not_to permit(support, location)
+      end
+    end
+
+    context "with incomplete location" do
+      before do
+        location.update!(units: nil)
+      end
+
+      it "does not allow deleting a location as a provider" do
+        expect(policy).not_to permit(data_provider, location)
+      end
+
+      it "does not allow allows deleting a location as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, location)
+      end
+
+      it "allows deleting a location as a support user" do
+        expect(policy).to permit(support, location)
+      end
+    end
+
+    context "with deactivated location" do
+      before do
+        location.location_deactivation_periods << create(:location_deactivation_period, deactivation_date: Time.zone.local(2024, 4, 10), location:)
+        location.save!
+        Timecop.freeze(Time.utc(2024, 4, 10))
+        log = create(:lettings_log, scheme: location.scheme, location:)
+        log.startdate = Time.zone.local(2022, 10, 10)
+        log.save!(validate: false)
+      end
+
+      after do
+        Timecop.unfreeze
+      end
+
+      context "and associated logs in editable collection period" do
+        before do
+          create(:lettings_log, scheme: location.scheme, location:)
+        end
+
+        it "does not allow deleting a location as a provider" do
+          expect(policy).not_to permit(data_provider, location)
+        end
+
+        it "does not allow allows deleting a location as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, location)
+        end
+
+        it "does not allow deleting a location as a support user" do
+          expect(policy).not_to permit(support, location)
+        end
+      end
+
+      context "and no associated logs in editable collection period" do
+        it "does not allow deleting a location as a provider" do
+          expect(policy).not_to permit(data_provider, location)
+        end
+
+        it "does not allow allows deleting a location as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, location)
+        end
+
+        it "allows deleting a location as a support user" do
+          expect(policy).to permit(support, location)
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/scheme_policy_spec.rb
+++ b/spec/policies/scheme_policy_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe SchemePolicy do
+  subject(:policy) { described_class }
+
+  let(:data_provider) { create(:user, :data_provider) }
+  let(:data_coordinator) { create(:user, :data_coordinator) }
+  let(:support) { create(:user, :support) }
+
+  permissions :delete? do
+    let(:scheme) { create(:scheme) }
+
+    before do
+      create(:location, scheme:)
+    end
+
+    context "with active scheme" do
+      it "does not allow deleting a scheme as a provider" do
+        expect(policy).not_to permit(data_provider, scheme)
+      end
+
+      it "does not allow allows deleting a scheme as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, scheme)
+      end
+
+      it "does not allow deleting a scheme as a support user" do
+        expect(policy).not_to permit(support, scheme)
+      end
+    end
+
+    context "with incomplete scheme" do
+      let(:scheme) { create(:scheme, :incomplete) }
+
+      it "does not allow deleting a scheme as a provider" do
+        expect(policy).not_to permit(data_provider, scheme)
+      end
+
+      it "does not allow allows deleting a scheme as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, scheme)
+      end
+
+      it "allows deleting a scheme as a support user" do
+        expect(policy).to permit(support, scheme)
+      end
+    end
+
+    context "with deactivated scheme" do
+      before do
+        scheme.scheme_deactivation_periods << create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2024, 4, 10), scheme:)
+        scheme.save!
+        Timecop.freeze(Time.utc(2024, 4, 10))
+        log = create(:lettings_log, :sh, owning_organisation: scheme.owning_organisation, scheme:)
+        log.startdate = Time.zone.local(2022, 10, 10)
+        log.save!(validate: false)
+      end
+
+      after do
+        Timecop.unfreeze
+      end
+
+      context "and associated logs in editable collection period" do
+        before do
+          create(:lettings_log, :sh, owning_organisation: scheme.owning_organisation, scheme:, startdate: Time.zone.local(2024, 4, 9))
+        end
+
+        it "does not allow deleting a scheme as a provider" do
+          expect(policy).not_to permit(data_provider, scheme)
+        end
+
+        it "does not allow allows deleting a scheme as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, scheme)
+        end
+
+        it "does not allow deleting a scheme as a support user" do
+          expect(policy).not_to permit(support, scheme)
+        end
+      end
+
+      context "and no associated logs in editable collection period" do
+        it "does not allow deleting a scheme as a provider" do
+          expect(policy).not_to permit(data_provider, scheme)
+        end
+
+        it "does not allow allows deleting a scheme as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, scheme)
+        end
+
+        it "allows deleting a scheme as a support user" do
+          expect(policy).to permit(support, scheme)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -1405,6 +1405,23 @@ RSpec.describe LocationsController, type: :request do
         expect(page).to have_content("Check your answers")
       end
 
+      context "with an active location" do
+        it "does not render delete this location" do
+          expect(location.status).to eq(:active)
+          expect(page).not_to have_link("Delete this location", href: "/schemes/#{scheme.id}/locations/#{location.id}/delete-confirmation")
+        end
+      end
+
+      context "with an incomplete location" do
+        it "renders delete this location" do
+          location.update!(units: nil)
+          get "/schemes/#{scheme.id}/locations/#{location.id}/check-answers"
+
+          expect(location.reload.status).to eq(:incomplete)
+          expect(page).to have_link("Delete this location", href: "/schemes/#{scheme.id}/locations/#{location.id}/delete-confirmation")
+        end
+      end
+
       context "when location is confirmed" do
         let(:params) { { location: { confirmed: true } } }
 

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe OrganisationsController, type: :request do
         let(:user) { create(:user, :support) }
         let!(:schemes) { create_list(:scheme, 5) }
         let!(:same_org_scheme) { create(:scheme, owning_organisation: user.organisation) }
+        let!(:deleted_scheme) { create(:scheme, owning_organisation: user.organisation, discarded_at: Time.zone.yesterday) }
 
         before do
           allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -129,6 +130,10 @@ RSpec.describe OrganisationsController, type: :request do
           schemes.each do |scheme|
             expect(page).not_to have_content(scheme.id_to_display)
           end
+        end
+
+        it "does not show deleted schemes" do
+          expect(page).not_to have_content(deleted_scheme.id_to_display)
         end
 
         context "when searching" do

--- a/spec/views/locations/show.html.erb_spec.rb
+++ b/spec/views/locations/show.html.erb_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "locations/show.html.erb" do
       assign(:location, location)
 
       allow(view).to receive(:current_user).and_return(user)
+      allow(location).to receive(:deactivated?).and_return(false)
 
       render
 
@@ -62,6 +63,7 @@ RSpec.describe "locations/show.html.erb" do
       assign(:location, location)
 
       allow(view).to receive(:current_user).and_return(user)
+      allow(location).to receive(:deactivated?).and_return(false)
 
       render
 


### PR DESCRIPTION
Allow support users to delete incomplete or deactivated locations that are not used in editable collection periods:
<img width="931" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/c2b202f7-b4ee-447d-8fc9-3b11cf035896">
<img width="1164" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/f6ab7ccb-06a7-4d68-8079-cd8c5c5ae17c">
or
<img width="686" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/71bc0429-46d6-4692-aca6-299276c60041">


Incomplete locations open on check answers page, so added a delete button there as well:
<img width="701" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/31965464-6d3e-412e-82e6-d9062264b882">


Will add deleting schemes separately