### PR TITLE
add db_host variable to example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DB_USERNAME=postgres-user
 DB_PASSWORD=postgres-password
+DB_HOST=localhost
 
 GOVUK_NOTIFY_API_KEY=<notify-key-here-if-testing-emails-or-admin-users>
 OTP_SECRET_ENCRYPTION_KEY="<Generate this using bundle exec rake secret>"


### PR DESCRIPTION
I had to add this to my env file to run `db:create`. Otherwise `db:create` fails with `connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  Peer authentication failed for user`

(this can be safely tested with a local database already set up - if the database already exists it just skips it)