### PR TITLE
CLDC-2478 Allow deleting scheme

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,7 @@ class OrganisationsController < ApplicationController
   end
 
   def schemes
-    organisation_schemes = Scheme.where(owning_organisation: [@organisation] + @organisation.parent_organisations)
+    organisation_schemes = Scheme.visible.where(owning_organisation: [@organisation] + @organisation.parent_organisations)
 
     @pagy, @schemes = pagy(filter_manager.filtered_schemes(organisation_schemes, search_term, session_filters))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -13,7 +13,7 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_visible_schemes = Scheme.all.visible
+    all_visible_schemes = Scheme.visible
 
     @pagy, @schemes = pagy(filter_manager.filtered_schemes(all_visible_schemes, search_term, session_filters))
     @searched = search_term.presence

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -13,11 +13,11 @@ class SchemesController < ApplicationController
 
   def index
     redirect_to schemes_organisation_path(current_user.organisation) unless current_user.support?
-    all_schemes = Scheme.all
+    all_visible_schemes = Scheme.all.visible
 
-    @pagy, @schemes = pagy(filter_manager.filtered_schemes(all_schemes, search_term, session_filters))
+    @pagy, @schemes = pagy(filter_manager.filtered_schemes(all_visible_schemes, search_term, session_filters))
     @searched = search_term.presence
-    @total_count = all_schemes.size
+    @total_count = all_visible_schemes.size
     @filter_type = "schemes"
   end
 
@@ -222,6 +222,11 @@ class SchemesController < ApplicationController
   end
 
   def csv_confirmation; end
+
+  def delete
+    @scheme.discard!
+    redirect_to schemes_organisation_path(@scheme.owning_organisation), notice: I18n.t("notification.scheme_deleted", service_name: @scheme.service_name)
+  end
 
 private
 

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -15,6 +15,10 @@ module SchemesHelper
     return govuk_button_link_to "Reactivate this scheme", scheme_new_reactivation_path(scheme) if scheme.deactivated?
   end
 
+  def delete_scheme_link(scheme)
+    govuk_button_link_to "Delete this scheme", scheme_delete_confirmation_path(scheme), warning: true
+  end
+
   def owning_organisation_options(current_user)
     all_orgs = Organisation.all.map { |org| OpenStruct.new(id: org.id, name: org.name) }
     user_org = [OpenStruct.new(id: current_user.organisation_id, name: current_user.organisation.name)]

--- a/app/models/form/lettings/questions/scheme_id.rb
+++ b/app/models/form/lettings/questions/scheme_id.rb
@@ -20,8 +20,8 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
     answer_opts = { "" => "Select an option" }
     return answer_opts unless ActiveRecord::Base.connected?
 
-    Scheme.select(:id, :service_name, :primary_client_group,
-                  :secondary_client_group).each_with_object(answer_opts) do |scheme, hsh|
+    Scheme.visible.select(:id, :service_name, :primary_client_group,
+                          :secondary_client_group).each_with_object(answer_opts) do |scheme, hsh|
       hsh[scheme.id.to_s] = scheme
       hsh
     end
@@ -30,10 +30,10 @@ class Form::Lettings::Questions::SchemeId < ::Form::Question
   def displayed_answer_options(lettings_log, _user = nil)
     organisation = lettings_log.owning_organisation || lettings_log.created_by&.organisation
     schemes = if organisation
-                Scheme.includes(:locations).select(:id).where(owning_organisation_id: organisation.id,
-                                                              confirmed: true)
+                Scheme.visible.includes(:locations).select(:id).where(owning_organisation_id: organisation.id,
+                                                                      confirmed: true)
               else
-                Scheme.includes(:locations).select(:id).where(confirmed: true)
+                Scheme.visible.includes(:locations).select(:id).where(confirmed: true)
               end
     filtered_scheme_ids = schemes.joins(:locations).merge(Location.started_in_2_weeks).map(&:id)
     answer_options.select do |k, _v|

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -84,8 +84,7 @@ private
 
   def has_any_logs_in_editable_collection_period
     editable_from_date = FormHandler.instance.earliest_open_for_editing_collection_start_date
