### PR TITLE
CLDC-3835-Allow support users to see logs after merge

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -176,7 +176,7 @@ class OrganisationsController < ApplicationController
   end
 
   def lettings_logs
-    organisation_logs = LettingsLog.visible.filter_by_organisation(@organisation).filter_by_years_or_nil(FormHandler.instance.years_of_available_lettings_forms)
+    organisation_logs = LettingsLog.visible.filter_by_organisation(@organisation.absorbed_organisations + [@organisation]).filter_by_years_or_nil(FormHandler.instance.years_of_available_lettings_forms)
     unpaginated_filtered_logs = filter_manager.filtered_logs(organisation_logs, search_term, session_filters)
 
     @search_term = search_term
@@ -206,7 +206,7 @@ class OrganisationsController < ApplicationController
   end
 
   def sales_logs
-    organisation_logs = SalesLog.visible.filter_by_organisation(@organisation).filter_by_years_or_nil(FormHandler.instance.years_of_available_sales_forms)
+    organisation_logs = SalesLog.visible.filter_by_organisation(@organisation.absorbed_organisations + [@organisation]).filter_by_years_or_nil(FormHandler.instance.years_of_available_sales_forms)
     unpaginated_filtered_logs = filter_manager.filtered_logs(organisation_logs, search_term, session_filters)
 
     respond_to do |format|

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -1307,6 +1307,37 @@ RSpec.describe OrganisationsController, type: :request do
               end
             end
           end
+
+          context "when the organisation has absorbed another organisation" do
+            let(:absorbed_organisation) { create(:organisation) }
+            let(:number_of_absorbed_org_lettings_logs) { 3 }
+            let(:lettings_log) { create(:lettings_log, owning_organisation: absorbed_organisation) }
+
+            before do
+              organisation.update!(absorbed_organisations: [absorbed_organisation])
+              create_list(:lettings_log, number_of_absorbed_org_lettings_logs, owning_organisation: absorbed_organisation)
+            end
+
+            context "without search query" do
+              before do
+                get "/organisations/#{organisation.id}/lettings-logs", headers:, params: {}
+              end
+
+              it "returns a count of all logs for both the merging and absorbed organisations" do
+                expect(page).to have_content("#{total_number_of_org1_logs + number_of_absorbed_org_lettings_logs} total logs")
+              end
+            end
+
+            context "when searching for an absorbing organisation by ID" do
+              before do
+                get "/organisations/#{organisation.id}/lettings-logs?search=#{lettings_log.id}", headers:, params: {}
+              end
+
+              it "displays the lettings log from the absorbed organisation" do
+                expect(page).to have_content(lettings_log.id)
+              end
+            end
+          end
         end
 
         context "when viewing a specific organisation's sales logs" do
@@ -1395,6 +1426,37 @@ RSpec.describe OrganisationsController, type: :request do
                 logs.each do |log|
                   expect(page).not_to have_link(log.id.to_s)
                 end
+              end
+            end
+          end
+
+          context "when the organisation has absorbed another organisation" do
+            let(:absorbed_organisation) { create(:organisation) }
+            let(:number_of_absorbed_org_sales_logs) { 3 }
+            let(:sales_log) { create(:sales_log, owning_organisation: absorbed_organisation) }
+
+            before do
+              organisation.update!(absorbed_organisations: [absorbed_organisation])
+              create_list(:sales_log, number_of_absorbed_org_sales_logs, owning_organisation: absorbed_organisation)
+            end
+
+            context "without search query" do
+              before do
+                get "/organisations/#{organisation.id}/sales-logs", headers:, params: {}
+              end
+
+              it "returns a count of all logs for both the merging and absorbed organisations" do
+                expect(page).to have_content("#{number_of_org1_sales_logs + number_of_absorbed_org_sales_logs} total logs")
+              end
+            end
+
+            context "when searching for an absorbing organisation by ID" do
+              before do
+                get "/organisations/#{organisation.id}/sales-logs?search=#{sales_log.id}", headers:, params: {}
+              end
+
+              it "displays the sales log from the absorbed organisation" do
+                expect(page).to have_content(sales_log.id)
               end
             end
           end


### PR DESCRIPTION
This PR fixes an issue support users came across where when visiting a specific organisation's logs page they were unable to see all the logs from a merging organisation only those of the absorbing organisation.