### PR TITLE
CLDC-3605 View relationships page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,7 +379,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.3)
+    rexml (3.3.6)
       strscan
     roo (2.10.1)
       nokogiri (~> 1)

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -9,6 +9,7 @@ class MergeRequestsController < ApplicationController
   def helpdesk_ticket; end
   def merge_start_confirmation; end
   def user_outcomes; end
+  def relationship_outcomes; end
 
   def create
     ActiveRecord::Base.transaction do
@@ -63,7 +64,13 @@ class MergeRequestsController < ApplicationController
 
   def start_merge
     if @merge_request.status == "ready_to_merge"
-      @merge_request.update!(processing: true, last_failed_attempt: nil, total_users: @merge_request.total_visible_users_after_merge)
+      @merge_request.update!(
+        processing: true,
+        last_failed_attempt: nil,
+        total_users: @merge_request.total_visible_users_after_merge,
+        total_stock_owners: @merge_request.total_stock_owners_after_merge,
+        total_managing_agents: @merge_request.total_managing_agents_after_merge,
+      )
       ProcessMergeRequestJob.perform_later(merge_request: @merge_request)
     end
 

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -143,7 +143,7 @@ module MergeRequestsHelper
       organisation_count = org.send(relationship_type.pluralize).visible.count
       next if organisation_count.zero?
 
-      link_text = generate_link_text(organisation_count, org, relationship_type)
+      link_text = generate_organisation_link_text(organisation_count, org, relationship_type)
       text += "#{govuk_link_to(link_text, send(organisation_path_helper, org), target: '_blank')}<br><br>"
     end
 
@@ -170,7 +170,7 @@ module MergeRequestsHelper
     "#{org_names} #{verb} no #{relationship_type.humanize(capitalize: false).pluralize}.<br><br>"
   end
 
-  def generate_link_text(organisation_count, org, relationship_type)
+  def generate_organisation_link_text(organisation_count, org, relationship_type)
     "View #{organisation_count == 1 ? 'the' : 'all'} #{organisation_count} #{org.name} #{relationship_type.humanize(capitalize: false).pluralize(organisation_count)} (opens in a new tab)"
   end
 

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -61,8 +61,29 @@ class MergeRequest < ApplicationRecord
     absorbing_organisation.users.visible.count + merging_organisations.sum { |org| org.users.visible.count }
   end
 
+  def total_stock_owners_after_merge
+    return total_stock_owners if status == STATUS[:request_merged] || status == STATUS[:processing]
+
+    stock_owners = absorbing_organisation.stock_owners.visible + merging_organisations.flat_map { |org| org.stock_owners.visible }
+    stock_owners.uniq.count
+  end
+
+  def total_managing_agents_after_merge
+    return total_managing_agents if status == STATUS[:request_merged] || status == STATUS[:processing]
+
+    managing_agents = absorbing_organisation.managing_agents.visible + merging_organisations.flat_map { |org| org.managing_agents.visible }
+    managing_agents.uniq.count
+  end
+
   def total_users_label
-    "#{total_visible_users_after_merge} #{'User'.pluralize(total_visible_users_after_merge)}"
+    "#{total_visible_users_after_merge} #{'user'.pluralize(total_visible_users_after_merge)}"
+  end
+
+  def total_stock_owners_managing_agents_label
+    stock_owners_count = total_stock_owners_after_merge
+    managing_agents_count = total_managing_agents_after_merge
+
+    "#{stock_owners_count} #{'stock owner'.pluralize(stock_owners_count)}\n#{managing_agents_count} #{'managing agent'.pluralize(managing_agents_count)}"
   end
 
   def organisations_with_users

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -61,29 +61,8 @@ class MergeRequest < ApplicationRecord
     absorbing_organisation.users.visible.count + merging_organisations.sum { |org| org.users.visible.count }
   end
 
-  def total_stock_owners_after_merge
-    return total_stock_owners if status == STATUS[:request_merged] || status == STATUS[:processing]
-
-    stock_owners = absorbing_organisation.stock_owners.visible + merging_organisations.flat_map { |org| org.stock_owners.visible }
-    stock_owners.uniq.count
-  end
-
-  def total_managing_agents_after_merge
-    return total_managing_agents if status == STATUS[:request_merged] || status == STATUS[:processing]
-
-    managing_agents = absorbing_organisation.managing_agents.visible + merging_organisations.flat_map { |org| org.managing_agents.visible }
-    managing_agents.uniq.count
-  end
-
   def total_users_label
     "#{total_visible_users_after_merge} #{'user'.pluralize(total_visible_users_after_merge)}"
