### PR TITLE
CLDC-3343 Check relat fields for people we collect data for

### DIFF
--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -194,8 +194,8 @@ module Validations::SoftValidations
   def multiple_partners?
     return unless hhmemb
 
-    max_person = sales? ? [hhmemb, 6].min : [hhmemb, 8].min
-    (2..max_person).many? { |n| public_send("relat#{n}") == "P" }
+    max_person_with_details = sales? ? [hhmemb, 6].min : [hhmemb, 8].min
+    (2..max_person_with_details).many? { |n| public_send("relat#{n}") == "P" }
   end
 
 private

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -194,7 +194,8 @@ module Validations::SoftValidations
   def multiple_partners?
     return unless hhmemb
 
-    (2..hhmemb).many? { |n| public_send("relat#{n}") == "P" }
+    max_person = sales? ? [hhmemb, 6].min : [hhmemb, 8].min
+    (2..max_person).many? { |n| public_send("relat#{n}") == "P" }
   end
 
 private

--- a/spec/models/validations/sales/soft_validations_spec.rb
+++ b/spec/models/validations/sales/soft_validations_spec.rb
@@ -1324,4 +1324,42 @@ RSpec.describe Validations::Sales::SoftValidations do
       end
     end
   end
+
+  describe "#multiple_partners?" do
+    let(:record) { FactoryBot.create(:sales_log, :completed, ownershipsch: 1, jointpur: 1) }
+
+    context "when there are multiple partners" do
+      before do
+        record.hhmemb = 3
+        record.relat2 = "P"
+        record.relat3 = "P"
+      end
+
+      it "returns true" do
+        expect(record).to be_multiple_partners
+      end
+    end
+
+    context "when there are not multiple partners" do
+      before do
+        record.hhmemb = 2
+        record.relat2 = "P"
+      end
+
+      it "returns false" do
+        expect(record).not_to be_multiple_partners
+      end
+    end
+
+    context "when hhmemb is more than the number of person details we require for joint purchase" do
+      before do
+        record.hhmemb = 14
+        record.relat2 = "P"
+      end
+
+      it "correctly runs the method" do
+        expect(record).not_to be_multiple_partners
+      end
+    end
+  end
 end


### PR DESCRIPTION
`multiple_partners?` method was trying to access relat7 fields and above for sales, because hholdcount can be up to 15 and hhmemb = hholdcount + buyers. We only collect data of up to 6 people so if there are more household members than that we should not try to access information for them.