### PR TITLE
CLDC-3495 Reduce persisted models in tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,12 +40,8 @@ This documentation outlines the objects that are created and/or persisted to the
 ### Lettings Log
 Objects Created/Persisted:
 - **User**: The `assigned_to` user is created.
-  - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `assigned_to` user by `User` factory.
   - **Organisation**: The `assigned_to` user’s organisation created by `User` factory.
-    - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
-    - **User**: Data protection officer that signs the data protection confirmation
-        - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
-
+- **DataProtectionConfirmation**: If `organisation` does not have DSA signed, `DataProtectionConfirmation` gets created with `assigned_to` user as a `data_protection_officer`
 - **OrganisationRentPeriod**: If `log.period` is present and the `managing_organisation` does not have an `OrganisationRentPeriod` for that period, a new `OrganisationRentPeriod` is created and associated with `managing_organisation`.
 
 Example Usage:
@@ -56,11 +52,8 @@ let(:lettings_log) { create(:lettings_log) }
 ### Sales Log
 Objects Created/Persisted:
 - **User**: The `assigned_to` user is created.
-  - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `assigned_to` user by `User` factory.
   - **Organisation**: The `assigned_to` user’s organisation created by `User` factory.
-    - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
-    - **User**: Data protection officer that signs the data protection confirmation
-        - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+- **DataProtectionConfirmation**: If `organisation` does not have DSA signed, `DataProtectionConfirmation` gets created with `assigned_to` user as a `data_protection_officer`
 
 Example Usage:
 ```
@@ -72,7 +65,6 @@ Objects Created/Persisted:
 - **OrganisationRentPeriod**: For each rent period in transient attribute `rent_periods`, an `OrganisationRentPeriod` is created.
 - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
 - **User**: Data protection officer that signs the data protection confirmation
-      - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
 
 Example Usage:
 ```
@@ -81,11 +73,8 @@ let(:organisation) { create(:organisation, rent_periods: [1, 2])}
 
 ### User
 Objects Created/Persisted:
-- **LegacyUser**: A `LegacyUser` is created and associated with the newly created user.
 - **Organisation**: User’s organisation.
-  - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
-  - **User**: Data protection officer that signs the data protection confirmation
-      - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+- **DataProtectionConfirmation**: If `organisation` does not have DSA signed, `DataProtectionConfirmation` gets created with this user as a `data_protection_officer`
 
 Example Usage:
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,3 +31,63 @@ bundle exec rake parallel:setup
 ```sh
 RAILS_ENV=test bundle exec rake parallel:spec
 ```
+
+## Factories for Lettings Log, Sales Log, Organisation, and User 
+Each of these factories has nested relationships and callbacks that ensure associated objects are created and linked properly. For instance, creating a `lettings_log` involves creating or associating with a `user`, which in turn is linked to an `organisation`, potentially leading to creating `organisation_rent_periods` and a `data_protection_confirmation`.
+
+This documentation outlines the objects that are created and/or persisted to the database when using FactoryBot to create or build models for LettingsLog, SalesLog, Organisation, and User. There are other factories, but they are simpler, less frequently used and don't have as much resource hierarchy.
+
+### Lettings Log
+Objects Created/Persisted:
+- **User**: The `assigned_to` user is created.
+  - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `assigned_to` user by `User` factory.
+  - **Organisation**: The `assigned_to` user’s organisation created by `User` factory.
+    - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
+    - **User**: Data protection officer that signs the data protection confirmation
+        - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+
+- **OrganisationRentPeriod**: If `log.period` is present and the `managing_organisation` does not have an `OrganisationRentPeriod` for that period, a new `OrganisationRentPeriod` is created and associated with `managing_organisation`.
+
+Example Usage:
+```
+let(:lettings_log) { create(:lettings_log) }
+```
+
+### Sales Log
+Objects Created/Persisted:
+- **User**: The `assigned_to` user is created.
+  - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `assigned_to` user by `User` factory.
+  - **Organisation**: The `assigned_to` user’s organisation created by `User` factory.
+    - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
+    - **User**: Data protection officer that signs the data protection confirmation
+        - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+
+Example Usage:
+```
+let(:sales_log) { create(:sales_log) }
+```
+
+### Organisation
+Objects Created/Persisted:
+- **OrganisationRentPeriod**: For each rent period in transient attribute `rent_periods`, an `OrganisationRentPeriod` is created.
+- **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
+- **User**: Data protection officer that signs the data protection confirmation
+      - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+
+Example Usage:
+```
+let(:organisation) { create(:organisation, rent_periods: [1, 2])}
+```
+
+### User
+Objects Created/Persisted:
+- **LegacyUser**: A `LegacyUser` is created and associated with the newly created user.
+- **Organisation**: User’s organisation.
+  - **DataProtectionConfirmation**: If `with_dsa` is `true` (default), a `DataProtectionConfirmation` is created with a `data_protection_officer`
+  - **User**: Data protection officer that signs the data protection confirmation
+      - **LegacyUser**: A `LegacyUser` is created and associated with the newly created `data_protection_officer` user by `User` factory.
+
+Example Usage:
+```
+let(:user) { create(:user) }
+```

