### PR TITLE
CLDC-3562 Add scheme ID to the hint text

### DIFF
--- a/app/helpers/question_view_helper.rb
+++ b/app/helpers/question_view_helper.rb
@@ -34,7 +34,7 @@ module QuestionViewHelper
   def answer_option_hint(resource)
     return unless resource.instance_of?(Scheme)
 
-    [resource.primary_client_group, resource.secondary_client_group].compact.join(", ")
+    "(S#{resource.id})" + [resource.primary_client_group, resource.secondary_client_group].compact.join(", ")
   end
 
   def select_option_name(value)

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe SalesLog, type: :model do
   end
 
   describe "#search_by" do
-    let!(:sales_log_to_search) { create(:sales_log, :completed) }
+    let!(:sales_log_to_search) { create(:sales_log, :completed, id: 193_285) }
 
     it "allows searching using ID" do
       result = described_class.search_by(sales_log_to_search.id.to_s)


### PR DESCRIPTION
There’s an issue when selecting schemes from the dropdown.
If there are multiple schemes with the same name, and if the hint texts (primary and secondary client groups) match it always selects the same scheme in the dropdown.
This PR adds the scheme code into the hint text, cause that’s a unique ID.

It’s similar to this issue:
https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/2394