### PR TITLE
CLDC-3345 Save created by values

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -47,9 +47,9 @@ private
 
   def log_params
     if current_user && !current_user.support?
-      org_params.merge(api_log_params)
+      org_params.merge(api_log_params).merge(created_by_params)
     else
-      api_log_params
+      api_log_params.merge(created_by_params)
     end
   end
 
@@ -69,6 +69,12 @@ private
       "assigned_to_id" => current_user.id,
       "managing_organisation_id" => current_user.organisation.id,
     }
+  end
+
+  def created_by_params
+    return {} unless current_user
+
+    { "created_by_id" => current_user.id }
   end
 
   def search_term

--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1089,6 +1089,7 @@ private
     attributes["scheme"] = scheme
     attributes["location"] = location
     attributes["assigned_to"] = assigned_to || bulk_upload.user
+    attributes["created_by"] = bulk_upload.user
     attributes["needstype"] = field_4
     attributes["rent_type"] = rent_type
     attributes["startdate"] = startdate

--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -1114,6 +1114,7 @@ private
     attributes["scheme"] = scheme
     attributes["location"] = location
     attributes["assigned_to"] = assigned_to || bulk_upload.user
+    attributes["created_by"] = bulk_upload.user
     attributes["needstype"] = field_4
     attributes["rent_type"] = field_11
     attributes["startdate"] = startdate

--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -897,6 +897,7 @@ private
     attributes["owning_organisation"] = owning_organisation
     attributes["managing_organisation"] = managing_organisation
     attributes["assigned_to"] = assigned_to || bulk_upload.user
+    attributes["created_by"] = bulk_upload.user
     attributes["hhregres"] = field_73
     attributes["hhregresstill"] = field_74
     attributes["armedforcesspouse"] = field_75

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -911,6 +911,7 @@ private
     attributes["owning_organisation"] = owning_organisation
     attributes["managing_organisation"] = managing_organisation
     attributes["assigned_to"] = assigned_to || bulk_upload.user
+    attributes["created_by"] = bulk_upload.user
     attributes["hhregres"] = field_72
     attributes["hhregresstill"] = field_73
     attributes["armedforcesspouse"] = field_74

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -139,9 +139,11 @@ RSpec.describe LettingsLogsController, type: :request do
 
       it "tracks who created the record" do
         created_id = response.location.match(/[0-9]+/)[0]
-        whodunnit_actor = LettingsLog.find_by(id: created_id).versions.last.actor
+        log = LettingsLog.find(created_id)
+        whodunnit_actor = log.versions.last.actor
         expect(whodunnit_actor).to be_a(User)
         expect(whodunnit_actor.id).to eq(user.id)
+        expect(log.reload.created_by).to eq(user)
       end
 
       context "when creating a new log" do
@@ -161,6 +163,12 @@ RSpec.describe LettingsLogsController, type: :request do
             expect(lettings_log.owning_organisation).to eq(nil)
             expect(lettings_log.managing_organisation).to eq(nil)
           end
+
+          it "sets created_by to current user" do
+            created_id = response.location.match(/[0-9]+/)[0]
+            lettings_log = LettingsLog.find(created_id)
+            expect(lettings_log.created_by).to eq(support_user)
+          end
         end
 
         context "when the user is not support" do
@@ -179,6 +187,12 @@ RSpec.describe LettingsLogsController, type: :request do
               lettings_log = LettingsLog.find_by(id: created_id)
               expect(lettings_log.owning_organisation.name).to eq("User org")
               expect(lettings_log.managing_organisation.name).to eq("User org")
+            end
+
+            it "sets created_by to current user" do
+              created_id = response.location.match(/[0-9]+/)[0]
+              lettings_log = LettingsLog.find(created_id)
+              expect(lettings_log.created_by).to eq(user)
             end
           end
 

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -724,6 +724,14 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
         end
+
+        it "sets assigned to to bulk upload user" do
+          expect(parser.log.assigned_to).to eq(bulk_upload.user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
+        end
       end
 
       context "when user could not be found" do
@@ -748,13 +756,21 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
         end
       end
 
-      context "when an user part of owning org" do
+      context "when a user part of owning org" do
         let(:other_user) { create(:user, organisation: owning_org) }
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email, field_2: managing_org.old_visible_id } }
 
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
+        end
+
+        it "sets assigned to to the user" do
+          expect(parser.log.assigned_to).to eq(other_user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
@@ -827,6 +827,14 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
         end
+
+        it "sets assigned to to bulk upload user" do
+          expect(parser.log.assigned_to).to eq(bulk_upload.user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
+        end
       end
 
       context "when user could not be found" do
@@ -851,13 +859,21 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
         end
       end
 
-      context "when an user part of owning org" do
+      context "when a user part of owning org" do
         let(:other_user) { create(:user, organisation: owning_org) }
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email, field_2: managing_org.old_visible_id } }
 
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
+        end
+
+        it "sets assigned to to the user" do
+          expect(parser.log.assigned_to).to eq(other_user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
         end
       end
 

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -500,6 +500,14 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         it "is permitted" do
           expect(parser.errors[:field_2]).to be_blank
         end
+
+        it "sets assigned to to bulk upload user" do
+          expect(parser.log.assigned_to).to eq(bulk_upload.user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
+        end
       end
 
       context "when user could not be found" do
@@ -524,13 +532,21 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         end
       end
 
-      context "when an user part of owning org" do
+      context "when a user part of owning org" do
         let(:other_user) { create(:user, organisation: owning_org) }
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_2: other_user.email } }
 
         it "is permitted" do
           expect(parser.errors[:field_2]).to be_blank
+        end
+
+        it "sets assigned to to the user" do
+          expect(parser.log.assigned_to).to eq(other_user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
         end
       end
 

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -531,6 +531,14 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
         end
+
+        it "sets assigned to to bulk upload user" do
+          expect(parser.log.assigned_to).to eq(bulk_upload.user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
+        end
       end
 
       context "when user could not be found" do
@@ -555,13 +563,21 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
       end
 
-      context "when an user part of owning org" do
+      context "when a user part of owning org" do
         let(:other_user) { create(:user, organisation: owning_org) }
 
         let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_3: other_user.email } }
 
         it "is permitted" do
           expect(parser.errors[:field_3]).to be_blank
+        end
+
+        it "sets assigned to to the user" do
+          expect(parser.log.assigned_to).to eq(other_user)
+        end
+
+        it "sets created by to bulk upload user" do
+          expect(parser.log.created_by).to eq(bulk_upload.user)
         end
       end
 


### PR DESCRIPTION
We are replacing `created_by` with `assigned_to` and repurposing `created_by` to track users who actually made the action of creating the log.
This PR correctly saves `created_by` for any new single log submission or BU logs.

It builds on top of this feature branch https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2368