--- a/spec/components/create_log_actions_component_spec.rb
+++ b/spec/components/create_log_actions_component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CreateLogActionsComponent, type: :component do
 
     context "when not support user" do
       context "without data sharing agreement" do
-        let(:user) { create(:user, organisation: create(:organisation, :without_dpc)) }
+        let(:user) { create(:user, organisation: create(:organisation, :without_dpc), with_dsa: false) }
 
         it "does not render actions" do
           expect(component).not_to be_display_actions

--- a/spec/components/data_protection_confirmation_banner_component_spec.rb
+++ b/spec/components/data_protection_confirmation_banner_component_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
 
   let(:component) { described_class.new(user:, organisation:) }
   let(:render) { render_inline(component) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, with_dsa: false) }
   let(:organisation) { user.organisation }
 
   context "when user is support and organisation is blank" do
-    let(:user) { create(:user, :support) }
+    let(:user) { create(:user, :support, with_dsa: false) }
     let(:organisation) { nil }
 
     it "does not display banner" do
@@ -37,8 +37,8 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
     context "when org does not have a signed data sharing agreement" do
       context "when user is not a DPO" do
         let(:organisation) { create(:organisation, :without_dpc) }
-        let(:user) { create(:user, organisation:) }
-        let!(:dpo) { create(:user, :data_protection_officer, organisation:) }
+        let(:user) { create(:user, organisation:, with_dsa: false) }
+        let!(:dpo) { create(:user, :data_protection_officer, organisation:, with_dsa: false) }
 
         it "displays the banner and shows DPOs" do
           expect(component.display_banner?).to eq(true)
@@ -50,7 +50,7 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
 
       context "when user is a DPO" do
         let(:organisation) { create(:organisation, :without_dpc) }
-        let(:user) { create(:user, :data_protection_officer, organisation:) }
+        let(:user) { create(:user, :data_protection_officer, organisation:, with_dsa: false) }
 
         it "displays the banner and asks to sign" do
           expect(component.display_banner?).to eq(true)
@@ -141,8 +141,8 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
       context "when org does not have a signed data sharing agreement" do
         context "when user is not a DPO" do
           let(:organisation) { create(:organisation, :without_dpc) }
-          let(:user) { create(:user, organisation:) }
-          let!(:dpo) { create(:user, :data_protection_officer, organisation:) }
+          let(:user) { create(:user, organisation:, with_dsa: false) }
+          let!(:dpo) { create(:user, :data_protection_officer, organisation:, with_dsa: false) }
 
           it "displays the banner and shows DPOs" do
             expect(component.display_banner?).to eq(true)
@@ -168,7 +168,7 @@ RSpec.describe DataProtectionConfirmationBannerComponent, type: :component do
 
         context "when user is a DPO" do
           let(:organisation) { create(:organisation, :without_dpc) }
-          let(:user) { create(:user, :data_protection_officer, organisation:) }
+          let(:user) { create(:user, :data_protection_officer, organisation:, with_dsa: false) }
 
           it "displays the banner and asks to sign" do
             expect(component.display_banner?).to eq(true)

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -25,11 +25,11 @@ FactoryBot.define do
     end
 
     after(:create) do |org, evaluator|
-      if evaluator.with_dsa
+      if evaluator.with_dsa && !org.data_protection_confirmed?
         create(
           :data_protection_confirmation,
           organisation: org,
-          data_protection_officer: org.users.any? ? org.users.first : create(:user, :data_protection_officer, organisation: org),
+          data_protection_officer: org.users.any? ? org.users.first : create(:user, :data_protection_officer, organisation: org, with_dsa: false),
         )
       end
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:email) { "test#{SecureRandom.hex}@example.com" }
     name { "Danny Rojas" }
     password { "pAssword1" }
-    organisation
+    organisation { association :organisation, with_dsa: is_dpo ? false : true }
     role { "data_provider" }
     phone { "1234512345123" }
     trait :data_provider do
@@ -25,6 +25,16 @@ FactoryBot.define do
 
     transient do
       old_user_id { SecureRandom.uuid }
