### PR TITLE
CLDC-3441 Reset previous location for renewals

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -82,25 +82,6 @@ module DerivedVariables::LettingsLogVariables
     self.has_benefits = get_has_benefits
     self.tshortfall_known = 0 if tshortfall
     self.nocharge = household_charge&.zero? ? 1 : 0
-    if is_renewal?
-      self.underoccupation_benefitcap = 2 if collection_start_year == 2021
-      self.voiddate = startdate
-      self.unitletas = form.start_date.year >= 2023 ? UNITLETAS_MAPPING_23_24[rent_type] : UNITLETAS_MAPPING[rent_type]
-      if is_general_needs?
-        self.prevten = 32 if owning_organisation&.provider_type == "PRP"
-        self.prevten = 30 if owning_organisation&.provider_type == "LA"
-      end
-      self.ppostcode_full = postcode_full
-      self.ppcodenk = case postcode_known
-                      when 0
-                        1
-                      when 1
-                        0
-                      end
-      self.is_previous_la_inferred = is_la_inferred
-      self.previous_la_known = 1 if la.present?
-      self.prevloc = la
-    end
     if form.start_year_after_2024? && is_bedsit?
       self.beds = 1
     end
@@ -113,7 +94,6 @@ module DerivedVariables::LettingsLogVariables
     if is_supported_housing? && location
       self.wchair = location.mobility_type_before_type_cast == "W" ? 1 : 2
     end
-    self.vacdays = property_vacant_days
 
     set_housingneeds_fields if housingneeds?
 
@@ -134,7 +114,30 @@ module DerivedVariables::LettingsLogVariables
       self.postcode_known = nil
       self.postcode_full = nil
       self.la = nil
+      self.previous_la_known = nil if is_renewal?
     end
+
+    if is_renewal?
+      self.underoccupation_benefitcap = 2 if collection_start_year == 2021
+      self.voiddate = startdate
+      self.unitletas = form.start_date.year >= 2023 ? UNITLETAS_MAPPING_23_24[rent_type] : UNITLETAS_MAPPING[rent_type]
+      if is_general_needs?
+        self.prevten = 32 if owning_organisation&.provider_type == "PRP"
+        self.prevten = 30 if owning_organisation&.provider_type == "LA"
+      end
+      self.ppostcode_full = postcode_full
+      self.ppcodenk = case postcode_known
+                      when 0
+                        1
+                      when 1
+                        0
+                      end
+      self.is_previous_la_inferred = is_la_inferred
+      self.previous_la_known = 1 if la.present?
+      self.prevloc = la
+    end
+
+    self.vacdays = property_vacant_days
 
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
 

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1337,6 +1337,26 @@ RSpec.describe LettingsLog do
       end
     end
 
+    context "when uprn is not confirmed" do
+      it "clears previous address on renewal logs" do
+        log = FactoryBot.build(:lettings_log, uprn_known: 1, uprn: 1, uprn_confirmed: 0, renewal: 1, prevloc: "E08000003", ppostcode_full: "A1 1AA", ppcodenk: 0, previous_la_known: 1)
+
+        expect { log.set_derived_fields! }.to change(log, :prevloc).from("E08000003").to(nil)
+                                          .and change(log, :ppostcode_full).from("A1 1AA").to(nil)
+                                          .and change(log, :ppcodenk).from(0).to(nil)
+                                          .and change(log, :previous_la_known).from(1).to(nil)
+      end
+
+      it "does not clear previous address on non renewal logs" do
+        log = FactoryBot.build(:lettings_log, uprn_known: 1, uprn: 1, uprn_confirmed: 0, renewal: 0, prevloc: "E08000003", ppostcode_full: "A1 1AA", ppcodenk: 0, previous_la_known: 1)
+        log.set_derived_fields!
+        expect(log.prevloc).to eq("E08000003")
+        expect(log.ppostcode_full).to eq("A1 1AA")
+        expect(log.ppcodenk).to eq(0)
+        expect(log.previous_la_known).to eq(1)
+      end
+    end
+
     context "when saving previous address" do
       before do
         stub_request(:get, /api.postcodes.io/)


### PR DESCRIPTION
Selecting `No, I want to search for the address` for UPRN confirmation resets all of the address fields. 
When the log is a renewal previous and current addresses are set to the same address.
We want to set the previous address after we have cleared the current address as part of un-confirming the UPRN as it would otherwise set the previous address to the old version of the address and make the log invalid.