### PR TITLE
Allow discarding users for merged orgs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,7 +264,8 @@ class User < ApplicationRecord
   end
 
   def discard!
-    update!(discarded_at: Time.zone.now)
+    self.discarded_at = Time.zone.now
+    save!(validate: false)
   end
 
 protected

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -298,4 +298,25 @@ RSpec.describe Organisation, type: :model do
       expect(organisation.status).to be(:active)
     end
   end
+
+  describe "discard" do
+    let(:organisation) { create(:organisation) }
+    let!(:user) { create(:user, organisation:) }
+    let!(:scheme) { create(:scheme, owning_organisation: organisation) }
+
+    context "when merged organisation is discarded" do
+      before do
+        organisation.merge_date = Time.zone.yesterday
+        organisation.absorbing_organisation_id = create(:organisation).id
+        organisation.save!
+      end
+
+      it "discards all of the organisation resources" do
+        organisation.discard!
+        expect(organisation.status).to eq(:deleted)
+        expect(user.reload.status).to eq(:deleted)
+        expect(scheme.reload.status).to eq(:deleted)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When discarding a user for merged org we might get a validation `That organisation has already been merged. Select a different organisation.`

This PR omits validation when discarding users to avoid that