+    end
+
+    after(:create) do |user, _evaluator|
+      unless user.organisation.data_protection_confirmed?
+        create(
+          :data_protection_confirmation,
+          organisation: user.organisation,
+          data_protection_officer: user,
+        )
+      end
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -27,8 +27,12 @@ FactoryBot.define do
       old_user_id { SecureRandom.uuid }
     end
 
-    after(:create) do |user, _evaluator|
-      unless user.organisation.data_protection_confirmed?
+    transient do
+      with_dsa { true }
+    end
+
+    after(:create) do |user, evaluator|
+      if evaluator.with_dsa && !user.organisation.data_protection_confirmed?
         create(
           :data_protection_confirmation,
           organisation: user.organisation,

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -26,11 +26,5 @@ FactoryBot.define do
     transient do
       old_user_id { SecureRandom.uuid }
     end
-
-    after(:create) do |user, evaluator|
-      FactoryBot.create(:legacy_user, old_user_id: evaluator.old_user_id, user:)
-
-      user.reload
-    end
   end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -594,7 +594,7 @@ RSpec.describe "User Features" do
       end
 
       before do
-        other_user.update!(initial_confirmation_sent: true, last_sign_in_at: nil)
+        other_user.update!(initial_confirmation_sent: true, last_sign_in_at: nil, old_user_id: "old-user-id")
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in(user)
         visit(user_path(other_user))

--- a/spec/mailers/resend_invitation_mailer_spec.rb
+++ b/spec/mailers/resend_invitation_mailer_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ResendInvitationMailer do
       end
 
       it "sends an initial invitation" do
+        FactoryBot.create(:legacy_user, old_user_id: new_active_migrated_user.old_user_id, user: new_active_migrated_user)
         expect(notify_client).to receive(:send_email).with(email_address: "new_active_migrated_user@example.com", template_id: User::BETA_ONBOARDING_TEMPLATE_ID, personalisation:).once
         described_class.new.resend_invitation_email(new_active_migrated_user)
       end

--- a/spec/models/form/lettings/pages/address_matcher_spec.rb
+++ b/spec/models/form/lettings/pages/address_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Lettings::Pages::AddressMatcher, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
-  let(:log) { create(:lettings_log) }
+  let(:log) { build(:lettings_log) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/lettings/pages/uprn_selection_spec.rb
+++ b/spec/models/form/lettings/pages/uprn_selection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Lettings::Pages::UprnSelection, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
-  let(:log) { create(:lettings_log) }
+  let(:log) { build(:lettings_log) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/lettings/pages/uprn_spec.rb
+++ b/spec/models/form/lettings/pages/uprn_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Form::Lettings::Pages::Uprn, type: :model do
     end
 
     context "when log is present" do
-      let(:log) { create(:lettings_log) }
+      let(:log) { build(:lettings_log) }
 
       context "with 2023/24 form" do
         it "points to address page" do

--- a/spec/models/form/lettings/questions/property_reference_spec.rb
+++ b/spec/models/form/lettings/questions/property_reference_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Lettings::Questions::PropertyReference, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
-  let(:lettings_log) { FactoryBot.create(:lettings_log) }
+  let(:lettings_log) { FactoryBot.build(:lettings_log) }
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/lettings/questions/uprn_confirmation_spec.rb
+++ b/spec/models/form/lettings/questions/uprn_confirmation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
   describe "notification_banner" do
     context "when address is not present" do
       it "returns nil" do
-        log = create(:lettings_log)
+        log = build(:lettings_log)
 
         expect(question.notification_banner(log)).to be_nil
       end
@@ -50,7 +50,7 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
 
     context "when address is present" do
       it "returns formatted value" do
-        log = create(:lettings_log, :setup_completed, address_line1: "1, Test Street", town_or_city: "Test Town", postcode_full: "AA1 1AA", uprn: "1", uprn_known: 1)
+        log = build(:lettings_log, :setup_completed, address_line1: "1, Test Street", town_or_city: "Test Town", postcode_full: "AA1 1AA", uprn: "1", uprn_known: 1)
 
         expect(question.notification_banner(log)).to eq(
           {
@@ -64,7 +64,7 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
 
   describe "has the correct hidden_in_check_answers" do
     context "when uprn_known != 1 && uprn_confirmed == nil" do
-      let(:log) { create(:lettings_log, uprn_known: 0, uprn_confirmed: nil) }
+      let(:log) { build(:lettings_log, uprn_known: 0, uprn_confirmed: nil) }
 
       it "returns true" do
         expect(question.hidden_in_check_answers?(log)).to eq(true)
@@ -72,7 +72,7 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
     end
 
     context "when uprn_known == 1 && uprn_confirmed == nil" do
-      let(:log) { create(:lettings_log, :completed, uprn_known: 1, uprn: 1, uprn_confirmed: nil) }
+      let(:log) { build(:lettings_log, :completed, uprn_known: 1, uprn: 1, uprn_confirmed: nil) }
 
       it "returns false" do
         expect(question.hidden_in_check_answers?(log)).to eq(false)
@@ -80,7 +80,7 @@ RSpec.describe Form::Lettings::Questions::UprnConfirmation, type: :model do
     end
 
     context "when uprn_known != 1 && uprn_confirmed == 1" do
-      let(:log) { create(:lettings_log) }
+      let(:log) { build(:lettings_log) }
 
       it "returns true" do
         log.uprn_known = 1

--- a/spec/models/form/sales/pages/address_matcher_spec.rb
+++ b/spec/models/form/sales/pages/address_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Pages::AddressMatcher, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
-  let(:log) { create(:sales_log) }
+  let(:log) { build(:sales_log) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/sales/pages/uprn_confirmation_spec.rb
+++ b/spec/models/form/sales/pages/uprn_confirmation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Form::Sales::Pages::UprnConfirmation, type: :model do
 
   describe "has correct routed_to?" do
     context "when uprn present && uprn_known == 1 " do
-      let(:log) { create(:sales_log) }
+      let(:log) { build(:sales_log) }
 
       it "returns true" do
         log.uprn_known = 1
@@ -43,7 +43,7 @@ RSpec.describe Form::Sales::Pages::UprnConfirmation, type: :model do
     end
 
     context "when uprn = nil" do
-      let(:log) { create(:sales_log, uprn_known: 1, uprn: nil) }
+      let(:log) { build(:sales_log, uprn_known: 1, uprn: nil) }
 
       it "returns false" do
         expect(page.routed_to?(log)).to eq(false)
@@ -51,7 +51,7 @@ RSpec.describe Form::Sales::Pages::UprnConfirmation, type: :model do
     end
 
     context "when uprn_known == 0" do
-      let(:log) { create(:sales_log, uprn_known: 0, uprn: "123456789") }
+      let(:log) { build(:sales_log, uprn_known: 0, uprn: "123456789") }
 
       it "returns false" do
         expect(page.routed_to?(log)).to eq(false)

--- a/spec/models/form/sales/pages/uprn_selection_spec.rb
+++ b/spec/models/form/sales/pages/uprn_selection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Pages::UprnSelection, type: :model do
   let(:page_id) { nil }
   let(:page_definition) { nil }
   let(:subsection) { instance_double(Form::Subsection) }
-  let(:log) { create(:sales_log) }
+  let(:log) { build(:sales_log) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/sales/pages/uprn_spec.rb
+++ b/spec/models/form/sales/pages/uprn_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Form::Sales::Pages::Uprn, type: :model do
     end
 
     context "when log is present" do
-      let(:log) { create(:sales_log) }
+      let(:log) { build(:sales_log) }
 
       context "with 2023/24 form" do
         it "points to address page" do

--- a/spec/models/form/sales/questions/address_line1_for_address_matcher_spec.rb
+++ b/spec/models/form/sales/questions/address_line1_for_address_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Questions::AddressLine1ForAddressMatcher, type: :mod
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
-  let(:log) { create(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
+  let(:log) { build(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/sales/questions/buyer1_mortgage_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_mortgage_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Questions::Buyer1Mortgage, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
-  let(:log) { create(:sales_log) }
+  let(:log) { build(:sales_log) }
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/sales/questions/buyer2_mortgage_spec.rb
+++ b/spec/models/form/sales/questions/buyer2_mortgage_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Questions::Buyer2Mortgage, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
-  let(:log) { create(:sales_log) }
+  let(:log) { build(:sales_log) }
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/sales/questions/buyers_organisations_spec.rb
+++ b/spec/models/form/sales/questions/buyers_organisations_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Form::Sales::Questions::BuyersOrganisations, type: :model do
   end
 
   it "has the correct displayed answer_options" do
-    expect(question.displayed_answer_options(FactoryBot.create(:sales_log))).to eq(
+    expect(question.displayed_answer_options(FactoryBot.build(:sales_log))).to eq(
       {
         "pregyrha" => { "value" => "Their private registered provider (PRP) - housing association" },
         "pregother" => { "value" => "Other private registered provider (PRP) - housing association" },

--- a/spec/models/form/sales/questions/deposit_amount_spec.rb
+++ b/spec/models/form/sales/questions/deposit_amount_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Form::Sales::Questions::DepositAmount, type: :model do
   end
 
   context "when the ownership type is shared" do
-    let(:log) { create(:sales_log, :completed, ownershipsch: 1, mortgageused: 2) }
+    let(:log) { build(:sales_log, :completed, ownershipsch: 1, mortgageused: 2) }
 
     it "is not marked as derived" do
       expect(question.derived?(log)).to be false
@@ -36,7 +36,7 @@ RSpec.describe Form::Sales::Questions::DepositAmount, type: :model do
   end
 
   context "when the ownership type is discounted for 2023" do
-    let(:log) { create(:sales_log, :completed, ownershipsch: 2, mortgageused: 2, saledate: Time.zone.local(2024, 3, 1)) }
+    let(:log) { build(:sales_log, :completed, ownershipsch: 2, mortgageused: 2, saledate: Time.zone.local(2024, 3, 1)) }
 
     it "is not marked as derived" do
       expect(question.derived?(log)).to be false
@@ -44,7 +44,7 @@ RSpec.describe Form::Sales::Questions::DepositAmount, type: :model do
   end
 
   context "when the ownership type is outright" do
-    let(:log) { create(:sales_log, :completed, ownershipsch: 3, mortgageused: 2) }
+    let(:log) { build(:sales_log, :completed, ownershipsch: 3, mortgageused: 2) }
 
     it "is not marked as derived when a mortgage is used" do
       log.mortgageused = 1

--- a/spec/models/form/sales/questions/postcode_for_address_matcher_spec.rb
+++ b/spec/models/form/sales/questions/postcode_for_address_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Questions::PostcodeForAddressMatcher, type: :model d
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page) }
-  let(:log) { create(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
+  let(:log) { build(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/sales/questions/uprn_confirmation_spec.rb
+++ b/spec/models/form/sales/questions/uprn_confirmation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Sales::Questions::UprnConfirmation, type: :model do
   describe "notification_banner" do
     context "when address is not present" do
       it "returns nil" do
-        log = create(:sales_log)
+        log = build(:sales_log)
 
         expect(question.notification_banner(log)).to be_nil
       end
@@ -64,7 +64,7 @@ RSpec.describe Form::Sales::Questions::UprnConfirmation, type: :model do
 
   describe "has the correct hidden_in_check_answers" do
     context "when uprn_known != 1 && uprn_confirmed == nil" do
-      let(:log) { create(:sales_log, uprn_known: 0, uprn_confirmed: nil) }
+      let(:log) { build(:sales_log, uprn_known: 0, uprn_confirmed: nil) }
 
       it "returns true" do
         expect(question.hidden_in_check_answers?(log)).to eq(true)
@@ -72,7 +72,7 @@ RSpec.describe Form::Sales::Questions::UprnConfirmation, type: :model do
     end
 
     context "when uprn_known == 1 && uprn_confirmed == nil" do
-      let(:log) { create(:sales_log) }
+      let(:log) { build(:sales_log) }
 
       it "returns false" do
         log.uprn_known = 1
@@ -83,7 +83,7 @@ RSpec.describe Form::Sales::Questions::UprnConfirmation, type: :model do
     end
 
     context "when uprn_known != 1 && uprn_confirmed == 1" do
-      let(:log) { create(:sales_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1) }
+      let(:log) { build(:sales_log, uprn_known: 1, uprn: "12345", uprn_confirmed: 1) }
 
       it "returns true" do
         expect(question.hidden_in_check_answers?(log)).to eq(true)

--- a/spec/models/form/sales/questions/uprn_selection_spec.rb
+++ b/spec/models/form/sales/questions/uprn_selection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Form::Sales::Questions::UprnSelection, type: :model do
   let(:question_id) { nil }
   let(:question_definition) { nil }
   let(:page) { instance_double(Form::Page, skip_href: "skip_href") }
-  let(:log) { create(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
+  let(:log) { build(:sales_log, :in_progress, address_line1_input: "Address line 1", postcode_full_input: "AA1 1AA") }
   let(:address_client_instance) { AddressClient.new(log.address_string) }
 
   before do

--- a/spec/models/form/sales/questions/uprn_spec.rb
+++ b/spec/models/form/sales/questions/uprn_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Form::Sales::Questions::Uprn, type: :model do
 
   describe "get_extra_check_answer_value" do
     context "when address is not present" do
-      let(:log) { create(:sales_log) }
+      let(:log) { build(:sales_log) }
 
       it "returns nil" do
         expect(question.get_extra_check_answer_value(log)).to be_nil

--- a/spec/models/form/sales/subsections/discounted_ownership_scheme_spec.rb
+++ b/spec/models/form/sales/subsections/discounted_ownership_scheme_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Form::Sales::Subsections::DiscountedOwnershipScheme, type: :model
   end
 
   context "when it is a discounted ownership scheme" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 2) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 2) }
 
     it "is displayed in tasklist" do
       expect(discounted_ownership_scheme.displayed_in_tasklist?(log)).to eq(true)
@@ -75,7 +75,7 @@ RSpec.describe Form::Sales::Subsections::DiscountedOwnershipScheme, type: :model
   end
 
   context "when it is not a discounted ownership scheme" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 1) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 1) }
 
     it "is displayed in tasklist" do
       expect(discounted_ownership_scheme.displayed_in_tasklist?(log)).to eq(false)

--- a/spec/models/form/sales/subsections/household_characteristics_spec.rb
+++ b/spec/models/form/sales/subsections/household_characteristics_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Form::Sales::Subsections::HouseholdCharacteristics, type: :model 
   end
 
   context "when the sale is to a company buyer" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 3, companybuy: 1) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 3, companybuy: 1) }
 
     it "is not displayed in tasklist" do
       expect(household_characteristics.displayed_in_tasklist?(log)).to eq(false)
@@ -386,7 +386,7 @@ RSpec.describe Form::Sales::Subsections::HouseholdCharacteristics, type: :model 
   end
 
   context "when the sale is not to a company buyer" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 3, companybuy: 2) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 3, companybuy: 2) }
 
     it "is displayed in tasklist" do
       expect(household_characteristics.displayed_in_tasklist?(log)).to eq(true)

--- a/spec/models/form/sales/subsections/outright_sale_spec.rb
+++ b/spec/models/form/sales/subsections/outright_sale_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Form::Sales::Subsections::OutrightSale, type: :model do
   end
 
   context "when it is a outright sale" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 3) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 3) }
 
     it "is displayed in tasklist" do
       expect(outright_sale.displayed_in_tasklist?(log)).to eq(true)
@@ -130,7 +130,7 @@ RSpec.describe Form::Sales::Subsections::OutrightSale, type: :model do
   end
 
   context "when it is not a outright sale" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 2) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 2) }
 
     it "is displayed in tasklist" do
       expect(outright_sale.displayed_in_tasklist?(log)).to eq(false)

