### PR TITLE
Handle non json address responses

### DIFF
--- a/app/services/address_client.rb
+++ b/app/services/address_client.rb
@@ -20,7 +20,11 @@ class AddressClient
   end
 
   def result
-    @result ||= JSON.parse(response.body)["results"]&.map { |address| address["DPA"] }
+    if response.is_a?(Net::HTTPSuccess)
+      @result ||= JSON.parse(response.body)["results"]&.map { |address| address["DPA"] }
+    else
+      @result = nil
+    end
   end
 
 private

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1317,6 +1317,31 @@ RSpec.describe LettingsLogsController, type: :request do
       end
     end
 
+    context "when os places api returns non json response" do
+      let(:lettings_log) do
+        build(:lettings_log,
+              :completed,
+              assigned_to: user,
+              uprn_known: 0,
+              uprn: nil,
+              address_line1_input: "Address line 1",
+              postcode_full_input: "SW1A 1AA")
+      end
+      let(:id) { lettings_log.id }
+
+      before do
+        lettings_log.save!(validate: false)
+        WebMock.stub_request(:get, /https:\/\/api.os.uk\/search\/places\/v1\/find/)
+        .to_return(status: 503, body: "something went wrong", headers: {})
+        sign_in user
+      end
+
+      it "renders the property information check answers without error" do
+        get "/lettings-logs/#{id}/property-information/check-answers"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context "when requesting CSV download" do
       let(:headers) { { "Accept" => "text/html" } }
       let(:search_term) { "foo" }

--- a/spec/requests/lettings_logs_controller_spec.rb
+++ b/spec/requests/lettings_logs_controller_spec.rb
@@ -1331,7 +1331,7 @@ RSpec.describe LettingsLogsController, type: :request do
 
       before do
         lettings_log.save!(validate: false)
-        WebMock.stub_request(:get, /https:\/\/api.os.uk\/search\/places\/v1\/find/)
+        WebMock.stub_request(:get, /https:\/\/api\.os\.uk\/search\/places\/v1\/find/)
         .to_return(status: 503, body: "something went wrong", headers: {})
         sign_in user
       end


### PR DESCRIPTION
`AddressService::.result` gets called from `address_options`/`address_options_present?` which in most cases gets called for routing. If at any point `api.os.uk` returns a non json response, our service would fail with internal error and prevent us from viewing the log.
This double checks that api response is successful before parsing it as a json