### PR TITLE
Memoise empty address options result

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -130,7 +130,10 @@ class Log < ApplicationRecord
     if [address_line1_input, postcode_full_input].all?(&:present?)
       service = AddressClient.new(address_string)
       service.call
-      return nil if service.result.blank? || service.error.present?
+      if service.result.blank? || service.error.present?
+        @address_options = []
+        return @answer_options
+      end
 
       address_opts = []
       service.result.first(10).each do |result|


### PR DESCRIPTION
We call address_options method many times for routing etc, as a few questions depend on address_options being present/absent. In most cases where either address option is present or the input for search is not given, we either memoise the result or don't call the postcodes service. 

When address input doesn't return any results we keep on calling postcodes service every time address_options is called, which is a lot, and often results in timeout.