### PR TITLE
CLDC-3305 Update previous postcode routing for renewals

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -90,6 +90,16 @@ module DerivedVariables::LettingsLogVariables
         self.prevten = 32 if owning_organisation&.provider_type == "PRP"
         self.prevten = 30 if owning_organisation&.provider_type == "LA"
       end
+      self.ppostcode_full = postcode_full
+      self.ppcodenk = case postcode_known
+                      when 0
+                        1
+                      when 1
+                        0
+                      end
+      self.is_previous_la_inferred = is_la_inferred
+      self.previous_la_known = 1 if la.present?
+      self.prevloc = la
     end
     if form.start_year_after_2024? && is_bedsit?
       self.beds = 1

--- a/app/models/form/lettings/pages/previous_local_authority.rb
+++ b/app/models/form/lettings/pages/previous_local_authority.rb
@@ -2,7 +2,7 @@ class Form::Lettings::Pages::PreviousLocalAuthority < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "previous_local_authority"
-    @depends_on = [{ "is_previous_la_inferred" => false }]
+    @depends_on = [{ "is_previous_la_inferred" => false, "renewal" => 0 }]
   end
 
   def questions

--- a/app/models/form/lettings/pages/previous_postcode.rb
+++ b/app/models/form/lettings/pages/previous_postcode.rb
@@ -1,4 +1,9 @@
 class Form::Lettings::Pages::PreviousPostcode < ::Form::Page
+  def initialize(id, hsh, page)
+    super
+    @depends_on = [{ "renewal" => 0 }]
+  end
+
   def questions
     @questions ||= [
       Form::Lettings::Questions::Ppcodenk.new(nil, nil, self),

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Accessible Autocomplete" do
     FactoryBot.create(
       :lettings_log,
       :in_progress,
+      renewal: 0,
       previous_la_known: 1,
       prevloc: "E09000033",
       illness: 1,

--- a/spec/models/form/lettings/pages/previous_local_authority_spec.rb
+++ b/spec/models/form/lettings/pages/previous_local_authority_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Form::Lettings::Pages::PreviousLocalAuthority, type: :model do
+  subject(:page) { described_class.new(page_id, page_definition, subsection) }
+
+  let(:page_id) { nil }
+  let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_year_after_2024?: false, start_date: Time.zone.local(2023, 4, 1))) }
+
+  it "has correct subsection" do
+    expect(page.subsection).to eq(subsection)
+  end
+
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(
+      %w[
+        previous_la_known
+        prevloc
+      ],
+    )
+  end
+
+  it "has the correct id" do
+    expect(page.id).to eq("previous_local_authority")
+  end
+
+  it "has the correct header" do
+    expect(page.header).to be_nil
+  end
+
+  it "has the correct description" do
+    expect(page.description).to be_nil
+  end
+
+  it "has the correct depends_on" do
+    expect(page.depends_on).to match([{ "is_previous_la_inferred" => false, "renewal" => 0 }])
+  end
+end

--- a/spec/models/form/lettings/pages/previous_postcode_spec.rb
+++ b/spec/models/form/lettings/pages/previous_postcode_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Form::Lettings::Pages::PreviousPostcode, type: :model do
+  subject(:page) { described_class.new(page_id, page_definition, subsection) }
+
+  let(:page_id) { "previous_postcode" }
+  let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_year_after_2024?: false, start_date: Time.zone.local(2023, 4, 1))) }
+
+  it "has correct subsection" do
+    expect(page.subsection).to eq(subsection)
+  end
+
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(
+      %w[
+        ppcodenk
+        ppostcode_full
+      ],
+    )
+  end
+
+  it "has the correct id" do
+    expect(page.id).to eq("previous_postcode")
+  end
+
+  it "has the correct header" do
+    expect(page.header).to be_nil
+  end
+
+  it "has the correct description" do
+    expect(page.description).to be_nil
+  end
+
+  it "has the correct depends_on" do
+    expect(page.depends_on).to match([{ "renewal" => 0 }])
+  end
+end

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1586,6 +1586,15 @@ RSpec.describe LettingsLog do
         expect { lettings_log.update!(startdate: Time.zone.local(2023, 4, 1)) }.to change(lettings_log, :underoccupation_benefitcap).from(2).to nil
       end
 
+      it "derives ppostcode_full as postcode_full if log is renewal" do
+        lettings_log.update!(renewal: 0, postcode_full: "M1 1AE", postcode_known: 1, ppostcode_full: "M1 1AD")
+        lettings_log.update!(renewal: 1)
+        lettings_log.reload
+        expect(lettings_log.ppostcode_full).to eq("M1 1AE")
+        expect(lettings_log.ppcodenk).to eq(0)
+        expect(lettings_log.prevloc).to eq(lettings_log.la)
+      end
+
       context "when the log is general needs" do
         context "and the managing organisation is a private registered provider" do
           before do


### PR DESCRIPTION
Renewals should have same address, so we don't want to route to previous address questions for renewals, instead we want to infer them
PR to correct existing records https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2326