### PR TITLE
CLDC-3412 set derived? on mortgage amount

### DIFF
--- a/app/models/form/sales/questions/mortgage_amount.rb
+++ b/app/models/form/sales/questions/mortgage_amount.rb
@@ -20,6 +20,6 @@ class Form::Sales::Questions::MortgageAmount < ::Form::Question
   }.freeze
 
   def derived?(log)
-    log && log.mortgage_not_used?
+    log&.mortgage_not_used?
   end
 end

--- a/app/models/form/sales/questions/mortgage_amount.rb
+++ b/app/models/form/sales/questions/mortgage_amount.rb
@@ -18,4 +18,8 @@ class Form::Sales::Questions::MortgageAmount < ::Form::Question
     2023 => { 1 => 91, 2 => 104, 3 => 112 },
     2024 => { 1 => 92, 2 => 105, 3 => 113 },
   }.freeze
+
+  def derived?(log)
+    log && log.mortgage_not_used?
+  end
 end

--- a/spec/models/form/sales/questions/mortgage_amount_spec.rb
+++ b/spec/models/form/sales/questions/mortgage_amount_spec.rb
@@ -48,18 +48,18 @@ RSpec.describe Form::Sales::Questions::MortgageAmount, type: :model do
   end
 
   context "when the mortgage is not used" do
-    let(:log) { create(:sales_log, :completed, mortgageused: 2, deposit: nil) }
+    let(:log) { build(:sales_log, :completed, mortgageused: 2, deposit: nil) }
 
     it "is marked as derived" do
-      expect(question.derived?(log)).to be true
+      expect(question).to be_derived(log)
     end
   end
 
   context "when the mortgage is used" do
-    let(:log) { create(:sales_log, :completed, mortgageused: 1) }
+    let(:log) { build(:sales_log, :completed, mortgageused: 1) }
 
     it "is marked as derived" do
-      expect(question.derived?(log)).to be false
+      expect(question).not_to be_derived(log)
     end
   end
 end

--- a/spec/models/form/sales/questions/mortgage_amount_spec.rb
+++ b/spec/models/form/sales/questions/mortgage_amount_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Form::Sales::Questions::MortgageAmount, type: :model do
   end
 
   it "is not marked as derived" do
-    expect(question.derived?(nil)).to be false
+    expect(question).not_to be_derived(nil)
   end
 
   it "has the correct hint" do
@@ -45,5 +45,21 @@ RSpec.describe Form::Sales::Questions::MortgageAmount, type: :model do
 
   it "has correct min" do
     expect(question.min).to be(1)
+  end
+
+  context "when the mortgage is not used" do
+    let(:log) { create(:sales_log, :completed, mortgageused: 2, deposit: nil) }
+
+    it "is marked as derived" do
+      expect(question.derived?(log)).to be true
+    end
+  end
+
+  context "when the mortgage is used" do
+    let(:log) { create(:sales_log, :completed, mortgageused: 1) }
+
+    it "is marked as derived" do
+      expect(question.derived?(log)).to be false
+    end
   end
 end


### PR DESCRIPTION
## What's the issue?
When pressing confirm and continue on `DepositAndMortgageValueCheck` soft validation, it does not get marked confirmed and still appears on the CYA page.

## Why did it happen?
This happens when mortgage is not used. In those cases we set the `mortgage` to 0. However when we try to set `deposit_and_mortgage_value_check` this sequence of events occurs:
1. `mortgage` gets cleared in the first part of `reset_free_user_input_questions_if_not_routed` method, because it's not routed to
2. `deposit_and_mortgage_value_check` gets reset in the second part of `reset_free_user_input_questions_if_not_routed` method, as `mortgage` is now nil and `deposit_and_mortgage_value_check` soft validation no longer triggers/is not routed to
3. `mortgage` is set to 0 again in `sales_log_variables` and `deposit_and_mortgage_value_check` is routed to again, but is not answered

This is likely to be an issue in other places where we use mortgage to surface a soft validation, even if mortgage is not used.

## Solution

This change prevents `mortgage` from being cleared in the first place if the mortgage is not used