### PR TITLE
CLDC-3305 Log unsuccessful updates

### DIFF
--- a/lib/tasks/correct_renewal_postcodes.rake
+++ b/lib/tasks/correct_renewal_postcodes.rake
@@ -19,6 +19,8 @@ task correct_renewal_postcodes: :environment do
     log.previous_la_known = log.la.present? ? 1 : 0
     log.prevloc = log.la
     log.values_updated_at = Time.zone.now
-    log.save!
+    unless log.save
+      Rails.logger.info("Failed to save log #{log.id}: #{log.errors.full_messages}")
+    end
   end
 end


### PR DESCRIPTION
If a log has different error we can't perform the updates, we probably still want to validate and run before validation hooks, so feels sensible to log unsuccessful updates instead and deal with them on case by case basis if there are any.