### PR TITLE
CLDC-3737 Route only to buyer questions for staircase transactions

### DIFF
--- a/app/models/form/sales/pages/buyer1_ethnic_group.rb
+++ b/app/models/form/sales/pages/buyer1_ethnic_group.rb
@@ -2,19 +2,21 @@ class Form::Sales::Pages::Buyer1EthnicGroup < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_1_ethnic_group"
-    @depends_on = [
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-      },
-    ]
   end
 
   def questions
     @questions ||= [
       Form::Sales::Questions::Buyer1EthnicGroup.new(nil, nil, self),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/app/models/form/sales/pages/buyer1_live_in_property.rb
+++ b/app/models/form/sales/pages/buyer1_live_in_property.rb
@@ -2,31 +2,28 @@ class Form::Sales::Pages::Buyer1LiveInProperty < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_1_live_in_property"
-    @depends_on = [
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "outright_sale?" => false,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "outright_sale?" => false,
-      },
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-    ]
   end
 
   def questions
     @questions ||= [
       Form::Sales::Questions::Buyer1LiveInProperty.new(nil, nil, self),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    privacy_notice_seen_or_not_interviewed = log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
+    not_outright_sale = !log.outright_sale?
+    joint_purchase_and_live_in = log.joint_purchase? && log.buyers_will_live_in?
+
+    return true if privacy_notice_seen_or_not_interviewed && not_outright_sale
+    return true if privacy_notice_seen_or_not_interviewed && joint_purchase_and_live_in
+
+    false
   end
 end

--- a/app/models/form/sales/pages/buyer1_nationality.rb
+++ b/app/models/form/sales/pages/buyer1_nationality.rb
@@ -2,14 +2,6 @@ class Form::Sales::Pages::Buyer1Nationality < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_1_nationality"
-    @depends_on = [
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-      },
-    ]
   end
 
   def questions
@@ -21,5 +13,15 @@ class Form::Sales::Pages::Buyer1Nationality < ::Form::Page
                    else
                      [Form::Sales::Questions::Buyer1Nationality.new(nil, nil, self)]
                    end
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/app/models/form/sales/pages/buyer1_working_situation.rb
+++ b/app/models/form/sales/pages/buyer1_working_situation.rb
@@ -17,4 +17,14 @@ class Form::Sales::Pages::Buyer1WorkingSituation < ::Form::Page
       Form::Sales::Questions::Buyer1WorkingSituation.new(nil, nil, self),
     ]
   end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
+  end
 end

