### PR TITLE
CLDC-3404 Allow support to update user organisation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -153,6 +153,16 @@ class UsersController < ApplicationController
     redirect_to users_organisation_path(@user.organisation), notice: I18n.t("notification.user_deleted", name: @user.name)
   end
 
+  def log_reassignment
+    authorize @user
+
+    if params[:organisation_id].present? && Organisation.where(id: params[:organisation_id]).exists?
+      @new_organisation = Organisation.find(params[:organisation_id])
+    else
+      redirect_to user_path(@user)
+    end
+  end
+
 private
 
   def validate_attributes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -155,7 +155,7 @@ class UsersController < ApplicationController
 
   def log_reassignment
     authorize @user
-    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.visible.count + @user.assigned_to_sales_logs.visible.count
     return redirect_to user_organisation_change_confirmation_path(@user, organisation_id: params[:organisation_id]) if assigned_to_logs_count.zero?
 
     if params[:organisation_id].present? && Organisation.where(id: params[:organisation_id]).exists?
@@ -182,7 +182,7 @@ class UsersController < ApplicationController
 
   def organisation_change_confirmation
     authorize @user
-    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.visible.count + @user.assigned_to_sales_logs.visible.count
 
     return redirect_to user_path(@user) if params[:organisation_id].blank? || !Organisation.where(id: params[:organisation_id]).exists?
     return redirect_to user_path(@user) if params[:log_reassignment].blank? && assigned_to_logs_count.positive?
@@ -193,7 +193,7 @@ class UsersController < ApplicationController
 
   def confirm_organisation_change
     authorize @user
-    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.visible.count + @user.assigned_to_sales_logs.visible.count
 
     return redirect_to user_path(@user) if log_reassignment_params[:organisation_id].blank? || !Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
     return redirect_to user_path(@user) if log_reassignment_params[:log_reassignment].blank? && assigned_to_logs_count.positive?
@@ -319,7 +319,7 @@ private
 
     case log_reassignment_params[:log_reassignment]
     when "reassign_stock_owner"
-      required_managing_agents = (@user.assigned_to_lettings_logs.map(&:managing_organisation) + @user.assigned_to_sales_logs.map(&:managing_organisation)).uniq
+      required_managing_agents = (@user.assigned_to_lettings_logs.visible.map(&:managing_organisation) + @user.assigned_to_sales_logs.visible.map(&:managing_organisation)).uniq
       current_managing_agents = @new_organisation.managing_agents
       missing_managing_agents = required_managing_agents - current_managing_agents
 
@@ -329,7 +329,7 @@ private
         @user.errors.add :log_reassignment, I18n.t("activerecord.errors.models.user.attributes.log_reassignment.missing_managing_agents", new_organisation:, missing_managing_agents:)
       end
     when "reassign_managing_agent"
-      required_stock_owners = (@user.assigned_to_lettings_logs.map(&:owning_organisation) + @user.assigned_to_sales_logs.map(&:owning_organisation)).uniq
+      required_stock_owners = (@user.assigned_to_lettings_logs.visible.map(&:owning_organisation) + @user.assigned_to_sales_logs.visible.map(&:owning_organisation)).uniq
       current_stock_owners = @new_organisation.stock_owners
       missing_stock_owners = required_stock_owners - current_stock_owners
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -155,6 +155,8 @@ class UsersController < ApplicationController
 
   def log_reassignment
     authorize @user
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+    return redirect_to user_organisation_change_confirmation_path(@user, organisation_id: params[:organisation_id]) if assigned_to_logs_count.zero?
 
     if params[:organisation_id].present? && Organisation.where(id: params[:organisation_id]).exists?
       @new_organisation = Organisation.find(params[:organisation_id])
@@ -164,6 +166,7 @@ class UsersController < ApplicationController
   end
 
   def update_log_reassignment
+    authorize @user
     return redirect_to user_path(@user) unless log_reassignment_params[:organisation_id].present? && Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
 
     @new_organisation = Organisation.find(log_reassignment_params[:organisation_id])
@@ -178,6 +181,7 @@ class UsersController < ApplicationController
   end
 
   def organisation_change_confirmation
+    authorize @user
     if params[:organisation_id].blank? || params[:log_reassignment].blank? || !Organisation.where(id: params[:organisation_id]).exists?
       return redirect_to user_path(@user)
     end
@@ -187,6 +191,7 @@ class UsersController < ApplicationController
   end
 
   def confirm_organisation_change
+    authorize @user
     if log_reassignment_params[:organisation_id].blank? || log_reassignment_params[:log_reassignment].blank? || !Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
       return redirect_to user_path(@user)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,7 +65,7 @@ class UsersController < ApplicationController
       if @user == current_user
         bypass_sign_in @user
         flash[:notice] = I18n.t("devise.passwords.updated") if user_params.key?("password")
-        if user_params.key?("email")
+        if user_params.key?("email") && user_params[:email] != @user.email
           flash[:notice] = I18n.t("devise.email.updated", email: @user.unconfirmed_email)
         end
 
@@ -83,7 +83,7 @@ class UsersController < ApplicationController
           @user.reactivate!
           @user.send_confirmation_instructions
           flash[:notice] = I18n.t("devise.activation.reactivated", user_name:)
-        elsif user_params.key?("email")
+        elsif user_params.key?("email") && user_params[:email] != @user.email
           flash[:notice] = I18n.t("devise.email.updated", email: @user.unconfirmed_email)
         end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -171,10 +171,19 @@ class UsersController < ApplicationController
     validate_log_reassignment
 
     if @user.errors.empty?
-      redirect_to user_confirm_organisation_change_path(@user, log_reassignment_params)
+      redirect_to user_organisation_change_confirmation_path(@user, log_reassignment_params)
     else
       render :log_reassignment, status: :unprocessable_entity
     end
+  end
+
+  def organisation_change_confirmation
+    if params[:organisation_id].blank? || params[:log_reassignment].blank? || !Organisation.where(id: params[:organisation_id]).exists?
+      return redirect_to user_path(@user)
+    end
+
+    @new_organisation = Organisation.find(params[:organisation_id])
+    @log_reassignment = params[:log_reassignment]
   end
 
 private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
   def key_contact; end
 
   def edit
-    redirect_to user_path(@user) unless @user.active?
+    redirect_to user_path(@user) unless @user.active? || current_user.support?
   end
 
   def update
@@ -182,9 +182,10 @@ class UsersController < ApplicationController
 
   def organisation_change_confirmation
     authorize @user
-    if params[:organisation_id].blank? || params[:log_reassignment].blank? || !Organisation.where(id: params[:organisation_id]).exists?
-      return redirect_to user_path(@user)
-    end
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+
+    return redirect_to user_path(@user) if params[:organisation_id].blank? || !Organisation.where(id: params[:organisation_id]).exists?
+    return redirect_to user_path(@user) if params[:log_reassignment].blank? && assigned_to_logs_count.positive?
 
     @new_organisation = Organisation.find(params[:organisation_id])
     @log_reassignment = params[:log_reassignment]
@@ -192,9 +193,10 @@ class UsersController < ApplicationController
 
   def confirm_organisation_change
     authorize @user
