### PR TITLE
CLDC-2831 Update profiler storage

### DIFF
--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,4 +1,3 @@
-
 require "configuration/configuration_service"
 require "configuration/env_configuration_service"
 

--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,0 +1,12 @@
+
+require "configuration/configuration_service"
+require "configuration/env_configuration_service"
+
+# set RedisStore
+if Rails.env.staging?
+  configuration_service = Configuration::EnvConfigurationService.new
+  redis_url = configuration_service.redis_uris.to_a[0][1]
+
+  Rack::MiniProfiler.config.storage_options = { url: redis_url }
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+end


### PR DESCRIPTION
Currently staging is returning a 404 on /mini-profiler-resources/results post request.
I think by default profiler is using FileStore,  that might not be working as expected with our staging env, setting a different storage is one of the main things suggested on the readme and a lot of the issues for mini-profiler, so will give that a go