### PR TITLE
CLDC-3465 Do not display non persisted values in check errors page

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -418,6 +418,7 @@ private
       responses_for_page = responses_for_page(@page)
       @log.assign_attributes(responses_for_page)
       @log.valid?
+      @log.reload
       error_attributes = @log.errors.map(&:attribute)
       @questions = @log.form.questions.select { |q| error_attributes.include?(q.id.to_sym) }
     end

--- a/app/views/check_errors/confirm_clear_all_answers.html.erb
+++ b/app/views/check_errors/confirm_clear_all_answers.html.erb
@@ -9,7 +9,7 @@
     </h1>
     <p class="govuk-body">You've selected <%= @questions_to_clear.count %> answers to clear</p>
 
-    <%= govuk_warning_text(text: "You will not be able to undo this action") %>
+    <%= govuk_warning_text(text: "Dependent answers related to this question may also get cleared. You will not be able to undo this action") %>
       <%= form_with model: @log, url: send("#{@log.model_name.param_key}_#{@page.id}_path", @log), method: "post", local: true do |f| %>
 
       <% @related_question_ids.each do |id| %>

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -78,7 +78,7 @@
 
       <% if all_questions_with_errors.count > 1 %>
         <div class="govuk-button-group">
-          <%= f.govuk_submit "See all related answers", name: "check_errors", class: "govuk-body govuk-link submit-button-link" %>
+          <%= f.submit "See all related answers", name: "check_errors", class: "govuk-body govuk-link submit-button-link" %>
         </div>
       <% end %>
 

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CheckErrorsController, type: :request do
 
         it "displays correct clear links" do
           expect(page).to have_selector("input[type=submit][value='Clear']", count: 2)
-          expect(page).to have_link("Clear all", href: "/lettings-logs/#{lettings_log.id}/confirm-clear-all-answers")
+          expect(page).to have_button("Clear all")
         end
       end
 

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe CheckErrorsController, type: :request do
         end
 
         before do
-          lettings_log.update!(needstype: 1, declaration: 1, ecstat1: 10, hhmemb: 2, net_income_known: 0, incfreq: 1, earnings: 1000)
+          lettings_log.update!(needstype: 1, declaration: 1, ecstat1: 10, hhmemb: 2, net_income_known: 0, incfreq: nil, earnings: nil)
           sign_in user
           post "/lettings-logs/#{lettings_log.id}/income-amount", params: params
         end
 
         it "displays correct clear links" do
-          expect(page).to have_selector("input[type=submit][value='Clear']", count: 3)
-          expect(page).to have_button("Clear all")
+          expect(page).to have_selector("input[type=submit][value='Clear']", count: 2)
+          expect(page).to have_link("Clear all", href: "/lettings-logs/#{lettings_log.id}/confirm-clear-all-answers")
         end
       end
 


### PR DESCRIPTION
This builds on top of [#2472](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2472)