### PR TITLE
CLDC-3345 Add and set assigned to fields

### DIFF
--- a/db/migrate/20240404072714_add_assigned_to.rb
+++ b/db/migrate/20240404072714_add_assigned_to.rb
@@ -1,0 +1,9 @@
+class AddAssignedTo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lettings_logs, :assigned_to_id, :integer
+    add_column :sales_logs, :assigned_to_id, :integer
+    
+    LettingsLog.update_all("assigned_to_id=created_by_id")
+    SalesLog.update_all("assigned_to_id=created_by_id")
+  end
+end

--- a/db/migrate/20240404072714_add_assigned_to.rb
+++ b/db/migrate/20240404072714_add_assigned_to.rb
@@ -2,7 +2,7 @@ class AddAssignedTo < ActiveRecord::Migration[7.0]
   def change
     add_column :lettings_logs, :assigned_to_id, :integer
     add_column :sales_logs, :assigned_to_id, :integer
-    
+
     LettingsLog.update_all("assigned_to_id=created_by_id")
     SalesLog.update_all("assigned_to_id=created_by_id")
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_122706) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_072714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -320,6 +320,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_122706) do
     t.string "la_as_entered"
     t.integer "partner_under_16_value_check"
     t.integer "multiple_partners_value_check"
+    t.integer "assigned_to_id"
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
     t.index ["location_id"], name: "index_lettings_logs_on_location_id"
@@ -686,6 +687,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_122706) do
     t.string "la_as_entered"
     t.integer "partner_under_16_value_check"
     t.integer "multiple_partners_value_check"
+    t.integer "assigned_to_id"
     t.index ["bulk_upload_id"], name: "index_sales_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_sales_logs_on_created_by_id"
     t.index ["managing_organisation_id"], name: "index_sales_logs_on_managing_organisation_id"


### PR DESCRIPTION
The first step to replacing `created_by` with `assigned_to`
This only creates `assignded_to` column and copies over the `created_by` values. 
It should be merged and deployed before we start using `assigned_to`