### PR TITLE
Do not check duplicates on empty rows

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -513,6 +513,8 @@ class BulkUpload::Lettings::Year2024::RowParser
   end
 
   def log_already_exists?
+    return false if blank_row?
+
     @log_already_exists ||= LettingsLog
       .where(status: %w[not_started in_progress completed])
       .exists?(duplicate_check_fields.index_with { |field| log.public_send(field) })

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -539,6 +539,8 @@ class BulkUpload::Sales::Year2024::RowParser
   end
 
   def log_already_exists?
+    return false if blank_row?
+
     @log_already_exists ||= SalesLog
       .where(status: %w[not_started in_progress completed])
       .exists?(duplicate_check_fields.index_with { |field| log.public_send(field) })

--- a/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
@@ -1843,6 +1843,18 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
         end
       end
     end
+
+    describe "log_already_exists?" do
+      let(:attributes) { { bulk_upload: } }
+
+      before do
+        build(:lettings_log, owning_organisation: nil, startdate: nil, tenancycode: nil, location: nil, age1: nil, sex1: nil, ecstat1: nil, brent: nil, scharge: nil, pscharge: nil, supcharg: nil).save(validate: false)
+      end
+
+      it "does not add duplicate logs validation to the blank row" do
+        expect(parser.log_already_exists?).to eq(false)
+      end
+    end
   end
 
   describe "#log" do

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -1417,6 +1417,18 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
       end
     end
+
+    describe "log_already_exists?" do
+      let(:attributes) { { bulk_upload: } }
+
+      before do
+        build(:sales_log, owning_organisation: nil, saledate: nil, purchid: nil, age1: nil, sex1: nil, ecstat1: nil).save(validate: false)
+      end
+
+      it "does not add duplicate logs validation to the blank row" do
+        expect(parser.log_already_exists?).to eq(false)
+      end
+    end
   end
 
   describe "#log" do


### PR DESCRIPTION
We run `log_already_exists?` on rows directly from `validator` so it runs for all rows, including the empty ones.
It doesn't get caught as a setup error, because in `row_parser` `valid?` method we check and skip any empty rows before we run validations.

We shouldn't mark empty rows as invalid, because we skip them during the creation in `log_creator` anyway `next if row_parser.blank_row?`