-    editable_logs = LettingsLog.where(scheme_id: scheme.id).after_date(editable_from_date)
 
-    LettingsLog.where(scheme_id: scheme.id, startdate: nil).any? || editable_logs.any?
+    LettingsLog.where(scheme_id: scheme.id).after_date(editable_from_date).or(LettingsLog.where(startdate: nil, scheme_id: scheme.id)).any?
   end
 end

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -66,11 +66,11 @@ class SchemePolicy
   end
 
   def delete_confirmation?
-    user.support?
+    delete?
   end
 
   def delete?
-    user.support?
+    user.support? && (scheme.status == :incomplete || scheme.status == :deactivated)
   end
 
 private

--- a/app/policies/scheme_policy.rb
+++ b/app/policies/scheme_policy.rb
@@ -65,6 +65,14 @@ class SchemePolicy
     end
   end
 
+  def delete_confirmation?
+    user.support?
+  end
+
+  def delete?
+    user.support?
+  end
+
 private
 
   def scheme_owned_by_user_org_or_stock_owner

--- a/app/views/schemes/check_answers.html.erb
+++ b/app/views/schemes/check_answers.html.erb
@@ -23,4 +23,8 @@
   <% if SchemePolicy.new(current_user, @scheme).create? %>
     <%= f.govuk_submit button_label %>
   <% end %>
+
+  <% if SchemePolicy.new(current_user, @scheme).delete? %>
+    <%= delete_scheme_link(@scheme) %>
+  <% end %>
 <% end %>

--- a/app/views/schemes/delete_confirmation.html.erb
+++ b/app/views/schemes/delete_confirmation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content do %>
+  <% content_for :title, "Are you sure you want to delete this scheme?" %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-xl">Delete <%= @scheme.service_name %></span>
+    <h1 class="govuk-heading-xl">
+      <%= content_for(:title) %>
+    </h1>
+
+    <%= govuk_warning_text(text: "You will not be able to undo this action.") %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        "Delete this scheme",
+        scheme_delete_path(@scheme),
+        method: :delete,
+      ) %>
+      <%= govuk_button_link_to "Cancel", scheme_path(@scheme), html: { method: :get }, secondary: true %>
+    </div>
+  </div>
+</div>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -49,3 +49,7 @@
 <% if SchemePolicy.new(current_user, @scheme).deactivate? %>
   <%= toggle_scheme_link(@scheme) %>
 <% end %>
+
+<% if SchemePolicy.new(current_user, @scheme).delete? %>
+  <%= delete_scheme_link(@scheme) %>
+<% end %>

--- a/app/views/schemes/show.html.erb
+++ b/app/views/schemes/show.html.erb
@@ -29,6 +29,9 @@
               <% if @scheme.confirmed? && @scheme.locations.confirmed.none? && LocationPolicy.new(current_user, @scheme.locations.new).create? %>
                 <span class="app-!-colour-muted">Complete this scheme by adding a location using the <%= govuk_link_to("‘locations’ tab", scheme_locations_path(@scheme)) %>.</span>
               <% end %>
+              <% if @scheme.deactivated? && current_user.support? && !SchemePolicy.new(current_user, @scheme).delete? %>
+                  <span class="app-!-colour-muted">This scheme was active in an open or editable collection year, and cannot be deleted.</span>
+              <% end %>
             </dd>
           </div>
         <% elsif attr[:id] != "secondary_client_group" || @scheme.has_other_client_group == "Yes" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,7 @@ en:
       one: "There is %{count} set of duplicate logs"
       other: "There are %{count} sets of duplicate logs"
     location_deleted: "%{postcode} has been deleted."
+    scheme_deleted: "%{service_name} has been deleted."
 
   validations:
     organisation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
     patch "new-deactivation", to: "schemes#new_deactivation"
     patch "deactivate", to: "schemes#deactivate"
     patch "reactivate", to: "schemes#reactivate"
+    get "delete-confirmation", to: "schemes#delete_confirmation"
+    delete "delete", to: "schemes#delete"
 
     collection do
       get "csv-download", to: "schemes#download_csv"

