### PR TITLE
CLDC-3234: Prevent errors from nil hhmemb

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -119,12 +119,13 @@ class Log < ApplicationRecord
 
   def blank_invalid_non_setup_fields!
     setup_ids = form.setup_sections.flat_map(&:subsections).flat_map(&:questions).map(&:id)
+    fields_to_keep = setup_ids + %w[hhmemb]
 
     2.times do
       next if valid?
 
       errors.each do |error|
-        next if setup_ids.include?(error.attribute.to_s)
+        next if fields_to_keep.include?(error.attribute.to_s)
 
         question = form.questions.find { |q| q.id == error.attribute.to_s }
         if question&.type == "checkbox"

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -73,13 +73,17 @@ module Validations::SoftValidations
   end
 
   def all_tenants_age_and_gender_information_completed?
-    (1..hhmemb).all? do |n|
+    person_count = hhmemb || 8
+
+    (1..person_count).all? do |n|
       public_send("sex#{n}").present? && public_send("age#{n}").present? && details_known_or_lead_tenant?(n) && public_send("age#{n}_known").present? && public_send("age#{n}_known").zero?
     end
   end
 
   def all_tenants_gender_information_completed?
-    (1..hhmemb).all? do |n|
+    person_count = hhmemb || 8
+
+    (1..person_count).all? do |n|
       public_send("sex#{n}").present? && details_known_or_lead_tenant?(n)
     end
   end
@@ -197,13 +201,17 @@ private
   end
 
   def females_in_age_range(min, max)
-    (1..hhmemb).any? do |n|
+    person_count = hhmemb || 8
+
+    (1..person_count).any? do |n|
       public_send("sex#{n}") == "F" && public_send("age#{n}").present? && public_send("age#{n}").between?(min, max)
     end
   end
 
   def females_in_the_household?
-    (1..hhmemb).any? do |n|
+    person_count = hhmemb || 8
+
+    (1..person_count).any? do |n|
       public_send("sex#{n}") == "F" || public_send("sex#{n}").nil?
     end
   end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -76,5 +76,16 @@ RSpec.describe Log, type: :model do
         expect(model.previous_la_known).to be_nil
       end
     end
+
+    context "when hhmemb is invalid for a lettings log" do
+      subject(:model) { build(:lettings_log, :setup_completed, hhmemb: 1, joint: 1) }
+
+      it "does not blank it" do
+        model.valid?
+        model.blank_invalid_non_setup_fields!
+        expect(model.hhmemb).to be(1)
+        expect(model.joint).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes the "undefined method sex9" problem. 

The log in question had a validation error that applied to hhmemb, so the value was getting cleared.