### PR TITLE
CLDC-3518 Allow updating mandatory collection resources

### DIFF
--- a/app/services/mandatory_collection_resources_service.rb
+++ b/app/services/mandatory_collection_resources_service.rb
@@ -16,6 +16,8 @@ class MandatoryCollectionResourcesService
   end
 
   def self.generate_resource(log_type, year, resource_type)
+    return unless log_type && year && resource_type
+    return unless %w[lettings sales].include?(log_type)
     return unless MANDATORY_RESOURCES.include?(resource_type)
 
     CollectionResource.new(

--- a/app/services/upload_collection_resources_service.rb
+++ b/app/services/upload_collection_resources_service.rb
@@ -1,0 +1,6 @@
+class UploadCollectionResourcesService
+  def self.upload_collection_resource(filename, file)
+    storage_service = Storage::S3Service.new(Configuration::EnvConfigurationService.new, ENV["COLLECTION_RESOURCES_BUCKET"])
+    storage_service.write_file(filename, file)
+  end
+end

--- a/app/views/collection_resources/_collection_resource_summary_list.erb
+++ b/app/views/collection_resources/_collection_resource_summary_list.erb
@@ -10,7 +10,7 @@
             <% end %>
             <% row.with_action(
               text: "Change",
-              href: "/",
+              href: update_mandatory_collection_resource_path(year: resource.year, log_type: resource.log_type, resource_type: resource.resource_type),
             ) %>
           <% else %>
             <% row.with_value do %>

--- a/app/views/collection_resources/_collection_resource_summary_list.erb
+++ b/app/views/collection_resources/_collection_resource_summary_list.erb
@@ -10,7 +10,7 @@
             <% end %>
             <% row.with_action(
               text: "Change",
-              href: update_mandatory_collection_resource_path(year: resource.year, log_type: resource.log_type, resource_type: resource.resource_type),
+              href: edit_mandatory_collection_resource_path(year: resource.year, log_type: resource.log_type, resource_type: resource.resource_type),
             ) %>
           <% else %>
             <% row.with_value do %>

--- a/app/views/collection_resources/edit.html.erb
+++ b/app/views/collection_resources/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @collection_resource, scope: :form, url: update_mandatory_collection_resource_path, method: :patch do |f| %>
+    <%= form_with model: @collection_resource, url: update_mandatory_collection_resource_path, method: :patch do |f| %>
       <%= f.hidden_field :year %>
       <%= f.hidden_field :log_type %>
       <%= f.hidden_field :resource_type %>

--- a/app/views/collection_resources/edit.html.erb
+++ b/app/views/collection_resources/edit.html.erb
@@ -1,0 +1,28 @@
+<% content_for :before_content do %>
+  <%= govuk_back_link href: collection_resources_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @collection_resource, scope: :form, url: update_mandatory_collection_resource_path, method: :patch do |f| %>
+      <%= f.hidden_field :year %>
+      <%= f.hidden_field :log_type %>
+      <%= f.hidden_field :resource_type %>
+
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= "#{@collection_resource.log_type.humanize} #{text_year_range_format(@collection_resource.year)}" %></span>
+      <h1 class="govuk-heading-l">Change the <%= @collection_resource.resource_type.humanize.downcase %></h1>
+
+      <p class="govuk-body">
+        This file will be available for all users to download.
+      </p>
+
+      <%= f.govuk_file_field :file,
+        label: { text: "Upload file", size: "m" } %>
+
+      <%= f.govuk_submit "Save changes" %>
+      <%= govuk_button_link_to "Cancel", collection_resources_path, secondary: true %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
 
   get "collection-resources", to: "collection_resources#index"
   get "/collection-resources/:log_type/:year/:resource_type/download", to: "collection_resources#download_mandatory_collection_resource", as: :download_mandatory_collection_resource
+  get "/collection-resources/:log_type/:year/:resource_type/edit", to: "collection_resources#update_mandatory_collection_resource", as: :update_mandatory_collection_resource
 
   resources :collection_resources, path: "/collection-resources" do
     get "/download", to: "collection_resources#download_additional_collection_resource" # when we get to adding them

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,8 @@ Rails.application.routes.draw do
 
   get "collection-resources", to: "collection_resources#index"
   get "/collection-resources/:log_type/:year/:resource_type/download", to: "collection_resources#download_mandatory_collection_resource", as: :download_mandatory_collection_resource
-  get "/collection-resources/:log_type/:year/:resource_type/edit", to: "collection_resources#update_mandatory_collection_resource", as: :update_mandatory_collection_resource
+  get "/collection-resources/:log_type/:year/:resource_type/edit", to: "collection_resources#edit", as: :edit_mandatory_collection_resource
+  patch "/collection-resources", to: "collection_resources#update", as: :update_mandatory_collection_resource
 
   resources :collection_resources, path: "/collection-resources" do
     get "/download", to: "collection_resources#download_additional_collection_resource" # when we get to adding them

--- a/spec/requests/collection_resources_controller_spec.rb
+++ b/spec/requests/collection_resources_controller_spec.rb
@@ -86,6 +86,19 @@ RSpec.describe CollectionResourcesController, type: :request do
 
         it "displays change links" do
           expect(page).to have_selector(:link_or_button, "Change", count: 12)
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_specification"))
+
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_specification"))
         end
       end
 
@@ -179,6 +192,63 @@ RSpec.describe CollectionResourcesController, type: :request do
           expect(response.status).to eq(200)
           expect(response.body).to eq("file")
         end
+      end
+    end
+  end
+
+  describe "GET #update_mandatory_collection_resource" do
+    context "when user is not signed in" do
+      it "redirects to the sign in page" do
+        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is signed in as a data coordinator" do
+      let(:user) { create(:user, :data_coordinator) }
+
+      before do
+        sign_in user
+      end
+
+      it "returns page not found" do
+        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is signed in as a data provider" do
+      let(:user) { create(:user, :data_provider) }
+
+      before do
+        sign_in user
+      end
+
+      it "returns page not found" do
+        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is signed in as a support user" do
+      let(:user) { create(:user, :support) }
+
+      before do
+        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2025, 1, 8))
+        allow(user).to receive(:need_two_factor_authentication?).and_return(false)
+        sign_in user
+      end
+
+      it "displays update collection resources page content" do
+        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+
+        expect(page).to have_content("Sales 2024 to 2025")
+        expect(page).to have_content("Change the bulk upload template")
+        expect(page).to have_content("This file will be available for all users to download.")
+        expect(page).to have_content("Upload file")
+        expect(page).to have_button("Save changes")
+        expect(page).to have_link("Back", href: collection_resources_path)
+        expect(page).to have_link("Cancel", href: collection_resources_path)
       end
     end
   end