--- a/spec/models/form/sales/subsections/shared_ownership_scheme_spec.rb
+++ b/spec/models/form/sales/subsections/shared_ownership_scheme_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipScheme, type: :model do
   end
 
   context "when it is a shared ownership scheme" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 1) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 1) }
 
     it "is displayed in tasklist" do
       expect(shared_ownership_scheme.displayed_in_tasklist?(log)).to eq(true)
@@ -85,7 +85,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipScheme, type: :model do
   end
 
   context "when it is not a shared ownership scheme" do
-    let(:log) { FactoryBot.create(:sales_log, ownershipsch: 2) }
+    let(:log) { FactoryBot.build(:sales_log, ownershipsch: 2) }
 
     it "is displayed in tasklist" do
       expect(shared_ownership_scheme.displayed_in_tasklist?(log)).to eq(false)

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe Scheme, type: :model do
     end
 
     context "when scheme has discarded_at value" do
-      let(:scheme) { FactoryBot.create(:scheme, discarded_at: Time.zone.now) }
+      let(:scheme) { FactoryBot.build(:scheme, discarded_at: Time.zone.now) }
 
       it "returns deleted" do
         expect(scheme.status).to eq(:deleted)
@@ -368,7 +368,7 @@ RSpec.describe Scheme, type: :model do
   describe "owning organisation" do
     let(:stock_owning_org) { FactoryBot.create(:organisation, holds_own_stock: true) }
     let(:non_stock_owning_org) { FactoryBot.create(:organisation, holds_own_stock: false) }
