### PR TITLE
CLDC-3838: Unlock users on password reset

### DIFF
--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -35,7 +35,7 @@ class Auth::PasswordsController < Devise::PasswordsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      resource.unlock_access! if unlockable?(resource)
+      resource.unlock_access! if resource.respond_to?(:unlock_access!)
       if Devise.sign_in_after_reset_password
         set_flash_message!(:notice, password_update_flash_message)
         resource.after_database_authentication

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -205,7 +205,7 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -205,7 +205,7 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :time
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.

--- a/spec/requests/auth/passwords_controller_spec.rb
+++ b/spec/requests/auth/passwords_controller_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Auth::PasswordsController, type: :request do
         follow_redirect!
         expect(page).to have_css("p", class: "govuk-notification-banner__heading", text: message)
       end
+
+      context "when the user had been locked out" do
+        let(:user) { create(:user, locked_at: Time.zone.now, failed_attempts: 5) }
+
+        it "after password change, unlocks the user account and signs them in" do
+          put "/account/password", params: update_password_params
+          follow_redirect!
+          user.reload
+          expect(user.locked_at).to be_nil
+          expect(user.failed_attempts).to be 0
+          expect(page).to have_content("Welcome back, #{user.name}")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Notes: 

I tried just enabling the email unlock strategy initially (which would make this happen automatically), but that also adds in various links to resend unlock instructions (which look confusing to me) and caused an app error when it tried to send that email (which is probably fixable, and may be a review app thing, but put me off anyway). 

So this just changes the check when resetting a password for whether to unlock.