### PR TITLE
Fix flaky tests and use a Faker class Lorem

### DIFF
--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scheme do
-    service_name { Faker::Space.constellation }
+    service_name { Faker::Lorem.word }
     sensitive { Faker::Number.within(range: 0..1) }
     registered_under_care_act { 1 }
     support_type { [0, 2, 3, 4, 5].sample }

--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scheme do
-    service_name { Faker::Lorem.word }
+    service_name { Faker::Lorem.characters(number: 16) }
     sensitive { Faker::Number.within(range: 0..1) }
     registered_under_care_act { 1 }
     support_type { [0, 2, 3, 4, 5].sample }

--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scheme do
-    service_name { Faker::Name.name }
+    service_name { Faker::Space.constellation }
     sensitive { Faker::Number.within(range: 0..1) }
     registered_under_care_act { 1 }
     support_type { [0, 2, 3, 4, 5].sample }


### PR DESCRIPTION
Using `Faker::Name.name` can result in names with special characters, such as “O’Riley” which we’ve encountered in the scheme factory bot.

**Solution:** Switched to using `Faker::Lorem.characters`, which should return a random combination of characters.

Other options caused test failures due to duplicate elements. For example, `Space.constellation` produced “Leo” twice on a page, and `Lorem.word` resulted in “sed” appearing twice. These duplicates caused tests that search for a term to fail.

To minimise the risk of further clashes, we also now generate the service_name with 16 characters, making it highly improbable to encounter duplicates.