### PR TITLE
Remove invalid option causing migration errors

### DIFF
--- a/db/migrate/20211126142105_user_case_logs_belong_to_organisation.rb
+++ b/db/migrate/20211126142105_user_case_logs_belong_to_organisation.rb
@@ -5,8 +5,8 @@ class UserCaseLogsBelongToOrganisation < ActiveRecord::Migration[6.1]
       t.belongs_to :organisation
     end
     change_table :case_logs, bulk: true do |t|
-      t.belongs_to :owning_organisation, class_name: "Organisation"
-      t.belongs_to :managing_organisation, class_name: "Organisation"
+      t.belongs_to :owning_organisation
+      t.belongs_to :managing_organisation
     end
   end
 

--- a/db/migrate/20220323094418_create_data_protection_confirmation.rb
+++ b/db/migrate/20220323094418_create_data_protection_confirmation.rb
@@ -2,7 +2,7 @@ class CreateDataProtectionConfirmation < ActiveRecord::Migration[7.0]
   def change
     create_table :data_protection_confirmations do |t|
       t.belongs_to :organisation
-      t.belongs_to :data_protection_officer, class_name: "User", index: { name: :dpo_user_id }
+      t.belongs_to :data_protection_officer, index: { name: :dpo_user_id }
       t.column :confirmed, :boolean
       t.column :old_id, :string
       t.column :old_org_id, :string

--- a/db/migrate/20220427160536_add_created_by_to_case_logs.rb
+++ b/db/migrate/20220427160536_add_created_by_to_case_logs.rb
@@ -1,7 +1,7 @@
 class AddCreatedByToCaseLogs < ActiveRecord::Migration[7.0]
   def change
     change_table :case_logs, bulk: true do |t|
-      t.belongs_to :created_by, class_name: "User"
+      t.belongs_to :created_by
     end
   end
 end

--- a/db/migrate/20220826093411_add_sales_log.rb
+++ b/db/migrate/20220826093411_add_sales_log.rb
@@ -4,9 +4,9 @@ class AddSalesLog < ActiveRecord::Migration[7.0]
       t.integer :status, default: 0
       t.datetime :saledate
       t.timestamps
-      t.references :owning_organisation, class_name: "Organisation", foreign_key: { to_table: :organisations, on_delete: :cascade }
-      t.references :managing_organisation, class_name: "Organisation"
-      t.references :created_by, class_name: "User"
+      t.references :owning_organisation, foreign_key: { to_table: :organisations, on_delete: :cascade }
+      t.references :managing_organisation
+      t.references :created_by
     end
   end
 end

--- a/db/migrate/20221207141947_add_updated_by_to_logs.rb
+++ b/db/migrate/20221207141947_add_updated_by_to_logs.rb
@@ -1,10 +1,10 @@
 class AddUpdatedByToLogs < ActiveRecord::Migration[7.0]
   def change
     change_table :lettings_logs, bulk: true do |t|
-      t.belongs_to :updated_by, class_name: "User"
+      t.belongs_to :updated_by
     end
     change_table :sales_logs, bulk: true do |t|
-      t.belongs_to :updated_by, class_name: "User"
+      t.belongs_to :updated_by
     end
   end
 end

--- a/db/migrate/20230530094653_add_data_sharing_agreement.rb
+++ b/db/migrate/20230530094653_add_data_sharing_agreement.rb
@@ -2,7 +2,7 @@ class AddDataSharingAgreement < ActiveRecord::Migration[7.0]
   def change
     create_table :data_sharing_agreements do |t|
       t.belongs_to :organisation
-      t.belongs_to :data_protection_officer, class_name: "User"
+      t.belongs_to :data_protection_officer
 
       t.datetime :signed_at, null: false
       t.string :organisation_name, null: false

--- a/db/migrate/20231121131725_add_sales_managing_organisation.rb
+++ b/db/migrate/20231121131725_add_sales_managing_organisation.rb
@@ -1,7 +1,7 @@
 class AddSalesManagingOrganisation < ActiveRecord::Migration[7.0]
   def change
     change_table :sales_logs, bulk: true do |t|
-      t.references :managing_organisation, class_name: "Organisation"
+      t.references :managing_organisation
     end
   end
 end

--- a/db/migrate/20240408102550_add_created_by.rb
+++ b/db/migrate/20240408102550_add_created_by.rb
@@ -1,11 +1,11 @@
 class AddCreatedBy < ActiveRecord::Migration[7.0]
   def change
     change_table :sales_logs do |t|
-      t.references :created_by, class_name: "User"
+      t.references :created_by
     end
 
     change_table :lettings_logs do |t|
-      t.references :created_by, class_name: "User"
+      t.references :created_by
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -245,14 +245,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_10_150609) do
     t.integer "hb"
     t.integer "hbrentshortfall"
     t.integer "property_relet"
-    t.datetime "mrcdate"
+    t.datetime "mrcdate", precision: nil
     t.integer "incref"
-    t.datetime "startdate"
+    t.datetime "startdate", precision: nil
     t.integer "armedforces"
     t.integer "first_time_property_let_as_social_housing"
     t.integer "unitletas"
     t.integer "builtype"
-    t.datetime "voiddate"
+    t.datetime "voiddate", precision: nil
     t.bigint "owning_organisation_id"
     t.bigint "managing_organisation_id"
     t.integer "renttype"
@@ -822,8 +822,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_10_150609) do
     t.string "name"
     t.bigint "organisation_id"
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role"


### PR DESCRIPTION
These class_name options cause errors in Rails 7.2 (and I think 7.1) - I think they were being ignored anyway so have been having no effect.