### PR TITLE
CLDC-3465 Allow clearing all error questions

### DIFF
--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -36,7 +36,7 @@
             <% if @log.collection_period_open_for_editing? %>
               <% row.with_action(
                 text: question.action_text(log, correcting_hard_validation: @correcting_hard_validation),
-                href: @correcting_hard_validation ? correct_validation_action_href(question, log, applicable_questions.map(&:id)) : action_href(question, log),
+                href: correct_validation_action_href(question, log, applicable_questions.map(&:id), @correcting_hard_validation),
                 visually_hidden_text: question.check_answer_label.to_s.downcase,
               ) %>
             <% end %>

--- a/app/components/check_answers_summary_list_card_component.rb
+++ b/app/components/check_answers_summary_list_card_component.rb
@@ -34,7 +34,9 @@ class CheckAnswersSummaryListCardComponent < ViewComponent::Base
     send("#{log.model_name.param_key}_#{question.page.id}_path", log, referrer:)
   end
 
-  def correct_validation_action_href(question, log, _related_question_ids)
+  def correct_validation_action_href(question, log, _related_question_ids, correcting_hard_validation)
+    return action_href(question, log) unless correcting_hard_validation
+
     if question.displayed_as_answered?(log)
       send("#{log.model_name.param_key}_confirm_clear_answer_path", log, question_id: question.id)
     else

--- a/app/controllers/check_errors_controller.rb
+++ b/app/controllers/check_errors_controller.rb
@@ -11,7 +11,13 @@ class CheckErrorsController < ApplicationController
     @page = @log.form.get_page(params[@log.model_name.param_key]["page_id"])
 
     if params["clear_all"]
-      @questions_to_clear = @related_question_ids.map { |id| @log.form.get_question(id, @log).page.questions.map(&:id) }.flatten
+      @questions_to_clear = @related_question_ids.map { |id|
+        question = @log.form.get_question(id, @log)
+        next if question.subsection.id == "setup"
+
+        question.page.questions.map(&:id)
+      }.flatten.compact
+
       render :confirm_clear_all_answers
     else
       question_id = @related_question_ids.find { |id| !params[id].nil? }

--- a/app/controllers/check_errors_controller.rb
+++ b/app/controllers/check_errors_controller.rb
@@ -8,9 +8,15 @@ class CheckErrorsController < ApplicationController
     return render_not_found unless @log
 
     @related_question_ids = params[@log.model_name.param_key].keys.reject { |id| id == "page_id" }
-    question_id = @related_question_ids.find { |id| !params[id].nil? }
-    @question = @log.form.get_question(question_id, @log)
     @page = @log.form.get_page(params[@log.model_name.param_key]["page_id"])
+
+    if params["clear_all"]
+      @questions_to_clear = @related_question_ids.map { |id| @log.form.get_question(id, @log).page.questions.map(&:id) }.flatten
+      render :confirm_clear_all_answers
+    else
+      question_id = @related_question_ids.find { |id| !params[id].nil? }
+      @question = @log.form.get_question(question_id, @log)
+    end
   end
 
 private

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -402,11 +402,13 @@ private
   end
 
   def render_check_errors_page
-    if params[@log.model_name.param_key]["clear_question_id"]
-      question_id = params[@log.model_name.param_key]["clear_question_id"]
-      @log.form.get_question(question_id, @log).page.questions.map(&:id).each { |id| @log[id] = nil }
+    if params[@log.model_name.param_key]["clear_question_ids"].present?
+      question_ids = params[@log.model_name.param_key]["clear_question_ids"].split(" ")
+      question_ids.each do |question_id|
+        @log.form.get_question(question_id, @log).page.questions.map(&:id).each { |id| @log[id] = nil }
+      end
       @log.save!
-      @questions = params[@log.model_name.param_key].keys.reject { |id| %w[clear_question_id page].include?(id) }.map { |id| @log.form.get_question(id, @log) }
+      @questions = params[@log.model_name.param_key].keys.reject { |id| %w[clear_question_ids page].include?(id) }.map { |id| @log.form.get_question(id, @log) }
     else
       responses_for_page = responses_for_page(@page)
       @log.assign_attributes(responses_for_page)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -405,7 +405,10 @@ private
     if params[@log.model_name.param_key]["clear_question_ids"].present?
       question_ids = params[@log.model_name.param_key]["clear_question_ids"].split(" ")
       question_ids.each do |question_id|
-        @log.form.get_question(question_id, @log).page.questions.map(&:id).each { |id| @log[id] = nil }
+        question = @log.form.get_question(question_id, @log)
+        next if question.subsection.id == "setup"
+
+        question.page.questions.map(&:id).each { |id| @log[id] = nil }
       end
       @log.save!
       @questions = params[@log.model_name.param_key].keys.reject { |id| %w[clear_question_ids page].include?(id) }.map { |id| @log.form.get_question(id, @log) }

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -230,7 +230,9 @@ private
     if params[@log.model_name.param_key]["check_errors"]
       @page = form.get_page(params[@log.model_name.param_key]["page"])
       flash[:notice] = "You have successfully updated #{@page.questions.map(&:check_answer_label).to_sentence}"