-    if log_reassignment_params[:organisation_id].blank? || log_reassignment_params[:log_reassignment].blank? || !Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
-      return redirect_to user_path(@user)
-    end
+    assigned_to_logs_count = @user.assigned_to_lettings_logs.count + @user.assigned_to_sales_logs.count
+
+    return redirect_to user_path(@user) if log_reassignment_params[:organisation_id].blank? || !Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
+    return redirect_to user_path(@user) if log_reassignment_params[:log_reassignment].blank? && assigned_to_logs_count.positive?
 
     @new_organisation = Organisation.find(log_reassignment_params[:organisation_id])
     @log_reassignment = log_reassignment_params[:log_reassignment]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -186,6 +186,18 @@ class UsersController < ApplicationController
     @log_reassignment = params[:log_reassignment]
   end
 
+  def confirm_organisation_change
+    if log_reassignment_params[:organisation_id].blank? || log_reassignment_params[:log_reassignment].blank? || !Organisation.where(id: log_reassignment_params[:organisation_id]).exists?
+      return redirect_to user_path(@user)
+    end
+
+    @new_organisation = Organisation.find(log_reassignment_params[:organisation_id])
+    @log_reassignment = log_reassignment_params[:log_reassignment]
+    @user.reassign_logs_and_update_organisation(@new_organisation, @log_reassignment)
+
+    redirect_to user_path(@user)
+  end
+
 private
 
   def validate_attributes
@@ -201,7 +213,7 @@ private
     end
 
     if user_params.key?(:organisation_id) && user_params[:organisation_id].blank?
-      @user.errors.add :organisation, :blank
+      @user.errors.add :organisation_id, :blank
     end
   end
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -21,4 +21,24 @@ module UserHelper
 
     "You’re moving #{user.name} from #{user.organisation.name} to #{new_organisation.name}. There #{logs_count_text} assigned to them."
   end
+
+  def organisation_change_confirmation_warning(user, new_organisation, log_reassignment)
+    log_reassignment_text = "There are no logs assigned to them."
+
+    logs_count = user.assigned_to_lettings_logs.count + user.assigned_to_sales_logs.count
+    if logs_count.positive?
+      case log_reassignment
+      when "reassign_all"
+        log_reassignment_text = "The stock owner and managing agent on their logs will change to #{new_organisation.name}."
+      when "reassign_stock_owner"
+        log_reassignment_text = "The stock owner on their logs will change to #{new_organisation.name}."
+      when "reassign_managing_agent"
+        log_reassignment_text = "The managing agent on their logs will change to #{new_organisation.name}."
+      when "unassign"
+        log_reassignment_text = "Their logs will be unassigned."
+      end
+    end
+
+    "You’re moving #{user.name} from #{user.organisation.name} to #{new_organisation.name}. #{log_reassignment_text}"
+  end
 end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -41,4 +41,19 @@ module UserHelper
 
     "You’re moving #{user.name} from #{user.organisation.name} to #{new_organisation.name}. #{log_reassignment_text}"
   end
+
+  def remove_attributes_from_error_messages(user)
+    modified_errors = []
+
+    user.errors.each do |error|
+      cleaned_message = error.type.gsub(error.attribute.to_s.humanize, "").strip
+      modified_errors << [error.attribute, cleaned_message]
+    end
+
+    user.errors.clear
+
+    modified_errors.each do |attribute, message|
+      user.errors.add(attribute, message)
+    end
+  end
 end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -14,4 +14,11 @@ module UserHelper
   def delete_user_link(user)
     govuk_button_link_to "Delete this user", delete_confirmation_user_path(user), warning: true
   end
+
+  def organisation_change_warning(user, new_organisation)
+    logs_count = user.assigned_to_lettings_logs.count + user.assigned_to_sales_logs.count
+    logs_count_text = logs_count == 1 ? "is #{logs_count} log" : "are #{logs_count} logs"
+
+    "You’re moving #{user.name} from #{user.organisation.name} to #{new_organisation.name}. There #{logs_count_text} assigned to them."
+  end
 end

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -101,6 +101,10 @@ class BulkUpload < ApplicationRecord
     logs.filter_by_status("in_progress").map(&:missing_answers_count).sum(0)
   end
 
+  def moved_user_name
+    User.find_by(id: moved_user_id)&.name
+  end
+
 private
 
   def generate_identifier

--- a/app/models/forms/bulk_upload_lettings_resume/fix_choice.rb
+++ b/app/models/forms/bulk_upload_lettings_resume/fix_choice.rb
@@ -56,7 +56,7 @@ module Forms
       end
 
       def preflight_valid?
-        bulk_upload.choice != "create-fix-inline" && bulk_upload.choice != "bulk-confirm-soft-validations"
+        bulk_upload.choice.blank?
       end
 
       def preflight_redirect
@@ -65,6 +65,8 @@ module Forms
           page_bulk_upload_lettings_resume_path(bulk_upload, :chosen)
         when "bulk-confirm-soft-validations"
           page_bulk_upload_lettings_soft_validations_check_path(bulk_upload, :chosen)
+        else
+          bulk_upload_lettings_result_path(bulk_upload)
         end
       end
     end

--- a/app/models/forms/bulk_upload_sales_resume/fix_choice.rb
+++ b/app/models/forms/bulk_upload_sales_resume/fix_choice.rb
@@ -56,7 +56,7 @@ module Forms
       end
 
       def preflight_valid?
-        bulk_upload.choice != "create-fix-inline" && bulk_upload.choice != "bulk-confirm-soft-validations"
+        bulk_upload.choice.blank?
       end
 
       def preflight_redirect
@@ -65,6 +65,8 @@ module Forms
           page_bulk_upload_sales_resume_path(bulk_upload, :chosen)
         when "bulk-confirm-soft-validations"
           page_bulk_upload_sales_soft_validations_check_path(bulk_upload, :chosen)
+        else
+          bulk_upload_sales_result_path(bulk_upload)
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,8 +292,8 @@ class User < ApplicationRecord
     return unless new_organisation
 
     ActiveRecord::Base.transaction do
-      lettings_logs_to_reassign = assigned_to_lettings_logs
-      sales_logs_to_reassign = assigned_to_sales_logs
+      lettings_logs_to_reassign = assigned_to_lettings_logs.visible
+      sales_logs_to_reassign = assigned_to_sales_logs.visible
       current_organisation = organisation
 
       logs_count = lettings_logs_to_reassign.count + sales_logs_to_reassign.count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,13 @@ class User < ApplicationRecord
     support: 99,
   }.freeze
 
+  LOG_REASSIGNMENT = {
+    reassign_all: "Yes, change the stock owner and the managing agent",
+    reassign_stock_owner: "Yes, change the stock owner but keep the managing agent the same",
+    reassign_managing_agent: "Yes, change the managing agent but keep the stock owner the same",
+    unassign: "No, unassign the logs",
+  }.freeze
+
   enum role: ROLES
 
   scope :search_by_name, ->(name) { where("users.name ILIKE ?", "%#{name}%") }
@@ -79,6 +86,8 @@ class User < ApplicationRecord
   scope :active_status, -> { where(active: true).where.not(last_sign_in_at: nil) }
   scope :visible, -> { where(discarded_at: nil) }
   scope :own_and_managing_org_users, ->(organisation) { where(organisation: organisation.child_organisations + [organisation]) }
+
+  attr_accessor :log_reassignment
 
   def lettings_logs
     if support?
@@ -268,6 +277,14 @@ class User < ApplicationRecord
     return phone if phone_extension.blank?
 
     "#{phone}, Ext. #{phone_extension}"
