### PR TITLE
CLDC-3596 Fix loading times

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -581,11 +581,19 @@ class LettingsLog < Log
   def non_location_setup_questions_completed?
     form.setup_sections.all? do |section|
       section.subsections.all? do |subsection|
-        relevant_qs = subsection.applicable_questions(self).reject { |q| optional_fields.include?(q.id) || %w[scheme_id location_id].include?(q.id) }
-        relevant_qs.all? do |question|
+        relevant_qs = subsection.questions.reject { |q| optional_fields.include?(q.id) || %w[scheme_id location_id].include?(q.id) }
+        relevant_applicable_qs = select_applicable_questions(self, relevant_qs)
+        relevant_applicable_qs.all? do |question|
           question.completed?(self)
         end
       end
+    end
+  end
+
+  # this is the same as the subsection method, but only for given questions
+  def select_applicable_questions(log, questions)
+    questions.select do |q|
+      (q.displayed_to_user?(log) && !q.derived?(log)) || q.is_derived_or_has_inferred_check_answers_value?(log)
     end
   end
 


### PR DESCRIPTION
The method `non_location_setup_questions_completed?` gets called for every single question (~100?), every time a question is answered.
Within `subsection.applicable_questions` we call `q.displayed_to_user?` which in turn calls `page.routed_to?`.

The routing rules for location questions call the database and count available locations based on startdate. Which I _think_ means we call the database ~100 times every time a question is answered?

As in this method we filter out the `location_id` questions anyways, I've changed the ordering to filter it out before calling applicable questions so it's only called on the relevant questions. 

To give an example, benchmarking this locally `reset_not_routed_questions_and_invalid_answers(log)` ( which gets executed every time a question is answered) went from ~3.5s to ~0.33s