--- a/db/migrate/20240304100017_add_discarded_at_column_to_schemes.rb
+++ b/db/migrate/20240304100017_add_discarded_at_column_to_schemes.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtColumnToSchemes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schemes, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_01_125651) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_04_100017) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -699,6 +699,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_125651) do
     t.integer "total_units"
     t.boolean "confirmed"
     t.datetime "startdate"
+    t.datetime "discarded_at"
     t.index ["owning_organisation_id"], name: "index_schemes_on_owning_organisation_id"
   end
 

--- a/spec/models/form/lettings/questions/scheme_id_spec.rb
+++ b/spec/models/form/lettings/questions/scheme_id_spec.rb
@@ -122,6 +122,19 @@ RSpec.describe Form::Lettings::Questions::SchemeId, type: :model do
           expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
         end
       end
+
+      context "when the scheme is deleted" do
+        let(:scheme) { FactoryBot.create(:scheme, owning_organisation: organisation, discarded_at: Time.zone.yesterday) }
+
+        before do
+          FactoryBot.create(:location, startdate: Time.zone.tomorrow, scheme:)
+        end
+
+        it "has the correct answer_options based on the schemes the user's organisation owns or manages" do
+          expected_answer = { "" => "Select an option" }
+          expect(question.displayed_answer_options(lettings_log)).to eq(expected_answer)
+        end
+      end
     end
 
     context "when there are no schemes with locations" do

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -304,6 +304,14 @@ RSpec.describe Scheme, type: :model do
         expect(scheme.status).to eq(:activating_soon)
       end
     end
+
+    context "when scheme has discarded_at value" do
+      let(:scheme) { FactoryBot.create(:scheme, discarded_at: Time.zone.now) }
+
+      it "returns deleted" do
+        expect(scheme.status).to eq(:deleted)
+      end
+    end
   end
 
   describe "status_at" do

--- a/spec/policies/scheme_policy_spec.rb
+++ b/spec/policies/scheme_policy_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe SchemePolicy do
+  subject(:policy) { described_class }
+
+  let(:data_provider) { create(:user, :data_provider) }
+  let(:data_coordinator) { create(:user, :data_coordinator) }
+  let(:support) { create(:user, :support) }
+
+  permissions :delete? do
+    let(:scheme) { create(:scheme) }
+
+    before do
+      create(:location, scheme:)
+    end
+
+    context "with active scheme" do
+      it "does not allow deleting a scheme as a provider" do
+        expect(policy).not_to permit(data_provider, scheme)
+      end
+
+      it "does not allow allows deleting a scheme as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, scheme)
+      end
+
+      it "does not allow deleting a scheme as a support user" do
+        expect(policy).not_to permit(support, scheme)
+      end
+    end
+
+    context "with incomplete scheme" do
+      let(:scheme) { create(:scheme, :incomplete) }
+
+      it "does not allow deleting a scheme as a provider" do
+        expect(policy).not_to permit(data_provider, scheme)
+      end
+
+      it "does not allow allows deleting a scheme as a coordinator" do
+        expect(policy).not_to permit(data_coordinator, scheme)
+      end
+
+      it "allows deleting a scheme as a support user" do
+        expect(policy).to permit(support, scheme)
+      end
+    end
+
+    context "with deactivated scheme" do
+      before do
+        scheme.scheme_deactivation_periods << create(:scheme_deactivation_period, deactivation_date: Time.zone.local(2024, 4, 10), scheme:)
+        scheme.save!
+        Timecop.freeze(Time.utc(2024, 4, 10))
+        log = create(:lettings_log, :sh, owning_organisation: scheme.owning_organisation, scheme:)
+        log.startdate = Time.zone.local(2022, 10, 10)
+        log.save!(validate: false)
+      end
+
+      after do
+        Timecop.unfreeze
+      end
+
+      context "and associated logs in editable collection period" do
+        before do
+          create(:lettings_log, :sh, owning_organisation: scheme.owning_organisation, scheme:, startdate: Time.zone.local(2024, 4, 9))
+        end
+
+        it "does not allow deleting a scheme as a provider" do
+          expect(policy).not_to permit(data_provider, scheme)
+        end
+
+        it "does not allow allows deleting a scheme as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, scheme)
+        end
+
+        it "does not allow deleting a scheme as a support user" do
+          expect(policy).not_to permit(support, scheme)
+        end
+      end
+
+      context "and no associated logs in editable collection period" do
+        it "does not allow deleting a scheme as a provider" do
+          expect(policy).not_to permit(data_provider, scheme)
+        end
+
+        it "does not allow allows deleting a scheme as a coordinator" do
+          expect(policy).not_to permit(data_coordinator, scheme)
+        end
+
+        it "allows deleting a scheme as a support user" do
+          expect(policy).to permit(support, scheme)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe OrganisationsController, type: :request do
         let(:user) { create(:user, :support) }
         let!(:schemes) { create_list(:scheme, 5) }
         let!(:same_org_scheme) { create(:scheme, owning_organisation: user.organisation) }
