### PR TITLE
Stub some credentials in tests

### DIFF
--- a/spec/mailers/devise_notify_mailer_spec.rb
+++ b/spec/mailers/devise_notify_mailer_spec.rb
@@ -36,8 +36,11 @@ RSpec.describe DeviseNotifyMailer do
       end
 
       context "when the email domain is in the allowlist" do
-        let(:domain) { Rails.application.credentials[:email_allowlist].first }
-        let(:email) { "test@#{domain}" }
+        before do
+          allow(Rails.application.credentials).to receive(:[]).with(:email_allowlist).and_return(["example.com"])
+        end
+
+        let(:email) { "test@example.com" }
 
         it "does send emails" do
           expect(notify_client).to receive(:send_email).once
@@ -48,10 +51,10 @@ RSpec.describe DeviseNotifyMailer do
       context "when notify mailer raises BadRequestError" do
         before do
           allow(notify_client).to receive(:send_email).and_raise(bad_request_error)
+          allow(Rails.application.credentials).to receive(:[]).with(:email_allowlist).and_return(["example.com"])
         end
 
-        let(:domain) { Rails.application.credentials[:email_allowlist].first }
-        let(:email) { "test@#{domain}" }
+        let(:email) { "test@example.com" }
 
         it "does not raise an error" do
           expect {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -300,6 +300,7 @@ RSpec.describe User, type: :model do
     context "when the user is in staging environment" do
       before do
         allow(Rails.env).to receive(:staging?).and_return(true)
+        allow(Rails.application.credentials).to receive(:[]).with(:staging_role_update_email_allowlist).and_return(["not_one_of_the_examples.com"])
       end
 
       context "and the user is not in the staging role update email allowlist" do


### PR DESCRIPTION
Instead of relying on our actual credentials in tests, we should be stubbing them wherever they're used