### PR TITLE
CLDC-3285 Revert all charges bu validation for 2023

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -415,7 +415,6 @@ class BulkUpload::Lettings::Year2023::RowParser
 
   validate :validate_correct_intermediate_rent_type, on: :after_log, if: proc { renttype == :intermediate }
   validate :validate_correct_affordable_rent_type, on: :after_log, if: proc { renttype == :affordable }
-  validate :validate_all_charges_given, on: :after_log, if: proc { is_carehome.zero? }
 
   def self.question_for_field(field)
     QUESTIONS[field]
@@ -876,20 +875,6 @@ private
   def validate_correct_affordable_rent_type
     if field_10.blank? || ![1, 2, 3].include?(field_10.to_i)
       errors.add(:field_10, I18n.t("validations.not_answered", question: "is this a London Affordable Rent letting"), category: :setup)
-    end
-  end
-
-  def validate_all_charges_given
-    return if supported_housing? && field_125 == 1
-
-    { field_128: "basic rent",
-      field_129: "service charge",
-      field_130: "personal service charge",
-      field_131: "support charge",
-      field_132: "total charge" }.each do |field, charge|
-      if public_send(field.to_sym).blank?
-        errors.add(field, I18n.t("validations.financial.charges.missing_charges", question: charge))
-      end
     end
   end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -2321,7 +2321,7 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
     end
 
     describe "#chcharge" do
-      let(:attributes) { { bulk_upload:, field_127: "123.45", field_131: "123.45", field_130: "123.45", field_129: "123.45", field_128: "123.45" } }
+      let(:attributes) { { bulk_upload:, field_127: "123.45" } }
 
       it "sets value given" do
         expect(parser.log.chcharge).to eq(123.45)
@@ -2330,66 +2330,13 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
       it "sets is care home to yes" do
         expect(parser.log.is_carehome).to eq(1)
       end
-
-      it "clears any other given charges" do
-        parser.log.save!
-        expect(parser.log.tcharge).to be_nil
-        expect(parser.log.brent).to be_nil
-        expect(parser.log.supcharg).to be_nil
-        expect(parser.log.pscharge).to be_nil
-        expect(parser.log.scharge).to be_nil
-      end
     end
 
     describe "#tcharge" do
-      let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: "123.45", field_128: "123.45", field_129: "123.45", field_130: "123.45", field_131: "123.45" } }
+      let(:attributes) { { bulk_upload:, field_132: "123.45" } }
 
       it "sets value given" do
         expect(parser.log.tcharge).to eq(123.45)
-      end
-
-      context "when other charges are not given" do
-        context "and it is carehome" do
-          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: "123.45", field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
-
-          it "does not set charges values" do
-            parser.log.save!
-            expect(parser.log.tcharge).to be_nil
-            expect(parser.log.brent).to be_nil
-            expect(parser.log.supcharg).to be_nil
-            expect(parser.log.pscharge).to be_nil
-            expect(parser.log.scharge).to be_nil
-          end
-
-          it "does not add errors to missing charges" do
-            parser.valid?
-            expect(parser.errors[:field_128]).to be_empty
-            expect(parser.errors[:field_129]).to be_empty
-            expect(parser.errors[:field_130]).to be_empty
-            expect(parser.errors[:field_131]).to be_empty
-          end
-        end
-
-        context "and it is not carehome" do
-          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: nil, field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
-
-          it "does not set charges values" do
-            parser.log.save!
-            expect(parser.log.tcharge).to be_nil
-            expect(parser.log.brent).to be_nil
-            expect(parser.log.supcharg).to be_nil
-            expect(parser.log.pscharge).to be_nil
-            expect(parser.log.scharge).to be_nil
-          end
-
-          it "adds an error to all missing charges" do
-            parser.valid?
-            expect(parser.errors[:field_128]).to eql(["Please enter the basic rent. If there is no basic rent, please enter '0'."])
-            expect(parser.errors[:field_129]).to eql(["Please enter the service charge. If there is no service charge, please enter '0'."])
-            expect(parser.errors[:field_130]).to eql(["Please enter the personal service charge. If there is no personal service charge, please enter '0'."])
-            expect(parser.errors[:field_131]).to eql(["Please enter the support charge. If there is no support charge, please enter '0'."])
-          end
-        end
       end
     end
 
@@ -2398,50 +2345,6 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
 
       it "sets value given" do
         expect(parser.log.supcharg).to eq(123.45)
-      end
-
-      context "when other charges are not given" do
-        context "and it is carehome" do
-          let(:attributes) { { bulk_upload:, field_132: nil, field_127: "123.45", field_128: nil, field_129: nil, field_130: nil, field_131: "123.45" } }
-
-          it "does not set charges values" do
-            parser.log.save!
-            expect(parser.log.tcharge).to be_nil
-            expect(parser.log.brent).to be_nil
-            expect(parser.log.supcharg).to be_nil
-            expect(parser.log.pscharge).to be_nil
-            expect(parser.log.scharge).to be_nil
-          end
-
-          it "does not add errors to missing charges" do
-            parser.valid?
-            expect(parser.errors[:field_128]).to be_empty
-            expect(parser.errors[:field_129]).to be_empty
-            expect(parser.errors[:field_130]).to be_empty
-            expect(parser.errors[:field_131]).to be_empty
-          end
-        end
-
-        context "and it is not carehome" do
-          let(:attributes) { { bulk_upload:, field_132: "123.45", field_127: nil, field_128: nil, field_129: nil, field_130: nil, field_131: nil } }
-
-          it "does not set charges values" do
-            parser.log.save!
-            expect(parser.log.tcharge).to be_nil
-            expect(parser.log.brent).to be_nil
-            expect(parser.log.supcharg).to be_nil
-            expect(parser.log.pscharge).to be_nil
-            expect(parser.log.scharge).to be_nil
-          end
-
-          it "adds an error to all missing charges" do
-            parser.valid?
-            expect(parser.errors[:field_128]).to eql(["Please enter the basic rent. If there is no basic rent, please enter '0'."])
-            expect(parser.errors[:field_129]).to eql(["Please enter the service charge. If there is no service charge, please enter '0'."])
-            expect(parser.errors[:field_130]).to eql(["Please enter the personal service charge. If there is no personal service charge, please enter '0'."])
-            expect(parser.errors[:field_131]).to eql(["Please enter the support charge. If there is no support charge, please enter '0'."])
-          end
-        end
       end
     end
 


### PR DESCRIPTION
Reverting the 2023 part from here, this was only meant for 2024! https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2250