### PR TITLE
CLDC-2890 Clear LA if it's no longer valid

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -124,13 +124,11 @@ module DerivedVariables::LettingsLogVariables
 
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
 
-    if self.startdate_changed?
-      unless LocalAuthority.active(self.startdate).where(code: la).exists?
+    if startdate_changed? && !LocalAuthority.active(startdate).where(code: la).exists?
         self.la = nil
         self.is_la_inferred = false
-      end
     end
-    
+
     reset_address_fields! if is_supported_housing?
   end
 

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -124,6 +124,13 @@ module DerivedVariables::LettingsLogVariables
 
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
 
+    if self.startdate_changed?
+      unless LocalAuthority.active(self.startdate).where(code: la).exists?
+        self.la = nil
+        self.is_la_inferred = false
+      end
+    end
+    
     reset_address_fields! if is_supported_housing?
   end
 

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -125,8 +125,8 @@ module DerivedVariables::LettingsLogVariables
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
 
     if startdate_changed? && !LocalAuthority.active(startdate).where(code: la).exists?
-        self.la = nil
-        self.is_la_inferred = false
+      self.la = nil
+      self.is_la_inferred = false
     end
 
     reset_address_fields! if is_supported_housing?

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -75,11 +75,9 @@ module DerivedVariables::SalesLogVariables
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?
 
-    if self.saledate_changed?
-      unless LocalAuthority.active(self.saledate).where(code: la).exists?
+    if saledate_changed? && !LocalAuthority.active(saledate).where(code: la).exists?
         self.la = nil
         self.is_la_inferred = false
-      end
     end
 
     set_encoded_derived_values!(DEPENDENCIES)

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -75,6 +75,13 @@ module DerivedVariables::SalesLogVariables
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?
 
+    if self.saledate_changed?
+      unless LocalAuthority.active(self.saledate).where(code: la).exists?
+        self.la = nil
+        self.is_la_inferred = false
+      end
+    end
+
     set_encoded_derived_values!(DEPENDENCIES)
   end
 

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -76,8 +76,8 @@ module DerivedVariables::SalesLogVariables
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?
 
     if saledate_changed? && !LocalAuthority.active(saledate).where(code: la).exists?
-        self.la = nil
-        self.is_la_inferred = false
+      self.la = nil
+      self.is_la_inferred = false
     end
 
     set_encoded_derived_values!(DEPENDENCIES)

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -809,6 +809,21 @@ RSpec.describe LettingsLog do
         expect { lettings_log.update!(nationality_all_group: nil, declaration: 1) }.not_to change(lettings_log, :nationality_all)
       end
     end
+
+    context "when form year changes and LA is no longer active" do
+      before do
+        LocalAuthority.find_by(code: "E08000003").update!(end_date: Time.zone.today)
+      end
+
+      it "removes the LA" do
+        lettings_log.update!(startdate: Time.zone.yesterday, la: "E08000003")
+        expect(lettings_log.reload.la).to eq("E08000003")
+
+        lettings_log.update!(startdate: Time.zone.tomorrow)
+        expect(lettings_log.reload.la).to eq(nil)
+        expect(lettings_log.reload.is_la_inferred).to eq(false)
+      end
+    end
   end
 
   describe "optional fields" do

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -978,5 +978,22 @@ RSpec.describe SalesLog, type: :model do
       end
     end
   end
+
+  context "when form year changes and LA is no longer active" do
+    let!(:sales_log) { create(:sales_log) }
+
+    before do
+      LocalAuthority.find_by(code: "E08000003").update!(end_date: Time.zone.today)
+    end
+
+    it "removes the LA" do
+      sales_log.update!(saledate: Time.zone.yesterday, la: "E08000003")
+      expect(sales_log.reload.la).to eq("E08000003")
+
+      sales_log.update!(saledate: Time.zone.tomorrow)
+      expect(sales_log.reload.la).to eq(nil)
+      expect(sales_log.reload.is_la_inferred).to eq(false)
+    end
+  end
 end
 # rubocop:enable RSpec/MessageChain


### PR DESCRIPTION
There's is a situation, which should be pretty rare, but if we select an LA for a lettings log that has an end_date in the local_authorities table and then change the startdate to after the end_date the LA would previously not cleared