--- a/app/models/form/sales/pages/buyer2_ethnic_group.rb
+++ b/app/models/form/sales/pages/buyer2_ethnic_group.rb
@@ -2,21 +2,22 @@ class Form::Sales::Pages::Buyer2EthnicGroup < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_2_ethnic_group"
-    @depends_on = [
-      {
-        "joint_purchase?" => true,
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "joint_purchase?" => true,
-        "buyer_not_interviewed?" => true,
-      },
-    ]
   end
 
   def questions
     @questions ||= [
       Form::Sales::Questions::Buyer2EthnicGroup.new(nil, nil, self),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false unless log.joint_purchase?
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/app/models/form/sales/pages/buyer2_live_in_property.rb
+++ b/app/models/form/sales/pages/buyer2_live_in_property.rb
@@ -2,33 +2,28 @@ class Form::Sales::Pages::Buyer2LiveInProperty < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_2_live_in_property"
-    @depends_on = [
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "outright_sale?" => false,
-        "joint_purchase?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "outright_sale?" => false,
-        "joint_purchase?" => true,
-      },
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-    ]
   end
 
   def questions
     @questions ||= [
       Form::Sales::Questions::Buyer2LiveInProperty.new(nil, nil, self),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+    return false unless log.joint_purchase?
+
+    privacy_notice_seen_or_not_interviewed = log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
+    not_outright_sale = !log.outright_sale?
+
+    return true if privacy_notice_seen_or_not_interviewed && not_outright_sale
+    return true if privacy_notice_seen_or_not_interviewed && log.buyers_will_live_in?
+
+    false
   end
 end

--- a/app/models/form/sales/pages/buyer2_nationality.rb
+++ b/app/models/form/sales/pages/buyer2_nationality.rb
@@ -2,16 +2,6 @@ class Form::Sales::Pages::Buyer2Nationality < ::Form::Page
   def initialize(id, hsh, subsection)
     super
     @id = "buyer_2_nationality"
-    @depends_on = [
-      {
-        "joint_purchase?" => true,
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "joint_purchase?" => true,
-        "buyer_not_interviewed?" => true,
-      },
-    ]
   end
 
   def questions
@@ -23,5 +13,16 @@ class Form::Sales::Pages::Buyer2Nationality < ::Form::Page
                    else
                      [Form::Sales::Questions::Buyer2Nationality.new(nil, nil, self)]
                    end
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false unless log.joint_purchase?
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/app/models/form/sales/pages/buyer2_working_situation.rb
+++ b/app/models/form/sales/pages/buyer2_working_situation.rb
@@ -3,21 +3,22 @@ class Form::Sales::Pages::Buyer2WorkingSituation < ::Form::Page
     super
     @id = "buyer_2_working_situation"
     @copy_key = "sales.household_characteristics.ecstat2.buyer"
-    @depends_on = [
-      {
-        "joint_purchase?" => true,
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "joint_purchase?" => true,
-        "buyer_not_interviewed?" => true,
-      },
-    ]
   end
 
   def questions
     @questions ||= [
       Form::Sales::Questions::Buyer2WorkingSituation.new(nil, nil, self),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false unless log.joint_purchase?
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/app/models/form/sales/pages/number_of_others_in_property.rb
+++ b/app/models/form/sales/pages/number_of_others_in_property.rb
@@ -1,16 +1,6 @@
 class Form::Sales::Pages::NumberOfOthersInProperty < ::Form::Page
   def initialize(id, hsh, subsection, joint_purchase:)
     super(id, hsh, subsection)
-    @depends_on = [
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "joint_purchase?" => joint_purchase,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "joint_purchase?" => joint_purchase,
-      },
-    ]
     @joint_purchase = joint_purchase
   end
 
@@ -18,5 +8,16 @@ class Form::Sales::Pages::NumberOfOthersInProperty < ::Form::Page
     @questions ||= [
       Form::Sales::Questions::NumberOfOthersInProperty.new(nil, nil, self, joint_purchase: @joint_purchase),
     ]
+  end
+
+  def routed_to?(log, _current_user)
+    super && page_routed_to?(log)
+  end
+
+  def page_routed_to?(log)
+    return false unless log.joint_purchase? == @joint_purchase
+    return false if log.form.start_year_2025_or_later? && log.is_staircase?
+
+    log.buyer_has_seen_privacy_notice? || log.buyer_not_interviewed?
   end
 end

--- a/spec/models/form/sales/pages/buyer1_ethnic_group_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_ethnic_group_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::Buyer1EthnicGroup, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1), start_year_2024_or_later?: false)) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
+  let(:subsection) { instance_double(Form::Subsection, form:, depends_on: nil) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -23,7 +24,71 @@ RSpec.describe Form::Sales::Pages::Buyer1EthnicGroup, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq([{ "buyer_has_seen_privacy_notice?" => true }, { "buyer_not_interviewed?" => true }])
+  context "with year 2024" do
+    let(:form) { Form.new(nil, 2024, [], "sales") }
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
   end
 end

--- a/spec/models/form/sales/pages/buyer1_live_in_property_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_live_in_property_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::Buyer1LiveInProperty, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1), start_year_2024_or_later?: false)) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
+  let(:subsection) { instance_double(Form::Subsection, form:, enabled?: true, depends_on: nil) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -23,26 +24,87 @@ RSpec.describe Form::Sales::Pages::Buyer1LiveInProperty, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq([
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "outright_sale?" => false,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "outright_sale?" => false,
-      },
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-    ])
+  context "with year 2024" do
+    let(:form) { Form.new(nil, 2024, [], "sales") }
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when privacy notice seen and not outright sale" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 2, noint: nil, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer not interviewed and not outright sale" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 2, noint: 1, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when privacy notice seen, joint purchase and live in" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2, ownershipsch: 1, buylivein: 1) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer not interviewed, joint purchase and live in" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2, ownershipsch: 1, buylivein: 1) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed and it's outright sale" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 2, noint: 0, staircase: 2, ownershipsch: 3, buylivein: nil) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 2, noint: 0, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 2, noint: 1, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 2, noint: 1, ownershipsch: 1, buylivein: nil, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
   end
 end

--- a/spec/models/form/sales/pages/buyer1_nationality_spec.rb
+++ b/spec/models/form/sales/pages/buyer1_nationality_spec.rb
@@ -3,12 +3,11 @@ require "rails_helper"
 RSpec.describe Form::Sales::Pages::Buyer1Nationality, type: :model do
   subject(:page) { described_class.new(nil, nil, subsection) }
 
