### PR TITLE
CLDC-3595 Remove duplicate errors for check errors page

### DIFF
--- a/app/helpers/form_page_error_helper.rb
+++ b/app/helpers/form_page_error_helper.rb
@@ -5,7 +5,6 @@ module FormPageErrorHelper
   end
 
   def remove_duplicate_page_errors(lettings_log)
-    lettings_log.errors.map(&:message)
     lettings_log.errors.group_by(&:message).each do |_, errors|
       next if errors.size == 1
 

--- a/app/helpers/form_page_error_helper.rb
+++ b/app/helpers/form_page_error_helper.rb
@@ -4,6 +4,16 @@ module FormPageErrorHelper
     other_page_error_ids.each { |id| lettings_log.errors.delete(id) }
   end
 
+  def remove_duplicate_page_errors(lettings_log)
+    lettings_log.errors.map(&:message)
+    lettings_log.errors.group_by(&:message).each do |_, errors|
+      next if errors.size == 1
+
+      errors.shift
+      errors.each { |error| lettings_log.errors.delete(error.attribute) }
+    end
+  end
+
   def all_questions_affected_by_errors(log)
     log.errors.map(&:attribute) - [:base]
   end

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -222,7 +222,7 @@ module Validations::Sales::SaleInformationValidations
                                           value: record.field_formatted_as_currency("value"),
                                           equity: "#{record.equity}%",
                                           mortgage_and_deposit_total: record.field_formatted_as_currency("mortgage_and_deposit_total"),
-                                          expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value"))
+                                          expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
         end
         record.errors.add :type, :skip_bu_error, message: I18n.t("validations.sale_information.non_staircasing_mortgage.mortgage_used",
                                                                  mortgage: record.field_formatted_as_currency("mortgage"),
@@ -230,7 +230,7 @@ module Validations::Sales::SaleInformationValidations
                                                                  value: record.field_formatted_as_currency("value"),
                                                                  equity: "#{record.equity}%",
                                                                  mortgage_and_deposit_total: record.field_formatted_as_currency("mortgage_and_deposit_total"),
-                                                                 expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value"))
+                                                                 expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     elsif record.mortgage_not_used?
       if over_tolerance?(record.deposit, record.expected_shared_ownership_deposit_value, 1)

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -2,6 +2,7 @@
   <div class="govuk-grid-column-three-quarters-from-desktop">
 
     <%= form_with model: @log, url: send("#{@log.model_name.param_key}_confirm_clear_answer_path", @log), method: "post", local: true do |f| %>
+      <% remove_duplicate_page_errors(@log) %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :page_id, value: @page.id %>
 

--- a/spec/helpers/form_page_error_helper_spec.rb
+++ b/spec/helpers/form_page_error_helper_spec.rb
@@ -21,4 +21,22 @@ RSpec.describe FormPageErrorHelper do
       end
     end
   end
+
+  describe "#remove_duplicate_page_errors" do
+    context "when non base other questions are removed" do
+      let!(:lettings_log) { FactoryBot.create(:lettings_log, :in_progress) }
+
+      before do
+        lettings_log.errors.add :layear, "error"
+        lettings_log.errors.add :period, "error_one"
+        lettings_log.errors.add :base, "error_one"
+      end
+
+      it "returns details and user tabs" do
+        remove_duplicate_page_errors(lettings_log)
+        expect(lettings_log.errors.count).to eq(2)
+        expect(lettings_log.errors.map(&:message)).to match_array(%w[error_one error])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Example where all the errors are the same and get deduplicated:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/94120b23-1d8b-4d4d-b9bb-a868290cf1ba">

Example of different errors that would all get shown:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/c67bcbc3-f141-438a-a885-82a5f890d7c6">
