### PR TITLE
CLDC-3699 Update scheme_params order

### DIFF
--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -293,9 +293,9 @@ private
   def scheme_params
     required_params = params.require(:scheme).permit(:service_name,
                                                      :sensitive,
-                                                     :owning_organisation_id,
                                                      :scheme_type,
                                                      :registered_under_care_act,
+                                                     :owning_organisation_id,
                                                      :id,
                                                      :has_other_client_group,
                                                      :primary_client_group,


### PR DESCRIPTION
We use scheme params in validations, so when none of the questions are answered, the errors in the error summary show up in an order that does not correspond to the order of questions on the page. This updates that order:
<img width="948" alt="image" src="https://github.com/user-attachments/assets/cdcd2452-1c73-4d9f-a04f-57f01c4ca864">
