### PR TITLE
Handle flaky failing tests

### DIFF
--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scheme do
-    service_name { Faker::Name.name }
+    service_name { "#{Faker::Name.name}'s Housing & Co." }
     sensitive { Faker::Number.within(range: 0..1) }
     registered_under_care_act { 1 }
     support_type { [0, 2, 3, 4, 5].sample }

--- a/spec/requests/locations_controller_spec.rb
+++ b/spec/requests/locations_controller_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe LocationsController, type: :request do
 
     context "when signed in as a data coordinator user" do
       let(:user) { create(:user, :data_coordinator) }
-      let(:scheme) { create(:scheme, owning_organisation: user.organisation, service_name: "Some name") }
+      let(:scheme) { create(:scheme, owning_organisation: user.organisation) }
       let!(:locations) { create_list(:location, 3, scheme:, startdate: Time.zone.local(2022, 4, 1)) }
 
       before do
@@ -215,7 +215,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       it "has correct title" do
-        expected_title = CGI.escapeHTML("#{scheme.service_name} - Submit social housing lettings and sales data (CORE) - GOV.UK")
+        expected_title = CGI.unescapeHTML("#{scheme.service_name} - Submit social housing lettings and sales data (CORE) - GOV.UK")
         expect(page).to have_title(expected_title)
       end
 
@@ -232,7 +232,7 @@ RSpec.describe LocationsController, type: :request do
           end
 
           it "has correct page 1 of 2 title" do
-            expected_title = CGI.escapeHTML("#{scheme.service_name} (page 1 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+            expected_title = CGI.unescapeHTML("#{scheme.service_name} (page 1 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
             expect(page).to have_title(expected_title)
           end
 
@@ -254,7 +254,7 @@ RSpec.describe LocationsController, type: :request do
           end
 
           it "has correct page 2 of 2 title" do
-            expected_title = CGI.escapeHTML("#{scheme.service_name} (page 2 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+            expected_title = CGI.unescapeHTML("#{scheme.service_name} (page 2 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
             expect(page).to have_title(expected_title)
           end
 
@@ -287,7 +287,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         it "has search in the title" do
-          expected_title = CGI.escapeHTML("#{scheme.service_name} (1 location matching ‘#{search_param}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+          expected_title = CGI.unescapeHTML("#{scheme.service_name} (1 location matching ‘#{search_param}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
           expect(page.title).to eq(expected_title)
         end
       end
@@ -343,7 +343,7 @@ RSpec.describe LocationsController, type: :request do
       end
 
       it "has correct title" do
-        expected_title = CGI.escapeHTML("#{scheme.service_name} - Submit social housing lettings and sales data (CORE) - GOV.UK")
+        expected_title = CGI.unescapeHTML("#{scheme.service_name} - Submit social housing lettings and sales data (CORE) - GOV.UK")
         expect(page).to have_title(expected_title)
       end
 
@@ -360,7 +360,7 @@ RSpec.describe LocationsController, type: :request do
           end
 
           it "has correct page 1 of 2 title" do
-            expected_title = CGI.escapeHTML("#{scheme.service_name} (page 1 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+            expected_title = CGI.unescapeHTML("#{scheme.service_name} (page 1 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
             expect(page).to have_title(expected_title)
           end
 
@@ -382,7 +382,7 @@ RSpec.describe LocationsController, type: :request do
           end
 
           it "has correct page 1 of 2 title" do
-            expected_title = CGI.escapeHTML("#{scheme.service_name} (page 2 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+            expected_title = CGI.unescapeHTML("#{scheme.service_name} (page 2 of 2) - Submit social housing lettings and sales data (CORE) - GOV.UK")
             expect(page).to have_title(expected_title)
           end
 
@@ -415,7 +415,7 @@ RSpec.describe LocationsController, type: :request do
         end
 
         it "has search in the title" do
-          expected_title = CGI.escapeHTML("#{scheme.service_name} (1 location matching ‘#{search_param}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
+          expected_title = CGI.unescapeHTML("#{scheme.service_name} (1 location matching ‘#{search_param}’) - Submit social housing lettings and sales data (CORE) - GOV.UK")
           expect(page).to have_title(expected_title)
         end
       end


### PR DESCRIPTION
This branch uses `CGI.unescapeHTML` instead of `CGI.escapeHTML`, converting HTML entities back to their corresponding characters for accurate testing and matching. Previously, any randomly generated name with an apostrophe would fail in the tests. Now, `CGI.unescapeHTML` ensures that HTML entities in the `expected_title` are converted back to their original characters before comparison. This is crucial for verifying the page title, which may contain special characters.

Unlike in the service, the scheme names here are generated by Faker and not user-submitted data.