+        let!(:deleted_scheme) { create(:scheme, owning_organisation: user.organisation, discarded_at: Time.zone.yesterday) }
 
         before do
           allow(user).to receive(:need_two_factor_authentication?).and_return(false)
@@ -129,6 +130,10 @@ RSpec.describe OrganisationsController, type: :request do
           schemes.each do |scheme|
             expect(page).not_to have_content(scheme.id_to_display)
           end
+        end
+
+        it "does not show deleted schemes" do
+          expect(page).not_to have_content(deleted_scheme.id_to_display)
         end
 
         context "when searching" do

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe SchemesController, type: :request do
         end
       end
 
+      context "when there are deleted schemes" do
+        let!(:deleted_scheme) { create(:scheme, service_name: "deleted", discarded_at: Time.zone.yesterday, owning_organisation: user.organisation) }
+
+        before do
+          get "/schemes"
+        end
+
+        it "does not show deleted schemes" do
+          follow_redirect!
+          expect(page).not_to have_content(deleted_scheme.id_to_display)
+        end
+      end
+
       context "when parent organisation has schemes" do
         let(:parent_organisation) { create(:organisation) }
         let!(:parent_schemes) { create_list(:scheme, 5, owning_organisation: parent_organisation) }
@@ -189,6 +202,18 @@ RSpec.describe SchemesController, type: :request do
 
       it "has page heading" do
         expect(page).to have_content("Schemes")
+      end
+
+      context "when there are deleted schemes" do
+        let!(:deleted_scheme) { create(:scheme, service_name: "deleted", discarded_at: Time.zone.yesterday, owning_organisation: user.organisation) }
+
+        before do
+          get "/schemes"
+        end
+
+        it "does not show deleted schemes" do
+          expect(page).not_to have_content(deleted_scheme.id_to_display)
+        end
       end
 
       describe "scheme and location csv downloads" do

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -742,6 +742,11 @@ RSpec.describe SchemesController, type: :request do
             expect(response).to have_http_status(:ok)
             expect(page).not_to have_link("Delete this scheme", href: "/schemes/#{scheme.id}/delete-confirmation")
           end
+
+          it "does not render informative text about deleting the scheme" do
+            expect(response).to have_http_status(:ok)
+            expect(page).not_to have_content("This scheme was active in an open or editable collection year, and cannot be deleted.")
+          end
         end
 
         context "with deactivated scheme" do
@@ -750,6 +755,23 @@ RSpec.describe SchemesController, type: :request do
           it "renders delete this scheme" do
             expect(response).to have_http_status(:ok)
             expect(page).to have_link("Delete this scheme", href: "/schemes/#{scheme.id}/delete-confirmation")
+          end
+
+          context "and associated logs in editable collection period" do
+            before do
+              create(:lettings_log, :sh, scheme:, startdate: Time.zone.local(2022, 9, 9), owning_organisation: user.organisation)
+              get "/schemes/#{scheme.id}"
+            end
+
+            it "does not render delete this scheme" do
+              expect(response).to have_http_status(:ok)
+              expect(page).not_to have_link("Delete this scheme", href: "/schemes/#{scheme.id}/delete-confirmation")
+            end
+
+            it "adds informative text about deleting the scheme" do
+              expect(response).to have_http_status(:ok)
+              expect(page).to have_content("This scheme was active in an open or editable collection year, and cannot be deleted.")
+            end
           end
         end
 

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -2641,4 +2641,73 @@ RSpec.describe SchemesController, type: :request do
       end
     end
   end