-    let(:scheme) { FactoryBot.create(:scheme, owning_organisation_id: stock_owning_org.id) }
+    let(:scheme) { FactoryBot.build(:scheme, owning_organisation_id: stock_owning_org.id) }
 
     context "when the owning organisation is set as a non-stock-owning organisation" do
       it "throws the correct validation error" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe User, type: :model do
     end
 
     it "can have one or more legacy users" do
+      FactoryBot.create(:legacy_user, old_user_id: user.old_user_id, user:)
       expect(user.legacy_users.size).to eq(1)
     end
 

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Validations::DateValidations do
   subject(:date_validator) { validator_class.new }
 
   let(:validator_class) { Class.new { include Validations::DateValidations } }
-  let(:record) { create(:lettings_log) }
+  let(:record) { build(:lettings_log) }
   let(:scheme) { create(:scheme, end_date: Time.zone.today - 5.days) }
   let(:scheme_no_end_date) { create(:scheme, end_date: nil) }
 

--- a/spec/models/validations/local_authority_validations_spec.rb
+++ b/spec/models/validations/local_authority_validations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Validations::LocalAuthorityValidations do
   subject(:local_auth_validator) { validator_class.new }
 
   let(:validator_class) { Class.new { include Validations::LocalAuthorityValidations } }
