### PR TITLE
CLDC-3066: Show filters button bug

### DIFF
--- a/app/components/create_log_actions_component.html.erb
+++ b/app/components/create_log_actions_component.html.erb
@@ -1,6 +1,6 @@
 <% if display_actions? %>
   <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
-    <%= govuk_button_to create_button_copy, create_button_href, class: "govuk-!-margin-right-6" %>
+    <%= govuk_button_to create_button_copy, create_button_href, class: "govuk-!-margin-right-3" %>
     <% unless user.support? %>
     <%= govuk_button_link_to upload_button_copy, upload_button_href, secondary: true %>
     <% end %>

--- a/app/views/logs/_create_for_org_actions.html.erb
+++ b/app/views/logs/_create_for_org_actions.html.erb
@@ -1,13 +1,13 @@
-<div class="govuk-button-group app-filter-toggle">
+<div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
   <% if @organisation.data_protection_confirmed? %>
     <% if current_page?(controller: 'organisations', action: 'lettings_logs') %>
-      <%= govuk_button_to "Create a new lettings log", lettings_logs_path(lettings_log: { owning_organisation_id: @organisation.id }, method: :post), class: "govuk-!-margin-right-6" %>
-      <%= govuk_button_link_to "Upload lettings logs in bulk", bulk_upload_lettings_log_path(id: "start", organisation_id: @organisation.id), secondary: true, class: "govuk-!-margin-right-6" %>
+      <%= govuk_button_to "Create a new lettings log", lettings_logs_path(lettings_log: { owning_organisation_id: @organisation.id }, method: :post), class: "govuk-!-margin-right-3" %>
+      <%= govuk_button_link_to "Upload lettings logs in bulk", bulk_upload_lettings_log_path(id: "start", organisation_id: @organisation.id), secondary: true, class: "govuk-!-margin-right-3" %>
       <%= govuk_button_link_to "View lettings bulk uploads", bulk_uploads_lettings_logs_path(organisation_id: @organisation.id, clear_old_filters: true), secondary: true %>
 <% end %>
     <% if current_page?(controller: 'organisations', action: 'sales_logs') %>
-      <%= govuk_button_to "Create a new sales log", sales_logs_path(sales_log: { owning_organisation_id: @organisation.id }, method: :post), class: "govuk-!-margin-right-6" %>
-      <%= govuk_button_link_to "Upload sales logs in bulk", bulk_upload_sales_log_path(id: "start", organisation_id: @organisation.id), secondary: true, class: "govuk-!-margin-right-6" %>
+      <%= govuk_button_to "Create a new sales log", sales_logs_path(sales_log: { owning_organisation_id: @organisation.id }, method: :post), class: "govuk-!-margin-right-3" %>
+      <%= govuk_button_link_to "Upload sales logs in bulk", bulk_upload_sales_log_path(id: "start", organisation_id: @organisation.id), secondary: true, class: "govuk-!-margin-right-3" %>
       <%= govuk_button_link_to "View sales bulk uploads", bulk_uploads_sales_logs_path(organisation_id: @organisation.id, clear_old_filters: true), secondary: true %>
 <% end %>
   <% end %>

--- a/app/views/organisations/schemes.html.erb
+++ b/app/views/organisations/schemes.html.erb
@@ -23,7 +23,9 @@
 
 <div class="app-filter-layout" data-controller="filter-layout">
   <% if SchemePolicy.new(current_user, nil).create? %>
-    <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+    <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
+      <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+    </div>
   <% end %>
 
   <%= govuk_details(

--- a/app/views/organisations/users.html.erb
+++ b/app/views/organisations/users.html.erb
@@ -12,10 +12,12 @@
   <h2 class="govuk-visually-hidden">Users</h2>
 <% end %>
 
-<% if current_user.data_coordinator? || current_user.support? %>
-  <%= govuk_button_link_to "Invite user", new_user_path(organisation_id: @organisation.id), html: { method: :get } %>
-<% end %>
 <div class="app-filter-layout" data-controller="filter-layout">
+  <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
+    <% if current_user.data_coordinator? || current_user.support? %>
+      <%= govuk_button_link_to "Invite user", new_user_path(organisation_id: @organisation.id), html: { method: :get } %>
+    <% end %>
+  </div>
   <%= render partial: "users/user_filters" %>
   <div class="app-filter-layout__content">
 

--- a/app/views/schemes/index.html.erb
+++ b/app/views/schemes/index.html.erb
@@ -5,12 +5,12 @@
 
 <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Supported housing schemes", sub: nil } : { main: "Supported housing schemes", sub: current_user.organisation.name } %>
 
-<% if SchemePolicy.new(current_user, nil).create? %>
-  <div class="govuk-button-group govuk-!-margin-bottom-6">
-    <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
-  </div>
-<% end %>
 <div class="app-filter-layout" data-controller="filter-layout">
+  <% if SchemePolicy.new(current_user, nil).create? %>
+    <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
+      <%= govuk_button_link_to "Create a new supported housing scheme", new_scheme_path, html: { method: :post } %>
+    </div>
+  <% end %>
   <%= render partial: "schemes/scheme_filters" %>
   <div class="app-filter-layout__content">
     <%= render SearchComponent.new(current_user:, search_label: "Search by postcode, scheme name, scheme code or location name", value: @searched) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,12 +5,12 @@
 
 <%= render partial: "organisations/headings", locals: current_user.support? ? { main: "Users", sub: nil } : { main: "Users", sub: current_user.organisation.name } %>
 
+<div class="app-filter-layout" data-controller="filter-layout">
 <% if current_user.data_coordinator? || current_user.support? %>
-  <div class="govuk-button-group govuk-!-margin-bottom-6">
+  <div class="govuk-button-group app-filter-toggle govuk-!-margin-bottom-6">
     <%= govuk_button_link_to "Invite user", new_user_path, html: { method: :get } %>
   </div>
 <% end %>
-<div class="app-filter-layout" data-controller="filter-layout">
   <%= render partial: "users/user_filters" %>
   <div class="app-filter-layout__content">
     <%= render SearchComponent.new(current_user:, search_label: "Search by name or email address", value: @searched) %>


### PR DESCRIPTION
Adds the a show filters toggle to the user and scheme pages on smaller screens


## Additional change
This PR also adjusts the spacing between buttons to match that of the show filter button.

### Previously
The show filters button is added but does not fit with the existing buttons. It is possible to add more margin to the right of the button - adding a property to the `.app-filter-toggle__button` class using CSS `!important` which we shouldn't use (Rubycop).
<img width="500" alt="Screenshot 2024-11-04 at 18 54 09" src="https://github.com/user-attachments/assets/df3d5ce8-8aeb-45ff-80ce-09aecd1a275d">

### Alternative - Not compliant with RubyCop Lint tests.
<img width="500" alt="Screenshot 2024-11-04 at 19 10 39" src="https://github.com/user-attachments/assets/ea6348b5-1a55-450d-9eee-63c899880db5">

### Solution
<img width="500" alt="Screenshot 2024-11-04 at 18 59 40" src="https://github.com/user-attachments/assets/75ce499e-5494-48ac-80b4-7f947e96771c">