-  end
-
-  def total_stock_owners_managing_agents_label
-    stock_owners_count = total_stock_owners_after_merge
-    managing_agents_count = total_managing_agents_after_merge
-
-    "#{stock_owners_count} #{'stock owner'.pluralize(stock_owners_count)}\n#{managing_agents_count} #{'managing agent'.pluralize(managing_agents_count)}"
   end
 
   def organisations_with_users
@@ -118,5 +97,44 @@ class MergeRequest < ApplicationRecord
     return [] unless absorbing_organisation.present? && merging_organisations.any?
 
     ([absorbing_organisation] + merging_organisations).reject(&:has_visible_schemes?)
+  end
+
+  def filter_relationships(absorbing_relationships, merging_relationships, absorbing_organisation, merging_organisations)
+    filtered_absorbing_relationships = absorbing_relationships.reject do |relationship|
+      merging_relationships.include?(relationship) || merging_organisations.include?(relationship)
+    end
+
+    filtered_merging_relationships = merging_relationships.reject do |relationship|
+      absorbing_relationships.include?(relationship) || relationship == absorbing_organisation || merging_organisations.include?(relationship)
+    end
+
+    (filtered_absorbing_relationships + filtered_merging_relationships).uniq
+  end
+
+  def total_stock_owners_after_merge
+    return total_stock_owners if status == STATUS[:request_merged] || status == STATUS[:processing]
+
+    absorbing_stock_owners = absorbing_organisation.stock_owners.visible
+    merging_stock_owners = merging_organisations.flat_map { |org| org.stock_owners.visible }
+
+    total_filtered_stock_owners = filter_relationships(absorbing_stock_owners, merging_stock_owners, absorbing_organisation, merging_organisations)
+    total_filtered_stock_owners.count
+  end
+
+  def total_managing_agents_after_merge
+    return total_managing_agents if status == STATUS[:request_merged] || status == STATUS[:processing]
+
+    absorbing_managing_agents = absorbing_organisation.managing_agents.visible
+    merging_managing_agents = merging_organisations.flat_map { |org| org.managing_agents.visible }
+
+    total_filtered_managing_agents = filter_relationships(absorbing_managing_agents, merging_managing_agents, absorbing_organisation, merging_organisations)
+    total_filtered_managing_agents.count
+  end
+
+  def total_stock_owners_managing_agents_label
+    stock_owners_count = total_stock_owners_after_merge
+    managing_agents_count = total_managing_agents_after_merge
+
+    "#{stock_owners_count} #{'stock owner'.pluralize(stock_owners_count)}\n#{managing_agents_count} #{'managing agent'.pluralize(managing_agents_count)}"
   end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -105,7 +105,7 @@ class MergeRequest < ApplicationRecord
   end
 
   def total_schemes_label
-    "#{total_visible_schemes_after_merge} #{'Scheme'.pluralize(total_visible_schemes_after_merge)}"
+    "#{total_visible_schemes_after_merge} #{'scheme'.pluralize(total_visible_schemes_after_merge)}"
   end
 
   def organisations_with_schemes

--- a/app/views/merge_requests/relationship_outcomes.html.erb
+++ b/app/views/merge_requests/relationship_outcomes.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <% title = "Stock owners & managing agents" %>
+  <% title = "Stock owners & managing agents".html_safe %>
   <% content_for :title, title %>
   <%= govuk_back_link href: merge_request_path(@merge_request) %>
 <% end %>

--- a/app/views/merge_requests/relationship_outcomes.html.erb
+++ b/app/views/merge_requests/relationship_outcomes.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_content do %>
+  <% title = "Stock owners & managing agents" %>
+  <% content_for :title, title %>
+  <%= govuk_back_link href: merge_request_path(@merge_request) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @merge_request.absorbing_organisation_name %></span>
+  Stock owners & managing agents
+</h1>
+
+<% unless @merge_request.status == "request_merged" || @merge_request.status == "processing" %>
+  <h2 class="govuk-heading-m"><%= total_stock_owners_after_merge_text(@merge_request) %></h2>
+  <p class="govuk-body">
+    <%= stock_owners_text(@merge_request) %>
+  </p>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-width-one-half">
+  <br>
+  <h2 class="govuk-heading-m"><%= total_managing_agents_after_merge_text(@merge_request) %></h2>
+  <p class="govuk-body">
+    <%= managing_agent_text(@merge_request) %>
+  </p>
+<% end %>
+
+
+

--- a/app/views/merge_requests/relationship_outcomes.html.erb
+++ b/app/views/merge_requests/relationship_outcomes.html.erb
@@ -21,6 +21,3 @@
     <%= managing_agent_text(@merge_request) %>
   </p>
 <% end %>
