### PR TITLE
CLDC-3275 Only run mortgageused validation for shared ownership

### DIFF
--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -344,7 +344,7 @@ class BulkUpload::Sales::Year2024::RowParser
   validates :field_103,
             inclusion: {
               in: [1, 2],
-              if: proc { field_88 != 100 },
+              if: proc { field_88.present? && field_88 != 100 && shared_ownership? },
               question: QUESTIONS[:field_103],
             },
             on: :before_log

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -995,6 +995,22 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
       end
 
+      context "when value is 3 and stairowned is not answered" do
+        let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "1", field_87: "50", field_88: nil, field_109: nil) }
+
+        it "does not add errors" do
+          expect(parser.errors[:field_103]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
+
+      context "when it's not shared ownership" do
+        let(:attributes) { setup_section_params.merge(field_8: "2", field_103: "3", field_86: "1", field_87: "50", field_88: "99", field_109: nil) }
+
+        it "does not add errors" do
+          expect(parser.errors[:field_103]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
+
       context "when value is 3 and stairowned is 100" do
         let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "1", field_87: "50", field_88: "100", field_109: nil) }
 


### PR DESCRIPTION
Came out of CLDC-3176, so whenever stairowned wasn’t 100 it expected mortgageused to be either 1 or 2 (cause 3 is only allowed when stairowned is 100). We’re now only running this validation for shared ownership and only if stairowned is given