### PR TITLE
CLDC-3334 Improve address search flow

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -249,7 +249,7 @@ private
     redirect_to lettings_log_path(@log) unless @log.collection_period_open_for_editing?
   end
 
-  CONFIRMATION_PAGE_IDS = %w[uprn_confirmation].freeze
+  CONFIRMATION_PAGE_IDS = %w[uprn_confirmation uprn_selection].freeze
 
   def correcting_duplicate_logs_redirect_path
     class_name = @log.class.name.underscore

--- a/app/helpers/form_page_helper.rb
+++ b/app/helpers/form_page_helper.rb
@@ -20,6 +20,8 @@ module FormPageHelper
   end
 
   def submit_button_text(page, referrer)
+    return page.submit_text if page.submit_text.present?
+
     if accessed_from_duplicate_logs?(referrer) || returning_to_question_page?(page, referrer)
       "Save changes"
     else

--- a/app/helpers/form_page_helper.rb
+++ b/app/helpers/form_page_helper.rb
@@ -18,4 +18,30 @@ module FormPageHelper
   def relevant_check_answers_path(log, subsection)
     send("#{log.class.name.underscore}_#{subsection.id}_check_answers_path", log)
   end
+
+  def submit_button_text(page, referrer)
+    if accessed_from_duplicate_logs?(referrer) || returning_to_question_page?(page, referrer)
+      "Save changes"
+    else
+      "Save and continue"
+    end
+  end
+
+  def cancel_button_text(page, referrer)
+    if accessed_from_duplicate_logs?(referrer) || returning_to_question_page?(page, referrer)
+      "Cancel"
+    else
+      page.skip_text || "Skip for now"
+    end
+  end
+
+  def cancel_button_link(page, referrer, original_log_id, log)
+    if accessed_from_duplicate_logs?(referrer)
+      duplicate_log_set_path(log, original_log_id)
+    elsif returning_to_question_page?(page, referrer)
+      send(log.form.cancel_path(page, log), log)
+    else
+      page.skip_href(log) || send(log.form.next_page_redirect_path(page, log, current_user), log)
+    end
+  end
 end

--- a/app/models/form/lettings/pages/address_matcher.rb
+++ b/app/models/form/lettings/pages/address_matcher.rb
@@ -16,4 +16,8 @@ class Form::Lettings::Pages::AddressMatcher < ::Form::Page
       Form::Lettings::Questions::PostcodeForAddressMatcher.new(nil, nil, self),
     ]
   end
+
+  def submit_text
+    "Search"
+  end
 end

--- a/app/models/form/page.rb
+++ b/app/models/form/page.rb
@@ -1,7 +1,7 @@
 class Form::Page
   attr_accessor :id, :header, :header_partial, :description, :questions, :depends_on, :title_text,
                 :informative_text, :subsection, :hide_subsection_label, :next_unresolved_page_id,
-                :skip_text, :interruption_screen_question_ids
+                :skip_text, :interruption_screen_question_ids, :submit_text
 
   def initialize(id, hsh, subsection)
     @id = id
@@ -17,6 +17,7 @@ class Form::Page
       @hide_subsection_label = hsh["hide_subsection_label"]
       @next_unresolved_page_id = hsh["next_unresolved_page_id"]
       @skip_text = hsh["skip_text"]
+      @submit_text = hsh["submit_text"]
       @interruption_screen_question_ids = hsh["interruption_screen_question_ids"] || []
     end
   end

--- a/app/models/form/sales/pages/address_matcher.rb
+++ b/app/models/form/sales/pages/address_matcher.rb
@@ -16,4 +16,8 @@ class Form::Sales::Pages::AddressMatcher < ::Form::Page
       Form::Sales::Questions::PostcodeForAddressMatcher.new(nil, nil, self),
     ]
   end
+
+  def submit_text
+    "Search"
+  end
 end

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -72,19 +72,8 @@
 
       <div class="govuk-button-group">
       <% if !@page.interruption_screen? %>
-        <% if accessed_from_duplicate_logs?(request.query_parameters["referrer"]) %>
-          <%= f.govuk_submit "Save changes" %>
-          <%= govuk_link_to "Cancel", duplicate_log_set_path(@log, request.query_parameters["original_log_id"]) %>
-        <% elsif returning_to_question_page?(@page, request.query_parameters["referrer"]) %>
-          <%= f.govuk_submit "Save changes" %>
-          <%= govuk_link_to "Cancel", send(@log.form.cancel_path(@page, @log), @log) %>
-        <% else %>
-          <%= f.govuk_submit "Save and continue" %>
-            <%= govuk_link_to(
-              (@page.skip_text || "Skip for now"),
-              (@page.skip_href(@log) || send(@log.form.next_page_redirect_path(@page, @log, current_user), @log)),
-            ) %>
-        <% end %>
+        <%= f.govuk_submit submit_button_text(@page, request.query_parameters["referrer"]) %>
+        <%= govuk_link_to cancel_button_text(@page, request.query_parameters["referrer"]), cancel_button_link(@page, request.query_parameters["referrer"], request.query_parameters["original_log_id"], @log) %>
       <% end %>
       </div>
     </div>


### PR DESCRIPTION
Always route to search results page when searching for an address instead of routing back to check your answers
Change submit text to "Search" for find address page