-
-
-

--- a/app/views/merge_requests/user_outcomes.html.erb
+++ b/app/views/merge_requests/user_outcomes.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content do %>
   <% title = "Users" %>
   <% content_for :title, title %>
-  <%= govuk_back_link href: organisations_path(tab: "merge-requests") %>
+  <%= govuk_back_link href: merge_request_path(@merge_request) %>
 <% end %>
 
 <h1 class="govuk-heading-l">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,6 +211,7 @@ Rails.application.routes.draw do
       get "helpdesk-ticket"
       get "merge-start-confirmation"
       get "user-outcomes"
+      get "relationship-outcomes"
       get "delete-confirmation", to: "merge_requests#delete_confirmation"
       delete "delete", to: "merge_requests#delete"
       patch "start-merge", to: "merge_requests#start_merge"

--- a/spec/helpers/merge_requests_helper_spec.rb
+++ b/spec/helpers/merge_requests_helper_spec.rb
@@ -110,4 +110,52 @@ RSpec.describe MergeRequestsHelper do
       end
     end
   end
+
+  describe "when creating relationship outcomes content" do
+    let(:stock_owner1) { create(:organisation, name: "Stock owner 1") }
+    let(:stock_owner2) { create(:organisation, name: "Stock owner 2") }
+    let(:managing_agent1) { create(:organisation, name: "Managing agent 1") }
+    let(:managing_agent2) { create(:organisation, name: "Managing agent 2") }
+    let(:absorbing_organisation) { create(:organisation, name: "Absorbing Org") }
+    let(:merging_organisations) { create_list(:organisation, 2) { |org, i| org.name = "Dummy Org #{i + 1}" } }
+    let(:merge_request) { create(:merge_request, absorbing_organisation:, merging_organisations:) }
+
+    context "when there are no relationships" do
+      it "returns text stating there are no stock owners" do
+        expect(stock_owners_text(merge_request)).to eq("Absorbing Org, Dummy Org 1, and Dummy Org 2 have no stock owners.<br><br>")
+      end
+
+      it "returns text stating there are no managing agents" do
+        expect(managing_agent_text(merge_request)).to eq("Absorbing Org, Dummy Org 1, and Dummy Org 2 have no managing agents.<br><br>")
+      end
+    end
+
+    context "when there are stock owners" do
+      before do
+        create(:organisation_relationship, child_organisation: absorbing_organisation, parent_organisation: stock_owner1)
+        create(:organisation_relationship, child_organisation: merging_organisations.first, parent_organisation: stock_owner2)
+        create(:organisation_relationship, child_organisation: merging_organisations.first, parent_organisation: stock_owner1)
+      end
+
+      it "returns text stating the relationships" do
+        expect(stock_owners_text(merge_request)).to include("Some of the organisations merging have common stock owners.")
+        expect(stock_owners_text(merge_request)).to include("Dummy Org 2 has no stock owners.")
+        expect(stock_owners_text(merge_request)).to include("<a class=\"govuk-link\" target=\"_blank\" href=\"/organisations/#{merging_organisations.first.id}/stock-owners\">View all 2 Dummy Org 1 stock owners (opens in a new tab)</a>")
+      end
+    end
+
+    context "when there are managing agents" do
+      before do
+        create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: managing_agent1)
+        create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: managing_agent2)
+        create(:organisation_relationship, parent_organisation: merging_organisations.first, child_organisation: managing_agent2)
+      end
+
+      it "returns text stating the relationships" do
+        expect(managing_agent_text(merge_request)).to include("Some of the organisations merging have common managing agents.")
+        expect(managing_agent_text(merge_request)).to include("Dummy Org 2 has no managing agents.")
+        expect(managing_agent_text(merge_request)).to include("<a class=\"govuk-link\" target=\"_blank\" href=\"/organisations/#{merging_organisations.first.id}/managing-agents\">View the 1 Dummy Org 1 managing agent (opens in a new tab)</a>")
+      end
+    end
+  end
 end

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -397,4 +397,43 @@ RSpec.describe MergeRequest, type: :model do
       end
     end
   end
