### PR TITLE
CLDC-3027 Remove unused admin user code

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,4 @@
-<% if resource_name == :admin_user %>
-  <% title = "Sign in to your CORE administration account" %>
-<% else %>
-  <% title = "Sign in to your account to submit CORE data" %>
-<% end %>
+<% title = "Sign in to your account to submit CORE data" %>
 
 <% content_for :title, title %>
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,12 +17,6 @@ Rack::Attack.throttle("password reset requests", limit: 5, period: 60.seconds) d
   end
 end
 
-Rack::Attack.throttle("admin password reset requests", limit: 5, period: 60.seconds) do |request|
-  if request.params["admin_user"].present? && request.path == "/admin/password" && request.post?
-    request.params["admin_user"]["email"].to_s.downcase.gsub(/\s+/, "")
-  end
-end
-
 Rack::Attack.throttled_responder = lambda do |_env|
   headers = {
     "Location" => "/429",

--- a/spec/factories/admin_user.rb
+++ b/spec/factories/admin_user.rb
@@ -1,9 +1,0 @@
-FactoryBot.define do
-  factory :admin_user do
-    sequence(:email) { |i| "admin#{i}@example.com" }
-    password { "pAssword1" }
-    phone { "07563867654" }
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
-  end
-end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -892,7 +892,7 @@ RSpec.describe SalesLog, type: :model do
   end
 
   context "when searching logs" do
-    let!(:sales_log_to_search) { create(:sales_log, purchid: "to search", postcode_full: "ME0 0WW") }
+    let!(:sales_log_to_search) { create(:sales_log, purchid: "to search", postcode_full: "ME0 0WW", id: 4_843_695) }
 
     before do
       create_list(:sales_log, 5, :completed)
@@ -934,8 +934,6 @@ RSpec.describe SalesLog, type: :model do
 
     describe "#search_by" do
       it "allows searching using ID" do
-        sales_log_to_search.id += 30_000
-        sales_log_to_search.save!
         result = described_class.search_by(sales_log_to_search.id.to_s)
         expect(result.count).to eq(1)
         expect(result.first.id).to eq sales_log_to_search.id

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Scheme, type: :model do
     end
 
     describe "scopes" do
-      let!(:scheme_1) { FactoryBot.create(:scheme) }
+      let!(:scheme_1) { FactoryBot.create(:scheme, id: 583_964) }
       let!(:scheme_2) { FactoryBot.create(:scheme) }
       let!(:location) { FactoryBot.create(:location, :export, scheme: scheme_1) }
       let!(:location_2) { FactoryBot.create(:location, scheme: scheme_2, postcode: "NE4 6TR", name: "second location") }


### PR DESCRIPTION
There used to be a concept of admin user in the past, it has been deleted a while ago (https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/611) this PR removes some leftover admin user code