+  end
+
+  def assigned_to_lettings_logs
+    lettings_logs.where(assigned_to: self)
+  end
+
+  def assigned_to_sales_logs
+    sales_logs.where(assigned_to: self)
   end
 
 protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -383,15 +383,17 @@ private
 
   def send_organisation_change_email(current_organisation, new_organisation, log_reassignment, logs_count)
     reassigned_logs_text = ""
+    assigned_logs_count = logs_count == 1 ? "is 1 log" : "are #{logs_count} logs"
+
     case log_reassignment
     when "reassign_all"
-      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The stock owner and managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There #{assigned_logs_count} assigned to you. The stock owner and managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "reassign_stock_owner"
-      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The stock owner on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There #{assigned_logs_count} assigned to you. The stock owner on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "reassign_managing_agent"
-      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There #{assigned_logs_count} assigned to you. The managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "unassign"
-      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. #{logs_count == 1 ? 'This' : 'These'} have now been unassigned."
+      reassigned_logs_text = "There #{assigned_logs_count} assigned to you. #{logs_count == 1 ? 'This' : 'These'} have now been unassigned."
     end
 
     template_id = ORGANISATION_UPDATE_TEMPLATE_ID

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -295,6 +295,9 @@ class User < ApplicationRecord
       sales_logs_to_reassign = assigned_to_sales_logs
       current_organisation = organisation
 
+      logs_count = lettings_logs_to_reassign.count + sales_logs_to_reassign.count
+      return if logs_count.positive? && (log_reassignment.blank? || !LOG_REASSIGNMENT.key?(log_reassignment.to_sym))
+
       update!(organisation: new_organisation)
 
       case log_reassignment

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -384,13 +384,13 @@ private
     reassigned_logs_text = ""
     case log_reassignment
     when "reassign_all"
-      reassigned_logs_text = "There are #{logs_count} logs assigned to you. The stock owner and managing agent on these logs has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The stock owner and managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "reassign_stock_owner"
-      reassigned_logs_text = "There are #{logs_count} logs assigned to you. The stock owner on these logs has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The stock owner on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "reassign_managing_agent"
-      reassigned_logs_text = "There are #{logs_count} logs assigned to you. The managing agent on these logs has been changed from #{current_organisation.name} to #{new_organisation.name}."
+      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. The managing agent on #{logs_count == 1 ? 'this log' : 'these logs'} has been changed from #{current_organisation.name} to #{new_organisation.name}."
     when "unassign"
-      reassigned_logs_text = "There are #{logs_count} logs assigned to you. These have now been unassigned."
+      reassigned_logs_text = "There are #{logs_count} #{'log'.pluralize(logs_count)} assigned to you. #{logs_count == 1 ? 'This' : 'These'} have now been unassigned."
     end
 
     template_id = ORGANISATION_UPDATE_TEMPLATE_ID

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,7 +313,7 @@ class User < ApplicationRecord
       end
 
       send_organisation_change_email(current_organisation, new_organisation, log_reassignment, logs_count)
-    rescue ActiveRecord::RecordInvalid => e
+    rescue StandardError => e
       Rails.logger.error("User update failed with: #{e.message}")
       Sentry.capture_exception(e)
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,17 +10,15 @@ class UserPolicy
     @current_user == @user
   end
 
-  def edit_roles?
-    (@current_user.data_coordinator? || @current_user.support?) && @user.active?
-  end
-
   %w[
     edit_roles?
     edit_dpo?
     edit_key_contact?
   ].each do |method_name|
     define_method method_name do
-      (@current_user.data_coordinator? || @current_user.support?) && @user.active?
+      return true if @current_user.support?
+
+      @current_user.data_coordinator? && @user.active?
     end
   end
 
@@ -30,7 +28,9 @@ class UserPolicy
     edit_names?
   ].each do |method_name|
     define_method method_name do
-      (@current_user == @user || @current_user.data_coordinator? || @current_user.support?) && @user.active?
+      return true if @current_user.support?
+
+      (@current_user == @user || @current_user.data_coordinator?) && @user.active?
     end
   end
 
@@ -53,7 +53,7 @@ class UserPolicy
     confirm_organisation_change?
   ].each do |method_name|
     define_method method_name do
-      @current_user.support? && @user.active?
+      @current_user.support?
     end
   end
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -49,6 +49,10 @@ class UserPolicy
     @current_user.support? && @user.active?
   end
 
+  def log_reassignment?
+    edit_organisation?
+  end
+
 private
 
   def has_any_logs_in_editable_collection_period

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -45,6 +45,10 @@ class UserPolicy
     !has_any_logs_in_editable_collection_period && !has_signed_data_protection_agreement?
   end
 
+  def edit_organisation?
+    @current_user.support? && @user.active?
+  end
+
 private
 
   def has_any_logs_in_editable_collection_period

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -45,12 +45,16 @@ class UserPolicy
     !has_any_logs_in_editable_collection_period && !has_signed_data_protection_agreement?
   end
 
-  def edit_organisation?
-    @current_user.support? && @user.active?
-  end
-
-  def log_reassignment?
+  %w[
     edit_organisation?
+    log_reassignment?
+    update_log_reassignment?
+    organisation_change_confirmation?
+    confirm_organisation_change?
+  ].each do |method_name|
+    define_method method_name do
+      @current_user.support? && @user.active?
+    end
   end
 
 private

--- a/app/views/bulk_upload_lettings_results/show.html.erb
+++ b/app/views/bulk_upload_lettings_results/show.html.erb
@@ -2,6 +2,8 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
+<%= render partial: "bulk_upload_shared/moved_user_banner" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>

--- a/app/views/bulk_upload_lettings_results/summary.html.erb
+++ b/app/views/bulk_upload_lettings_results/summary.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "bulk_upload_shared/moved_user_banner" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for lettings (<%= @bulk_upload.year_combo %>)</span>

--- a/app/views/bulk_upload_sales_results/show.html.erb
+++ b/app/views/bulk_upload_sales_results/show.html.erb
@@ -2,6 +2,8 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
+<%= render partial: "bulk_upload_shared/moved_user_banner" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk Upload for sales (<%= @bulk_upload.year_combo %>)</span>

--- a/app/views/bulk_upload_sales_results/summary.html.erb
+++ b/app/views/bulk_upload_sales_results/summary.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "bulk_upload_shared/moved_user_banner" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Bulk upload for sales (<%= @bulk_upload.year_combo %>)</span>

--- a/app/views/bulk_upload_shared/_moved_user_banner.html.erb
+++ b/app/views/bulk_upload_shared/_moved_user_banner.html.erb
@@ -1,0 +1,12 @@
+<% if @bulk_upload.choice == "cancelled-by-moved-user" %>
+  <%= govuk_notification_banner(title_text: "Important") do %>
+    <p class="govuk-notification-banner__heading govuk-!-width-full" style="max-width: fit-content">
+      This error report is out of date.
+    <p>
+    <% if current_user.id == @bulk_upload.moved_user_id %>
+      You moved to a different organisation since this file was uploaded. Reupload the file to get an accurate error report.
+    <% else %>
+      Some logs in this upload are assigned to <%= @bulk_upload.moved_user_name %>, who has moved to a different organisation since this file was uploaded. Reupload the file to get an accurate error report.
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,6 +7,7 @@
 <%= form_for(@user, as: :user, html: { method: :patch }) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <% remove_attributes_from_error_messages(@user) %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -42,6 +42,24 @@
           legend: { text: "Role", size: "m" } %>
       <% end %>
 