+
+  describe "relationship outcomes" do
+    let(:stock_owner1) { create(:organisation, name: "Stock owner 1") }
+    let(:stock_owner2) { create(:organisation, name: "Stock owner 2") }
+    let(:stock_owner3) { create(:organisation, name: "Stock owner 3") }
+    let(:managing_agent1) { create(:organisation, name: "Managing agent 1") }
+    let(:managing_agent2) { create(:organisation, name: "Managing agent 2") }
+    let(:absorbing_organisation) { create(:organisation, name: "Absorbing Org") }
+    let(:merging_organisations) { create_list(:organisation, 2) { |org, i| org.name = "Dummy Org #{i + 1}" } }
+    let(:merge_request) { create(:merge_request, absorbing_organisation:, merging_organisations:) }
+
+    before do
+      create(:organisation_relationship, child_organisation: absorbing_organisation, parent_organisation: stock_owner1)
+      create(:organisation_relationship, child_organisation: merging_organisations.first, parent_organisation: stock_owner2)
+      create(:organisation_relationship, child_organisation: merging_organisations.first, parent_organisation: stock_owner1)
+      create(:organisation_relationship, child_organisation: merging_organisations.first, parent_organisation: stock_owner3)
+      create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: managing_agent1)
+      create(:organisation_relationship, parent_organisation: absorbing_organisation, child_organisation: managing_agent2)
+      create(:organisation_relationship, parent_organisation: merging_organisations.first, child_organisation: managing_agent2)
+    end
+
+    describe "#total_stock_owners_after_merge" do
+      it "returns the correct count of stock owners after merge" do
+        expect(merge_request.total_stock_owners_after_merge).to eq(2)
+      end
+    end
+
+    describe "#total_managing_agents_after_merge"do
+      it "returns the correct count of managing agents after merge" do
+        expect(merge_request.total_managing_agents_after_merge).to eq(1)
+      end
+    end
+
+    describe "#total_stock_owners_managing_agents_label" do
+      it "returns the correct label" do
+        expect(merge_request.total_stock_owners_managing_agents_label).to eq("2 stock owners\n1 managing agent")
+      end
+    end
+  end
 end

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe MergeRequest, type: :model do
       end
     end
 
-    describe "#total_managing_agents_after_merge"do
+    describe "#total_managing_agents_after_merge" do
       it "returns the correct count of managing agents after merge" do
         expect(merge_request.total_managing_agents_after_merge).to eq(1)
       end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe MergeRequestsController, type: :request do
       end
 
       context "with a merged request" do
-        let(:merge_request) { create(:merge_request, request_merged: true, total_users: 34, total_schemes: 12, total_stock_owners:  8, total_managing_agents:  5) }
+        let(:merge_request) { create(:merge_request, request_merged: true, total_users: 34, total_schemes: 12, total_stock_owners: 8, total_managing_agents: 5) }
 
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("request_merged")
@@ -506,7 +506,7 @@ RSpec.describe MergeRequestsController, type: :request do
         end
 
         it "shows stock owners and managing agents count and doesn't have links to view merge outcomes" do
-          expect(merge_request.status).to eq("processing")
+          expect(merge_request.status).to eq("request_merged")
           expect(page).not_to have_link("View", href: relationship_outcomes_merge_request_path(merge_request))
           expect(page).to have_content("8 stock owners")
           expect(page).to have_content("5 managing agents")
@@ -514,7 +514,7 @@ RSpec.describe MergeRequestsController, type: :request do
       end
 
       context "with a processing request" do
-        let(:merge_request) { create(:merge_request, processing: true, total_users: 51, total_schemes: 33, total_stock_owners:  15, total_managing_agents:  20) }
+        let(:merge_request) { create(:merge_request, processing: true, total_users: 51, total_schemes: 33, total_stock_owners: 15, total_managing_agents: 20) }
 
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("processing")

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe MergeRequestsController, type: :request do
       end
 
       context "with a merged request" do
-        let(:merge_request) { create(:merge_request, request_merged: true, total_users: 34, total_schemes: 12) }
+        let(:merge_request) { create(:merge_request, request_merged: true, total_users: 34, total_schemes: 12, total_stock_owners:  8, total_managing_agents:  5) }
 
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("request_merged")
@@ -504,10 +504,17 @@ RSpec.describe MergeRequestsController, type: :request do
           expect(page).not_to have_link("View", href: scheme_outcomes_merge_request_path(merge_request))
           expect(page).to have_content("12 schemes")
         end
+
+        it "shows stock owners and managing agents count and doesn't have links to view merge outcomes" do
+          expect(merge_request.status).to eq("processing")
+          expect(page).not_to have_link("View", href: relationship_outcomes_merge_request_path(merge_request))
+          expect(page).to have_content("8 stock owners")
+          expect(page).to have_content("5 managing agents")
+        end
       end
 
       context "with a processing request" do
