### PR TITLE
CLDC-3465 Handle additional errors

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -229,11 +229,13 @@ private
 
     if params[@log.model_name.param_key]["check_errors"]
       @page = form.get_page(params[@log.model_name.param_key]["page"])
+      flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).to_sentence}"
       return send("#{@log.class.name.underscore}_#{params[@log.model_name.param_key]['original_page_id']}_path", @log, { check_errors: true, related_question_ids: params[@log.model_name.param_key]["related_question_ids"].split(" ") }.compact)
     end
 
     if params["referrer"] == "check_errors"
       @page = form.get_page(params[@log.model_name.param_key]["page"])
+      flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).to_sentence}"
       return send("#{@log.class.name.underscore}_#{params['original_page_id']}_path", @log, { check_errors: true, related_question_ids: params["related_question_ids"] }.compact)
     end
 

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -232,6 +232,11 @@ private
       return send("#{@log.class.name.underscore}_#{params[@log.model_name.param_key]['original_page_id']}_path", @log, { check_errors: true, related_question_ids: params[@log.model_name.param_key]["related_question_ids"].split(" ") }.compact)
     end
 
+    if params["referrer"] == "check_errors"
+      @page = form.get_page(params[@log.model_name.param_key]["page"])
+      return send("#{@log.class.name.underscore}_#{params['original_page_id']}_path", @log, { check_errors: true, related_question_ids: params["related_question_ids"] }.compact)
+    end
+
     is_new_answer_from_check_answers = is_referrer_type?("check_answers_new_answer")
     redirect_path = form.next_page_redirect_path(@page, @log, current_user, ignore_answered: is_new_answer_from_check_answers)
     referrer = is_new_answer_from_check_answers ? "check_answers_new_answer" : nil

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -61,6 +61,6 @@
       </div>
     <% end %>
 
-    <%= govuk_button_link_to "Confirm and continue", "/" %>
+    <%= govuk_button_link_to "Confirm and continue", @original_page_id ? send("#{@log.model_name.param_key}_#{@original_page_id}_path", @log) : send("#{@log.model_name.param_key}_#{@page.id}_path", @log) %>
   </div>
 </div>

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe CheckErrorsController, type: :request do
       context "and answering specific lettings question" do
         let(:params) do
           {
-            original_page_id: "income_amount",
+            original_page_id: "household_members",
             referrer: "check_errors",
             related_question_ids: %w[hhmemb ecstat1 earnings],
             lettings_log: {
@@ -293,6 +293,7 @@ RSpec.describe CheckErrorsController, type: :request do
           follow_redirect!
           expect(request.query_parameters["check_errors"]).to eq("true")
           expect(request.query_parameters["related_question_ids"]).to eq(%w[hhmemb ecstat1 earnings])
+          expect(page).to have_content("You have successfully updated Number of household members")
         end
       end
 
@@ -319,6 +320,7 @@ RSpec.describe CheckErrorsController, type: :request do
           follow_redirect!
           expect(request.query_parameters["check_errors"]).to eq("true")
           expect(request.query_parameters["related_question_ids"]).to eq(%w[income1 la ownershipsch])
+          expect(page).to have_content("You have successfully updated Buyer 1’s gross annual income known? and Buyer 1’s gross annual income")
         end
       end
     end

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -294,6 +294,7 @@ RSpec.describe CheckErrorsController, type: :request do
           expect(request.query_parameters["check_errors"]).to eq("true")
           expect(request.query_parameters["related_question_ids"]).to eq(%w[hhmemb ecstat1 earnings])
           expect(page).to have_content("You have successfully updated Number of household members")
+          expect(page).to have_link("Confirm and continue", href: "/lettings-logs/#{lettings_log.id}/household-members")
         end
       end
 
@@ -321,6 +322,7 @@ RSpec.describe CheckErrorsController, type: :request do
           expect(request.query_parameters["check_errors"]).to eq("true")
           expect(request.query_parameters["related_question_ids"]).to eq(%w[income1 la ownershipsch])
           expect(page).to have_content("You have successfully updated Buyer 1’s gross annual income known? and Buyer 1’s gross annual income")
+          expect(page).to have_link("Confirm and continue", href: "/sales-logs/#{sales_log.id}/buyer-1-income")
         end
       end
     end

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -268,4 +268,59 @@ RSpec.describe CheckErrorsController, type: :request do
       end
     end
   end
+
+  describe "answer incomplete question" do
+    context "when user is signed in" do
+      context "and answering specific lettings question" do
+        let(:params) do
+          {
+            original_page_id: "income_amount",
+            referrer: "check_errors",
+            related_question_ids: %w[hhmemb ecstat1 earnings],
+            lettings_log: {
+              page: "household_members",
+              hhmemb: "2",
+            },
+          }
+        end
+
+        before do
+          sign_in user
+          post "/lettings-logs/#{lettings_log.id}/household-members", params:
+        end
+
+        it "maintains original check_errors data in query params" do
+          follow_redirect!
+          expect(request.query_parameters["check_errors"]).to eq("true")
+          expect(request.query_parameters["related_question_ids"]).to eq(%w[hhmemb ecstat1 earnings])
+        end
+      end
+
+      context "and answering specific sales question" do
+        let(:params) do
+          {
+            original_page_id: "buyer_1_income",
+            referrer: "check_errors",
+            related_question_ids: %w[income1 la ownershipsch],
+            sales_log: {
+              page: "buyer_1_income",
+              income1: "1000",
+              income1nk: "0",
+            },
+          }
+        end
+
+        before do
+          sign_in user
+          post "/sales-logs/#{sales_log.id}/buyer-1-income", params:
+        end
+
+        it "maintains original check_errors data in query params" do
+          follow_redirect!
+          expect(request.query_parameters["check_errors"]).to eq("true")
+          expect(request.query_parameters["related_question_ids"]).to eq(%w[income1 la ownershipsch])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is building on top of https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2472
If an error gets triggered while answering a question from check_errors page, we persist the original page id and the related questions in the URL