-  let(:log) { create(:lettings_log) }
+  let(:log) { build(:lettings_log) }
 
   describe "#validate_previous_accommodation_postcode" do
     it "does not add an error if the log ppostcode_full is missing" do

--- a/spec/models/validations/sales/soft_validations_spec.rb
+++ b/spec/models/validations/sales/soft_validations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Validations::Sales::SoftValidations do
-  let(:record) { create(:sales_log) }
+  let(:record) { build(:sales_log) }
 
   describe "income1 min validations" do
     context "when validating soft min" do

--- a/spec/models/validations/setup_validations_spec.rb
+++ b/spec/models/validations/setup_validations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Validations::SetupValidations do
   subject(:setup_validator) { setup_validator_class.new }
 
   let(:setup_validator_class) { Class.new { include Validations::SetupValidations } }
-  let(:record) { create(:lettings_log) }
+  let(:record) { build(:lettings_log) }
 
   describe "tenancy start date" do
     context "when in 22/23 collection" do
@@ -853,7 +853,7 @@ RSpec.describe Validations::SetupValidations do
     end
 
     context "when updating" do
-      let(:log) { create(:lettings_log, :in_progress) }
+      let(:log) { build(:lettings_log, :in_progress) }
       let(:org_with_dpc) { create(:organisation) }
       let(:org_without_dpc) { create(:organisation, :without_dpc) }
 

