### PR TITLE
CLDC-3558 Display correct orgs data protection confirmation

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -238,7 +238,7 @@ class OrganisationsController < ApplicationController
   end
 
   def data_sharing_agreement
-    @data_protection_confirmation = current_user.organisation.data_protection_confirmation
+    @data_protection_confirmation = @organisation.data_protection_confirmation
   end
 
   def confirm_data_sharing_agreement

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -2114,7 +2114,6 @@ RSpec.describe OrganisationsController, type: :request do
           get "/organisations/#{organisation.id}/data-sharing-agreement", headers: headers
           expect(response).to have_http_status(:ok)
           expect(page).to have_content("This agreement is made the 2nd day of March 2001")
-          # binding.pry
           expect(page).to have_content("1) Org name")
         end
       end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -2099,6 +2099,26 @@ RSpec.describe OrganisationsController, type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "when signed in as support" do
+      let(:support_user) { create(:user, :support, with_dsa: false) }
+
+      before do
+        organisation.data_protection_confirmation.update!(signed_at: Time.zone.local(2001, 3, 2), organisation_name: "Org name")
+        allow(support_user).to receive(:need_two_factor_authentication?).and_return(false)
+        sign_in support_user
+      end
+
+      context "and viewing other org dsa" do
+        it "shows correct org data and dates" do
+          get "/organisations/#{organisation.id}/data-sharing-agreement", headers: headers
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_content("This agreement is made the 2nd day of March 2001")
+          # binding.pry
+          expect(page).to have_content("1) Org name")
+        end
+      end
+    end
   end
 
   describe "POST #data_sharing_agreement" do


### PR DESCRIPTION
This would have only been an issue for support users, cause all the other users can only access their own org anyway