### PR TITLE
Do not save BU log when setting creation method

### DIFF
--- a/app/services/bulk_upload/lettings/log_creator.rb
+++ b/app/services/bulk_upload/lettings/log_creator.rb
@@ -15,7 +15,7 @@ class BulkUpload::Lettings::LogCreator
 
       row_parser.log.blank_invalid_non_setup_fields!
       row_parser.log.bulk_upload = bulk_upload
-      row_parser.log.creation_method_bulk_upload!
+      row_parser.log.creation_method = "bulk upload"
       row_parser.log.skip_update_status = true
       row_parser.log.status = "pending"
       row_parser.log.status_cache = row_parser.log.calculate_status

--- a/app/services/bulk_upload/sales/log_creator.rb
+++ b/app/services/bulk_upload/sales/log_creator.rb
@@ -14,7 +14,7 @@ class BulkUpload::Sales::LogCreator
 
       row_parser.log.blank_invalid_non_setup_fields!
       row_parser.log.bulk_upload = bulk_upload
-      row_parser.log.creation_method_bulk_upload!
+      row_parser.log.creation_method = "bulk upload"
       row_parser.log.skip_update_status = true
       row_parser.log.status = "pending"
       row_parser.log.status_cache = row_parser.log.calculate_status


### PR DESCRIPTION
`creation_method_bulk_upload!` would have saved the log, but there isn't really a reason for that as we're saving the log further in the method and it's wrapped in `rescue` block
```
begin
  row_parser.log.save!
rescue StandardError => e
  Sentry.capture_exception(e)
end
```