--- a/spec/models/validations/tenancy_validations_spec.rb
+++ b/spec/models/validations/tenancy_validations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Validations::TenancyValidations do
   let(:validator_class) { Class.new { include Validations::TenancyValidations } }
 
   describe "tenancy length validations" do
-    let(:record) { FactoryBot.create(:lettings_log, :setup_completed) }
+    let(:record) { FactoryBot.build(:lettings_log, :setup_completed) }
 
     shared_examples "adds expected errors based on the tenancy length" do |tenancy_type_case, error_fields, min_tenancy_length|
       context "and tenancy type is #{tenancy_type_case[:name]}" do
@@ -276,7 +276,7 @@ RSpec.describe Validations::TenancyValidations do
   end
 
   describe "tenancy type validations" do
-    let(:record) { FactoryBot.create(:lettings_log, :setup_completed) }
+    let(:record) { FactoryBot.build(:lettings_log, :setup_completed) }
     let(:field) { "validations.other_field_missing" }
     let(:main_field_label) { "tenancy type" }
     let(:other_field) { "tenancyother" }
@@ -320,7 +320,7 @@ RSpec.describe Validations::TenancyValidations do
 
   describe "joint tenancy validation" do
     context "when the data inputter has said that there is only one member in the household" do
-      let(:record) { FactoryBot.create(:lettings_log, :setup_completed, hhmemb: 1) }
+      let(:record) { FactoryBot.build(:lettings_log, :setup_completed, hhmemb: 1) }
       let(:expected_error) { I18n.t("validations.tenancy.not_joint") }
       let(:hhmemb_expected_error) { I18n.t("validations.tenancy.joint_more_than_one_member") }
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe UserPolicy do
       end
 
       context "and user is the DPO that hasn't signed the agreement" do
-        let(:user) { create(:user, active: false, is_dpo: true) }
+        let(:user) { create(:user, active: false, is_dpo: true, with_dsa: false) }
 
         it "does not allow deleting a user as a provider" do
           expect(policy).not_to permit(data_provider, user)

--- a/spec/requests/bulk_upload_lettings_logs_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_logs_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BulkUploadLettingsLogsController, type: :request do
   describe "GET /lettings-logs/bulk-upload-logs/start" do
     context "when data protection confirmation not signed" do
       let(:organisation) { create(:organisation, :without_dpc) }
-      let(:user) { create(:user, organisation:) }
+      let(:user) { create(:user, organisation:, with_dsa: false) }
 
       it "redirects to lettings index page" do
         get "/lettings-logs/bulk-upload-logs/start", params: {}

--- a/spec/requests/bulk_upload_sales_logs_controller_spec.rb
+++ b/spec/requests/bulk_upload_sales_logs_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BulkUploadSalesLogsController, type: :request do
   describe "GET /sales-logs/bulk-upload-logs/start" do
     context "when data protection confirmation not signed" do
       let(:organisation) { create(:organisation, :without_dpc) }
-      let(:user) { create(:user, organisation:) }
+      let(:user) { create(:user, organisation:, with_dsa: false) }
 
       it "redirects to sales index page" do
         get "/sales-logs/bulk-upload-logs/start", params: {}

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -2145,7 +2145,7 @@ RSpec.describe OrganisationsController, type: :request do
             Timecop.unfreeze
           end
 
