### PR TITLE
CLDC-3300 Update BU mortgageused error

### DIFF
--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -150,11 +150,18 @@ module Validations::Sales::SaleInformationValidations
 
   def validate_mortgage_used_and_stairbought(record)
     return unless record.stairowned && record.mortgageused
-    return unless record.saledate && record.form.start_year_after_2024?
 
     if !record.stairowned_100? && record.mortgageused == 3
       record.errors.add :stairowned, I18n.t("validations.sale_information.stairowned.mortgageused_dont_know")
       record.errors.add :mortgageused, I18n.t("validations.sale_information.stairowned.mortgageused_dont_know")
+    end
+  end
+
+  def validate_mortgage_used_dont_know(record)
+    return unless record.mortgageused
+
+    if (record.discounted_ownership_sale? || record.outright_sale?) && record.mortgageused == 3
+      record.errors.add(:mortgageused, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property?"))
     end
   end
 end

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -158,9 +158,15 @@ module Validations::Sales::SaleInformationValidations
   end
 
   def validate_mortgage_used_dont_know(record)
-    return unless record.mortgageused
+    return unless record.mortgageused == 3
 
-    if (record.discounted_ownership_sale? || record.outright_sale?) && record.mortgageused == 3
+    if record.discounted_ownership_sale?
+      record.errors.add(:mortgageused, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property?"))
+    end
+    if record.outright_sale? && record.saledate && !record.form.start_year_after_2024?
+      record.errors.add(:mortgageused, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property?"))
+    end
+    if record.shared_ownership_scheme? && record.staircase && record.staircase != 1
       record.errors.add(:mortgageused, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property?"))
     end
   end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -450,6 +450,7 @@ class BulkUpload::Sales::Year2023::RowParser
             on: :after_log
 
   validate :validate_buyer1_economic_status, on: :before_log
+  validate :validate_mortgageused, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -1330,6 +1331,14 @@ private
   def validate_buyer1_economic_status
     if field_35 == 9
       errors.add(:field_35, "Buyer 1 cannot be a child under 16")
+    end
+  end
+
+  def validate_mortgageused
+    if mortgageused.present? && mortgageused.to_i != 1 && mortgageused.to_i != 2
+      errors.add(:field_105, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Shared ownership")) if shared_ownership?
+      errors.add(:field_119, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Discounted ownership")) if discounted_ownership?
+      errors.add(:field_128, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Outright sale")) if outright_sale?
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -425,6 +425,14 @@ class BulkUpload::Sales::Year2023::RowParser
             },
             on: :before_log
 
+  validates :field_105,
+            inclusion: {
+              in: [1, 2],
+              if: proc { field_89.present? && field_89 != 100 && shared_ownership? },
+              question: QUESTIONS[:field_105],
+            },
+            on: :before_log
+
   validates :field_13,
             presence: {
               message: I18n.t("validations.not_answered", question: "buyers living in property"),
@@ -1336,7 +1344,6 @@ private
 
   def validate_mortgageused
     if mortgageused.present? && mortgageused.to_i != 1 && mortgageused.to_i != 2
-      errors.add(:field_105, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Shared ownership")) if shared_ownership?
       errors.add(:field_119, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Discounted ownership")) if discounted_ownership?
       errors.add(:field_128, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Outright sale")) if outright_sale?
     end

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -425,14 +425,6 @@ class BulkUpload::Sales::Year2023::RowParser
             },
             on: :before_log
 
-  validates :field_105,
-            inclusion: {
-              in: [1, 2],
-              if: proc { field_89.present? && field_89 != 100 && shared_ownership? },
-              question: QUESTIONS[:field_105],
-            },
-            on: :before_log
-
   validates :field_13,
             presence: {
               message: I18n.t("validations.not_answered", question: "buyers living in property"),
@@ -458,7 +450,6 @@ class BulkUpload::Sales::Year2023::RowParser
             on: :after_log
 
   validate :validate_buyer1_economic_status, on: :before_log
-  validate :validate_mortgageused, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -1339,13 +1330,6 @@ private
   def validate_buyer1_economic_status
     if field_35 == 9
       errors.add(:field_35, "Buyer 1 cannot be a child under 16")
-    end
-  end
-
-  def validate_mortgageused
-    if mortgageused.present? && mortgageused.to_i != 1 && mortgageused.to_i != 2
-      errors.add(:field_119, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Discounted ownership")) if discounted_ownership?
-      errors.add(:field_128, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Outright sale")) if outright_sale?
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -451,6 +451,7 @@ class BulkUpload::Sales::Year2024::RowParser
 
   validate :validate_buyer1_economic_status, on: :before_log
   validate :validate_address_option_found, on: :after_log
+  validate :validate_mortgageused, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -1376,5 +1377,11 @@ private
 
   def valid_nationality_options
     %w[0] + GlobalConstants::COUNTRIES_ANSWER_OPTIONS.keys # 0 is "Prefers not to say"
+  end
+
+  def validate_mortgageused
+    if discounted_ownership? && mortgageused.present? && mortgageused.to_i != 1 && mortgageused.to_i != 2
+      errors.add(:field_117, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Discounted ownership"))
+    end
   end
 end

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -341,14 +341,6 @@ class BulkUpload::Sales::Year2024::RowParser
             },
             on: :before_log
 
-  validates :field_103,
-            inclusion: {
-              in: [1, 2],
-              if: proc { field_88.present? && field_88 != 100 && shared_ownership? },
-              question: QUESTIONS[:field_103],
-            },
-            on: :before_log
-
   validates :field_9,
             presence: {
               message: I18n.t("validations.not_answered", question: "type of shared ownership sale"),
@@ -451,7 +443,6 @@ class BulkUpload::Sales::Year2024::RowParser
 
   validate :validate_buyer1_economic_status, on: :before_log
   validate :validate_address_option_found, on: :after_log
-  validate :validate_mortgageused, on: :before_log
   validate :validate_nulls, on: :after_log
   validate :validate_valid_radio_option, on: :before_log
 
@@ -1377,11 +1368,5 @@ private
 
   def valid_nationality_options
     %w[0] + GlobalConstants::COUNTRIES_ANSWER_OPTIONS.keys # 0 is "Prefers not to say"
-  end
-
-  def validate_mortgageused
-    if discounted_ownership? && mortgageused.present? && mortgageused.to_i != 1 && mortgageused.to_i != 2
-      errors.add(:field_117, I18n.t("validations.invalid_option", question: "Was a mortgage used for the purchase of this property? - Discounted ownership"))
-    end
   end
 end

--- a/spec/models/validations/sales/sale_information_validations_spec.rb
+++ b/spec/models/validations/sales/sale_information_validations_spec.rb
@@ -1010,10 +1010,11 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
       let(:record) { build(:sales_log, ownershipsch: 1, type: 9, saledate: now, mortgageused: 3, stairowned: 90) }
       let(:now) { Time.zone.local(2023, 4, 4) }
 
-      it "does not add an error" do
+      it "adds an error" do
         sale_information_validator.validate_mortgage_used_and_stairbought(record)
 
-        expect(record.errors).to be_empty
+        expect(record.errors[:stairowned]).to include("The percentage owned has to be 100% if the mortgage used is 'Don’t know'")
+        expect(record.errors[:mortgageused]).to include("The percentage owned has to be 100% if the mortgage used is 'Don’t know'")
       end
     end
   end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -1027,6 +1027,9 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
         it "returns correct errors" do
           expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+          parser.log.blank_invalid_non_setup_fields!
+          parser.log.save!
+          expect(parser.log.mortgageused).to be_nil
         end
       end
 
@@ -1034,7 +1037,10 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "1", field_88: "50", field_89: "99", field_111: nil) }
 
         it "returns correct errors" do
-          expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+          expect(parser.errors[:field_105]).to include("The percentage owned has to be 100% if the mortgage used is 'Don’t know'")
+          parser.log.blank_invalid_non_setup_fields!
+          parser.log.save!
+          expect(parser.log.mortgageused).to be_nil
         end
       end
 
@@ -1043,6 +1049,7 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
         it "does not add errors" do
           expect(parser.errors[:field_105]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+          expect(parser.errors[:field_105]).not_to include("The percentage owned has to be 100% if the mortgage used is 'Don’t know'")
         end
       end
 
@@ -1053,6 +1060,9 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           expect(parser.errors[:field_105]).to be_empty
           expect(parser.errors[:field_119]).to be_empty
           expect(parser.errors[:field_128]).to be_empty
+          parser.log.blank_invalid_non_setup_fields!
+          parser.log.save!
+          expect(parser.log.mortgageused).to eq(3)
         end
       end
     end
@@ -1061,19 +1071,21 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       let(:attributes) { valid_attributes.merge({ field_7: "2", field_9: "8", field_119: "3" }) }
 
       it "does not allow 3 (don't know) as an option for discounted ownership" do
-        expect(parser.errors[:field_119]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Discounted ownership")
-        expect(parser.errors[:field_105]).to be_empty
-        expect(parser.errors[:field_128]).to be_empty
+        expect(parser.errors[:field_119]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+        parser.log.blank_invalid_non_setup_fields!
+        parser.log.save!
+        expect(parser.log.mortgageused).to be_nil
       end
     end
 
     describe "#field_128" do
-      let(:attributes) { valid_attributes.merge({ field_7: "3", field_10: "10", field_128: "3" }) }
+      let(:attributes) { valid_attributes.merge({ field_7: "3", field_10: "10", field_128: "3", field_12: "2" }) }
 
       it "does not allow 3 (don't know) as an option for outright sale" do
-        expect(parser.errors[:field_128]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Outright sale")
-        expect(parser.errors[:field_105]).to be_empty
-        expect(parser.errors[:field_119]).to be_empty
+        expect(parser.errors[:field_128]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+        parser.log.blank_invalid_non_setup_fields!
+        parser.log.save!
+        expect(parser.log.mortgageused).to be_nil
       end
     end
   end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -981,18 +981,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
       end
     end
 
-    describe "#field_119" do
-      context "when validate_discounted_ownership_value is triggered" do
-        let(:attributes) { setup_section_params.merge(field_116: 100, field_125: 100, field_7: 2, field_9: 9, field_119: 2, field_118: 10) }
-
-        it "only adds errors to the discounted ownership field" do
-          expect(parser.errors[:field_105]).to be_empty
-          expect(parser.errors[:field_119]).to include("Mortgage, deposit, and grant total must equal £90.00. Your given mortgage, deposit and grant total is £100.00")
-          expect(parser.errors[:field_128]).to be_empty
-        end
-      end
-    end
-
     describe "soft validations" do
       context "when soft validation is triggered" do
         let(:attributes) { valid_attributes.merge({ field_30: 22, field_35: 5 }) }
@@ -1099,6 +1087,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         parser.log.blank_invalid_non_setup_fields!
         parser.log.save!
         expect(parser.log.mortgageused).to be_nil
+      end
+
+      context "when validate_discounted_ownership_value is triggered" do
+        let(:attributes) { setup_section_params.merge(field_116: 100, field_125: 100, field_7: 2, field_9: 9, field_119: 2, field_118: 10) }
+
+        it "only adds errors to the discounted ownership field" do
+          expect(parser.errors[:field_105]).to be_empty
+          expect(parser.errors[:field_119]).to include("Mortgage, deposit, and grant total must equal £90.00. Your given mortgage, deposit and grant total is £100.00")
+          expect(parser.errors[:field_128]).to be_empty
+        end
       end
     end
 

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -1065,6 +1065,30 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
           expect(parser.log.mortgageused).to eq(3)
         end
       end
+
+      context "when it is not a staircasing transaction" do
+        context "when value is 3 and stairowned is not answered" do
+          let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "2", field_88: "50", field_89: nil, field_111: nil) }
+
+          it "returns correct errors" do
+            expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+            parser.log.blank_invalid_non_setup_fields!
+            parser.log.save!
+            expect(parser.log.mortgageused).to be_nil
+          end
+        end
+
+        context "when value is 3 and stairowned is 100" do
+          let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "2", field_88: "50", field_89: "100", field_111: nil) }
+
+          it "returns correct errors" do
+            expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+            parser.log.blank_invalid_non_setup_fields!
+            parser.log.save!
+            expect(parser.log.mortgageused).to be_nil
+          end
+        end
+      end
     end
 
     describe "#field_119" do

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -1020,6 +1020,36 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         end
       end
     end
+
+    describe "#field_105" do
+      let(:attributes) { valid_attributes.merge({ field_7: "1", field_105: "3" }) }
+
+      it "does not allow 3 (don't know) as an option for shared ownership" do
+        expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        expect(parser.errors[:field_119]).to be_empty
+        expect(parser.errors[:field_128]).to be_empty
+      end
+    end
+
+    describe "#field_119" do
+      let(:attributes) { valid_attributes.merge({ field_7: "2", field_9: "8", field_119: "3" }) }
+
+      it "does not allow 3 (don't know) as an option for discounted ownership" do
+        expect(parser.errors[:field_119]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Discounted ownership")
+        expect(parser.errors[:field_105]).to be_empty
+        expect(parser.errors[:field_128]).to be_empty
+      end
+    end
+
+    describe "#field_128" do
+      let(:attributes) { valid_attributes.merge({ field_7: "3", field_10: "10", field_128: "3" }) }
+
+      it "does not allow 3 (don't know) as an option for outright sale" do
+        expect(parser.errors[:field_128]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Outright sale")
+        expect(parser.errors[:field_105]).to be_empty
+        expect(parser.errors[:field_119]).to be_empty
+      end
+    end
   end
 
   describe "#log" do

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -1022,14 +1022,6 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
     end
 
     describe "#field_105" do
-      let(:attributes) { valid_attributes.merge({ field_7: "1", field_105: "3" }) }
-
-      it "does not allow 3 (don't know) as an option for shared ownership" do
-        expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
-        expect(parser.errors[:field_119]).to be_empty
-        expect(parser.errors[:field_128]).to be_empty
-      end
-
       context "when invalid value" do
         let(:attributes) { setup_section_params.merge(field_105: "4") }
 
@@ -1051,6 +1043,16 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
 
         it "does not add errors" do
           expect(parser.errors[:field_105]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
+
+      context "when value is 3 and stairowned is 100" do
+        let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "1", field_88: "50", field_89: "100", field_111: nil) }
+
+        it "does not add errors" do
+          expect(parser.errors[:field_105]).to be_empty
+          expect(parser.errors[:field_119]).to be_empty
+          expect(parser.errors[:field_128]).to be_empty
         end
       end
     end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -1029,6 +1029,30 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         expect(parser.errors[:field_119]).to be_empty
         expect(parser.errors[:field_128]).to be_empty
       end
+
+      context "when invalid value" do
+        let(:attributes) { setup_section_params.merge(field_105: "4") }
+
+        it "returns correct errors" do
+          expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
+
+      context "when value is 3 and stairowned is not 100" do
+        let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "1", field_88: "50", field_89: "99", field_111: nil) }
+
+        it "returns correct errors" do
+          expect(parser.errors[:field_105]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
+
+      context "when value is 3 and stairowned is not answered" do
+        let(:attributes) { setup_section_params.merge(field_105: "3", field_87: "1", field_88: "50", field_89: nil, field_111: nil) }
+
+        it "does not add errors" do
+          expect(parser.errors[:field_105]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
+        end
+      end
     end
 
     describe "#field_119" do

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -1024,6 +1024,30 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
       end
 
+      context "when it is not a staircasing transaction" do
+        context "when value is 3 and stairowned is not answered" do
+          let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "2", field_87: "50", field_88: nil, field_109: nil) }
+
+          it "returns correct errors" do
+            expect(parser.errors[:field_103]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+            parser.log.blank_invalid_non_setup_fields!
+            parser.log.save!
+            expect(parser.log.mortgageused).to be_nil
+          end
+        end
+
+        context "when value is 3 and stairowned is 100" do
+          let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "2", field_87: "50", field_88: "100", field_109: nil) }
+
+          it "returns correct errors" do
+            expect(parser.errors[:field_103]).to include("Enter a valid value for Was a mortgage used for the purchase of this property?")
+            parser.log.blank_invalid_non_setup_fields!
+            parser.log.save!
+            expect(parser.log.mortgageused).to be_nil
+          end
+        end
+      end
+
       context "when value is 3 and stairowned is 100" do
         let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "1", field_87: "50", field_88: "100", field_109: nil) }
 
@@ -1059,7 +1083,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
     end
 
     describe "#field_126" do
-      let(:attributes) { valid_attributes.merge({ field_8: "3", field_10: "10", field_126: "3", field_13: "2" }) }
+      let(:attributes) { valid_attributes.merge({ field_8: "3", field_11: "10", field_126: "3", field_13: "2" }) }
 
       it "allows 3 (don't know) as an option for outright sale" do
         expect(parser.errors[:field_126]).to be_empty
@@ -1067,7 +1091,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         expect(parser.errors[:field_117]).to be_empty
         parser.log.blank_invalid_non_setup_fields!
         parser.log.save!
-        expect(parser.log.mortgageused).to be_nil
+        expect(parser.log.mortgageused).to eq(3)
       end
     end
 

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -1017,14 +1017,6 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
       end
 
-      context "when it's not shared ownership" do
-        let(:attributes) { setup_section_params.merge(field_8: "2", field_103: "3", field_86: "1", field_87: "50", field_88: "99", field_109: nil) }
-
-        it "does not add errors" do
-          expect(parser.errors[:field_103]).not_to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Shared ownership")
-        end
-      end
-
       context "when value is 3 and stairowned is 100" do
         let(:attributes) { setup_section_params.merge(field_103: "3", field_86: "1", field_87: "50", field_88: "100", field_109: nil) }
 
@@ -1039,6 +1031,14 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
     end
 
     describe "#field_117" do
+      let(:attributes) { valid_attributes.merge({ field_8: "2", field_117: "3" }) }
+
+      it "does not allow 3 (don't know) as an option for discounted ownership" do
+        expect(parser.errors[:field_117]).to include("Enter a valid value for Was a mortgage used for the purchase of this property? - Discounted ownership")
+        expect(parser.errors[:field_103]).to be_empty
+        expect(parser.errors[:field_126]).to be_empty
+      end
+
       context "when validate_discounted_ownership_value is triggered" do
         let(:attributes) { setup_section_params.merge(field_114: 100, field_123: 100, field_8: 2, field_10: 9, field_117: 2, field_116: 10) }
 
@@ -1047,6 +1047,16 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
           expect(parser.errors[:field_117]).to include("The mortgage, deposit, and grant when added together is £100.00, and the purchase purchase price times by the discount is £90.00. These figures should be the same")
           expect(parser.errors[:field_126]).to be_empty
         end
+      end
+    end
+
+    describe "#field_126" do
+      let(:attributes) { valid_attributes.merge({ field_8: "3", field_126: "3" }) }
+
+      it "allows 3 (don't know) as an option for outright sale" do
+        expect(parser.errors[:field_126]).to be_empty
+        expect(parser.errors[:field_103]).to be_empty
+        expect(parser.errors[:field_117]).to be_empty
       end
     end
 
@@ -1061,7 +1071,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
 
         it "populates with correct error message" do
           expect(parser.errors.where(:field_31, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
-          expect(parser.errors.where(:field_31, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
+          expect(parser.errors.where(:field_35, category: :soft_validation).first.message).to eql("You told us this person is aged 22 years and retired.")
         end
       end
     end


### PR DESCRIPTION
option 3 (don't know) for mortgage used it a conditional option, but we've not been validating it on BU.
It shouldn't be allowed for 23/24 logs, discounted ownership logs or shared ownership logs where stairowned is not 100 (we already have a validation for that)