### PR TITLE
CLDC-1718 Update numeric questions to text fields

### DIFF
--- a/app/models/validations/shared_validations.rb
+++ b/app/models/validations/shared_validations.rb
@@ -16,6 +16,16 @@ module Validations::SharedValidations
     end
   end
 
+  def validate_numeric_input(record)
+    record.form.numeric_questions.each do |question|
+      next unless record[question.id] && question.page.routed_to?(record, nil)
+      next if record.send("#{question.id}_before_type_cast").to_s.match?(/\A\d+(\.\d+)?\z/)
+
+      field = question.check_answer_label || question.id
+      record.errors.add question.id.to_sym, I18n.t("validations.numeric.format", field:)
+    end
+  end
+
   def validate_numeric_min_max(record)
     record.form.numeric_questions.each do |question|
       next unless question.min || question.max

--- a/app/views/form/_numeric_question.html.erb
+++ b/app/views/form/_numeric_question.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "form/guidance/#{question.top_guidance_partial}" if question.top_guidance? %>
 
-<%= f.govuk_number_field(
+<%= f.govuk_text_field(
   question.id.to_sym,
   caption: caption(caption_text, page_header, conditional),
   label: legend(question, page_header, conditional),
@@ -13,6 +13,8 @@
   prefix_text: question.prefix.to_s,
   suffix_text: question.suffix_label(@log),
   value: format_money_input(log: @log, question:),
+  inputmode: "numeric",
+  pattern: "\d*\.?\d*",
   **stimulus_html_attributes(question),
 ) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
       nearest_ten: "%{field} must be given to the nearest ten"
       nearest_hundredth: "%{field} must be given to the nearest hundredth"
       normal_format: "Enter a number"
+      format: "%{field} must be a number"
 
     date:
       invalid_date: "Enter a date in the correct format, for example 31 1 2022"

--- a/spec/models/validations/shared_validations_spec.rb
+++ b/spec/models/validations/shared_validations_spec.rb
@@ -240,5 +240,11 @@ RSpec.describe Validations::SharedValidations do
       shared_validator.validate_numeric_input(sales_log)
       expect(sales_log.errors[:income1]).to be_empty
     end
+
+    it "does not allow decimal point in a wrong format" do
+      sales_log.income1 = "300.09.78"
+      shared_validator.validate_numeric_input(sales_log)
+      expect(sales_log.errors[:income1]).to include I18n.t("validations.numeric.format", field: "Buyer 1’s gross annual income")
+    end
   end
 end

--- a/spec/models/validations/shared_validations_spec.rb
+++ b/spec/models/validations/shared_validations_spec.rb
@@ -215,4 +215,30 @@ RSpec.describe Validations::SharedValidations do
       end
     end
   end
+
+  describe "validate numeric question input" do
+    it "does not allow letters" do
+      sales_log.income1 = "abc"
+      shared_validator.validate_numeric_input(sales_log)
+      expect(sales_log.errors[:income1]).to include I18n.t("validations.numeric.format", field: "Buyer 1’s gross annual income")
+    end
+
+    it "does not allow special characters" do
+      sales_log.income1 = "3%5"
+      shared_validator.validate_numeric_input(sales_log)
+      expect(sales_log.errors[:income1]).to include I18n.t("validations.numeric.format", field: "Buyer 1’s gross annual income")
+    end
+
+    it "allows a digit" do
+      sales_log.income1 = "300"
+      shared_validator.validate_numeric_input(sales_log)
+      expect(sales_log.errors[:income1]).to be_empty
+    end
+
+    it "allows a decimal point" do
+      sales_log.income1 = "300.78"
+      shared_validator.validate_numeric_input(sales_log)
+      expect(sales_log.errors[:income1]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Our current implementation for numeric inputs (govuk_number_field) is to use input type="number", there are a few issues with that which are outlined here: https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

In the past we didn't allow any characters other that numbers to be entered into the numeric input field, but there's an issue with it not showing any feedback to the user when a different character is being entered.

Now instead of preventing non numeric characters we validate the input format.