### PR TITLE
Make sure archived filters are removed after crossover

### DIFF
--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -95,11 +95,16 @@ module FiltersHelper
   end
 
   def collection_year_options
-    {
+    years = {
       current_collection_start_year.to_s => year_combo(current_collection_start_year),
       previous_collection_start_year.to_s => year_combo(previous_collection_start_year),
-      archived_collection_start_year.to_s => year_combo(archived_collection_start_year),
     }
+
+    if FormHandler.instance.in_crossover_period?
+      return years.merge({ archived_collection_start_year.to_s => year_combo(archived_collection_start_year) })
+    end
+
+    years
   end
 
   def collection_year_radio_options

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe "User Features" do
       let(:number_of_lettings_logs) { LettingsLog.count }
 
       before do
+        allow(FormHandler.instance).to receive(:in_crossover_period?).and_return(true)
         visit("/organisations/#{org_id}/lettings-logs")
       end
 
@@ -220,6 +221,7 @@ RSpec.describe "User Features" do
       let(:number_of_sales_logs) { SalesLog.count }
 
       before do
+        allow(FormHandler.instance).to receive(:in_crossover_period?).and_return(true)
         FactoryBot.create_list(:sales_log, 4, owning_organisation_id: organisation.id)
         visit("/organisations/#{org_id}/sales-logs")
       end

--- a/spec/helpers/filters_helper_spec.rb
+++ b/spec/helpers/filters_helper_spec.rb
@@ -245,12 +245,32 @@ RSpec.describe FiltersHelper do
         allow(Time).to receive(:now).and_return(Time.zone.local(2023, 5, 1))
       end
 
-      it "has the correct options" do
-        expect(collection_year_options).to eq(
-          {
-            "2023" => "2023/24", "2022" => "2022/23", "2021" => "2021/22"
-          },
-        )
+      context "and in crossover period" do
+        before do
+          allow(FormHandler.instance).to receive(:in_crossover_period?).and_return(true)
+        end
+
+        it "has the correct options" do
+          expect(collection_year_options).to eq(
+            {
+              "2023" => "2023/24", "2022" => "2022/23", "2021" => "2021/22"
+            },
+          )
+        end
+      end
+
+      context "and not in crossover period" do
+        before do
+          allow(FormHandler.instance).to receive(:in_crossover_period?).and_return(false)
+        end
+
+        it "has the correct options" do
+          expect(collection_year_options).to eq(
+            {
+              "2023" => "2023/24", "2022" => "2022/23"
+            },
+          )
+        end
       end
     end
 


### PR DESCRIPTION
We should not be displaying archived form logs after collection year close, looks like the filters were semi-hardcoded for the years tho, this should fix it