+      <% if UserPolicy.new(current_user, @user).edit_organisation? %>
+        <% null_option = [OpenStruct.new(id: "", name: "Select an option")] %>
+        <% organisations = Organisation.filter_by_active.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
+        <% answer_options = null_option + organisations %>
+
+          <%= f.govuk_select(:organisation_id,
+            label: { text: "Organisation", size: "m" },
+            "data-controller": "accessible-autocomplete") do %>
+              <% answer_options.each do |answer| %>
+                <option value="<%= answer.id %>"
+                  data-synonyms="<%= answer_option_synonyms(answer.resource) %>"
+                  data-append="<%= answer_option_append(answer.resource) %>"
+                  data-hint="<%= answer_option_hint(answer.resource) %>"
+                  <%= @user.organisation_id == answer.id ? "selected" : "" %>><%= answer.name || answer.resource %></option>
+              <% end %>
+          <% end %>
+        <% end %>
+
       <%= f.govuk_submit "Save changes" %>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -32,6 +32,24 @@
         autocomplete: "tel-extension",
         spellcheck: "false" %>
 
+      <% if UserPolicy.new(current_user, @user).edit_organisation? %>
+        <% null_option = [OpenStruct.new(id: "", name: "Select an option")] %>
+        <% organisations = Organisation.filter_by_active.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
+        <% answer_options = null_option + organisations %>
+
+        <%= f.govuk_select(:organisation_id,
+          label: { text: "Organisation", size: "m" },
+          "data-controller": "accessible-autocomplete") do %>
+            <% answer_options.each do |answer| %>
+              <option value="<%= answer.id %>"
+                data-synonyms="<%= answer_option_synonyms(answer.resource) %>"
+                data-append="<%= answer_option_append(answer.resource) %>"
+                data-hint="<%= answer_option_hint(answer.resource) %>"
+                <%= @user.organisation_id == answer.id ? "selected" : "" %>><%= answer.name || answer.resource %></option>
+            <% end %>
+        <% end %>
+      <% end %>
+
       <% if current_user.data_coordinator? || current_user.support? %>
         <% roles = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize) } %>
 
@@ -41,24 +59,6 @@
           :name,
           legend: { text: "Role", size: "m" } %>
       <% end %>
-
-      <% if UserPolicy.new(current_user, @user).edit_organisation? %>
-        <% null_option = [OpenStruct.new(id: "", name: "Select an option")] %>
-        <% organisations = Organisation.filter_by_active.map { |org| OpenStruct.new(id: org.id, name: org.name) } %>
-        <% answer_options = null_option + organisations %>
-
-          <%= f.govuk_select(:organisation_id,
-            label: { text: "Organisation", size: "m" },
-            "data-controller": "accessible-autocomplete") do %>
-              <% answer_options.each do |answer| %>
-                <option value="<%= answer.id %>"
-                  data-synonyms="<%= answer_option_synonyms(answer.resource) %>"
-                  data-append="<%= answer_option_append(answer.resource) %>"
-                  data-hint="<%= answer_option_hint(answer.resource) %>"
-                  <%= @user.organisation_id == answer.id ? "selected" : "" %>><%= answer.name || answer.resource %></option>
-              <% end %>
-          <% end %>
-        <% end %>
 
       <%= f.govuk_submit "Save changes" %>
     </div>

--- a/app/views/users/log_reassignment.html.erb
+++ b/app/views/users/log_reassignment.html.erb
@@ -4,7 +4,7 @@
   <%= govuk_back_link(href: aliased_user_edit(@user, current_user)) %>
 <% end %>
 
-<%= form_for(@user, html: { method: :patch }) do |f| %>
+<%= form_with model: @user, method: :patch, url: user_log_reassignment_path(@user) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
@@ -24,6 +24,8 @@
         :id,
         :name,
         legend: { text: "Log reassignment", hidden: true } %>
+
+      <%= f.hidden_field :organisation_id, value: @new_organisation.id %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit "Continue" %>

--- a/app/views/users/log_reassignment.html.erb
+++ b/app/views/users/log_reassignment.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, "Should this user’s logs move to their new organisation?" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link(href: aliased_user_edit(@user, current_user)) %>
+<% end %>
+
+<%= form_for(@user, html: { method: :patch }) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= content_for(:title) %>
+      </h1>
+
+      <%= govuk_warning_text do %>
+        <%= organisation_change_warning(@user, @new_organisation) %>
+      <% end %>
+
+      <% log_reassignment = User::LOG_REASSIGNMENT.map { |key, value| OpenStruct.new(id: key, name: value) } %>
+
+      <%= f.govuk_collection_radio_buttons :log_reassignment,
+        log_reassignment,
+        :id,
+        :name,
+        legend: { text: "Log reassignment", hidden: true } %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Continue" %>
+        <%= govuk_button_link_to "Cancel", aliased_user_edit(@user, current_user), secondary: true %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/organisation_change_confirmation.html.erb
+++ b/app/views/users/organisation_change_confirmation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content do %>
+  <% content_for :title, "Are you sure you want to move this user?" %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-xl">
+      <%= content_for(:title) %>
+    </h1>
+
+    <%= govuk_warning_text(text: organisation_change_confirmation_warning(@user, @new_organisation, @log_reassignment)) %>
+
+    <%= form_with model: @user, url: user_organisation_change_confirmation_path(@user), method: :patch do |f| %>
+      <%= f.hidden_field :organisation_id, value: @new_organisation.id %>
+      <%= f.hidden_field :log_reassignment, value: @log_reassignment %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Move this user" %>
+        <%= govuk_button_link_to "Cancel", user_log_reassignment_path(@user, organisation_id: @new_organisation.id, log_reassignment: @log_reassignment), secondary: true %>
+      </div>
+      <% end %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -68,7 +68,15 @@
       <%= summary_list.with_row do |row|
             row.with_key { "Organisation" }
             row.with_value { current_user.support? ? govuk_link_to(@user.organisation.name, lettings_logs_organisation_path(@user.organisation)) : @user.organisation.name }
-            row.with_action
+            if UserPolicy.new(current_user, @user).edit_organisation?
+              row.with_action(
+                visually_hidden_text: "organisation",
+                href: aliased_user_edit(@user, current_user),
+                html_attributes: { "data-qa": "change-organisation" },
+              )
+            else
+              row.with_action
+            end
           end %>
 
       <%= summary_list.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,6 +172,10 @@ en:
               too_short: The password you entered is too short. Enter a password that is %{count} characters or longer.
             reset_password_token:
               invalid: "That link is invalid. Check you are using the correct link."
+            log_reassignment:
+              blank: "Select if you want to reassign logs"
+              missing_managing_agents: "%{new_organisation} must be a stock owner of %{missing_managing_agents} to make this change."
+              missing_stock_owners: "%{new_organisation} must be a managing agent of %{missing_stock_owners} to make this change."
         merge_request:
           attributes:
             absorbing_organisation_id:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,8 @@ Rails.application.routes.draw do
     get "edit-dpo", to: "users#dpo"
     get "edit-key-contact", to: "users#key_contact"
     get "log-reassignment", to: "users#log_reassignment"
+    patch "log-reassignment", to: "users#update_log_reassignment"
+    patch "confirm-organisation-change", to: "users#confirm-organisation-change"
 
     collection do
       get :search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
     get "edit-key-contact", to: "users#key_contact"
     get "log-reassignment", to: "users#log_reassignment"
     patch "log-reassignment", to: "users#update_log_reassignment"
