### PR TITLE
CLDC-3731 Count unique error attributes

### DIFF
--- a/app/helpers/form_page_error_helper.rb
+++ b/app/helpers/form_page_error_helper.rb
@@ -14,6 +14,6 @@ module FormPageErrorHelper
   end
 
   def all_questions_affected_by_errors(log)
-    log.errors.map(&:attribute) - [:base]
+    (log.errors.map(&:attribute) - [:base]).uniq
   end
 end


### PR DESCRIPTION
There are instances where more than 1 errors get added to the same attribute so we display `see all related answers` even if it's not a composite validation.
For example, if we enter a non number value for beds we add 2 error messages:
`Number of bedrooms must be a number.` and `Number of bedrooms must be between 1 and 12.`