### PR TITLE
CLDC-3817 Only run net income validations when applicable_income_range exists

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -240,7 +240,7 @@ class LettingsLog < Log
   end
 
   def applicable_income_range
-    return unless ecstat1 && hhmemb
+    return unless ecstat1 && hhmemb && ALLOWED_INCOME_RANGES[ecstat1]
 
     range = ALLOWED_INCOME_RANGES[ecstat1].clone
 

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -440,9 +440,9 @@ class SalesLog < Log
   def income_soft_min_for_ecstat(ecstat_field)
     economic_status_code = public_send(ecstat_field)
 
-    return unless ALLOWED_INCOME_RANGES_SALES
+    return unless ALLOWED_INCOME_RANGES_SALES && ALLOWED_INCOME_RANGES_SALES[economic_status_code]
 
-    soft_min = ALLOWED_INCOME_RANGES_SALES[economic_status_code]&.soft_min
+    soft_min = ALLOWED_INCOME_RANGES_SALES[economic_status_code].soft_min
     format_as_currency(soft_min)
   end
 

--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -16,13 +16,13 @@ module Validations::SoftValidations
   }.freeze
 
   def net_income_in_soft_max_range?
-    return unless weekly_net_income && ecstat1 && hhmemb
+    return unless weekly_net_income && ecstat1 && hhmemb && applicable_income_range
 
     weekly_net_income.between?(applicable_income_range.soft_max, applicable_income_range.hard_max)
   end
 
   def net_income_in_soft_min_range?
-    return unless weekly_net_income && ecstat1 && hhmemb
+    return unless weekly_net_income && ecstat1 && hhmemb && applicable_income_range
 
     weekly_net_income.between?(applicable_income_range.hard_min, applicable_income_range.soft_min)
   end

--- a/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
@@ -1915,6 +1915,15 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
           expect(parser.errors.where(:field_125, category: :soft_validation).first.message).to eql("You told us the rent is £120.00 every week. This is higher than we would expect.")
         end
       end
+
+      context "when an invalid ecstat1 is given" do
+        let(:attributes) { setup_section_params.merge({ field_46: 11, field_119: 123, field_118: 1 }) }
+
+        it "does not run net income soft validations validation" do
+          parser.valid?
+          expect(parser.errors.where(:field_46).count).to be(1)
+        end
+      end
     end
 
     describe "log_already_exists?" do


### PR DESCRIPTION
Invalid ecstat1 value (for example 11) in bulk upload CSV will cause applicable_income_range to be nil in net_income_in_soft_min_range? method, which in turn fails the whole bulk upload.