+
+  describe "#delete-confirmation" do
+    let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+
+    before do
+      get "/schemes/#{scheme.id}/delete-confirmation"
+    end
+
+    context "when not signed in" do
+      it "redirects to the sign in page" do
+        expect(response).to redirect_to("/account/sign-in")
+      end
+    end
+
+    context "when signed in" do
+      before do
+        allow(user).to receive(:need_two_factor_authentication?).and_return(false)
+        sign_in user
+        get "/schemes/#{scheme.id}/delete-confirmation"
+      end
+
+      context "with a data provider user" do
+        let(:user) { create(:user) }
+
+        it "returns 401 unauthorized" do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "with a data coordinator user" do
+        let(:user) { create(:user, :data_coordinator) }
+
+        it "returns 401 unauthorized" do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "with a support user user" do
+        let(:user) { create(:user, :support) }
+
+        it "shows the correct title" do
+          expect(page.find("h1").text).to include "Are you sure you want to delete this scheme?"
+        end
+
+        it "shows a warning to the user" do
+          expect(page).to have_selector(".govuk-warning-text", text: "You will not be able to undo this action")
+        end
+
+        it "shows a button to delete the selected scheme" do
+          expect(page).to have_selector("form.button_to button", text: "Delete this scheme")
+        end
+
+        it "the delete scheme button submits the correct data to the correct path" do
+          form_containing_button = page.find("form.button_to")
+
+          expect(form_containing_button[:action]).to eq scheme_delete_path(scheme)
+          expect(form_containing_button).to have_field "_method", type: :hidden, with: "delete"
+        end
+
+        it "shows a cancel link with the correct style" do
+          expect(page).to have_selector("a.govuk-button--secondary", text: "Cancel")
+        end
+
+        it "shows cancel link that links back to the scheme page" do
+          expect(page).to have_link(text: "Cancel", href: scheme_path(scheme))
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/schemes_controller_spec.rb
+++ b/spec/requests/schemes_controller_spec.rb
@@ -2201,6 +2201,7 @@ RSpec.describe SchemesController, type: :request do
       let!(:scheme) { create(:scheme) }
 
       before do
+        create(:location, scheme:)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
         get "/schemes/#{scheme.id}/check-answers"
@@ -2209,6 +2210,22 @@ RSpec.describe SchemesController, type: :request do
       it "returns a template for a support" do
         expect(response).to have_http_status(:ok)
         expect(page).to have_content("Check your changes before creating this scheme")
+      end
+
+      context "with an active scheme" do
+        it "does not render delete this scheme" do
+          expect(scheme.status).to eq(:active)
+          expect(page).not_to have_link("Delete this scheme", href: "/schemes/#{scheme.id}/delete-confirmation")
+        end
+      end
+
+      context "with an incomplete scheme" do
+        let(:scheme) { create(:scheme, :incomplete) }
+
+        it "renders delete this scheme" do
+          expect(scheme.reload.status).to eq(:incomplete)
+          expect(page).to have_link("Delete this scheme", href: "/schemes/#{scheme.id}/delete-confirmation")
+        end
       end
     end
   end


### PR DESCRIPTION
Merging into https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2285 to separate tech and PO review.
Allow support users to delete incomplete or deactivated schemes that are not used in editable collection periods:

<img width="629" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/13aefec9-be9e-4bee-8fcc-c9a7dee3b36a">
<img width="912" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/94b3ee54-f739-4a4c-b5cf-52b88699ff17">
<img width="672" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/ea9f424b-39a2-4bed-b49c-69bde5f2f11b">

Incomplete schemes open on check answers page, so added a delete button there as well:
<img width="982" alt="image" src="https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/assets/54268893/33212bd2-775e-4156-a6b5-d318d9e8113e">
