### PR TITLE
CLDC-3465 Update setup question link

### DIFF
--- a/app/helpers/check_errors_helper.rb
+++ b/app/helpers/check_errors_helper.rb
@@ -1,0 +1,11 @@
+module CheckErrorsHelper
+  include GovukLinkHelper
+
+  def check_errors_answer_text(question, log)
+    question.displayed_as_answered?(log) ? "Change" : "Answer"
+  end
+
+  def check_errors_answer_link(log, question, page, applicable_questions)
+    send("#{log.model_name.param_key}_#{question.page.id}_path", log, referrer: "check_errors", original_page_id: page.id, related_question_ids: applicable_questions.map(&:id))
+  end
+end

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -48,10 +48,10 @@
                     <% end %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                  <% if question.displayed_as_answered?(@log) %>
-                    <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
+                  <% if !question.displayed_as_answered?(@log) || question.subsection.id == "setup" %>
+                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) %>
                   <% else %>
-                    <%= govuk_link_to "Answer", send("#{@log.model_name.param_key}_#{question.page.id}_path", @log, referrer: "check_errors", original_page_id: @page.id, related_question_ids: applicable_questions.map(&:id)) %>
+                    <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
                   <% end %>
                 </dd>
               </div>

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -83,8 +83,9 @@ RSpec.describe CheckErrorsController, type: :request do
           post "/sales-logs/#{sales_log.id}/buyer-1-income", params: params
         end
 
-        it "displays correct clear links" do
-          expect(page).to have_button("Clear", count: 3)
+        it "displays correct clear and change links" do
+          expect(page).to have_button("Clear", count: 2)
+          expect(page).to have_link("Change", count: 1)
           expect(page).to have_link("Clear all", href: "/sales-logs/#{sales_log.id}/confirm-clear-all-answers")
         end
       end


### PR DESCRIPTION
This builds on top of https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2472

When an error is added to a setup field, clearing it would make non setup sections unavailable and it would clear non setup answers.

Instead we're allowing to change a setup answer. Although there are a few places where changing an answer might reveal other setup questions and still clear the log (like ownership scheme)