### PR TITLE
CLDC-1988 Don't hide person known question in CYA

### DIFF
--- a/app/models/form/sales/questions/person_known.rb
+++ b/app/models/form/sales/questions/person_known.rb
@@ -5,13 +5,6 @@ class Form::Sales::Questions::PersonKnown < ::Form::Question
     @header = "Do you know the details for person #{person_index}?"
     @type = "radio"
     @answer_options = ANSWER_OPTIONS
-    @hidden_in_check_answers = {
-      "depends_on" => [
-        {
-          "details_known_#{person_index}" => 1,
-        },
-      ],
-    }
     @check_answers_card_number = person_index
   end
 

--- a/spec/models/form/sales/questions/person_known_spec.rb
+++ b/spec/models/form/sales/questions/person_known_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Form::Sales::Questions::PersonKnown, type: :model do
     expect(question.hint_text).to be_nil
   end
 
+  it "has the correct hidden_in_check_answers" do
+    expect(question.hidden_in_check_answers).to be_nil
+  end
+
   context "with person 2" do
     let(:question_id) { "details_known_2" }
     let(:person_index) { 2 }
@@ -49,12 +53,6 @@ RSpec.describe Form::Sales::Questions::PersonKnown, type: :model do
 
     it "has the correct check_answer_label" do
       expect(question.check_answer_label).to eq("Details known for person 2?")
-    end
-
-    it "has the correct hidden_in_check_answers" do
-      expect(question.hidden_in_check_answers).to eq(
-        "depends_on" => [{ "details_known_2" => 1 }],
-      )
     end
 
     it "has the correct check_answers_card_number" do
@@ -78,12 +76,6 @@ RSpec.describe Form::Sales::Questions::PersonKnown, type: :model do
       expect(question.check_answer_label).to eq("Details known for person 3?")
     end
 
-    it "has the correct hidden_in_check_answers" do
-      expect(question.hidden_in_check_answers).to eq(
-        "depends_on" => [{ "details_known_3" => 1 }],
-      )
-    end
-
     it "has the correct check_answers_card_number" do
       expect(question.check_answers_card_number).to eq(3)
     end
@@ -105,12 +97,6 @@ RSpec.describe Form::Sales::Questions::PersonKnown, type: :model do
       expect(question.check_answer_label).to eq("Details known for person 4?")
     end
 
-    it "has the correct hidden_in_check_answers" do
-      expect(question.hidden_in_check_answers).to eq(
-        "depends_on" => [{ "details_known_4" => 1 }],
-      )
-    end
-
     it "has the correct check_answers_card_number" do
       expect(question.check_answers_card_number).to eq(4)
     end
@@ -130,12 +116,6 @@ RSpec.describe Form::Sales::Questions::PersonKnown, type: :model do
 
     it "has the correct check_answer_label" do
       expect(question.check_answer_label).to eq("Details known for person 5?")
-    end
-
-    it "has the correct hidden_in_check_answers" do
-      expect(question.hidden_in_check_answers).to eq(
-        "depends_on" => [{ "details_known_5" => 1 }],
-      )
     end
 
     it "has the correct check_answers_card_number" do


### PR DESCRIPTION
If user says "yes" to "do you know the details for person X" they are taken to all the questions for that person.
If they change their mind and don't know the details, they can't change this answer because it's not in the CYA page for the Household Characteristics section. 
Instead we want the ability to change this answer. This is already the case for lettings.