-    patch "confirm-organisation-change", to: "users#confirm-organisation-change"
+    get "organisation-change-confirmation", to: "users#organisation_change_confirmation"
 
     collection do
       get :search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
   resources :users do
     get "edit-dpo", to: "users#dpo"
     get "edit-key-contact", to: "users#key_contact"
+    get "log-reassignment", to: "users#log_reassignment"
 
     collection do
       get :search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
     get "log-reassignment", to: "users#log_reassignment"
     patch "log-reassignment", to: "users#update_log_reassignment"
     get "organisation-change-confirmation", to: "users#organisation_change_confirmation"
+    patch "organisation-change-confirmation", to: "users#confirm_organisation_change"
 
     collection do
       get :search

--- a/db/migrate/20240911152702_add_moved_user_to_bu.rb
+++ b/db/migrate/20240911152702_add_moved_user_to_bu.rb
@@ -1,0 +1,5 @@
+class AddMovedUserToBu < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_uploads, :moved_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_22_080228) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_11_152702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_080228) do
     t.text "choice"
     t.integer "total_logs_count"
     t.string "rent_type_fix_status", default: "not_applied"
+    t.integer "moved_user_id"
     t.index ["identifier"], name: "index_bulk_uploads_on_identifier", unique: true
     t.index ["user_id"], name: "index_bulk_uploads_on_user_id"
   end

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -29,7 +29,13 @@ RSpec.describe "Accessibility", js: true do
       Rails.application.routes.routes.select { |route| route.verb == "GET" && route.path.spec.to_s.start_with?("/user") }.map { |route|
         route_path = route.path.spec.to_s
         route_path.gsub(":id", other_user.id.to_s).gsub(":user_id", other_user.id.to_s).gsub("(.:format)", "")
+        .gsub("log-reassignment", "log-reassignment?&organisation_id=#{other_user.organisation_id}")
+        .gsub("organisation-change-confirmation", "organisation-change-confirmation?&organisation_id=#{other_user.organisation_id}&log_reassignment=reassign_all")
       }.uniq
+    end
+
+    before do
+      create(:lettings_log, assigned_to: other_user)
     end
 
     it "is has accessible pages" do

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -125,14 +125,14 @@ RSpec.describe UserHelper do
         end
       end
 
-      context "with reassign all choice" do
+      context "with reassign managing agent choice" do
         it "returns the correct message" do
           expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. The managing agent on their logs will change to #{current_user.organisation.name}."
           expect(organisation_change_confirmation_warning(user, current_user.organisation, "reassign_managing_agent")).to eq(expected_text)
         end
       end
 
-      context "with reassign all choice" do
+      context "with unassign choice" do
         it "returns the correct message" do
           expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. Their logs will be unassigned."
           expect(organisation_change_confirmation_warning(user, current_user.organisation, "unassign")).to eq(expected_text)

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -61,4 +61,47 @@ RSpec.describe UserHelper do
       end
     end
   end
+
+  describe "organisation_change_warning" do
+    context "when user doesn't own any logs" do
+      it "returns a message with the number of logs" do
+        expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There are 0 logs assigned to them."
+        expect(organisation_change_warning(user, current_user.organisation)).to eq(expected_text)
+      end
+    end
+
+    context "when user owns 1 lettings log" do
+      before do
+        create(:lettings_log, assigned_to: user)
+      end
+
+      it "returns a message with the number of logs" do
+        expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There is 1 log assigned to them."
+        expect(organisation_change_warning(user, current_user.organisation)).to eq(expected_text)
+      end
+    end
+
+    context "when user owns 1 sales log" do
+      before do
+        create(:sales_log, assigned_to: user)
+      end
+
+      it "returns a message with the number of logs" do
+        expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There is 1 log assigned to them."
+        expect(organisation_change_warning(user, current_user.organisation)).to eq(expected_text)
+      end
+    end
+
+    context "when user owns multiple log" do
+      before do
+        create(:lettings_log, assigned_to: user)
+        create(:sales_log, assigned_to: user)
+      end
+
+      it "returns a message with the number of logs" do
+        expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There are 2 logs assigned to them."
+        expect(organisation_change_warning(user, current_user.organisation)).to eq(expected_text)
+      end
+    end
+  end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe UserHelper do
       end
     end
 
-    context "when user owns multiple log" do
+    context "when user owns multiple logs" do
       before do
         create(:lettings_log, assigned_to: user)
         create(:sales_log, assigned_to: user)
@@ -101,6 +101,49 @@ RSpec.describe UserHelper do
       it "returns a message with the number of logs" do
         expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There are 2 logs assigned to them."
         expect(organisation_change_warning(user, current_user.organisation)).to eq(expected_text)
+      end
+    end
+  end
+
+  describe "organisation_change_confirmation_warning" do
+    context "when user owns logs" do
+      before do
+        create(:lettings_log, assigned_to: user)
+      end
+
+      context "with reassign all choice" do
+        it "returns the correct message" do
+          expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. The stock owner and managing agent on their logs will change to #{current_user.organisation.name}."
+          expect(organisation_change_confirmation_warning(user, current_user.organisation, "reassign_all")).to eq(expected_text)
+        end
+      end
+
+      context "with reassign stock owners choice" do
+        it "returns the correct message" do
+          expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. The stock owner on their logs will change to #{current_user.organisation.name}."
+          expect(organisation_change_confirmation_warning(user, current_user.organisation, "reassign_stock_owner")).to eq(expected_text)
+        end
+      end
+
+      context "with reassign all choice" do
+        it "returns the correct message" do
+          expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. The managing agent on their logs will change to #{current_user.organisation.name}."
+          expect(organisation_change_confirmation_warning(user, current_user.organisation, "reassign_managing_agent")).to eq(expected_text)
+        end
+      end
+
+      context "with reassign all choice" do
+        it "returns the correct message" do
+          expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. Their logs will be unassigned."
+          expect(organisation_change_confirmation_warning(user, current_user.organisation, "unassign")).to eq(expected_text)
+        end
+      end
+    end
+
+    context "when user doesn't own logs" do
+      it "returns the correct message" do
+        expected_text = "You’re moving #{user.name} from #{user.organisation.name} to #{current_user.organisation.name}. There are no logs assigned to them."
+        expect(organisation_change_confirmation_warning(user, current_user.organisation, "reassign_all")).to eq(expected_text)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -707,5 +707,36 @@ RSpec.describe User, type: :model do
         end
       end
     end
