### PR TITLE
Update flaky test

### DIFF
--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe LocationsController, type: :request do
 
     context "when signed in as a data coordinator user" do
       let(:user) { create(:user, :data_coordinator) }
-      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation, service_name: "Some name") }
       let!(:locations) { create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
 
       before do
@@ -288,7 +288,7 @@ RSpec.describe LocationsController, type: :request do
 
         it "has search in the title" do
           expected_title = CGI.escapeHTML("#{scheme.service_name} (1 location matching ‘#{search_param}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
-          expect(page).to have_title(expected_title)
+          expect(page.title).to eq(expected_title)
         end
       end
 


### PR DESCRIPTION
Hardcode the service name, cause sometimes faker creates a service name with characters that need to be escaped and the comparison fails