-        let(:merge_request) { create(:merge_request, processing: true, total_users: 51, total_schemes: 33) }
+        let(:merge_request) { create(:merge_request, processing: true, total_users: 51, total_schemes: 33, total_stock_owners:  15, total_managing_agents:  20) }
 
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("processing")
@@ -519,6 +526,13 @@ RSpec.describe MergeRequestsController, type: :request do
           expect(merge_request.status).to eq("processing")
           expect(page).not_to have_link("View", href: scheme_outcomes_merge_request_path(merge_request))
           expect(page).to have_content("33 schemes")
+        end
+
+        it "shows stock owners and managing agents count and doesn't have links to view merge outcomes" do
+          expect(merge_request.status).to eq("processing")
+          expect(page).not_to have_link("View", href: relationship_outcomes_merge_request_path(merge_request))
+          expect(page).to have_content("15 stock owners")
+          expect(page).to have_content("20 managing agents")
         end
       end
     end

--- a/spec/requests/merge_requests_controller_spec.rb
+++ b/spec/requests/merge_requests_controller_spec.rb
@@ -485,8 +485,8 @@ RSpec.describe MergeRequestsController, type: :request do
 
         it "shows users and schemes count and has links to view merge outcomes" do
           expect(page).to have_link("View", href: scheme_outcomes_merge_request_path(merge_request))
-          expect(page).to have_content("4 Users")
-          expect(page).to have_content("4 Schemes")
+          expect(page).to have_content("4 users")
+          expect(page).to have_content("4 schemes")
         end
       end
 
@@ -496,13 +496,13 @@ RSpec.describe MergeRequestsController, type: :request do
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("request_merged")
           expect(page).not_to have_link("View", href: user_outcomes_merge_request_path(merge_request))
-          expect(page).to have_content("34 Users")
+          expect(page).to have_content("34 users")
         end
 
         it "shows saved schemes count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("request_merged")
           expect(page).not_to have_link("View", href: scheme_outcomes_merge_request_path(merge_request))
-          expect(page).to have_content("12 Schemes")
+          expect(page).to have_content("12 schemes")
         end
       end
 
@@ -512,13 +512,13 @@ RSpec.describe MergeRequestsController, type: :request do
         it "shows saved users count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("processing")
           expect(page).not_to have_link("View", href: user_outcomes_merge_request_path(merge_request))
-          expect(page).to have_content("51 Users")
+          expect(page).to have_content("51 users")
         end
 
         it "shows saved schemes count and doesn't have links to view merge outcomes" do
           expect(merge_request.status).to eq("processing")
           expect(page).not_to have_link("View", href: scheme_outcomes_merge_request_path(merge_request))
-          expect(page).to have_content("33 Schemes")
+          expect(page).to have_content("33 schemes")
         end
       end
     end

--- a/spec/views/merge_requests/show.html.erb_spec.rb
+++ b/spec/views/merge_requests/show.html.erb_spec.rb
@@ -84,12 +84,10 @@ RSpec.describe "merge_requests/show.html.erb", type: :view do
 
     it "displays the total stock owners & managing agents after merge details" do
       expect(rendered).to have_selector("dt", text: "Total stock owners & managing agents after merge")
-      if merge_request.total_stock_owners.present? || merge_request.total_managing_agents.present?
-        combined_text = []
-        combined_text << "#{merge_request.total_stock_owners} stock owners" if merge_request.total_stock_owners.present?
-        combined_text << "#{merge_request.total_managing_agents} managing agents" if merge_request.total_managing_agents.present?
-        expect(rendered).to have_selector("dd", text: combined_text.join(""))
-      end
+      combined_text = []
+      combined_text << "#{merge_request.total_stock_owners} stock owners" if merge_request.total_stock_owners.present?
+      combined_text << "#{merge_request.total_managing_agents} managing agents" if merge_request.total_managing_agents.present?
+      expect(rendered).to have_selector("dd", text: combined_text.join("\n"))
     end
   end
 end


### PR DESCRIPTION
This branch adds as page to view all stock owners and managing agents of the absorbing org and merging orgs. It shows the total stock owners and managing agents that will be present on the new org after the merge.

In the cases where any merging org or absorbing org is also a stock owner/managing agent they'll be excluded from the count (as seen below with the managing agent count). That relationship will no longer exist.

The relationship outcomes page:
<img width="733" alt="Screenshot 2024-08-29 at 10 26 24" src="https://github.com/user-attachments/assets/2b77b37f-7b40-40b0-a18c-a8f65ccf2d3c">

The details page:
<img width="968" alt="Screenshot 2024-08-29 at 10 28 11" src="https://github.com/user-attachments/assets/5ed85bb1-a5cb-4643-aba0-de14fcc7fccc">
