### PR TITLE
CLDC-3613 Add merge start confirmation page

### DIFF
--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -7,6 +7,7 @@ class MergeRequestsController < ApplicationController
   def absorbing_organisation; end
   def merge_date; end
   def helpdesk_ticket; end
+  def merge_start_confirmation; end
 
   def create
     ActiveRecord::Base.transaction do

--- a/app/views/merge_requests/merge_start_confirmation.html.erb
+++ b/app/views/merge_requests/merge_start_confirmation.html.erb
@@ -1,0 +1,27 @@
+<% content_for :before_content do %>
+  <% content_for :title, "Are you sure you want to begin this merge?" %>
+  <%= govuk_back_link href: merge_request_path(@merge_request) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-xl">
+      <%= content_for(:title) %>
+    </h1>
+
+    <%= govuk_warning_text(text: "You will not be able to undo this action.") %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        "Begin merge",
+        start_merge_merge_request_path(@merge_request),
+        method: :patch,
+      ) %>
+      <%= govuk_button_link_to(
+        "Cancel",
+        merge_request_path(@merge_request),
+        secondary: true,
+      ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/merge_requests/show.html.erb
+++ b/app/views/merge_requests/show.html.erb
@@ -12,9 +12,7 @@
 </h1>
 <% unless @merge_request.status == "request_merged" || @merge_request.status == "processing" %>
 <div class="govuk-button-group">
-   <%= form_with model: @merge_request, url: start_merge_merge_request_path(@merge_request) do |f| %>
-    <%= f.govuk_submit "Begin merge", disabled: @merge_request.status != "ready_to_merge" %>
-  <% end %>
+  <%= govuk_button_link_to "Begin merge", merge_start_confirmation_merge_request_path(@merge_request), disabled: @merge_request.status != "ready_to_merge" %>
   <%= govuk_button_link_to "Delete merge request", delete_confirmation_merge_request_path(@merge_request), warning: true %>
 </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
       get "absorbing-organisation"
       get "merge-date"
       get "helpdesk-ticket"
+      get "merge-start-confirmation"
       get "delete-confirmation", to: "merge_requests#delete_confirmation"
       delete "delete", to: "merge_requests#delete"
       patch "start-merge", to: "merge_requests#start_merge"

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -402,6 +402,19 @@ RSpec.describe MergeRequestsController, type: :request do
       end
     end
 
+    describe "#merge_start_confirmation" do
+      before do
+        get "/merge-request/#{merge_request.id}/merge-start-confirmation", headers:
+      end
+
+      it "has correct content" do
+        expect(page).to have_content("Are you sure you want to begin this merge?")
+        expect(page).to have_content("You will not be able to undo this action")
+        expect(page).to have_link("Back", href: merge_request_path(merge_request))
+        expect(page).to have_button("Begin merge")
+      end
+    end
+
     describe "#start_merge" do
       let(:merge_request) { MergeRequest.create!(requesting_organisation: organisation, absorbing_organisation: organisation, merge_date: Time.zone.local(2022, 3, 3)) }
       let(:merging_organisation) { create(:organisation, name: "Merging Test Org") }
@@ -455,6 +468,10 @@ RSpec.describe MergeRequestsController, type: :request do
           expect(page).not_to have_content("An error occurred while processing the merge.")
           expect(page).not_to have_content("No changes have been made. Try beginning the merge again.")
         end
+      end
+
+      it "has begin merge button" do
+        expect(page).to have_link("Begin merge", href: merge_start_confirmation_merge_request_path(merge_request))
       end
     end
   end


### PR DESCRIPTION
Add merge start confirmation page before performing the merge
<img width="832" alt="image" src="https://github.com/user-attachments/assets/3d7d2008-8f96-4adb-ac1c-abbe11016150">
