### PR TITLE
CLDC-3406-remove-validation-on-gender-for-refuge

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -145,11 +145,6 @@ module Validations::HouseholdValidations
       record.errors.add :age1, I18n.t("validations.household.age.lead.over_25")
     end
 
-    if record.sex1 == "M" && record.previous_tenancy_was_refuge?
-      record.errors.add :prevten, I18n.t("validations.household.prevten.male_refuge")
-      record.errors.add :sex1, I18n.t("validations.household.gender.male_refuge")
-    end
-
     # 3  Private Sector Tenancy
     # 4  Tied housing or rented with job
     # 7  Direct access hostel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -516,7 +516,6 @@ en:
       prevten:
         non_temp_accommodation: "Answer cannot be non-temporary accommodation as this is a re-let to a tenant who occupied the same property as temporary accommodation"
         over_25_foster_care: "Answer cannot be a children’s home or foster care as the lead tenant is 26 or older"
-        male_refuge: "Answer cannot be a refuge as the lead tenant identifies as male"
         internal_transfer: "Answer cannot be %{prevten} as this tenancy is an internal transfer"
         la_general_needs:
           internal_transfer: "Answer cannot be a fixed-term or lifetime local authority general needs tenancy as it’s an internal transfer and a private registered provider is on the tenancy agreement"
@@ -551,7 +550,6 @@ en:
       gender:
         retired_male: "Answer cannot be ‘male’ as tenant is under 65 and retired"
         retired_female: "Answer cannot be ‘female’ as tenant is under 60 and retired"
-        male_refuge: "Answer cannot be ‘male’ as you told us their housing situation immediately before this letting was a refuge"
       reason:
         not_internal_transfer: "Answer cannot be ‘permanently decanted from another property owned by this landlord’ as you told us the source of referral for this tenancy was not an internal transfer"
         renewal_reason_needed: 'The reason for leaving must be "End of assured shorthold tenancy - no fault" or "End of fixed term tenancy - no fault" if the letting is a renewal'

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -777,18 +777,6 @@ RSpec.describe Validations::HouseholdValidations do
       end
     end
 
-    context "when the lead tenant is male" do
-      it "cannot be refuge" do
-        record.prevten = 21
-        record.sex1 = "M"
-        household_validator.validate_previous_housing_situation(record)
-        expect(record.errors["prevten"])
-          .to include(match I18n.t("validations.household.prevten.male_refuge"))
-        expect(record.errors["sex1"])
-          .to include(match I18n.t("validations.household.gender.male_refuge"))
-      end
-    end
-
     context "when the referral is internal transfer" do
       it "prevten can be 9" do
         record.referral = 1


### PR DESCRIPTION
remove validation that male cannot have been in refuge

https://dluhcdigital.atlassian.net/browse/CLDC-3406

n.b when creating log for PO review: to get the relevant questions to appear, the log needs to not be renewal on setup