### PR TITLE
Empty bulk upload row parsing

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/csv_parser.rb
@@ -32,7 +32,8 @@ class BulkUpload::Lettings::Year2024::CsvParser
   def row_parsers
     @row_parsers ||= body_rows.map do |row|
       stripped_row = row[col_offset..]
-      hash = Hash[field_numbers.zip(stripped_row)]
+      
+      hash = Hash[field_numbers.zip(nil)]
 
       BulkUpload::Lettings::Year2024::RowParser.new(hash)
     end

--- a/app/services/bulk_upload/lettings/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/csv_parser.rb
@@ -32,8 +32,8 @@ class BulkUpload::Lettings::Year2024::CsvParser
   def row_parsers
     @row_parsers ||= body_rows.map do |row|
       stripped_row = row[col_offset..]
-      
-      hash = Hash[field_numbers.zip(nil)]
+
+      hash = Hash[field_numbers.zip(stripped_row)]
 
       BulkUpload::Lettings::Year2024::RowParser.new(hash)
     end

--- a/app/services/bulk_upload/lettings/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/csv_parser.rb
@@ -30,13 +30,15 @@ class BulkUpload::Lettings::Year2024::CsvParser
   end
 
   def row_parsers
-    @row_parsers ||= body_rows.map do |row|
+    @row_parsers ||= body_rows.map { |row|
+      next if row.empty?
+
       stripped_row = row[col_offset..]
 
       hash = Hash[field_numbers.zip(stripped_row)]
 
       BulkUpload::Lettings::Year2024::RowParser.new(hash)
-    end
+    }.compact
   end
 
   def body_rows

--- a/app/services/bulk_upload/sales/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/csv_parser.rb
@@ -30,12 +30,14 @@ class BulkUpload::Sales::Year2024::CsvParser
   end
 
   def row_parsers
-    @row_parsers ||= body_rows.map do |row|
+    @row_parsers ||= body_rows.map { |row|
+      next if row.empty?
+
       stripped_row = row[col_offset..]
       hash = Hash[field_numbers.zip(stripped_row)]
 
       BulkUpload::Sales::Year2024::RowParser.new(hash)
-    end
+    }.compact
   end
 
   def body_rows

--- a/spec/services/bulk_upload/lettings/year2024/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/csv_parser_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe BulkUpload::Lettings::Year2024::CsvParser do
       file.write("Duplicate check field?\n")
       file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2024_field_numbers_row)
       file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2024_csv_row)
+      file.write("\n")
       file.rewind
     end
 
@@ -51,6 +52,10 @@ RSpec.describe BulkUpload::Lettings::Year2024::CsvParser do
 
     it "parses csv correctly" do
       expect(service.row_parsers[0].field_13).to eql(log.tenancycode)
+    end
+
+    it "does not parse the last empty row" do
+      expect(service.row_parsers.count).to eq(1)
     end
   end
 

--- a/spec/services/bulk_upload/sales/year2024/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/csv_parser_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe BulkUpload::Sales::Year2024::CsvParser do
       file.write("Duplicate check field?\n")
       file.write(BulkUpload::SalesLogToCsv.new(log:).default_2024_field_numbers_row)
       file.write(BulkUpload::SalesLogToCsv.new(log:).to_2024_csv_row)
+      file.write("\n")
       file.rewind
     end
 
@@ -31,6 +32,10 @@ RSpec.describe BulkUpload::Sales::Year2024::CsvParser do
 
     it "counts the number of valid field numbers correctly" do
       expect(service).to be_correct_field_count
+    end
+
+    it "does not parse the last empty row" do
+      expect(service.row_parsers.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
There were a few `wrong argument type NilClass (must respond to :each)` errors on `hash = Hash[field_numbers.zip(stripped_row)]` this line which looked like stripped rows were coming through empty. We can replicate it by adding an empty line at the end of the file.