### PR TITLE
CLDC-3536 Strip scheme ID

### DIFF
--- a/app/services/bulk_upload/lettings/year2023/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2023/row_parser.rb
@@ -1317,11 +1317,11 @@ private
   end
 
   def log_uses_new_scheme_id?
-    field_16&.start_with?("S")
+    field_16&.strip&.start_with?("S")
   end
 
   def log_uses_old_scheme_id?
-    field_16.present? && !field_16.start_with?("S")
+    field_16.present? && !field_16.strip.start_with?("S")
   end
 
   def scheme_field
@@ -1330,7 +1330,7 @@ private
   end
 
   def scheme_id
-    return field_16 if log_uses_new_scheme_id?
+    return field_16.strip if log_uses_new_scheme_id?
     return field_15 if log_uses_old_scheme_id?
   end
 

--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -1358,7 +1358,7 @@ private
   def scheme
     return if field_5.nil? || owning_organisation.nil? || managing_organisation.nil?
 
-    @scheme ||= Scheme.where(id: (owning_organisation.owned_schemes + managing_organisation.owned_schemes).map(&:id)).find_by_id_on_multiple_fields(field_5, field_6)
+    @scheme ||= Scheme.where(id: (owning_organisation.owned_schemes + managing_organisation.owned_schemes).map(&:id)).find_by_id_on_multiple_fields(field_5.strip, field_6)
   end
 
   def location

--- a/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2023/row_parser_spec.rb
@@ -1004,6 +1004,16 @@ RSpec.describe BulkUpload::Lettings::Year2023::RowParser do
           end
         end
 
+        context "when scheme ID has leading spaces" do
+          let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id, field_4: "2", field_5: "2", field_16: "  S#{scheme.id}", field_17: location.id } }
+
+          it "does not return an error" do
+            expect(parser.errors[:field_15]).to be_blank
+            expect(parser.errors[:field_16]).to be_blank
+            expect(parser.errors[:field_17]).to be_blank
+          end
+        end
+
         context "when location exists but not related" do
           let(:other_scheme) { create(:scheme, :with_old_visible_id) }
           let(:other_location) { create(:location, :with_old_visible_id, scheme: other_scheme) }

--- a/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
@@ -936,6 +936,15 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
           end
         end
 
+        context "when scheme ID has leading spaces" do
+          let(:attributes) { { bulk_upload:, field_1: owning_org.old_visible_id, field_2: owning_org.old_visible_id, field_4: "2", field_11: "1", field_5: " S#{scheme.id}", field_6: location.id } }
+
+          it "does not return an error" do
+            expect(parser.errors[:field_5]).to be_blank
+            expect(parser.errors[:field_6]).to be_blank
+          end
+        end
+
         context "when location exists but not related" do
           let(:other_scheme) { create(:scheme, :with_old_visible_id) }
           let(:other_location) { create(:location, :with_old_visible_id, scheme: other_scheme) }


### PR DESCRIPTION
When the new scheme ID is used, but it's has leading spaces it is considered old scheme ID, because it doesn't start with "S", so we get errors requiring management code to be entered