### PR TITLE
Capture failed bulk uploads

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -42,14 +42,25 @@ class BulkUpload::Lettings::Validator
 
   def create_logs?
     return false if any_setup_errors?
-    return false if row_parsers.any?(&:block_log_creation?)
-    return false if any_logs_already_exist? && FeatureToggle.bulk_upload_duplicate_log_check_enabled?
+
+    if row_parsers.any?(&:block_log_creation?)
+      Sentry.capture_exception("Bulk upload log creation blocked: #{bulk_upload.id}.")
+      return false
+    end
+
+    if any_logs_already_exist? && FeatureToggle.bulk_upload_duplicate_log_check_enabled?
+      Sentry.capture_exception("Bulk upload log creation blocked due to duplicate logs: #{bulk_upload.id}.")
+      return false
+    end
 
     row_parsers.each do |row_parser|
       row_parser.log.blank_invalid_non_setup_fields!
     end
 
-    return false if any_logs_invalid?
+    if any_logs_invalid?
+      Sentry.capture_exception("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      return false
+    end
 
     true
   end

--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -44,12 +44,12 @@ class BulkUpload::Lettings::Validator
     return false if any_setup_errors?
 
     if row_parsers.any?(&:block_log_creation?)
-      Sentry.capture_exception("Bulk upload log creation blocked: #{bulk_upload.id}.")
+      Sentry.capture_message("Bulk upload log creation blocked: #{bulk_upload.id}.")
       return false
     end
 
     if any_logs_already_exist? && FeatureToggle.bulk_upload_duplicate_log_check_enabled?
-      Sentry.capture_exception("Bulk upload log creation blocked due to duplicate logs: #{bulk_upload.id}.")
+      Sentry.capture_message("Bulk upload log creation blocked due to duplicate logs: #{bulk_upload.id}.")
       return false
     end
 
@@ -58,7 +58,7 @@ class BulkUpload::Lettings::Validator
     end
 
     if any_logs_invalid?
-      Sentry.capture_exception("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      Sentry.capture_message("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
       return false
     end
 

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -41,14 +41,25 @@ class BulkUpload::Sales::Validator
 
   def create_logs?
     return false if any_setup_errors?
-    return false if row_parsers.any?(&:block_log_creation?)
-    return false if any_logs_already_exist? && FeatureToggle.bulk_upload_duplicate_log_check_enabled?
+
+    if row_parsers.any?(&:block_log_creation?)
+      Sentry.capture_exception("Bulk upload log creation blocked: #{bulk_upload.id}.")
+      return false
+    end
+
+    if any_logs_already_exist? && FeatureToggle.bulk_upload_duplicate_log_check_enabled?
+      Sentry.capture_exception("Bulk upload log creation blocked due to duplicate logs: #{bulk_upload.id}.")
+      return false
+    end
 
     row_parsers.each do |row_parser|
       row_parser.log.blank_invalid_non_setup_fields!
     end
 
-    return false if any_logs_invalid?
+    if any_logs_invalid?
+      Sentry.capture_exception("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      return false
+    end
 
     true
   end


### PR DESCRIPTION
I think we should aim not to be sending this email, because it's never informative.

When `create_logs?` returns false we call `send_correct_and_upload_again_mail`, which sends an email saying `Your file has errors on important questions`.


`create_logs?` checks if:
- there are any setup errors, which we already check beforehand and send a different email anyway.
- we explicitly block log creation - it's unclear to me what situations there are where there are no setup errors, but log creation is blocked, I feel like all of these should be caught and saved as setup errors or explicitly added to error report, cause otherwise it's unclear what needs to be fixed.
- there are any duplicate logs (again) but it doesn't add any errors to the error report, so it's not very clear from the email/error report why it failed. I think the only way this would fail is if duplicate logs got created between calling validator and calling `create_logs?` method, which I guess could happen if it's a large file. There was also an issue with this triggering on blank rows not too long ago.
- the log(s) is still invalid after clearing all the invalid fields - I think this might happen in situations where a scheme changes between calling the validator and `create_logs?` method. It's unlikely, but not impossible. Would be good to know how often we hit this.