-          let(:user) { create(:user, is_dpo: true, organisation:) }
+          let(:user) { create(:user, is_dpo: true, organisation:, with_dsa: false) }
 
           it "returns redirects to details page" do
             post "/organisations/#{organisation.id}/data-sharing-agreement", headers: headers

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -1648,6 +1648,7 @@ RSpec.describe OrganisationsController, type: :request do
             allow(notify_client).to receive(:send_email).and_return(true)
 
             user_to_reactivate = create(:user, :data_coordinator, organisation:, active: false, reactivate_with_organisation: true)
+            FactoryBot.create(:legacy_user, old_user_id: user_to_reactivate.old_user_id, user: user_to_reactivate)
             user_not_to_reactivate = create(:user, :data_coordinator, organisation:, active: false, reactivate_with_organisation: false)
             patch "/organisations/#{organisation.id}", headers:, params:
           end

--- a/spec/views/logs/_create_for_org_actions.html.erb_spec.rb
+++ b/spec/views/logs/_create_for_org_actions.html.erb_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "logs/_create_for_org_actions.html.erb" do
   end
 
   context "without data sharing agreement" do
-    let(:user) { create(:user, organisation: create(:organisation, :without_dpc)) }
+    let(:user) { create(:user, organisation: create(:organisation, :without_dpc), with_dsa: false) }
 
     it "does not include create log buttons" do
       render

--- a/spec/views/organisations/data_sharing_agreement.html.erb_spec.rb
+++ b/spec/views/organisations/data_sharing_agreement.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "organisations/data_sharing_agreement.html.erb", :aggregate_failu
   let(:data_protection_confirmation) { nil }
 
   context "when dpo" do
-    let(:user) { create(:user, is_dpo: true, organisation: create(:organisation, :without_dpc)) }
+    let(:user) { create(:user, is_dpo: true, organisation: create(:organisation, :without_dpc), with_dsa: false) }
 
     it "renders dynamic content" do
       render

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "organisations/show.html.erb" do
   let(:organisation_with_dsa) { create(:organisation) }
 
   context "when dpo" do
-    let(:user) { create(:user, is_dpo: true, organisation: organisation_without_dpc) }
+    let(:user) { create(:user, is_dpo: true, organisation: organisation_without_dpc, with_dsa: false) }
 
     it "includes data sharing agreement row" do
       render
@@ -32,7 +32,7 @@ RSpec.describe "organisations/show.html.erb" do
     end
 
     context "when accepted" do
-      let(:user) { create(:user, organisation: organisation_with_dsa) }
+      let(:user) { create(:user, organisation: organisation_with_dsa, with_dsa: false) }
 
       it "includes data sharing agreement row" do
         render
@@ -55,7 +55,7 @@ RSpec.describe "organisations/show.html.erb" do
   end
 
   context "when support user" do
-    let(:user) { create(:user, :support, organisation: organisation_without_dpc) }
+    let(:user) { create(:user, :support, organisation: organisation_without_dpc, with_dsa: false) }
 
     it "includes data sharing agreement row" do
       render
@@ -82,7 +82,7 @@ RSpec.describe "organisations/show.html.erb" do
     end
 
     context "when accepted" do
-      let(:user) { create(:user, :support, organisation: organisation_with_dsa) }
+      let(:user) { create(:user, :support, organisation: organisation_with_dsa, with_dsa: false) }
 
       it "includes data sharing agreement row" do
         render
@@ -125,7 +125,7 @@ RSpec.describe "organisations/show.html.erb" do
   end
 
   context "when not dpo" do
-    let(:user) { create(:user, organisation: organisation_without_dpc) }
+    let(:user) { create(:user, organisation: organisation_without_dpc, with_dsa: false) }
 
     it "includes data sharing agreement row" do
       render
@@ -149,7 +149,7 @@ RSpec.describe "organisations/show.html.erb" do
     end
 
     context "when accepted" do
-      let(:user) { create(:user, organisation: organisation_with_dsa) }
+      let(:user) { create(:user, organisation: organisation_with_dsa, with_dsa: false) }
 
       it "includes data sharing agreement row" do
         render


### PR DESCRIPTION
Some of our factories have nested relationships and callbacks that ensure associated objects are created and linked properly. For instance, creating a `lettings_log` involves creating or associating with a `user`, which in turn is linked to an `organisation`, potentially leading to creating `organisation_rent_periods` and a `data_protection_confirmation`.
Not all of these are necessary and sometimes we end up creating more resources than intended. This change reduces some of those resources. 

The change to resource chains is probably best described by this commit:
https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2507/commits/c2aa68f93236054dc48feb5a3c8c8775e3dbb781

This PR also replaces some create -> build where appropriate