-      return send("#{@log.class.name.underscore}_#{params[@log.model_name.param_key]['original_page_id']}_path", @log, { check_errors: true, related_question_ids: params[@log.model_name.param_key]["related_question_ids"].split(" ") }.compact)
+      original_page_id = params[@log.model_name.param_key]["original_page_id"]
+      related_question_ids = params[@log.model_name.param_key]["related_question_ids"].split(" ")
+      return send("#{@log.class.name.underscore}_#{original_page_id}_path", @log, { check_errors: true, related_question_ids: }.compact)
     end
 
     if params["referrer"] == "check_errors"

--- a/app/helpers/check_errors_helper.rb
+++ b/app/helpers/check_errors_helper.rb
@@ -1,0 +1,11 @@
+module CheckErrorsHelper
+  include GovukLinkHelper
+
+  def check_errors_answer_text(question, log)
+    question.displayed_as_answered?(log) ? "Change" : "Answer"
+  end
+
+  def check_errors_answer_link(log, question, page, applicable_questions)
+    send("#{log.model_name.param_key}_#{question.page.id}_path", log, referrer: "check_errors", original_page_id: page.id, related_question_ids: applicable_questions.map(&:id))
+  end
+end

--- a/app/views/check_errors/confirm_clear_all_answers.html.erb
+++ b/app/views/check_errors/confirm_clear_all_answers.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <% content_for :title, "Are you sure you want to clear #{@question.check_answer_label}?" %>
+  <% content_for :title, "Are you sure you want to clear all?" %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -7,15 +7,16 @@
     <h1 class="govuk-heading-xl">
       <%= content_for(:title) %>
     </h1>
+    <p class="govuk-body">You've selected <%= @questions_to_clear.count %> answers to clear</p>
 
-    <%= govuk_warning_text(text: "This action is permanent") %>
+    <%= govuk_warning_text(text: "You will not be able to undo this action") %>
       <%= form_with model: @log, url: send("#{@log.model_name.param_key}_#{@page.id}_path", @log), method: "post", local: true do |f| %>
 
       <% @related_question_ids.each do |id| %>
         <%= f.hidden_field id, value: @log[id] %>
       <% end %>
 
-      <%= f.hidden_field :clear_question_ids, value: [@question.id] %>
+      <%= f.hidden_field :clear_question_ids, value: @questions_to_clear %>
       <%= f.hidden_field :page, value: @page.id %>
 
       <div class="govuk-button-group">

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -11,7 +11,7 @@
             Make sure these answers are correct:
           </span>
           <span class="govuk-body govuk-!-text-align-right govuk-grid-column-one-third">
-            <%= govuk_link_to "Clear all", send("#{@log.model_name.param_key}_confirm_clear_all_answers_path", @log) %>
+            <input type="submit" value="Clear all" class="govuk-body govuk-link submit-button-link" name="clear_all">
           </span>
         </div>
       </h1>

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -48,10 +48,10 @@
                     <% end %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                  <% if question.displayed_as_answered?(@log) %>
-                    <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
+                  <% if !question.displayed_as_answered?(@log) || question.subsection.id == "setup" %>
+                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) %>
                   <% else %>
-                    <%= govuk_link_to "Answer", send("#{@log.model_name.param_key}_#{question.page.id}_path", @log, referrer: "check_errors", original_page_id: @page.id, related_question_ids: applicable_questions.map(&:id)) %>
+                    <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
                   <% end %>
                 </dd>
               </div>

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe CheckErrorsController, type: :request do
           post "/sales-logs/#{sales_log.id}/buyer-1-income", params: params
         end
 
-        it "displays correct clear links" do
-          expect(page.all(:button, value: "Clear").count).to eq(3)
-          expect(page).to have_button("Clear all")
+        it "displays correct clear and change links" do
+          expect(page.all(:button, value: "Clear").count).to eq(2)
+          expect(page).to have_link("Change", count: 1)
+          expect(page).to have_link("Clear all", href: "/sales-logs/#{sales_log.id}/confirm-clear-all-answers")
         end
       end
     end

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CheckErrorsController, type: :request do
         it "displays correct clear and change links" do
           expect(page.all(:button, value: "Clear").count).to eq(2)
           expect(page).to have_link("Change", count: 1)
-          expect(page).to have_link("Clear all", href: "/sales-logs/#{sales_log.id}/confirm-clear-all-answers")
+          expect(page).to have_button("Clear all")
         end
       end
     end
@@ -231,7 +231,7 @@ RSpec.describe CheckErrorsController, type: :request do
 
         it "displays correct clear links" do
           expect(page).to have_content("Are you sure you want to clear all")
-          expect(page).to have_content("You've selected 4 answers to clear")
+          expect(page).to have_content("You've selected 3 answers to clear")
           expect(page).to have_content("You will not be able to undo this action")
           expect(page).to have_link("Cancel")
           expect(page).to have_button("Confirm and continue")
@@ -447,7 +447,7 @@ RSpec.describe CheckErrorsController, type: :request do
           expect(page.all(:button, value: "Clear").count).to eq(0)
           expect(sales_log.reload.income1).to eq(nil)
           expect(sales_log.reload.la).to eq(nil)
-          expect(sales_log.reload.ownershipsch).to eq(nil)
+          expect(sales_log.reload.ownershipsch).not_to eq(nil)
         end
       end
     end


### PR DESCRIPTION
This builds on top of https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2472
and adds functionality to clear all button/link