### PR TITLE
CLDC-3345 Update existing created_by values

### DIFF
--- a/lib/tasks/update_created_by_values.rake
+++ b/lib/tasks/update_created_by_values.rake
@@ -1,0 +1,26 @@
+desc "Updates created_by values for lettings and sales logs"
+task update_created_by_values: :environment do
+  LettingsLog.filter_by_years(%w[2023 2024]).where.not(bulk_upload_id: nil).update_all("created_by_id = (SELECT user_id FROM bulk_uploads WHERE bulk_uploads.id = lettings_logs.bulk_upload_id)")
+  LettingsLog.filter_by_years(%w[2023 2024]).where(bulk_upload_id: nil).each do |lettings_log|
+    whodunnit = PaperTrail::Version.find_by(item_id: lettings_log.id, event: "create")&.whodunnit
+    next if whodunnit.blank?
+
+    user = GlobalID::Locator.locate whodunnit
+    next if user.blank?
+
+    lettings_log.created_by = user
+    lettings_log.save!(touch: false, validate: false)
+  end
+
+  SalesLog.filter_by_years(%w[2023 2024]).where.not(bulk_upload_id: nil).update_all("created_by_id = (SELECT user_id FROM bulk_uploads WHERE bulk_uploads.id = sales_logs.bulk_upload_id)")
+  SalesLog.filter_by_years(%w[2023 2024]).where(bulk_upload_id: nil).each do |sales_log|
+    whodunnit = PaperTrail::Version.find_by(item_id: sales_log.id, event: "create")&.whodunnit
+    next if whodunnit.blank?
+
+    user = GlobalID::Locator.locate whodunnit
+    next if user.blank?
+
+    sales_log.created_by = user
+    sales_log.save!(touch: false, validate: false)
+  end
+end

--- a/spec/lib/tasks/update_created_by_values_spec.rb
+++ b/spec/lib/tasks/update_created_by_values_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "update_created_by_values" do
+  describe ":update_created_by_values", type: :task do
+    subject(:task) { Rake::Task["update_created_by_values"] }
+
+    before do
+      Rake.application.rake_require("tasks/update_created_by_values")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      let(:user) { create(:user) }
+
+      context "with bulk upload id" do
+        let(:bulk_upload) { create(:bulk_upload) }
+        let(:lettings_log) { create(:lettings_log, :completed, assigned_to: user, bulk_upload_id: bulk_upload.id, updated_at: Time.zone.yesterday) }
+        let(:sales_log) { create(:sales_log, :completed, assigned_to: user, bulk_upload_id: bulk_upload.id, updated_at: Time.zone.yesterday) }
+
+        it "updates created_by to bulk upload user id for lettings log" do
+          initial_updated_at = lettings_log.updated_at
+          expect(lettings_log.created_by_id).to eq(user.id)
+          expect(lettings_log.assigned_to_id).to eq(user.id)
+          task.invoke
+          lettings_log.reload
+          expect(lettings_log.created_by_id).to eq(bulk_upload.user_id)
+          expect(lettings_log.assigned_to_id).to eq(user.id)
+          expect(lettings_log.updated_at).to eq(initial_updated_at)
+        end
+
+        it "updates created_by to bulk upload user id for sales log" do
+          initial_updated_at = sales_log.updated_at
+          expect(sales_log.created_by_id).to eq(user.id)
+          expect(sales_log.assigned_to_id).to eq(user.id)
+          task.invoke
+          sales_log.reload
+          expect(sales_log.created_by_id).to eq(bulk_upload.user_id)
+          expect(sales_log.assigned_to_id).to eq(user.id)
+          expect(sales_log.updated_at).to eq(initial_updated_at)
+        end
+      end
+
+      context "without bulk upload id" do
+        context "and version whodunnit exists for create" do
+          let(:lettings_log) { create(:lettings_log, :completed, assigned_to: user, created_by_id: nil, updated_at: Time.zone.yesterday) }
+          let(:sales_log) { create(:sales_log, :completed, assigned_to: user, created_by_id: nil, updated_at: Time.zone.yesterday) }
+
+          before do
+            PaperTrail::Version.find_by(item_id: lettings_log.id, event: "create").update!(whodunnit: user.to_global_id.uri.to_s)
+            PaperTrail::Version.find_by(item_id: sales_log.id, event: "create").update!(whodunnit: user.to_global_id.uri.to_s)
+          end
+
+          it "updates created_by to create whodunnit for lettings" do
+            initial_updated_at = lettings_log.updated_at
+            expect(lettings_log.created_by_id).to eq(nil)
+            expect(lettings_log.assigned_to_id).to eq(user.id)
+            task.invoke
+            lettings_log.reload
+            expect(lettings_log.created_by_id).to eq(user.id)
+            expect(lettings_log.assigned_to_id).to eq(user.id)
+            expect(lettings_log.updated_at).to eq(initial_updated_at)
+          end
+
+          it "updates created_by to create whodunnit for sales" do
+            initial_updated_at = sales_log.updated_at
+            expect(sales_log.created_by_id).to eq(nil)
+            expect(sales_log.assigned_to_id).to eq(user.id)
+            task.invoke
+            sales_log.reload
+            expect(sales_log.created_by_id).to eq(user.id)
+            expect(sales_log.assigned_to_id).to eq(user.id)
+            expect(sales_log.updated_at).to eq(initial_updated_at)
+          end
+        end
+
+        context "and version whodunnit does not exist for create" do
+          let(:lettings_log) { create(:lettings_log, :completed, assigned_to: user, created_by_id: nil, updated_at: Time.zone.yesterday) }
+          let(:sales_log) { create(:sales_log, :completed, assigned_to: user, created_by_id: nil, updated_at: Time.zone.yesterday) }
+
+          before do
+            PaperTrail::Version.find_by(item_id: lettings_log.id, event: "create").update!(whodunnit: nil)
+            PaperTrail::Version.find_by(item_id: sales_log.id, event: "create").update!(whodunnit: nil)
+          end
+
+          it "does not update created_by for lettings" do
+            initial_updated_at = lettings_log.updated_at
+            expect(lettings_log.created_by_id).to eq(nil)
+            expect(lettings_log.assigned_to_id).to eq(user.id)
+            task.invoke
+            lettings_log.reload
+            expect(lettings_log.created_by_id).to eq(nil)
+            expect(lettings_log.assigned_to_id).to eq(user.id)
+            expect(lettings_log.updated_at).to eq(initial_updated_at)
+          end
+
+          it "does not update created_by for sales" do
+            initial_updated_at = sales_log.updated_at
+            expect(sales_log.created_by_id).to eq(nil)
+            expect(sales_log.assigned_to_id).to eq(user.id)
+            task.invoke
+            sales_log.reload
+            expect(sales_log.created_by_id).to eq(nil)
+            expect(sales_log.assigned_to_id).to eq(user.id)
+            expect(sales_log.updated_at).to eq(initial_updated_at)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are replacing `created_by` with `assigned_to` and repurposing `created_by` to track users who actually made the action of creating the log.
To backfill the values for `created_by` we are either getting them from bulk upload or paper trail. In the instances where paper trail create record does not have value associated with it, we leave `created_by` as is (same as `assigned_to`). This situation would likely to occur if the log was imported from the old system.

It builds on top of this feature branch https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2368