### PR TITLE
CLDC-3801 Do not put error objects into cookies

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -44,8 +44,8 @@ class FormController < ApplicationController
           end
         end
         flash[:log_data] = responses_for_page
-        question_ids = (log.errors.map(&:attribute) - [:base]).uniq
-        flash[:pages_with_errors_count] = question_ids.map { |id| log.form.get_question(id, log)&.page&.id }.compact.uniq.count
+        question_ids = (@log.errors.map(&:attribute) - [:base]).uniq
+        flash[:pages_with_errors_count] = question_ids.map { |id| @log.form.get_question(id, @log)&.page&.id }.compact.uniq.count
         redirect_to send("#{@log.class.name.underscore}_#{@page.id}_path", @log, { referrer: request.params["referrer"], original_page_id: request.params["original_page_id"], related_question_ids: request.params["related_question_ids"] })
       end
     else

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -38,8 +38,14 @@ class FormController < ApplicationController
         error_attributes = @log.errors.map(&:attribute)
         Rails.logger.info "User triggered validation(s) on: #{error_attributes.join(', ')}"
         @subsection = form.subsection_for_page(@page)
-        flash[:errors] = @log.errors
+        flash[:errors] = @log.errors.each_with_object({}) do |error, result|
+          if @page.questions.map(&:id).include?(error.attribute.to_s)
+            result[error.attribute.to_s] = error.message
+          end
+        end
         flash[:log_data] = responses_for_page
+        question_ids = (log.errors.map(&:attribute) - [:base]).uniq
+        flash[:pages_with_errors_count] = question_ids.map { |id| log.form.get_question(id, log)&.page&.id }.compact.uniq.count
         redirect_to send("#{@log.class.name.underscore}_#{@page.id}_path", @log, { referrer: request.params["referrer"], original_page_id: request.params["original_page_id"], related_question_ids: request.params["related_question_ids"] })
       end
     else
@@ -81,6 +87,7 @@ class FormController < ApplicationController
       page_id = request.path.split("/")[-1].underscore
       @page = form.get_page(page_id)
       @subsection = form.subsection_for_page(@page)
+      @pages_with_errors_count = 0
       if @page.routed_to?(@log, current_user) || is_referrer_type?("interruption_screen") || adding_answer_from_check_errors_page?
         if updated_answer_from_check_errors_page?
           @questions = request.params["related_question_ids"].map { |id| @log.form.get_question(id, @log) }
@@ -89,6 +96,7 @@ class FormController < ApplicationController
           if flash[:errors].present?
             restore_previous_errors(flash[:errors])
             restore_error_field_values(flash[:log_data])
+            @pages_with_errors_count = flash[:pages_with_errors_count]
           end
           render "form/page"
         end
@@ -121,7 +129,7 @@ private
     return unless previous_errors
 
     previous_errors.each do |attribute, message|
-      @log.errors.add attribute, message.first
+      @log.errors.add attribute, message.html_safe
     end
   end
 

--- a/app/helpers/form_page_error_helper.rb
+++ b/app/helpers/form_page_error_helper.rb
@@ -12,9 +12,4 @@ module FormPageErrorHelper
       errors.each { |error| lettings_log.errors.delete(error.attribute) }
     end
   end
-
-  def all_pages_affected_by_errors(log)
-    question_ids = (log.errors.map(&:attribute) - [:base]).uniq
-    question_ids.map { |id| log.form.get_question(id, log)&.page&.id }.compact.uniq
-  end
 end

--- a/app/views/form/page.html.erb
+++ b/app/views/form/page.html.erb
@@ -16,7 +16,6 @@
 <%= form_with model: @log, url: request.original_url, method: "post", local: true do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% all_pages_with_errors = all_pages_affected_by_errors(@log) %>
       <% remove_other_page_errors(@log, @page) %>
       <%= f.govuk_error_summary %>
 
@@ -76,7 +75,7 @@
         <%= f.hidden_field :check_errors, value: @check_errors %>
       <% end %>
 
-      <% if all_pages_with_errors.count > 1 %>
+      <% if @pages_with_errors_count > 1 %>
         <div class="govuk-button-group">
           <%= f.submit "See all related answers", name: "check_errors", class: "govuk-body govuk-link submit-button-link" %>
         </div>

--- a/spec/requests/form_controller_spec.rb
+++ b/spec/requests/form_controller_spec.rb
@@ -723,6 +723,26 @@ RSpec.describe FormController, type: :request do
               end
             end
           end
+
+          context "with long error messages" do
+            let(:sales_log) { create(:sales_log, :completed, assigned_to: user) }
+            let(:page_id) { "purchase_price" }
+            let(:params) do
+              {
+                id: sales_log.id,
+                sales_log: {
+                  page: page_id,
+                  "value" => 1,
+                },
+              }
+            end
+
+            it "can deal with long error messages" do
+              post "/sales-logs/#{sales_log.id}/#{page_id.dasherize}", params: params
+              follow_redirect!
+              expect(page).to have_content("There is a problem")
+            end
+          end
         end
 
         context "with invalid organisation answers" do

--- a/spec/views/form/page_view_spec.rb
+++ b/spec/views/form/page_view_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "form/page" do
     assign(:log, lettings_log)
     assign(:page, page)
     assign(:subsection, subsection)
-    assign(:questions_with_errors_count, 0)
+    assign(:pages_with_errors_count, 0)
     assign_attributes(page, page_attributes)
     assign_attributes(question, question_attributes)
     render

--- a/spec/views/form/page_view_spec.rb
+++ b/spec/views/form/page_view_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "form/page" do
     assign(:log, lettings_log)
     assign(:page, page)
     assign(:subsection, subsection)
+    assign(:questions_with_errors_count, 0)
     assign_attributes(page, page_attributes)
     assign_attributes(question, question_attributes)
     render


### PR DESCRIPTION
This was causing some issues with cookie overflow (I suspect when there were many larger errors being put into flash). This PR filters out the errors to the ones present on the page and only keeps the attributes and messages in flash