### PR TITLE
CLDC-3492-soft-validations-not-clearing

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -533,7 +533,9 @@ class LettingsLog < Log
   def beds_for_la_rent_range
     return 0 if is_supported_housing?
 
-    beds.nil? ? nil : [beds, LaRentRange::MAX_BEDS].min
+    real_beds = beds || (1 if is_bedsit?)
+
+    real_beds.nil? ? nil : [real_beds, LaRentRange::MAX_BEDS].min
   end
 
   def soft_min_for_period

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -1834,6 +1834,14 @@ RSpec.describe LettingsLog do
         expect(lettings_log.beds_for_la_rent_range).to eq(4)
       end
     end
+
+    context "when the log is for a bedsit, beds is not routed to and is not yet re-derived" do
+      let(:lettings_log) { build(:lettings_log, unittype_gn: 2, beds: nil) }
+
+      it "returns 1" do
+        expect(lettings_log.beds_for_la_rent_range).to eq(1)
+      end
+    end
   end
 
   describe "#collection_period_open?" do


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/CLDC-3492

ensure the correct number of beds is calculated if the log is for a bedsit and the beds attribute has been temporarily cleared

the soft validation for rent dependent on la, number of beds, etc appeared not to be clearing for the user.
This was because the log was for a bedsit, which stops routing to the beds question, so beds was cleared, the soft validation page was then not routed to and cleared, then beds was derived as 1 and the soft validation page was routed to again.

the fix is to ensure that the method returning the number of beds which is used to find the expected rent range for a given LA does return 1 if the property is a bedsit