### PR TITLE
CLDC-3822 Update date validations for 2025

### DIFF
--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -11,14 +11,26 @@ module Validations::DateValidations
       record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.not_first_let")
     end
 
-    if record["mrcdate"].present? && record["startdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 3650
+    return unless record["mrcdate"].present? && record["startdate"].present?
+
+    if record.form.start_year_2025_or_later?
+      if record["startdate"].to_date - record["mrcdate"].to_date > 7300
+        record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start")
+      end
+    elsif record["startdate"].to_date - record["mrcdate"].to_date > 3650
       record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start")
     end
   end
 
   def validate_property_void_date(record)
-    if record["voiddate"].present? && record["startdate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 3650
-      record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start")
+    if record["voiddate"].present? && record["startdate"].present?
+      if record.form.start_year_2025_or_later?
+        if record["startdate"].to_date - record["voiddate"].to_date > 7300
+          record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start")
+        end
+      elsif record["startdate"].to_date - record["voiddate"].to_date > 3650
+        record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start")
+      end
     end
 
     if record["voiddate"].present? && record["startdate"].present? && record["startdate"].to_date < record["voiddate"].to_date
@@ -42,18 +54,32 @@ module Validations::DateValidations
       record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.after_major_repair_date")
     end
 
-    if record["voiddate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 3650
-      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_void_date")
-    end
-
-    if record["mrcdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 3650
-      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date")
-    end
+    validate_startdate_against_mrc_and_void_dates(record)
   end
 
 private
 
   def is_rsnvac_first_let?(record)
     [15, 16, 17].include?(record["rsnvac"])
+  end
+
+  def validate_startdate_against_mrc_and_void_dates(record)
+    if record.form.start_year_2025_or_later?
+      if record["voiddate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 7300
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date")
+      end
+
+      if record["mrcdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 7300
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date")
+      end
+    else
+      if record["voiddate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 3650
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_void_date")
+      end
+
+      if record["mrcdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 3650
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date")
+      end
+    end
   end
 end

--- a/app/models/validations/date_validations.rb
+++ b/app/models/validations/date_validations.rb
@@ -2,84 +2,61 @@ module Validations::DateValidations
   include Validations::SharedValidations
 
   def validate_property_major_repairs(record)
-    date_valid?("mrcdate", record)
-    if record["startdate"].present? && record["mrcdate"].present? && record["startdate"] < record["mrcdate"]
-      record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.before_tenancy_start")
-    end
+    return unless record["mrcdate"].present? && date_valid?("mrcdate", record)
 
     if is_rsnvac_first_let?(record) && record["mrcdate"].present?
       record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.not_first_let")
     end
+    return unless record["startdate"].present? && date_valid?("startdate", record)
 
-    return unless record["mrcdate"].present? && record["startdate"].present?
+    if record["startdate"].present? && record["mrcdate"].present? && record["startdate"] < record["mrcdate"]
+      record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.before_tenancy_start")
+      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.after_major_repair_date")
+    end
 
     if record.form.start_year_2025_or_later?
-      if record["startdate"].to_date - record["mrcdate"].to_date > 7300
+      if record["startdate"].to_date - 20.years > record["mrcdate"].to_date
         record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start")
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date")
       end
-    elsif record["startdate"].to_date - record["mrcdate"].to_date > 3650
+    elsif record["startdate"].to_date - 10.years > record["mrcdate"].to_date
       record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start")
+      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date")
     end
   end
 
   def validate_property_void_date(record)
-    if record["voiddate"].present? && record["startdate"].present?
-      if record.form.start_year_2025_or_later?
-        if record["startdate"].to_date - record["voiddate"].to_date > 7300
-          record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start")
-        end
-      elsif record["startdate"].to_date - record["voiddate"].to_date > 3650
-        record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start")
-      end
-    end
+    return unless record["voiddate"].present? && date_valid?("voiddate", record)
 
-    if record["voiddate"].present? && record["startdate"].present? && record["startdate"].to_date < record["voiddate"].to_date
-      record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.before_tenancy_start")
-    end
-
-    if record["voiddate"].present? && record["mrcdate"].present? && record["mrcdate"].to_date < record["voiddate"].to_date
+    if record["mrcdate"].present? && record["mrcdate"].to_date < record["voiddate"].to_date
       record.errors.add :voiddate, :after_mrcdate, message: I18n.t("validations.lettings.date.void_date.after_mrcdate")
       record.errors.add :mrcdate, I18n.t("validations.lettings.date.mrcdate.before_void_date")
+    end
+    return unless record["startdate"].present? && date_valid?("startdate", record)
+
+    if record["startdate"].to_date < record["voiddate"].to_date
+      record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.before_tenancy_start")
+      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.after_void_date")
+    end
+
+    if record.form.start_year_2025_or_later?
+      if record["startdate"].to_date - 20.years > record["voiddate"].to_date
+        record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start")
+        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date")
+      end
+    elsif record["startdate"].to_date - 10.years > record["voiddate"].to_date
+      record.errors.add :voiddate, I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start")
+      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_void_date")
     end
   end
 
   def validate_startdate(record)
-    return unless record.startdate && date_valid?("startdate", record)
-
-    if record["voiddate"].present? && record.startdate < record["voiddate"]
-      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.after_void_date")
-    end
-
-    if record["mrcdate"].present? && record.startdate < record["mrcdate"]
-      record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.after_major_repair_date")
-    end
-
-    validate_startdate_against_mrc_and_void_dates(record)
+    date_valid?("startdate", record)
   end
 
 private
 
   def is_rsnvac_first_let?(record)
     [15, 16, 17].include?(record["rsnvac"])
-  end
-
-  def validate_startdate_against_mrc_and_void_dates(record)
-    if record.form.start_year_2025_or_later?
-      if record["voiddate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 7300
-        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date")
-      end
-
-      if record["mrcdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 7300
-        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date")
-      end
-    else
-      if record["voiddate"].present? && record["startdate"].to_date - record["voiddate"].to_date > 3650
-        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_void_date")
-      end
-
-      if record["mrcdate"].present? && record["startdate"].to_date - record["mrcdate"].to_date > 3650
-        record.errors.add :startdate, I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date")
-      end
-    end
   end
 end

--- a/config/locales/validations/lettings/date.en.yml
+++ b/config/locales/validations/lettings/date.en.yml
@@ -7,14 +7,18 @@ en:
           after_major_repair_date: "Enter a tenancy start date that is after the major repair date."
           ten_years_after_void_date: "Enter a tenancy start date that is no more than 10 years after the void date."
           ten_years_after_mrc_date: "Enter a tenancy start date that is no more than 10 years after the major repairs completion date."
+          twenty_years_after_void_date: "Enter a tenancy start date that is no more than 20 years after the void date."
+          twenty_years_after_mrc_date: "Enter a tenancy start date that is no more than 20 years after the major repairs completion date."
 
         mrcdate:
           before_tenancy_start: "Enter a major repairs date that is before the tenancy start date."
           not_first_let: "Major repairs date must not be completed if the tenancy is a first let."
           ten_years_before_tenancy_start: "Enter a major repairs completion date that is no more than 10 years before the tenancy start date."
+          twenty_years_before_tenancy_start: "Enter a major repairs completion date that is no more than 20 years before the tenancy start date."
           before_void_date: "Major repairs date must be after the void date if provided."
 
         void_date:
           ten_years_before_tenancy_start: "Enter a void date no more than 10 years before the tenancy start date."
+          twenty_years_before_tenancy_start: "Enter a void date no more than 20 years before the tenancy start date."
           before_tenancy_start: "Enter a void date that is before the tenancy start date."
           after_mrcdate: "Void date must be before the major repairs date if provided."

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -21,22 +21,6 @@ RSpec.describe Validations::DateValidations do
       expect(record.errors["startdate"]).to be_empty
     end
 
-    it "validates that the tenancy start date is after the void date if it has a void date" do
-      record.startdate = Time.zone.local(2022, 1, 1)
-      record.voiddate = Time.zone.local(2022, 2, 1)
-      date_validator.validate_startdate(record)
-      expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.lettings.date.startdate.after_void_date"))
-    end
-
-    it "validates that the tenancy start date is after the major repair date if it has a major repair date" do
-      record.startdate = Time.zone.local(2022, 1, 1)
-      record.mrcdate = Time.zone.local(2022, 2, 1)
-      date_validator.validate_startdate(record)
-      expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.lettings.date.startdate.after_major_repair_date"))
-    end
-
     it "produces no error when the tenancy start date is before the end date of the chosen scheme if it has an end date" do
       record.startdate = Time.zone.today - 30.days
       record.scheme = scheme
@@ -59,6 +43,8 @@ RSpec.describe Validations::DateValidations do
       date_validator.validate_property_major_repairs(record)
       expect(record.errors["mrcdate"])
         .to include(match I18n.t("validations.lettings.date.mrcdate.before_tenancy_start"))
+      expect(record.errors["startdate"])
+      .to include(match I18n.t("validations.lettings.date.startdate.after_major_repair_date"))
     end
 
     it "must be before the tenancy start date" do
@@ -71,9 +57,8 @@ RSpec.describe Validations::DateValidations do
     context "with 2024 logs or earlier" do
       it "cannot be more than 10 years before the tenancy start date" do
         record.startdate = Time.zone.local(2024, 2, 1)
-        record.mrcdate = Time.zone.local(2014, 1, 1)
+        record.mrcdate = Time.zone.local(2014, 1, 31)
         date_validator.validate_property_major_repairs(record)
-        date_validator.validate_startdate(record)
         expect(record.errors["mrcdate"])
           .to include(match I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start"))
         expect(record.errors["startdate"])
@@ -82,7 +67,7 @@ RSpec.describe Validations::DateValidations do
 
       it "must be within 10 years of the tenancy start date" do
         record.startdate = Time.zone.local(2024, 2, 1)
-        record.mrcdate = Time.zone.local(2014, 3, 1)
+        record.mrcdate = Time.zone.local(2014, 2, 1)
         date_validator.validate_property_major_repairs(record)
         expect(record.errors["mrcdate"]).to be_empty
         expect(record.errors["startdate"]).to be_empty
@@ -92,9 +77,8 @@ RSpec.describe Validations::DateValidations do
     context "with 2025 logs or later" do
       it "cannot be more than 20 years before the tenancy start date" do
         record.startdate = Time.zone.local(2026, 2, 1)
-        record.mrcdate = Time.zone.local(2006, 1, 1)
+        record.mrcdate = Time.zone.local(2006, 1, 31)
         date_validator.validate_property_major_repairs(record)
-        date_validator.validate_startdate(record)
         expect(record.errors["mrcdate"])
           .to include(match I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start"))
         expect(record.errors["startdate"])
@@ -103,7 +87,7 @@ RSpec.describe Validations::DateValidations do
 
       it "must be within 20 years of the tenancy start date" do
         record.startdate = Time.zone.local(2026, 2, 1)
-        record.mrcdate = Time.zone.local(2006, 3, 1)
+        record.mrcdate = Time.zone.local(2006, 2, 1)
         date_validator.validate_property_major_repairs(record)
         expect(record.errors["mrcdate"]).to be_empty
         expect(record.errors["startdate"]).to be_empty
@@ -153,6 +137,8 @@ RSpec.describe Validations::DateValidations do
       date_validator.validate_property_void_date(record)
       expect(record.errors["voiddate"])
         .to include(match I18n.t("validations.lettings.date.void_date.before_tenancy_start"))
+      expect(record.errors["startdate"])
+      .to include(match I18n.t("validations.lettings.date.startdate.after_void_date"))
     end
 
     it "must be before the tenancy start date" do
@@ -165,9 +151,8 @@ RSpec.describe Validations::DateValidations do
     context "with 2024 logs or earlier" do
       it "cannot be more than 10 years before the tenancy start date" do
         record.startdate = Time.zone.local(2024, 2, 1)
-        record.voiddate = Time.zone.local(2014, 1, 1)
+        record.voiddate = Time.zone.local(2014, 1, 31)
         date_validator.validate_property_void_date(record)
-        date_validator.validate_startdate(record)
         expect(record.errors["voiddate"])
           .to include(match I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start"))
         expect(record.errors["startdate"])
@@ -176,7 +161,7 @@ RSpec.describe Validations::DateValidations do
 
       it "must be within 10 years of the tenancy start date" do
         record.startdate = Time.zone.local(2024, 2, 1)
-        record.voiddate = Time.zone.local(2014, 3, 1)
+        record.voiddate = Time.zone.local(2014, 2, 1)
         date_validator.validate_property_void_date(record)
         expect(record.errors["voiddate"]).to be_empty
         expect(record.errors["startdate"]).to be_empty
@@ -186,7 +171,7 @@ RSpec.describe Validations::DateValidations do
     context "with 2025 logs or later" do
       it "cannot be more than 20 years before the tenancy start date" do
         record.startdate = Time.zone.local(2026, 2, 1)
-        record.voiddate = Time.zone.local(2006, 1, 1)
+        record.voiddate = Time.zone.local(2006, 1, 31)
         date_validator.validate_property_void_date(record)
         date_validator.validate_startdate(record)
         expect(record.errors["voiddate"])
@@ -197,7 +182,7 @@ RSpec.describe Validations::DateValidations do
 
       it "must be within 20 years of the tenancy start date" do
         record.startdate = Time.zone.local(2026, 2, 1)
-        record.voiddate = Time.zone.local(2006, 3, 1)
+        record.voiddate = Time.zone.local(2006, 2, 1)
         date_validator.validate_property_void_date(record)
         expect(record.errors["voiddate"]).to be_empty
         expect(record.errors["startdate"]).to be_empty

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -68,23 +68,46 @@ RSpec.describe Validations::DateValidations do
       expect(record.errors["mrcdate"]).to be_empty
     end
 
-    it "cannot be more than 10 years before the tenancy start date" do
-      record.startdate = Time.zone.local(2022, 2, 1)
-      record.mrcdate = Time.zone.local(2012, 1, 1)
-      date_validator.validate_property_major_repairs(record)
-      date_validator.validate_startdate(record)
-      expect(record.errors["mrcdate"])
-        .to include(match I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start"))
-      expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date"))
+    context "with 2024 logs or earlier" do
+      it "cannot be more than 10 years before the tenancy start date" do
+        record.startdate = Time.zone.local(2024, 2, 1)
+        record.mrcdate = Time.zone.local(2014, 1, 1)
+        date_validator.validate_property_major_repairs(record)
+        date_validator.validate_startdate(record)
+        expect(record.errors["mrcdate"])
+          .to include(match I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start"))
+        expect(record.errors["startdate"])
+          .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date"))
+      end
+
+      it "must be within 10 years of the tenancy start date" do
+        record.startdate = Time.zone.local(2024, 2, 1)
+        record.mrcdate = Time.zone.local(2014, 3, 1)
+        date_validator.validate_property_major_repairs(record)
+        expect(record.errors["mrcdate"]).to be_empty
+        expect(record.errors["startdate"]).to be_empty
+      end
     end
 
-    it "must be within 10 years of the tenancy start date" do
-      record.startdate = Time.zone.local(2022, 2, 1)
-      record.mrcdate = Time.zone.local(2012, 3, 1)
-      date_validator.validate_property_major_repairs(record)
-      expect(record.errors["mrcdate"]).to be_empty
-      expect(record.errors["startdate"]).to be_empty
+    context "with 2025 logs or later" do
+      it "cannot be more than 20 years before the tenancy start date" do
+        record.startdate = Time.zone.local(2026, 2, 1)
+        record.mrcdate = Time.zone.local(2006, 1, 1)
+        date_validator.validate_property_major_repairs(record)
+        date_validator.validate_startdate(record)
+        expect(record.errors["mrcdate"])
+          .to include(match I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start"))
+        expect(record.errors["startdate"])
+          .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date"))
+      end
+
+      it "must be within 20 years of the tenancy start date" do
+        record.startdate = Time.zone.local(2026, 2, 1)
+        record.mrcdate = Time.zone.local(2006, 3, 1)
+        date_validator.validate_property_major_repairs(record)
+        expect(record.errors["mrcdate"]).to be_empty
+        expect(record.errors["startdate"]).to be_empty
+      end
     end
 
     context "when reason for vacancy is first let of property" do
@@ -139,23 +162,46 @@ RSpec.describe Validations::DateValidations do
       expect(record.errors["voiddate"]).to be_empty
     end
 
-    it "cannot be more than 10 years before the tenancy start date" do
-      record.startdate = Time.zone.local(2022, 2, 1)
-      record.voiddate = Time.zone.local(2012, 1, 1)
-      date_validator.validate_property_void_date(record)
-      date_validator.validate_startdate(record)
-      expect(record.errors["voiddate"])
-        .to include(match I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start"))
-      expect(record.errors["startdate"])
-        .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_void_date"))
+    context "with 2024 logs or earlier" do
+      it "cannot be more than 10 years before the tenancy start date" do
+        record.startdate = Time.zone.local(2024, 2, 1)
+        record.voiddate = Time.zone.local(2014, 1, 1)
+        date_validator.validate_property_void_date(record)
+        date_validator.validate_startdate(record)
+        expect(record.errors["voiddate"])
+          .to include(match I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start"))
+        expect(record.errors["startdate"])
+          .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_void_date"))
+      end
+
+      it "must be within 10 years of the tenancy start date" do
+        record.startdate = Time.zone.local(2024, 2, 1)
+        record.voiddate = Time.zone.local(2014, 3, 1)
+        date_validator.validate_property_void_date(record)
+        expect(record.errors["voiddate"]).to be_empty
+        expect(record.errors["startdate"]).to be_empty
+      end
     end
 
-    it "must be within 10 years of the tenancy start date" do
-      record.startdate = Time.zone.local(2022, 2, 1)
-      record.voiddate = Time.zone.local(2012, 3, 1)
-      date_validator.validate_property_void_date(record)
-      expect(record.errors["voiddate"]).to be_empty
-      expect(record.errors["startdate"]).to be_empty
+    context "with 2025 logs or later" do
+      it "cannot be more than 20 years before the tenancy start date" do
+        record.startdate = Time.zone.local(2026, 2, 1)
+        record.voiddate = Time.zone.local(2006, 1, 1)
+        date_validator.validate_property_void_date(record)
+        date_validator.validate_startdate(record)
+        expect(record.errors["voiddate"])
+          .to include(match I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start"))
+        expect(record.errors["startdate"])
+          .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date"))
+      end
+
+      it "must be within 20 years of the tenancy start date" do
+        record.startdate = Time.zone.local(2026, 2, 1)
+        record.voiddate = Time.zone.local(2006, 3, 1)
+        date_validator.validate_property_void_date(record)
+        expect(record.errors["voiddate"]).to be_empty
+        expect(record.errors["startdate"]).to be_empty
+      end
     end
 
     context "when major repairs have been carried out" do


### PR DESCRIPTION
Allow 20 year gap between start date and void date/mrcdate for 2025 lettings.