### PR TITLE
CLDC-3777 Remove wrong copy key 

### DIFF
--- a/app/models/form/lettings/subsections/household_needs.rb
+++ b/app/models/form/lettings/subsections/household_needs.rb
@@ -2,7 +2,6 @@ class Form::Lettings::Subsections::HouseholdNeeds < ::Form::Subsection
   def initialize(id, hsh, section)
     super
     @id = "household_needs"
-    @copy_key = "lettings.household_needs.housingneeds_type"
     @label = "Household needs"
     @depends_on = [{ "non_location_setup_questions_completed?" => true }]
   end


### PR DESCRIPTION
The copy for household needs subsection is mostly missing because this subsection copy key is pointing to a wrong place