+
+    context "when log_reassignent is not given" do
+      context "and user has no logs" do
+        let(:user_without_logs) { create(:user) }
+
+        it "moves the user to the new organisation" do
+          user_without_logs.reassign_logs_and_update_organisation(new_organisation, nil)
+
+          expect(user_without_logs.organisation).to eq(new_organisation)
+        end
+
+        context "and there is an error" do
+          before do
+            allow(user_without_logs).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it "rolls back the changes" do
+            user_without_logs.reassign_logs_and_update_organisation(new_organisation, nil)
+            expect(user_without_logs.organisation).not_to eq(new_organisation)
+          end
+        end
+      end
+
+      context "and user has logs" do
+        it "does not move the user to the new organisation" do
+          user.reassign_logs_and_update_organisation(new_organisation, nil)
+
+          expect(user.organisation).not_to eq(new_organisation)
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -528,4 +528,184 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#reassign_logs_and_update_organisation" do
+    let(:user) { create(:user) }
+    let(:new_organisation) { create(:organisation) }
+    let!(:lettings_log) { create(:lettings_log, assigned_to: user) }
+    let!(:sales_log) { create(:sales_log, assigned_to: user) }
+
+    context "when reassigning all orgs for logs" do
+      it "reassigns all logs to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_all")
+        expect(lettings_log.reload.owning_organisation).to eq(new_organisation)
+        expect(lettings_log.managing_organisation).to eq(new_organisation)
+        expect(lettings_log.values_updated_at).not_to be_nil
+        expect(sales_log.reload.owning_organisation).to eq(new_organisation)
+        expect(sales_log.managing_organisation).to eq(new_organisation)
+        expect(sales_log.values_updated_at).not_to be_nil
+      end
+
+      it "moves the user to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_all")
+
+        expect(user.organisation).to eq(new_organisation)
+      end
+
+      context "and there is an error" do
+        before do
+          allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        end
+
+        it "rolls back the changes" do
+          user.reassign_logs_and_update_organisation(new_organisation, "reassign_all")
+          expect(lettings_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(lettings_log.managing_organisation).not_to eq(new_organisation)
+          expect(lettings_log.values_updated_at).to be_nil
+          expect(sales_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(sales_log.managing_organisation).not_to eq(new_organisation)
+          expect(sales_log.values_updated_at).to be_nil
+          expect(user.organisation).not_to eq(new_organisation)
+        end
+      end
+    end
+
+    context "when reassigning stock owners for logs" do
+      it "reassigns stock owners for logs to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_stock_owner")
+        expect(lettings_log.reload.owning_organisation).to eq(new_organisation)
+        expect(lettings_log.managing_organisation).not_to eq(new_organisation)
+        expect(lettings_log.values_updated_at).not_to be_nil
+        expect(sales_log.reload.owning_organisation).to eq(new_organisation)
+        expect(sales_log.managing_organisation).not_to eq(new_organisation)
+        expect(sales_log.values_updated_at).not_to be_nil
+      end
+
+      it "moves the user to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_stock_owner")
+
+        expect(user.organisation).to eq(new_organisation)
+      end
+
+      context "and there is an error" do
+        before do
+          allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        end
+
+        it "rolls back the changes" do
+          user.reassign_logs_and_update_organisation(new_organisation, "reassign_all")
+          expect(lettings_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(lettings_log.managing_organisation).not_to eq(new_organisation)
+          expect(lettings_log.values_updated_at).to be_nil
+          expect(sales_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(sales_log.managing_organisation).not_to eq(new_organisation)
+          expect(sales_log.values_updated_at).to be_nil
+          expect(user.organisation).not_to eq(new_organisation)
+        end
+      end
+    end
+
+    context "when reassigning managing agents for logs" do
+      it "reassigns managing agents for logs to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_managing_agent")
+        expect(lettings_log.reload.owning_organisation).not_to eq(new_organisation)
+        expect(lettings_log.managing_organisation).to eq(new_organisation)
+        expect(lettings_log.values_updated_at).not_to be_nil
+        expect(sales_log.reload.owning_organisation).not_to eq(new_organisation)
+        expect(sales_log.managing_organisation).to eq(new_organisation)
+        expect(sales_log.values_updated_at).not_to be_nil
+      end
+
+      it "moves the user to the new organisation" do
+        user.reassign_logs_and_update_organisation(new_organisation, "reassign_managing_agent")
+
+        expect(user.organisation).to eq(new_organisation)
+      end
+
+      context "and there is an error" do
+        before do
+          allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        end
+
+        it "rolls back the changes" do
+          user.reassign_logs_and_update_organisation(new_organisation, "reassign_all")
+          expect(lettings_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(lettings_log.managing_organisation).not_to eq(new_organisation)
+          expect(lettings_log.values_updated_at).to be_nil
+          expect(sales_log.reload.owning_organisation).not_to eq(new_organisation)
+          expect(sales_log.managing_organisation).not_to eq(new_organisation)
+          expect(sales_log.values_updated_at).to be_nil
+          expect(user.organisation).not_to eq(new_organisation)
+        end
+      end
+    end
+
+    context "when unassigning the logs" do
+      context "and unassigned user exists" do
+        let!(:unassigned_user) { create(:user, name: "Unassigned", organisation: user.organisation) }
+
+        it "reassigns all the logs to the unassigned user" do
+          user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+
+          expect(lettings_log.reload.assigned_to).to eq(unassigned_user)
+          expect(lettings_log.values_updated_at).not_to be_nil
+          expect(sales_log.reload.assigned_to).to eq(unassigned_user)
+          expect(sales_log.values_updated_at).not_to be_nil
+        end
+
+        it "moves the user to the new organisation" do
+          user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+
+          expect(user.organisation).to eq(new_organisation)
+        end
+
+        context "and there is an error" do
+          before do
+            allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it "rolls back the changes" do
+            user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+            expect(lettings_log.reload.assigned_to).to eq(user)
+            expect(lettings_log.values_updated_at).to be_nil
+            expect(sales_log.reload.assigned_to).to eq(user)
+            expect(sales_log.values_updated_at).to be_nil
+            expect(user.organisation).not_to eq(new_organisation)
+          end
+        end
+      end
+
+      context "and unassigned user doesn't exist" do
+        it "reassigns all the logs to the unassigned user" do
+          user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+
+          expect(lettings_log.reload.assigned_to.name).to eq("Unassigned")
+          expect(lettings_log.values_updated_at).not_to be_nil
+          expect(sales_log.reload.assigned_to.name).to eq("Unassigned")
+          expect(sales_log.values_updated_at).not_to be_nil
+        end
+
+        it "moves the user to the new organisation" do
+          user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+
+          expect(user.organisation).to eq(new_organisation)
+        end
+
+        context "and there is an error" do
+          before do
+            allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it "rolls back the changes" do
+            user.reassign_logs_and_update_organisation(new_organisation, "unassign")
+            expect(lettings_log.reload.assigned_to).to eq(user)
+            expect(lettings_log.values_updated_at).to be_nil
+            expect(sales_log.reload.assigned_to).to eq(user)
+            expect(sales_log.values_updated_at).to be_nil
+            expect(user.organisation).not_to eq(new_organisation)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe UserPolicy do
     end
   end
 
+  permissions :edit_organisation? do
+    it "as a provider it does not allow changing organisation" do
+      expect(policy).not_to permit(data_provider, data_provider)
+    end
+
+    it "as a coordinator it does not allow changing organisatio" do
+      expect(policy).not_to permit(data_coordinator, data_provider)
+    end
+
+    it "as a support user allows changing other user's organisation" do
+      expect(policy).to permit(support, data_provider)
+    end
+  end
+
   permissions :delete? do
     context "with active user" do
       let(:user) { create(:user, last_sign_in_at: Time.zone.yesterday) }

--- a/spec/requests/bulk_upload_lettings_resume_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_resume_controller_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe BulkUploadLettingsResumeController, type: :request do
         expect(response.body).to include("You have created logs from your bulk upload, and the logs are complete. Return to lettings logs to view them.")
       end
     end
+
+    context "when a choice to reupload has been made" do
+      it "redirects to the error report" do
+        bulk_upload.update!(choice: "upload-again")
+
+        get "/lettings-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/lettings-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
+
+    context "when bulk upload was cancelled by moved user" do
+      it "redirects to the error report" do
+        bulk_upload.update!(choice: "cancelled-by-moved-user")
+
+        get "/lettings-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/lettings-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
   end
 
   describe "GET /lettings-logs/bulk-upload-resume/:ID/fix-choice" do
@@ -71,6 +91,25 @@ RSpec.describe BulkUploadLettingsResumeController, type: :request do
         get "/lettings-logs/bulk-upload-resume/#{bulk_upload.id}/fix-choice"
 
         expect(response).to redirect_to("/lettings-logs/bulk-upload-soft-validations-check/#{bulk_upload.id}/chosen")
+      end
+    end
+
+    context "when a choice to reupload has been made" do
+      let(:bulk_upload) { create(:bulk_upload, :lettings, user:, bulk_upload_errors:, choice: "upload-again") }
+
+      it "redirects to the error report" do
+        get "/lettings-logs/bulk-upload-resume/#{bulk_upload.id}/fix-choice"
+        expect(response).to redirect_to("/lettings-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
+
+    context "when bulk upload was cancelled by moved user" do
+      let(:bulk_upload) { create(:bulk_upload, :lettings, user:, bulk_upload_errors:, choice: "cancelled-by-moved-user") }
+
+      it "redirects to the error report" do
+        get "/lettings-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/lettings-logs/bulk-upload-results/#{bulk_upload.id}")
       end
     end
   end

--- a/spec/requests/bulk_upload_sales_resume_controller_spec.rb
+++ b/spec/requests/bulk_upload_sales_resume_controller_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe BulkUploadSalesResumeController, type: :request do
         expect(response.body).to include("You have created logs from your bulk upload, and the logs are complete. Return to sales logs to view them.")
       end
     end
+
+    context "when a choice to reupload has been made" do
+      it "redirects to the error report" do
+        bulk_upload.update!(choice: "upload-again")
+
+        get "/sales-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
+
+    context "when bulk upload was cancelled by moved user" do
+      it "redirects to the error report" do
+        bulk_upload.update!(choice: "cancelled-by-moved-user")
+
+        get "/sales-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
   end
 
   describe "GET /sales-logs/bulk-upload-resume/:ID/fix-choice" do
@@ -71,6 +91,25 @@ RSpec.describe BulkUploadSalesResumeController, type: :request do
         get "/sales-logs/bulk-upload-resume/#{bulk_upload.id}/fix-choice"
 
         expect(response).to redirect_to("/sales-logs/bulk-upload-soft-validations-check/#{bulk_upload.id}/chosen")
+      end
+    end
+
+    context "when a choice to reupload has been made" do
+      let(:bulk_upload) { create(:bulk_upload, :sales, user:, bulk_upload_errors:, choice: "upload-again") }
+
+      it "redirects to the error report" do
+        get "/sales-logs/bulk-upload-resume/#{bulk_upload.id}/fix-choice"
+        expect(response).to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}")
+      end
+    end
+
+    context "when bulk upload was cancelled by moved user" do
+      let(:bulk_upload) { create(:bulk_upload, :sales, user:, bulk_upload_errors:, choice: "cancelled-by-moved-user") }
+
+      it "redirects to the error report" do
+        get "/sales-logs/bulk-upload-resume/#{bulk_upload.id}/start"
+        follow_redirect!
+        expect(response).to redirect_to("/sales-logs/bulk-upload-results/#{bulk_upload.id}")
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2108,7 +2108,7 @@ RSpec.describe UsersController, type: :request do
               end
 
               it "redirects to confirmation page" do
-                expect(response).to redirect_to("/users/#{other_user.id}/confirm-organisation-change?log_reassignment=reassign_all&organisation_id=#{new_organisation.id}")
+                expect(response).to redirect_to("/users/#{other_user.id}/organisation-change-confirmation?log_reassignment=reassign_all&organisation_id=#{new_organisation.id}")
               end
             end
 
@@ -2124,7 +2124,7 @@ RSpec.describe UsersController, type: :request do
               end
 
               it "redirects to confirmation page" do
-                expect(response).to redirect_to("/users/#{other_user.id}/confirm-organisation-change?log_reassignment=unassign&organisation_id=#{new_organisation.id}")
+                expect(response).to redirect_to("/users/#{other_user.id}/organisation-change-confirmation?log_reassignment=unassign&organisation_id=#{new_organisation.id}")
               end
             end
 
@@ -2438,6 +2438,45 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_button("Continue")
           expect(page).to have_link("Back", href: "/users/#{other_user.id}/edit")
           expect(page).to have_link("Cancel", href: "/users/#{other_user.id}/edit")
+        end
+      end
+    end
+
+    describe "#confirm_organisation_change" do
+      context "when organisation id is not given" do
+        it "redirects to the user page" do
+          get "/users/#{other_user.id}/organisation-change-confirmation?log_reassignment=reassign_all"
+          expect(response).to redirect_to("/users/#{other_user.id}")
+        end
+      end
+
+      context "when reassignment option is not given" do
+        let(:new_organisation) { create(:organisation, name: "new org") }
+
+        it "redirects to the user page" do
+          get "/users/#{other_user.id}/organisation-change-confirmation?organisation_id=#{new_organisation.id}"
+          expect(response).to redirect_to("/users/#{other_user.id}")
+        end
+      end
+
+      context "when organisation id does not exist" do
+        it "redirects to the user page" do
+          get "/users/#{other_user.id}/organisation-change-confirmation?organisation_id=123123&log_reassignment=reassign_all"
+          expect(response).to redirect_to("/users/#{other_user.id}")
+        end
+      end
+
+      context "with valid organisation id" do
+        let(:new_organisation) { create(:organisation, name: "new org") }
+
+        before do
+          create(:lettings_log, assigned_to: other_user)
+        end
+
+        it "displays confirm organisation change page" do
+          get "/users/#{other_user.id}/organisation-change-confirmation?organisation_id=#{new_organisation.id}&log_reassignment=reassign_all"
+          expect(page).to have_content("Are you sure you want to move this user?")
+          expect(page).to have_content("You’re moving #{other_user.name} from #{other_user.organisation_name} to #{new_organisation.name}. The stock owner and managing agent on their logs will change to #{new_organisation.name}.")
         end
       end
     end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1715,10 +1715,11 @@ RSpec.describe UsersController, type: :request do
             get "/users/#{other_user.id}/edit", headers:, params: {}
           end
 
-          it "redirects to user details page" do
-            expect(response).to redirect_to("/users/#{other_user.id}")
-            follow_redirect!
-            expect(page).not_to have_link("Change")
+          it "allows editing the user" do
+            expect(page).to have_field("user[name]")
+            expect(page).to have_field("user[email]")
+            expect(page).to have_field("user[role]")
+            expect(page).to have_field("user[organisation_id]")
           end
         end
       end
@@ -2469,6 +2470,10 @@ RSpec.describe UsersController, type: :request do
 
       context "when reassignment option is not given" do
         let(:new_organisation) { create(:organisation, name: "new org") }
+
+        before do
+          create(:lettings_log, assigned_to: other_user)
+        end
 
         it "redirects to the user page" do
           get "/users/#{other_user.id}/organisation-change-confirmation?organisation_id=#{new_organisation.id}"

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).not_to have_link("Change", text: "role")
           expect(page).not_to have_link("Change", text: "if data protection officer")
           expect(page).not_to have_link("Change", text: "if a key contact")
