### PR TITLE
Add new fields for user id export

### DIFF
--- a/app/services/exports/lettings_log_export_constants.rb
+++ b/app/services/exports/lettings_log_export_constants.rb
@@ -131,7 +131,7 @@ module Exports::LettingsLogExportConstants
     "log_id",
     "scheme_status",
     "location_status",
-    "amended_by",
+    "amended_by_id",
     "duplicate_set_id",
     "accessible_register",
     "nationality_all",
@@ -148,8 +148,8 @@ module Exports::LettingsLogExportConstants
     "pscharge_value_check",
     "supcharg_value_check",
     "carehome_charges_value_check",
-    "assigned_to",
-    "created_by",
+    "assigned_to_id",
+    "created_by_id",
   ]
 
   (1..8).each do |index|

--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -81,9 +81,7 @@ module Exports
       end
 
       attribute_hash["log_id"] = lettings_log.id
-      attribute_hash["assigned_to"] = lettings_log.assigned_to_id
-      attribute_hash["created_by"] = lettings_log.created_by_id
-      attribute_hash["amended_by"] = lettings_log.updated_by_id
+      attribute_hash["amended_by_id"] = lettings_log.updated_by_id
 
       attribute_hash["la"] = lettings_log.la
       attribute_hash["postcode_full"] = lettings_log.postcode_full

--- a/spec/fixtures/exports/general_needs_log.xml
+++ b/spec/fixtures/exports/general_needs_log.xml
@@ -131,6 +131,7 @@
     <relat8/>
     <lar>2</lar>
     <irproduct/>
+    <assigned_to_id>{assigned_to}</assigned_to_id>
     <sheltered/>
     <hhtype>4</hhtype>
     <new_old>2</new_old>
@@ -145,15 +146,14 @@
     <discarded_at/>
     <creation_method>1</creation_method>
     <duplicate_set_id/>
+    <created_by_id>{created_by}</created_by_id>
     <formid>{id}</formid>
     <owningorgid>{owning_org_id}</owningorgid>
     <maningorgid>{managing_org_id}</maningorgid>
     <createddate>2022-05-01T00:00:00+01:00</createddate>
     <uploaddate>2022-05-01T00:00:00+01:00</uploaddate>
     <log_id>{log_id}</log_id>
-    <assigned_to>{assigned_to}</assigned_to>
-    <created_by>{created_by}</created_by>
-    <amended_by/>
+    <amended_by_id/>
     <renttype_detail>2</renttype_detail>
   </form>
 </forms>

--- a/spec/fixtures/exports/general_needs_log_23_24.xml
+++ b/spec/fixtures/exports/general_needs_log_23_24.xml
@@ -132,6 +132,7 @@
     <lar>2</lar>
     <irproduct/>
     <joint>3</joint>
+    <assigned_to_id>{assigned_to}</assigned_to_id>
     <sheltered/>
     <hhtype>4</hhtype>
     <new_old>2</new_old>
@@ -146,15 +147,14 @@
     <discarded_at/>
     <creation_method>1</creation_method>
     <duplicate_set_id/>
+    <created_by_id>{created_by}</created_by_id>
     <formid>{id}</formid>
     <owningorgid>{owning_org_id}</owningorgid>
     <maningorgid>{managing_org_id}</maningorgid>
     <createddate>2023-04-03T00:00:00+01:00</createddate>
     <uploaddate>2023-04-03T00:00:00+01:00</uploaddate>
     <log_id>{log_id}</log_id>
-    <assigned_to>{assigned_to}</assigned_to>
-    <created_by>{created_by}</created_by>
-    <amended_by/>
+    <amended_by_id/>
     <renttype_detail>2</renttype_detail>
   </form>
 </forms>

--- a/spec/fixtures/exports/general_needs_log_24_25.xml
+++ b/spec/fixtures/exports/general_needs_log_24_25.xml
@@ -132,6 +132,7 @@
     <lar>2</lar>
     <irproduct/>
     <joint>3</joint>
+    <assigned_to_id>{assigned_to}</assigned_to_id>
     <sheltered/>
     <hhtype>4</hhtype>
     <new_old>2</new_old>
@@ -159,15 +160,14 @@
     <county_as_entered>county as entered</county_as_entered>
     <postcode_full_as_entered>AB1 2CD</postcode_full_as_entered>
     <la_as_entered>la as entered</la_as_entered>
+    <created_by_id>{created_by}</created_by_id>
     <formid>{id}</formid>
     <owningorgid>{owning_org_id}</owningorgid>
     <maningorgid>{managing_org_id}</maningorgid>
     <createddate>2024-04-03T00:00:00+01:00</createddate>
     <uploaddate>2024-04-03T00:00:00+01:00</uploaddate>
     <log_id>{log_id}</log_id>
-    <assigned_to>{assigned_to}</assigned_to>
-    <created_by>{created_by}</created_by>
-    <amended_by/>
+    <amended_by_id/>
     <renttype_detail>2</renttype_detail>
   </form>
 </forms>

--- a/spec/fixtures/exports/supported_housing_logs.xml
+++ b/spec/fixtures/exports/supported_housing_logs.xml
@@ -130,6 +130,7 @@
     <relat8/>
     <lar>2</lar>
     <irproduct/>
+    <assigned_to_id>{assigned_to}</assigned_to_id>
     <sheltered>1</sheltered>
     <hhtype>4</hhtype>
     <new_old>2</new_old>
@@ -144,15 +145,14 @@
     <discarded_at/>
     <creation_method>1</creation_method>
     <duplicate_set_id/>
+    <created_by_id>{created_by}</created_by_id>
     <formid>{id}</formid>
     <owningorgid>{owning_org_id}</owningorgid>
     <maningorgid>{managing_org_id}</maningorgid>
     <createddate>2022-05-01T00:00:00+01:00</createddate>
     <uploaddate>2022-05-01T00:00:00+01:00</uploaddate>
     <log_id>{log_id}</log_id>
-    <assigned_to>{assigned_to}</assigned_to>
-    <created_by>{created_by}</created_by>
-    <amended_by>{amended_by}</amended_by>
+    <amended_by_id>{amended_by}</amended_by_id>
     <unittype_sh>7</unittype_sh>
     <confidential>1</confidential>
     <cligrp1>G</cligrp1>


### PR DESCRIPTION
We're currently exporting emails in created_by/assigned_to/ammended_by. On [CLDC-3533-export-user-data](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/tree/CLDC-3533-export-user-data) we change that to IDs, but we don't actually want to be changing  the datatypes of existing fields, instead we want new fields