-  let(:subsection) { instance_double(Form::Subsection) }
-  let(:form) { instance_double(Form, start_date: Time.zone.local(2023, 4, 1)) }
+  let(:subsection) { instance_double(Form::Subsection, depends_on: nil) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
 
   before do
     allow(subsection).to receive(:form).and_return(form)
-    allow(form).to receive(:start_year_2024_or_later?).and_return(false)
   end
 
   it "has correct subsection" do
@@ -27,17 +26,75 @@ RSpec.describe Form::Sales::Pages::Buyer1Nationality, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq [{ "buyer_has_seen_privacy_notice?" => true }, { "buyer_not_interviewed?" => true }]
-  end
-
   context "with year 2024" do
-    before do
-      allow(form).to receive(:start_year_2024_or_later?).and_return(true)
-    end
+    let(:form) { Form.new(nil, 2024, [], "sales") }
 
     it "has correct questions" do
       expect(page.questions.map(&:id)).to eq %w[nationality_all_group nationality_all]
+    end
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
     end
   end
 end

--- a/spec/models/form/sales/pages/buyer2_ethnic_group_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_ethnic_group_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::Buyer2EthnicGroup, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1))) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
+  let(:subsection) { instance_double(Form::Subsection, form:, depends_on: nil) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -23,16 +24,79 @@ RSpec.describe Form::Sales::Pages::Buyer2EthnicGroup, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq([
-      {
-        "joint_purchase?" => true,
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "joint_purchase?" => true,
-        "buyer_not_interviewed?" => true,
-      },
-    ])
+  context "with year 2024" do
+    let(:form) { Form.new(nil, 2024, [], "sales") }
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when it's not a joint purchase" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 2, noint: 1, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
   end
 end

--- a/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_live_in_property_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::Buyer2LiveInProperty, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1))) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
+  let(:subsection) { instance_double(Form::Subsection, form:, depends_on: nil, enabled?: true) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -23,28 +24,87 @@ RSpec.describe Form::Sales::Pages::Buyer2LiveInProperty, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq([
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "outright_sale?" => false,
-        "joint_purchase?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "outright_sale?" => false,
-        "joint_purchase?" => true,
-      },
-      {
-        "buyer_has_seen_privacy_notice?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-      {
-        "buyer_not_interviewed?" => true,
-        "joint_purchase?" => true,
-        "buyers_will_live_in?" => true,
-      },
-    ])
+  context "with year 2024" do
+    let(:form) { Form.new(nil, 2024, [], "sales") }
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when privacy notice seen and not outright sale" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: nil, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer not interviewed and not outright sale" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when privacy notice seen, joint purchase and live in" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2, ownershipsch: 1, buylivein: 1) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer not interviewed, joint purchase and live in" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2, ownershipsch: 1, buylivein: 1) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed and it's outright sale" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2, ownershipsch: 3, buylivein: nil) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 0, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, staircase: 2, ownershipsch: 1, buylivein: nil) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, ownershipsch: 1, buylivein: nil, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
   end
 end

--- a/spec/models/form/sales/pages/buyer2_working_situation_spec.rb
+++ b/spec/models/form/sales/pages/buyer2_working_situation_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Form::Sales::Pages::Buyer2WorkingSituation, type: :model do
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1), start_year_2025_or_later?: false)) }
+  let(:form) { Form.new(nil, 2023, [], "sales") }
+  let(:subsection) { instance_double(Form::Subsection, form:, depends_on: nil) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -23,16 +24,79 @@ RSpec.describe Form::Sales::Pages::Buyer2WorkingSituation, type: :model do
     expect(page.description).to be_nil
   end
 
-  it "has correct depends_on" do
-    expect(page.depends_on).to eq([
-      {
-        "joint_purchase?" => true,
-        "buyer_has_seen_privacy_notice?" => true,
-      },
-      {
-        "joint_purchase?" => true,
-        "buyer_not_interviewed?" => true,
-      },
-    ])
+  context "with year 2024" do
+    let(:form) { Form.new(nil, 2024, [], "sales") }
+
+    context "when routing" do
+      before do
+        allow(log).to receive(:form).and_return(form)
+      end
+
+      context "when buyer has seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when buyer has seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+
+      context "and buyer has not seen privacy notice and buyer not interviewed" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 1, noint: 1, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "when it's not a joint purchase" do
+        let(:log) { build(:sales_log, privacynotice: nil, jointpur: 2, noint: 1, staircase: 2) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
+  end
+
+  context "with year 2025" do
+    let(:form) { Form.new(nil, 2025, [], "sales") }
+
+    before do
+      allow(log).to receive(:form).and_return(form)
+    end
+
+    context "when routing" do
+      context "and staircase is not 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 2) }
+
+        it "routes to the page" do
+          expect(page.routed_to?(log, nil)).to eq(true)
+        end
+      end
+
+      context "and staircase is 1" do
+        let(:log) { build(:sales_log, privacynotice: 1, jointpur: 1, noint: 0, staircase: 1) }
+
+        it "does not route to the page" do
+          expect(page).not_to be_routed_to(log, nil)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We only want to route to these questions in household characteristics for 2025 if it's a staircase transaction:
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/237b8194-8b5f-4b07-b32e-8ae7f713eceb">
