### PR TITLE
CLDC-3600 Clear unconfirmed emails for deactivated users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,6 +142,7 @@ class User < ApplicationRecord
       sign_in_count: 0,
       initial_confirmation_sent: false,
       reactivate_with_organisation:,
+      unconfirmed_email: nil,
     )
   end
 

--- a/lib/tasks/clear_unconfirmed_emails.rake
+++ b/lib/tasks/clear_unconfirmed_emails.rake
@@ -1,0 +1,4 @@
+desc "Clear unconfimed emails for deactivated users"
+task clear_unconfirmed_emails: :environment do
+  User.deactivated.where.not(unconfirmed_email: nil).update(unconfirmed_email: nil)
+end

--- a/spec/lib/tasks/clear_unconfirmed_emails_spec.rb
+++ b/spec/lib/tasks/clear_unconfirmed_emails_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "clear_unconfirmed_emails" do
+  describe ":clear_unconfirmed_emails", type: :task do
+    subject(:task) { Rake::Task["clear_unconfirmed_emails"] }
+
+    before do
+      Rake.application.rake_require("tasks/clear_unconfirmed_emails")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      context "and there are deactivated users with unconfirmed emails" do
+        let!(:user) { create(:user, active: false, unconfirmed_email: "some_email@example.com") }
+
+        it "clears unconfirmed_email" do
+          task.invoke
+
+          expect(user.reload.unconfirmed_email).to eq(nil)
+        end
+      end
+
+      context "and there are active users with unconfirmed emails" do
+        let!(:user) { create(:user, active: true, unconfirmed_email: "some_email@example.com") }
+
+        it "does not clear unconfirmed_email" do
+          task.invoke
+
+          expect(user.reload.unconfirmed_email).not_to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe UsersController, type: :request do
 
   context "when user is signed in as a data coordinator" do
     let(:user) { create(:user, :data_coordinator, email: "coordinator@example.com", organisation: create(:organisation, :without_dpc)) }
-    let!(:other_user) { create(:user, organisation: user.organisation, name: "filter name", email: "filter@example.com") }
+    let!(:other_user) { create(:user, organisation: user.organisation, name: "filter name", email: "filter@example.com", unconfirmed_email: "email@something.com") }
 
     before do
       sign_in user
@@ -884,6 +884,11 @@ RSpec.describe UsersController, type: :request do
               it "marks user as deactivated" do
                 expect { patch "/users/#{other_user.id}", headers:, params: }
                   .to change { other_user.reload.active }.from(true).to(false)
+              end
+
+              it "discards unconfirmed email" do
+                expect { patch "/users/#{other_user.id}", headers:, params: }
+                  .to change { other_user.reload.unconfirmed_email }.from("email@something.com").to(nil)
               end
             end
 


### PR DESCRIPTION
There’s a very fun scenario happening with user accounts! If we:
1. Change user email for a confirmed user (and they don’t confirm this change)
2. Deactivate user - We now have an unconfirmed account, with an unconfirmed email address. 
3. Reactivate user

Upon reactivation user gets: 
- Someone changed your email - to the old email address
- The email address for your core account has been changed, confirm it - to the new email address

So at this stage, the only way to confirm the account is from the new email, even if we didn’t want to change the email to begin with.
This would then confirm the email address change which might have been accidental.

I suggest we dismiss any unconfirmed email changes when we deactivate the user.
