### PR TITLE
CLDC-3477: Account for ecstat=9 inferernce when calculating applicable_income_range

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -234,7 +234,13 @@ class LettingsLog < Log
 
     if hhmemb > 1
       (2..hhmemb).each do |person_index|
-        ecstat = self["ecstat#{person_index}"] || 10
+        ecstat = self["ecstat#{person_index}"]
+
+        if ecstat.nil?
+          age = self["age#{person_index}"]
+          # This should match the conditions under which ecstat is inferred as 9 (child under 16)
+          ecstat = age && age < 16 ? 9 : 10
+        end
 
         person_range = ALLOWED_INCOME_RANGES[ecstat]
         range.soft_min += person_range.soft_min

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -95,6 +95,13 @@ RSpec.describe LettingsLog do
       lettings_log.update(age1: 25)
     end
 
+    it "correctly allows net_income_value_check to be set when earnings is near a range boundary" do
+      log = create(:lettings_log, :setup_completed, hhmemb: 2, ecstat1: 1, details_known_2: 0, age2_known: 0, age2: 10, incfreq: 1, net_income_known: 0, earnings: 191)
+      log.update!(net_income_value_check: 0)
+      log.reload
+      expect(log.net_income_value_check).to be 0
+    end
+
     it "validates start date" do
       expect(validator).to receive(:validate_startdate)
     end
@@ -3495,17 +3502,49 @@ RSpec.describe LettingsLog do
 
   describe "#applicable_income_range" do
     context "when ecstat for a non-lead tenant is not set" do
-      let(:lettings_log) { build(:lettings_log, hhmemb: 2, ecstat1: 1) }
+      context "and their age is >= 16" do
+        let(:lettings_log) { build(:lettings_log, hhmemb: 2, ecstat1: 1, age2: 16) }
 
-      it "uses the prefers-not-to-say values for that tenant to calculate the range" do
-        range = lettings_log.applicable_income_range
-        expected_range = OpenStruct.new(
-          soft_min: 143 + 47,
-          soft_max: 730 + 730,
-          hard_min: 90 + 10,
-          hard_max: 1230 + 2000,
-        )
-        expect(range).to eq(expected_range)
+        it "uses the prefers-not-to-say values for that tenant to calculate the range" do
+          range = lettings_log.applicable_income_range
+          expected_range = OpenStruct.new(
+            soft_min: 143 + 47,
+            soft_max: 730 + 730,
+            hard_min: 90 + 10,
+            hard_max: 1230 + 2000,
+          )
+          expect(range).to eq(expected_range)
+        end
+      end
+
+      context "and their age is blank" do
+        let(:lettings_log) { build(:lettings_log, hhmemb: 2, ecstat1: 1, age2: nil) }
+
+        it "uses the prefers-not-to-say values for that tenant to calculate the range" do
+          range = lettings_log.applicable_income_range
+          expected_range = OpenStruct.new(
+            soft_min: 143 + 47,
+            soft_max: 730 + 730,
+            hard_min: 90 + 10,
+            hard_max: 1230 + 2000,
+          )
+          expect(range).to eq(expected_range)
+        end
+      end
+
+      context "and their age is < 16" do
+        let(:lettings_log) { build(:lettings_log, hhmemb: 2, ecstat1: 1, age2: 15) }
+
+        it "uses the child-under-16 values for that tenant to calculate the range" do
+          range = lettings_log.applicable_income_range
+          expected_range = OpenStruct.new(
+            soft_min: 143 + 50,
+            soft_max: 730 + 450,
+            hard_min: 90 + 10,
+            hard_max: 1230 + 750,
+          )
+          expect(range).to eq(expected_range)
+        end
       end
     end
 


### PR DESCRIPTION
This avoids the problem where net income could not be confirmed for some logs triggering the soft validation because during save;
* ecstat values for children are cleared early in the save because they aren't routed to
* this changes the soft min / soft max for earnings, meaning net_income_value_check is no longer routed to and thus cleared
* ecstat values for children are set to 9 again, meaning net_income_value_check is routed to again (but now has nil value)