### PR TITLE
Restore invalid postcode input value in postcode field

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -93,6 +93,7 @@ class FormController < ApplicationController
           @questions = request.params["related_question_ids"].map { |id| @log.form.get_question(id, @log) }
           render "form/check_errors"
         else
+          restore_placeholder_values(@log, @page)
           if flash[:errors].present?
             restore_previous_errors(flash[:errors])
             restore_error_field_values(flash[:log_data])
@@ -123,6 +124,14 @@ private
     end
 
     @log.assign_attributes(previous_responses_to_reset)
+  end
+
+  def restore_placeholder_values(log, page)
+    page.questions.each do |question|
+      next if question.placeholder_method.blank?
+
+      log[question.id] ||= log.send(question.placeholder_method)
+    end
   end
 
   def restore_previous_errors(previous_errors)

--- a/app/models/form/lettings/questions/postcode_for_full_address.rb
+++ b/app/models/form/lettings/questions/postcode_for_full_address.rb
@@ -20,6 +20,7 @@ class Form::Lettings::Questions::PostcodeForFullAddress < ::Form::Question
     @disable_clearing_if_not_routed_or_dynamic_answer_options = true
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
     @hide_question_number_on_page = true
+    @placeholder_method = "postcode_full_input_placeholder"
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 12, 2024 => 13 }.freeze

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -8,7 +8,7 @@ class Form::Question
                 :top_guidance_partial, :bottom_guidance_partial, :prefix, :suffix,
                 :requires_js, :fields_added, :derived, :check_answers_card_number,
                 :unresolved_hint_text, :question_number, :hide_question_number_on_page,
-                :plain_label, :error_label
+                :plain_label, :error_label, :placeholder_method
 
   def initialize(id, hsh, page)
     @id = id

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -294,6 +294,10 @@ class Log < ApplicationRecord
     !!public_send("age#{person_num}_known")&.zero?
   end
 
+  def postcode_full_input_placeholder
+    postcode_full_input
+  end
+
 private
 
   # Handle logs that are older than previous collection start date


### PR DESCRIPTION
If an invalid postcode is input into the postcode search field we currently don't save it into the actual postcode answer.

This PR only surfaces the invalid postcode entry in the postcode field on address page if the postcode is not given. 

The idea is to reduce the mental load for users to input the postcode twice.

My concern with this is that if postcode is not given, whenever the user loads address input page, the postcode would show the postcode_input value, which might confuse the user as that value isn't actually saved.