### PR TITLE
CLDC-3474 Correctly construct dates for template validation

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/csv_parser.rb
@@ -111,7 +111,7 @@ private
     if with_headers?
       Date.new(row_parsers.first.field_9.to_i + 2000, row_parsers.first.field_8.to_i, row_parsers.first.field_7.to_i)
     else
-      Date.new(rows.first[8].to_i + 2000, rows.first[7].to_i, rows.first[6].to_i)
+      Date.new(rows.first[97].to_i + 2000, rows.first[96].to_i, rows.first[95].to_i)
     end
   end
 end

--- a/app/services/bulk_upload/sales/year2023/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/csv_parser.rb
@@ -111,7 +111,7 @@ private
 
   def first_record_start_date
     if with_headers?
-      Date.new(row_parsers.first.field_4.to_i + 2000, row_parsers.first.field_3.to_i, row_parsers.first.field_2.to_i)
+      Date.new(row_parsers.first.field_5.to_i + 2000, row_parsers.first.field_4.to_i, row_parsers.first.field_3.to_i)
     else
       Date.new(rows.first[3].to_i + 2000, rows.first[2].to_i, rows.first[1].to_i)
     end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
         end
       end
 
-      context "when uploading a 2022 template for 2023 bulk upload" do
+      context "when uploading a 2022 logs for 2023 bulk upload" do
         let(:bulk_upload) { create(:bulk_upload, user:, year: 2023) }
         let(:log) { build(:lettings_log, :completed, startdate: Time.zone.local(2022, 5, 6), tenancycode: "5") }
 
@@ -130,8 +130,8 @@ RSpec.describe BulkUpload::Lettings::Validator do
         context "with headers" do
           let(:seed) { rand }
           let(:log_to_csv) { BulkUpload::LettingsLogToCsv.new(log:) }
-          let(:field_numbers) { log_to_csv.default_2022_field_numbers + %w[invalid_field_number] }
-          let(:field_values) { log_to_csv.to_2022_row + %w[value_for_invalid_field_number] }
+          let(:field_numbers) { log_to_csv.default_2023_field_numbers }
+          let(:field_values) { log_to_csv.to_2023_row }
 
           before do
             file.write(log_to_csv.custom_field_numbers_row(seed:, field_numbers:))
@@ -145,7 +145,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
         end
       end
 
-      context "when uploading a 2023 template for 2024 bulk upload" do
+      context "when uploading a 2023 logs for 2024 bulk upload" do
         let(:bulk_upload) { create(:bulk_upload, user:, year: 2024) }
         let(:log) { build(:lettings_log, :completed, startdate: Time.zone.local(2023, 5, 6), tenancycode: "5234234234234") }
 
@@ -163,8 +163,8 @@ RSpec.describe BulkUpload::Lettings::Validator do
         context "with headers" do
           let(:seed) { rand }
           let(:log_to_csv) { BulkUpload::LettingsLogToCsv.new(log:) }
-          let(:field_numbers) { log_to_csv.default_2023_field_numbers + %w[invalid_field_number] }
-          let(:field_values) { log_to_csv.to_2023_row + %w[value_for_invalid_field_number] }
+          let(:field_numbers) { log_to_csv.default_2024_field_numbers }
+          let(:field_values) { log_to_csv.to_2024_row }
 
           before do
             file.write(log_to_csv.custom_field_numbers_row(seed:, field_numbers:))

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -144,6 +144,39 @@ RSpec.describe BulkUpload::Lettings::Validator do
           end
         end
       end
+
+      context "when uploading a 2023 template for 2024 bulk upload" do
+        let(:bulk_upload) { create(:bulk_upload, user:, year: 2024) }
+        let(:log) { build(:lettings_log, :completed, startdate: Time.zone.local(2023, 5, 6), tenancycode: "5234234234234") }
+
+        context "with no headers" do
+          before do
+            file.write(BulkUpload::LettingsLogToCsv.new(log:, line_ending: "\r\n", col_offset: 0).to_2024_csv_row)
+            file.close
+          end
+
+          it "is not valid" do
+            expect(validator).not_to be_valid
+          end
+        end
+
+        context "with headers" do
+          let(:seed) { rand }
+          let(:log_to_csv) { BulkUpload::LettingsLogToCsv.new(log:) }
+          let(:field_numbers) { log_to_csv.default_2023_field_numbers + %w[invalid_field_number] }
+          let(:field_values) { log_to_csv.to_2023_row + %w[value_for_invalid_field_number] }
+
+          before do
+            file.write(log_to_csv.custom_field_numbers_row(seed:, field_numbers:))
+            file.write(log_to_csv.to_custom_csv_row(seed:, field_values:))
+            file.rewind
+          end
+
+          it "is not valid" do
+            expect(validator).not_to be_valid
+          end
+        end
+      end
     end
   end
 

--- a/spec/support/bulk_upload/sales_log_to_csv.rb
+++ b/spec/support/bulk_upload/sales_log_to_csv.rb
@@ -377,11 +377,30 @@ class BulkUpload::SalesLogToCsv
     ]
   end
 
-private
-
   def default_2023_field_numbers
     [6, 3, 4, 5, nil, 28, 30, 38, 47, 51, 55, 59, 31, 39, 48, 52, 56, 60, 37, 46, 50, 54, 58, 35, 43, 49, 53, 57, 61, 32, 33, 78, 80, 79, 81, 83, 84, nil, 62, 66, 64, 65, 63, 67, 69, 70, 68, 76, 77, 16, 17, 18, 26, 24, 25, 27, 8, 91, 95, 96, 97, 92, 93, 94, 98, 100, 101, 103, 104, 106, 110, 111, 112, 113, 114, 9, 116, 117, 118, 120, 124, 125, 126, 10, 11, nil, 127, 129, 133, 134, 135, 1, 2, nil, 73, nil, 75, 107, 108, 121, 122, 130, 131, 82, 109, 123, 132, 115, 15, 86, 87, 29, 7, 12, 13, 14, 36, 44, 45, 88, 89, 102, 105, 119, 128, 19, 20, 21, 22, 23, 34, 40, 41, 42, 71, 72, 74, 85, 90, 99]
   end
+
+  def custom_field_numbers_row(seed: nil, field_numbers: nil)
+    if seed
+      ["Bulk upload field number"] + field_numbers.shuffle(random: Random.new(seed))
+    else
+      ["Bulk upload field number"] + field_numbers
+    end.flatten.join(",") + line_ending
+  end
+
+  def to_custom_csv_row(seed: nil, field_values: nil)
+    if seed
+      row = field_values.shuffle(random: Random.new(seed))
+    end
+    (row_prefix + row).flatten.join(",") + line_ending
+  end
+
+  def default_2024_field_numbers
+    (1..131).to_a
+  end
+
+private
 
   def hhregres
     if log.hhregres == 1
@@ -389,9 +408,5 @@ private
     else
       log.hhregres
     end
-  end
-
-  def default_2024_field_numbers
-    (1..131).to_a
   end
 end


### PR DESCRIPTION
In some instances when we're checking if the correct template is being used for correct year, we'd use the wrong fields to construct the date