+          expect(page).not_to have_link("Change", text: "organisation")
         end
 
         it "does not allow deactivating the user" do
@@ -208,6 +209,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).not_to have_link("Change", text: "role")
             expect(page).not_to have_link("Change", text: "if data protection officer")
             expect(page).not_to have_link("Change", text: "if a key contact")
+            expect(page).not_to have_link("Change", text: "organisation")
           end
 
           it "does not allow deactivating the user" do
@@ -258,6 +260,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).not_to have_field("user[role]")
           expect(page).not_to have_field("user[is_dpo]")
           expect(page).not_to have_field("user[is_key_contact]")
+          expect(page).not_to have_field("user[organisation_id]")
         end
       end
 
@@ -607,6 +610,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "role")
           expect(page).to have_link("Change", text: "if data protection officer")
           expect(page).to have_link("Change", text: "if a key contact")
+          expect(page).not_to have_link("Change", text: "organisation")
         end
 
         it "does not allow deactivating the user" do
@@ -655,6 +659,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Change", text: "role")
             expect(page).to have_link("Change", text: "if data protection officer")
             expect(page).to have_link("Change", text: "if a key contact")
+            expect(page).not_to have_link("Change", text: "organisation")
           end
 
           it "allows deactivating the user" do
@@ -713,6 +718,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_field("user[name]")
           expect(page).to have_field("user[email]")
           expect(page).to have_field("user[role]")
