### PR TITLE
CLDC-3265: Duplicate whitespace row fix to sales BU

### DIFF
--- a/app/services/bulk_upload/sales/year2023/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2023/row_parser.rb
@@ -483,6 +483,7 @@ class BulkUpload::Sales::Year2023::RowParser
       .to_hash
       .reject { |k, _| %w[bulk_upload block_log_creation].include?(k) }
       .values
+      .reject(&:blank?)
       .compact
       .empty?
   end

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -488,6 +488,7 @@ class BulkUpload::Sales::Year2024::RowParser
       .to_hash
       .reject { |k, _| %w[bulk_upload block_log_creation].include?(k) }
       .values
+      .reject(&:blank?)
       .compact
       .empty?
   end

--- a/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2023/row_parser_spec.rb
@@ -133,6 +133,17 @@ RSpec.describe BulkUpload::Sales::Year2023::RowParser do
         expect(parser).not_to be_blank_row
       end
     end
+
+    context "when the only populated fields are empty strings or whitespace" do
+      before do
+        parser.field_6 = " "
+        parser.field_19 = ""
+      end
+
+      it "returns true" do
+        expect(parser).to be_blank_row
+      end
+    end
   end
 
   describe "purchaser_code" do

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -1758,7 +1758,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
       end
 
       context "when blank" do
-        let(:attributes) { { bulk_upload:, field_2: "" } }
+        let(:attributes) { { bulk_upload:, field_2: "", field_6: "not blank" } }
 
         it "is not permitted as setup error" do
           parser.valid?

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         expect(parser).not_to be_blank_row
       end
     end
+
+    context "when the only populated fields are empty strings or whitespace" do
+      before do
+        parser.field_6 = " "
+        parser.field_19 = ""
+      end
+
+      it "returns true" do
+        expect(parser).to be_blank_row
+      end
+    end
   end
 
   describe "purchaser_code" do


### PR DESCRIPTION
This fix had been applied to lettings a while ago, but not to sales so I've copied it across.