### PR TITLE
CLDC-2588++update soft validation errors in bulk upload

### DIFF
--- a/app/components/bulk_upload_error_row_component.html.erb
+++ b/app/components/bulk_upload_error_row_component.html.erb
@@ -24,8 +24,8 @@
           <% critical_errors.each do |error| %>
             <% body.with_row do |row| %>
                 <% row.with_cell(text: error.cell) %>
-                <% row.with_cell(text: question_for_field(error.field)) %>
-                <% row.with_cell(text: error.error, html_attributes: { class: "govuk-!-font-weight-bold" }) %>
+                <% row.with_cell(text: question_for_field(error.field), html_attributes: { class: "govuk-!-width-one-half" }) %>
+                <% row.with_cell(text: error.error, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half" }) %>
                 <% row.with_cell(text: error.field.humanize) %>
             <% end %>
           <% end %>
@@ -54,9 +54,9 @@
                 <% row_class += " last-row" if index == errors.size - 1 %>
                 <% body.with_row(html_attributes: { class: row_class }) do |row| %>
                   <% row.with_cell(text: error.cell) %>
-                  <% row.with_cell(text: question_for_field(error.field)) %>
+                  <% row.with_cell(text: question_for_field(error.field), html_attributes: { class: "govuk-!-width-one-half" }) %>
                   <% if index == 0 %>
-                    <% row.with_cell(text: error_message, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold grouped-multirow-cell" }) %>
+                    <% row.with_cell(text: error_message, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half grouped-multirow-cell" }) %>
                   <% end %>
                   <% row.with_cell(text: error.field.humanize) %>
                 <% end %>

--- a/app/components/bulk_upload_error_row_component.html.erb
+++ b/app/components/bulk_upload_error_row_component.html.erb
@@ -25,7 +25,7 @@
             <% body.with_row do |row| %>
                 <% row.with_cell(text: error.cell) %>
                 <% row.with_cell(text: question_for_field(error.field), html_attributes: { class: "govuk-!-width-one-half" }) %>
-                <% row.with_cell(text: error.error, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half" }) %>
+                <% row.with_cell(text: error.error.html_safe, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half" }) %>
                 <% row.with_cell(text: error.field.humanize) %>
             <% end %>
           <% end %>
@@ -56,7 +56,7 @@
                   <% row.with_cell(text: error.cell) %>
                   <% row.with_cell(text: question_for_field(error.field), html_attributes: { class: "govuk-!-width-one-half" }) %>
                   <% if index == 0 %>
-                    <% row.with_cell(text: error_message, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half grouped-multirow-cell" }) %>
+                    <% row.with_cell(text: error_message.html_safe, rowspan: errors.size, html_attributes: { class: "govuk-!-font-weight-bold govuk-!-width-one-half grouped-multirow-cell" }) %>
                   <% end %>
                   <% row.with_cell(text: error.field.humanize) %>
                 <% end %>

--- a/app/components/bulk_upload_error_summary_table_component.html.erb
+++ b/app/components/bulk_upload_error_summary_table_component.html.erb
@@ -12,7 +12,7 @@
 
       <%= table.with_body do |body| %>
         <% body.with_row do |row| %>
-          <% row.with_cell(text: error[0][2]) %>
+          <% row.with_cell(text: error[0][2].html_safe) %>
           <% row.with_cell(text: pluralize(error[1], "error"), numeric: true) %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Additional changes to this previous ticket to improve the styling.

There are two tables on the full error report of the bulk uploads. Within the original designs the question and error columns are the same width and the same on both tables (critical and potential). This PR aims to achieve the correct styling.

Before:
![BUSoftBefore](https://github.com/user-attachments/assets/53488460-8e4f-4c7f-8841-f6b9b30509f9)


After:
![BUSoftAfter](https://github.com/user-attachments/assets/598cd28b-23a7-4eb1-a858-537c2213b9a2)