+          expect(page).not_to have_field("user[organisation_id]")
         end
 
         it "does not allow setting the role to `support`" do
@@ -738,6 +744,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_field("user[name]")
             expect(page).to have_field("user[email]")
             expect(page).to have_field("user[role]")
+            expect(page).not_to have_field("user[organisation_id]")
           end
         end
 
@@ -1459,6 +1466,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_link("Change", text: "role")
           expect(page).to have_link("Change", text: "if data protection officer")
           expect(page).to have_link("Change", text: "if a key contact")
+          expect(page).to have_link("Change", text: "organisation")
         end
 
         it "does not allow deactivating the user" do
@@ -1488,6 +1496,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_link("Change", text: "role")
             expect(page).to have_link("Change", text: "if data protection officer")
             expect(page).to have_link("Change", text: "if a key contact")
+            expect(page).to have_link("Change", text: "organisation")
           end
 
           it "links to user organisation" do
@@ -1626,6 +1635,7 @@ RSpec.describe UsersController, type: :request do
           expect(page).to have_field("user[role]")
           expect(page).to have_field("user[phone]")
           expect(page).to have_field("user[phone_extension]")
+          expect(page).to have_field("user[organisation_id]")
         end
 
         it "allows setting the role to `support`" do
@@ -1653,6 +1663,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_field("user[role]")
             expect(page).to have_field("user[phone]")
             expect(page).to have_field("user[phone_extension]")
+            expect(page).to have_field("user[organisation_id]")
           end
         end
 
@@ -1673,6 +1684,7 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_field("user[role]")
             expect(page).to have_field("user[phone]")
             expect(page).to have_field("user[phone_extension]")
+            expect(page).to have_field("user[organisation_id]")
           end
         end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1850,6 +1850,39 @@ RSpec.describe UsersController, type: :request do
             expect(page).to have_selector(".govuk-error-summary__title")
           end
         end
+
+        context "when updating organisation" do
+          let(:new_organisation) { create(:organisation) }
+
+          before do
+            patch "/users/#{user.id}", headers:, params:
+          end
+
+          context "and organisation id is nil" do
+            let(:params) { { id: user.id, user: { organisation_id: "" } } }
+
+            it "does not update the organisation" do
+              expect(response).to have_http_status(:unprocessable_entity)
+              expect(page).to have_selector(".govuk-error-summary__title")
+            end
+          end
+
+          context "and organisation id is not nil" do
+            let(:params) { { id: user.id, user: { organisation_id: new_organisation.id, name: "new_name" } } }
+
+            it "does not update the organisation" do
+              expect(user.reload.organisation).not_to eq(new_organisation)
+            end
+
+            it "redirects to log reassignment page" do
+              expect(response).to redirect_to("/users/#{user.id}/log-reassignment?organisation_id=#{new_organisation.id}")
+            end
+
+            it "updated other fields" do
+              expect(user.reload.name).to eq("new_name")
+            end
+          end
+        end
       end
 
       context "when the current user does not match the user ID" do
@@ -1985,6 +2018,39 @@ RSpec.describe UsersController, type: :request do
                 expect(notify_client).not_to receive(:send_email)
 
                 patch "/users/#{other_user.id}", headers:, params:
+              end
+            end
+
+            context "when updating organisation" do
+              let(:new_organisation) { create(:organisation) }
+
+              before do
+                patch "/users/#{other_user.id}", headers:, params:
+              end
+
+              context "and organisation id is nil" do
+                let(:params) { { id: other_user.id, user: { organisation_id: "" } } }
+
+                it "does not update the organisation" do
+                  expect(response).to have_http_status(:unprocessable_entity)
+                  expect(page).to have_selector(".govuk-error-summary__title")
+                end
+              end
+
+              context "and organisation id is not nil" do
+                let(:params) { { id: other_user.id, user: { organisation_id: new_organisation.id, name: "new_name" } } }
+
+                it "does not update the organisation" do
+                  expect(user.reload.organisation).not_to eq(new_organisation)
+                end
+
+                it "redirects to log reassignment page" do
+                  expect(response).to redirect_to("/users/#{other_user.id}/log-reassignment?organisation_id=#{new_organisation.id}")
+                end
+
+                it "updated other fields" do
+                  expect(other_user.reload.name).to eq("new_name")
+                end
               end
             end
           end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1854,6 +1854,20 @@ RSpec.describe UsersController, type: :request do
               patch "/users/#{other_user.id}", headers:, params:
             end
           end
+
+          context "and email address hasn't changed" do
+            let(:params) { { id: user.id, user: { name: new_name, email: other_user.email, is_dpo: "true", is_key_contact: "true" } } }
+
+            before do
+              user.legacy_users.destroy_all
+            end
+
+            it "shows flash notice" do
+              patch("/users/#{other_user.id}", headers:, params:)
+
+              expect(flash[:notice]).to be_nil
+            end
+          end
         end
 
         context "when we update the user password" do


### PR DESCRIPTION
Allow support users to change user organisations
<img width="699" alt="image" src="https://github.com/user-attachments/assets/418b5df7-9604-4de5-8608-78251cf22525">
<img width="971" alt="image" src="https://github.com/user-attachments/assets/13fb6554-f05d-4d0b-96e9-aa6e90ed3ea1">
Validate that relevant relationships are there to move the logs over
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/8bed44ff-b404-4132-afd1-be4d30b03ae1">
Choosing to unassign logs assigns them to a user in the current user organisation called "Unassigned", some of the organisations might already have this user as it would get created during migration from the old service in cases where no relevant user was created to own that log. If  "Unassigned" user doesn't exist for organisation, we'd create one
<img width="874" alt="image" src="https://github.com/user-attachments/assets/4a6e72b4-0f4d-413f-ba29-1f351856d8b8">

This PR also allows editing deactivated users by support user as we want to be able to move deactivated users between organisations. This does also mean that other user fields can be edited, I'm yet to check if that's okay, or whether we should do some work to split that up.