### PR TITLE
CLDC-3262 Ignore irrelevant empty BU headers

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/csv_parser.rb
@@ -15,7 +15,7 @@ class BulkUpload::Lettings::Year2024::CsvParser
 
   def row_offset
     if with_headers?
-      rows.find_index { |row| row[0].match(/field number/i) } + 1
+      rows.find_index { |row| row[0].present? && row[0].match(/field number/i) } + 1
     else
       0
     end

--- a/app/services/bulk_upload/sales/year2024/csv_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/csv_parser.rb
@@ -15,7 +15,7 @@ class BulkUpload::Sales::Year2024::CsvParser
 
   def row_offset
     if with_headers?
-      rows.find_index { |row| row[0].match(/field number/i) } + 1
+      rows.find_index { |row| row[0].present? && row[0].match(/field number/i) } + 1
     else
       0
     end

--- a/spec/services/bulk_upload/lettings/year2024/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/csv_parser_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe BulkUpload::Lettings::Year2024::CsvParser do
     end
   end
 
+  context "when some csv headers are empty (and we don't care about them)" do
+    before do
+      file.write("Question\n")
+      file.write("Additional info\n")
+      file.write("Values\n")
+      file.write("\n")
+      file.write("Type of letting the question applies to\n")
+      file.write("Duplicate check field?\n")
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).default_2024_field_numbers_row)
+      file.write(BulkUpload::LettingsLogToCsv.new(log:).to_2024_csv_row)
+      file.rewind
+    end
+
+    it "returns correct offsets" do
+      expect(service.row_offset).to eq(7)
+      expect(service.col_offset).to eq(1)
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_13).to eql(log.tenancycode)
+    end
+  end
+
   context "when parsing csv with headers with extra rows" do
     before do
       file.write("Section\n")

--- a/spec/services/bulk_upload/sales/year2024/csv_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/csv_parser_spec.rb
@@ -39,6 +39,38 @@ RSpec.describe BulkUpload::Sales::Year2024::CsvParser do
     end
   end
 
+  context "when some csv headers are empty (and we don't care about them)" do
+    before do
+      file.write("Question\n")
+      file.write("Additional info\n")
+      file.write("Values\n")
+      file.write("\n")
+      file.write("Type of letting the question applies to\n")
+      file.write("Duplicate check field?\n")
+      file.write(BulkUpload::SalesLogToCsv.new(log:).default_2024_field_numbers_row)
+      file.write(BulkUpload::SalesLogToCsv.new(log:).to_2024_csv_row)
+      file.write("\n")
+      file.rewind
+    end
+
+    it "returns correct offsets" do
+      expect(service.row_offset).to eq(7)
+      expect(service.col_offset).to eq(1)
+    end
+
+    it "parses csv correctly" do
+      expect(service.row_parsers[0].field_22).to eql(log.uprn)
+    end
+
+    it "counts the number of valid field numbers correctly" do
+      expect(service).to be_correct_field_count
+    end
+
+    it "does not parse the last empty row" do
+      expect(service.row_parsers.count).to eq(1)
+    end
+  end
+
   context "when parsing csv with headers in arbitrary order" do
     let(:seed) { rand }
 


### PR DESCRIPTION
If any of the headers in BU file (except for the field numbers header) don’t have a value in the first column, or if there’s an extra empty header between all the headers we fail with “something went wrong” error. 

This situation might happen when an excel file is weirdly formatted.
Although we have specifications around what headers should be included and how it should look in the csv, we can avoid this issue by ignoring the empty content in the headers, except the field_number header