### PR TITLE
CLDC-3569 Update guidance for shared ownership without mortgage

### DIFF
--- a/app/components/bulk_upload_error_row_component.html.erb
+++ b/app/components/bulk_upload_error_row_component.html.erb
@@ -25,7 +25,7 @@
             <% body.with_row do |row| %>
                 <% row.with_cell(text: error.cell) %>
                 <% row.with_cell(text: question_for_field(error.field)) %>
-                <% row.with_cell(text: error.error, html_attributes: { class: "govuk-!-font-weight-bold" }) %>
+                <% row.with_cell(text: error.error.html_safe, html_attributes: { class: "govuk-!-font-weight-bold" }) %>
                 <% row.with_cell(text: error.field.humanize) %>
             <% end %>
           <% end %>
@@ -56,7 +56,7 @@
                   <% row.with_cell(text: error.cell) %>
                   <% row.with_cell(text: question_for_field(error.field)) %>
                   <% if index == 0 %>
-                    <% row.with_cell(text: error_message, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold grouped-multirow-cell" }) %>
+                    <% row.with_cell(text: error_message.html_safe, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold grouped-multirow-cell" }) %>
                   <% end %>
                   <% row.with_cell(text: error.field.humanize) %>
                 <% end %>

--- a/app/models/form/sales/pages/mortgageused.rb
+++ b/app/models/form/sales/pages/mortgageused.rb
@@ -1,6 +1,7 @@
 class Form::Sales::Pages::Mortgageused < ::Form::Page
   def initialize(id, hsh, subsection, ownershipsch:)
     super(id, hsh, subsection)
+    @header = "Mortgage Amount"
     @ownershipsch = ownershipsch
   end
 

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -238,12 +238,12 @@ module Validations::Sales::SaleInformationValidations
           record.errors.add field, I18n.t("validations.sale_information.non_staircasing_mortgage.mortgage_not_used",
                                           deposit: record.field_formatted_as_currency("deposit"),
                                           value: record.field_formatted_as_currency("value"),
-                                          expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value"))
+                                          expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
         end
         record.errors.add :type, :skip_bu_error, message: I18n.t("validations.sale_information.non_staircasing_mortgage.mortgage_not_used",
                                                                  deposit: record.field_formatted_as_currency("deposit"),
                                                                  value: record.field_formatted_as_currency("value"),
-                                                                 expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value"))
+                                                                 expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     end
   end

--- a/app/views/form/guidance/_financial_calculations_shared_ownership.html.erb
+++ b/app/views/form/guidance/_financial_calculations_shared_ownership.html.erb
@@ -1,12 +1,20 @@
 <%= govuk_details(summary_text: "How the financial values are calculated") do %>
   <p class="govuk-body">
-    <% if log.type == 18 %>
-      The mortgage amount <%= question_link("mortgage", log, current_user) %>,
-      cash deposit <%= question_link("deposit", log, current_user) %>,
-      and cash discount <%= question_link("cashdis", log, current_user) %>
-    <% else %>
-      The mortgage amount <%= question_link("mortgage", log, current_user) %>
-      and cash deposit <%= question_link("deposit", log, current_user) %>
+    <% if log.mortgage_used? || log.mortgageused.blank? %>
+      The mortgage amount <%= log.mortgageused.blank? ? question_link("mortgageused", log, current_user) : question_link("mortgage", log, current_user) %>
+      <% if log.type == 18 %>
+        , cash deposit <%= question_link("deposit", log, current_user) %>,
+        and cash discount <%= question_link("cashdis", log, current_user) %>
+      <% else %>
+        and cash deposit <%= question_link("deposit", log, current_user) %>
+      <% end %>
+    <% elsif log.mortgage_not_used? || log.mortgage_use_unknown? %>
+        <% if log.type == 18 %>
+          The cash deposit <%= question_link("deposit", log, current_user) %>,
+          and cash discount <%= question_link("cashdis", log, current_user) %>
+        <% else %>
+          Cash deposit <%= question_link("deposit", log, current_user) %>
+        <% end %>
     <% end %>
     added together must equal
     the purchase price <%= question_link("value", log, current_user) %>

--- a/app/views/form/guidance/_financial_calculations_shared_ownership.html.erb
+++ b/app/views/form/guidance/_financial_calculations_shared_ownership.html.erb
@@ -5,18 +5,21 @@
       <% if log.type == 18 %>
         , cash deposit <%= question_link("deposit", log, current_user) %>,
         and cash discount <%= question_link("cashdis", log, current_user) %>
+        added together
       <% else %>
         and cash deposit <%= question_link("deposit", log, current_user) %>
+        added together
       <% end %>
     <% elsif log.mortgage_not_used? || log.mortgage_use_unknown? %>
         <% if log.type == 18 %>
           The cash deposit <%= question_link("deposit", log, current_user) %>,
           and cash discount <%= question_link("cashdis", log, current_user) %>
+          added together
         <% else %>
           Cash deposit <%= question_link("deposit", log, current_user) %>
         <% end %>
     <% end %>
-    added together must equal
+     must equal
     the purchase price <%= question_link("value", log, current_user) %>
     <% stairbought_page = log.form.get_question("stairbought", log).page %>
     <% if stairbought_page.routed_to?(log, current_user) %>


### PR DESCRIPTION
- Mortgage amount question is not routed to when mortgage used is "no", in this case in the guidance we would link to mortgage used question instead of mortgage amount.
- We want to format BU errors when there's html in the error message
- This also adds a header to the mortgage used question, to align it with other questions that have top guidance (because the guidance content is placed below the header)