--- a/spec/requests/collection_resources_controller_spec.rb
+++ b/spec/requests/collection_resources_controller_spec.rb
@@ -86,19 +86,19 @@ RSpec.describe CollectionResourcesController, type: :request do
 
         it "displays change links" do
           expect(page).to have_selector(:link_or_button, "Change", count: 12)
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "paper_form"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_template"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_specification"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "paper_form"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "lettings", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_specification"))
 
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "paper_form"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_template"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_specification"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "paper_form"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_template"))
-          expect(page).to have_link("Change", href: update_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "lettings", resource_type: "bulk_upload_specification"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "paper_form"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_template"))
+          expect(page).to have_link("Change", href: edit_mandatory_collection_resource_path(year: 2025, log_type: "sales", resource_type: "bulk_upload_specification"))
         end
       end
 
@@ -196,10 +196,10 @@ RSpec.describe CollectionResourcesController, type: :request do
     end
   end
 
-  describe "GET #update_mandatory_collection_resource" do
+  describe "GET #edit_mandatory_collection_resource" do
     context "when user is not signed in" do
       it "redirects to the sign in page" do
-        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        get edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -212,7 +212,7 @@ RSpec.describe CollectionResourcesController, type: :request do
       end
 
       it "returns page not found" do
-        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        get edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -225,7 +225,7 @@ RSpec.describe CollectionResourcesController, type: :request do
       end
 
       it "returns page not found" do
-        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        get edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -240,7 +240,7 @@ RSpec.describe CollectionResourcesController, type: :request do
       end
 
       it "displays update collection resources page content" do
-        get update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
+        get edit_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template")
 
         expect(page).to have_content("Sales 2024 to 2025")
         expect(page).to have_content("Change the bulk upload template")
@@ -249,6 +249,88 @@ RSpec.describe CollectionResourcesController, type: :request do
         expect(page).to have_button("Save changes")
         expect(page).to have_link("Back", href: collection_resources_path)
         expect(page).to have_link("Cancel", href: collection_resources_path)
+      end
+    end
+  end
+
+  describe "PATCH #update_mandatory_collection_resource" do
+    let(:some_file) { File.open(file_fixture("blank_bulk_upload_sales.csv")) }
+    let(:params) { { collection_resource: { year: 2024, log_type: "sales", resource_type: "bulk_upload_template", file: some_file } } }
+
+    before do
+      allow(UploadCollectionResourcesService).to receive(:upload_collection_resource)
+    end
+
+    context "when user is not signed in" do
+      it "redirects to the sign in page" do
+        patch update_mandatory_collection_resource_path(year: 2024, log_type: "sales", resource_type: "bulk_upload_template", file: some_file)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is signed in as a data coordinator" do
+      let(:user) { create(:user, :data_coordinator) }
+
+      before do
+        sign_in user
+      end
+
+      it "returns page not found" do
+        patch update_mandatory_collection_resource_path, params: params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is signed in as a data provider" do
+      let(:user) { create(:user, :data_provider) }
+
+      before do
+        sign_in user
+      end
+
+      it "returns page not found" do
+        patch update_mandatory_collection_resource_path, params: params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is signed in as a support user" do
+      let(:user) { create(:user, :support) }
+
+      before do
+        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2025, 1, 8))
+        allow(user).to receive(:need_two_factor_authentication?).and_return(false)
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(CollectionResourcesHelper).to receive(:editable_collection_resource_years).and_return([2024, 2025])
+        # rubocop:enable RSpec/AnyInstance
+        sign_in user
+      end
+
+      it "correcty updates a sales file" do
+        params = { collection_resource: { year: 2024, log_type: "sales", resource_type: "bulk_upload_template", file: some_file } }
+        patch update_mandatory_collection_resource_path, params: params
+
+        expect(response).to redirect_to(collection_resources_path)
+        expect(UploadCollectionResourcesService).to have_received(:upload_collection_resource).with("bulk-upload-sales-template-2024-25.xlsx", anything)
+        expect(flash[:notice]).to eq("The sales 2024 to 2025 bulk upload template has been updated")
+      end
+
+      it "correcty updates a lettings file" do
+        params = { collection_resource: { year: 2025, log_type: "lettings", resource_type: "paper_form", file: some_file } }
+        patch update_mandatory_collection_resource_path, params: params
+
+        expect(response).to redirect_to(collection_resources_path)
+        expect(UploadCollectionResourcesService).to have_received(:upload_collection_resource).with("2025_26_lettings_paper_form.pdf", anything)
+        expect(flash[:notice]).to eq("The lettings 2025 to 2026 paper form has been updated")
+      end
+
+      it "displays error message if the upload fails" do
+        allow(UploadCollectionResourcesService).to receive(:upload_collection_resource).and_raise(StandardError)
+
+        params = { collection_resource: { year: 2025, log_type: "lettings", resource_type: "paper_form", file: some_file } }
+        patch update_mandatory_collection_resource_path, params: params
+
+        expect(page).to have_content("There was an error uploading this file.")
       end
     end
   end

--- a/spec/services/upload_collection_resources_service_spec.rb
+++ b/spec/services/upload_collection_resources_service_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe UploadCollectionResourcesService do
+  let(:service) { described_class }
+  let(:some_file) { File.open(file_fixture("blank_bulk_upload_sales.csv")) }
+  let(:storage_service) { instance_double(Storage::S3Service) }
+
+  describe "#upload_collection_resource" do
+    before do
+      allow(Storage::S3Service).to receive(:new).and_return(storage_service)
+      allow(storage_service).to receive(:write_file)
+    end
+
+    it "calls write_file on S3 service" do
+      expect(storage_service).to receive(:write_file).with("2025_26_lettings_paper_form.pdf", some_file)
+      service.upload_collection_resource("2025_26_lettings_paper_form.pdf", some_file)
+    end
+  end
+end


### PR DESCRIPTION
Link to a page to update a resource (this error happens if there's an internal error, like s3 bucket cannot be found)
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/4dc452d9-e18b-4ee0-8c25-ddb967b52acc">

Upload the new resource to S3