### PR TITLE
CLDC-2831 Update logs ordering

### DIFF
--- a/app/services/filter_manager.rb
+++ b/app/services/filter_manager.rb
@@ -27,7 +27,7 @@ class FilterManager
 
       logs = logs.public_send("filter_by_#{category}", values, user)
     end
-    logs = logs.order(created_at: :desc)
+    logs = logs.order(id: :desc)
     if user.support?
       if logs.first&.lettings?
         logs.all.includes(:owning_organisation, :managing_organisation)


### PR DESCRIPTION
Tested sales logs page locally with ~500 000 records.
Before the change it would take:
initial load  - 3.180s 
consecutive loads - 1.299s, 1.324s, 1.353s, 1.303s, 1.338s

After the change:
initial load 2.000s
consecutive loads 0.276s, 0.274s, 0.293s, 0.278s, 0.301s (so like ~75% performance improvement 💁‍♀️ ✨)

This change shouldn't change the behaviour, cause we're using the default IDs so they should correlate with the created_at. We could add an index, but I'm not sure if we need to. Would like to test this on staging, cause it took a lot of records to see any sort of difference locally