### PR TITLE
CLDC-2141 Update form submit flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: compilation tools for bundle
 # yarn: node package manager
 # postgresql-dev: postgres driver and libraries
-RUN apk add --no-cache build-base=0.5-r3 busybox=1.36.1-r7 nodejs-current=20.8.1-r0 yarn=1.22.19-r0 postgresql13-dev=13.17-r0 git=2.40.3-r0 bash=5.2.15-r5
+RUN apk add --no-cache build-base=0.5-r3 busybox=1.36.1-r7 nodejs-current=20.8.1-r0 yarn=1.22.19-r0 postgresql13-dev=13.18-r0 git=2.40.3-r0 bash=5.2.15-r5
 
 # Bundler version should be the same version as what the Gemfile.lock was bundled with
 RUN gem install bundler:2.3.14 --no-document

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -106,7 +106,7 @@ private
     return unless previous_responses
 
     previous_responses_to_reset = previous_responses.reject do |key, _|
-      @log.form.get_question(key, @log).type == "date"
+      @log.form.get_question(key, @log)&.type == "date"
     end
 
     @log.assign_attributes(previous_responses_to_reset)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -5,6 +5,7 @@ class FormController < ApplicationController
   before_action :find_resource, only: %i[review]
   before_action :find_resource_by_named_id, except: %i[review]
   before_action :check_collection_period, only: %i[submit_form show_page]
+  before_action :set_cache_headers, only: [:show_page]
 
   def submit_form
     if @log
@@ -443,5 +444,11 @@ private
 
   def updated_answer_from_check_errors_page?
     params["check_errors"]
+  end
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
   end
 end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -80,7 +80,6 @@ class FormController < ApplicationController
       page_id = request.path.split("/")[-1].underscore
       @page = form.get_page(page_id)
       @subsection = form.subsection_for_page(@page)
-
       if @page.routed_to?(@log, current_user) || is_referrer_type?("interruption_screen") || adding_answer_from_check_errors_page?
         if updated_answer_from_check_errors_page?
           @questions = request.params["related_question_ids"].map { |id| @log.form.get_question(id, @log) }

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -582,8 +582,9 @@ RSpec.describe FormController, type: :request do
             allow(Rails.logger).to receive(:info)
           end
 
-          it "re-renders the same page with errors if validation fails" do
+          it "redirects to the same page with errors if validation fails" do
             post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
+            follow_redirect!
             expect(page).to have_content("There is a problem")
             expect(page).to have_content("Error: What is the tenant’s age?")
           end
@@ -591,6 +592,8 @@ RSpec.describe FormController, type: :request do
           it "resets errors when fixed" do
             post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
             post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: valid_params
+            follow_redirect!
+            expect(page).not_to have_content("There is a problem")
             get "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}"
             expect(page).not_to have_content("There is a problem")
           end
@@ -616,6 +619,7 @@ RSpec.describe FormController, type: :request do
 
             it "validates the date correctly" do
               post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
+              follow_redirect!
               expect(page).to have_content("There is a problem")
             end
           end
@@ -693,6 +697,7 @@ RSpec.describe FormController, type: :request do
 
               it "validates the date correctly" do
                 post "/lettings-logs/#{lettings_log.id}/#{page_id.dasherize}", params: params
+                follow_redirect!
                 expect(page).to have_content("There is a problem")
               end
             end
@@ -713,6 +718,7 @@ RSpec.describe FormController, type: :request do
 
               it "validates the date correctly" do
                 post "/sales-logs/#{sales_log.id}/#{page_id.dasherize}", params: params
+                follow_redirect!
                 expect(page).to have_content("There is a problem")
               end
             end
@@ -748,8 +754,9 @@ RSpec.describe FormController, type: :request do
             Timecop.unfreeze
           end
 
-          it "re-renders the same page with errors if validation fails" do
+          it "redirects the same page with errors if validation fails" do
             post "/lettings-logs/#{lettings_log.id}/managing-organisation", params: params
+            follow_redirect!
             expect(page).to have_content("There is a problem")
             expect(page).to have_content("Error: Which organisation manages this letting?")
           end


### PR DESCRIPTION
Update the submit form flow to follow post - redirect - get instead of rendering on post, which should help make navigation smoother.
We now restore the errors and log question answers on show_page instead of submit.

The initial issue this is solving:
1. Make a question error
2. Answer question correctly, save and continue
3. Click browser back - this would resubmit with and display the error again, now it should just call a get