### PR TITLE
CLDC-3258 Take hint into account in select input

### DIFF
--- a/app/frontend/controllers/accessible_autocomplete_controller.js
+++ b/app/frontend/controllers/accessible_autocomplete_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import accessibleAutocomplete from 'accessible-autocomplete'
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
-import { enhanceOption, suggestion, sort } from '../modules/search'
+import { enhanceOption, suggestion, sort, getSearchableName } from '../modules/search'
 
 export default class extends Controller {
   connect () {
@@ -28,7 +28,7 @@ export default class extends Controller {
       onConfirm: (val) => {
         const selectedOption = [].filter.call(
           selectOptions,
-          (option) => (option.textContent || option.innerText) === val
+          (option) => (getSearchableName(option)) === val
         )[0]
         if (selectedOption) selectedOption.selected = true
       }

--- a/app/frontend/modules/search.js
+++ b/app/frontend/modules/search.js
@@ -110,7 +110,7 @@ export const sort = (query, options) => {
 export const suggestion = (value, options) => {
   const option = options.find((o) => o.name === value)
   if (option) {
-    const html = option.append ? `<span class="autocomplete__option__append">${value}</span> <span>${option.append}</span>` : `<span>${value}</span>`
+    const html = option.append ? `<span class="autocomplete__option__append">${option.text}</span> <span>${option.append}</span>` : `<span>${option.text}</span>`
     return option.hint ? `${html}<div class="autocomplete__option__hint">${option.hint}</div>` : html
   } else {
     return '<span>No results found</span>'
@@ -119,10 +119,15 @@ export const suggestion = (value, options) => {
 
 export const enhanceOption = (option) => {
   return {
-    name: option.label,
+    text: option.text,
+    name: getSearchableName(option),
     synonyms: (option.getAttribute('data-synonyms') ? option.getAttribute('data-synonyms').split('|') : []),
     append: option.getAttribute('data-append'),
     hint: option.getAttribute('data-hint'),
     boost: parseFloat(option.getAttribute('data-boost')) || 1
   }
+}
+
+export const getSearchableName = (option) => {
+  return option.getAttribute('data-hint') ? option.text + ' ' + option.getAttribute('data-hint') : option.text
 }

--- a/spec/features/form/accessible_autocomplete_spec.rb
+++ b/spec/features/form/accessible_autocomplete_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Accessible Autocomplete" do
 
     it "can match on synonyms", js: true do
       find("#lettings-log-scheme-id-field").click.native.send_keys("w", "6", :down, :enter)
-      expect(find("#lettings-log-scheme-id-field").value).to eq(scheme.service_name)
+      expect(find("#lettings-log-scheme-id-field").value).to include(scheme.service_name)
     end
 
     it "displays appended text next to the options", js: true do


### PR DESCRIPTION
## What is the issue?
If there are 2 (or more) matches in accessible auto select with the same name (text value) the same option gets displayed in the matches twice (or more times)

## Why is it happening?
Suggestion method is matching on name because that's the only thing we get. So when there are 2 matches with the same name, the first one would get picked and displayed twice in the accessible autoselect. I'm pretty sure it's due to how the accessible-autoselect package works.

## Solution
This PR updates the "name" to include the hint text as well. As the issue was discovered when matching user names in the filters, the hint text is relevant there as it's email, and would therefore be unique. This also means that we can now search by email in the filter box which didn't work in the past.

## Notes
This also however means that for schemes we would be able to search by the hint text (client group) too, which might not be the worst thing, but if it is we could make this change user specific

I don't think we have hints anywhere else.

It doesn't feel like the most elegant solution as I'd prefer sending the actual value around (which we have in the select) but I don't think we have a choice with the package we're using (or it wasn't obvious to me)