### PR TITLE
CLDC-3277 Set managing org to created by org on date change

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -1,4 +1,6 @@
 class FormController < ApplicationController
+  include CollectionTimeHelper
+
   before_action :authenticate_user!
   before_action :find_resource, only: %i[review]
   before_action :find_resource_by_named_id, except: %i[review]
@@ -92,6 +94,11 @@ private
                                 Date.new(0, 1, 1)
                               end
       end
+
+      if question.id == "saledate" && set_managing_organisation_to_created_by_organisation?(result["saledate"])
+        result["managing_organisation_id"] = @log.created_by.organisation_id
+      end
+
       next unless question_params
 
       if %w[checkbox validation_override].include?(question.type)
@@ -104,13 +111,8 @@ private
 
       if question.id == "owning_organisation_id"
         owning_organisation = result["owning_organisation_id"].present? ? Organisation.find(result["owning_organisation_id"]) : nil
-        if current_user.support? && @log.managing_organisation.blank? && owning_organisation&.managing_agents&.empty?
-          result["managing_organisation_id"] = owning_organisation.id
-        elsif owning_organisation&.absorbing_organisation == current_user.organisation
-          result["managing_organisation_id"] = owning_organisation.id
-        elsif @log.managing_organisation&.absorbing_organisation == current_user.organisation && owning_organisation == current_user.organisation
-          result["managing_organisation_id"] = owning_organisation.id
-        end
+
+        result["managing_organisation_id"] = owning_organisation.id if set_managing_organisation_to_owning_organisation?(owning_organisation)
       end
 
       result
@@ -320,5 +322,20 @@ private
     dynamic_duplicates.each do |duplicate|
       duplicate.update!(duplicate_set_id: log.duplicate_set_id) if duplicate.duplicate_set_id != log.duplicate_set_id
     end
+  end
+
+  def set_managing_organisation_to_owning_organisation?(owning_organisation)
+    return true if current_user.support? && @log.managing_organisation.blank? && owning_organisation&.managing_agents&.empty?
+    return true if owning_organisation&.absorbing_organisation == current_user.organisation
+    return true if @log.managing_organisation&.absorbing_organisation == current_user.organisation && owning_organisation == current_user.organisation
+
+    false
+  end
+
+  def set_managing_organisation_to_created_by_organisation?(saledate)
+    return false if current_user.support?
+    return false if collection_start_year_for_date(saledate) >= 2024
+
+    true
   end
 end


### PR DESCRIPTION
For all 2023 sales logs we infer managing organisation as created by organisation. For 2024 we've added managing organisation question. If 2024 log is created with a manually selected managing organisation and the date then changes to 2023 we want to reset the managing organisation to created by organisation. 
We do this so that we keep consistent behaviour for all 2023 logs and there's also no way for non support users to change managing org once the date is in 2023