### PR TITLE
CLDC-3644: Remove Plausible Analytics script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,9 +60,6 @@
       </script>
     <% end %>
 
-    <% if Rails.env.production? && ENV["APP_HOST"].present? %>
-      <script defer data-domain="<%= ENV["APP_HOST"].split("https://")[1] %>" src="https://plausible.io/js/plausible.js"></script>
-    <% end %>
   </head>
 
   <body class="govuk-template__body app-template--wide">


### PR DESCRIPTION
Plausible analytics is not being used.

This branch reverts these commits:
**Add plausible analytics script**
https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/commit/3e920511a1da24d5e2f30de870adc53f93738f6e

**Domain string**
https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/commit/e87fc8bae65c4d61b8767fbab8b439a84a07513e