### PR TITLE
CLDC-3859 Validate reasonpref values

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -444,6 +444,7 @@ class BulkUpload::Lettings::Year2024::RowParser
 
   validate :validate_incomplete_soft_validations, on: :after_log
   validate :validate_nationality, on: :after_log
+  validate :validate_reasonpref_reason_values, on: :after_log
 
   validate :validate_nulls, on: :after_log
 
@@ -674,6 +675,17 @@ private
   def validate_nationality
     if field_45.present? && !valid_nationality_options.include?(field_45.to_s)
       errors.add(:field_45, I18n.t("#{ERROR_BASE_KEY}.nationality.invalid"))
+    end
+  end
+
+  def validate_reasonpref_reason_values
+    valid_reasonpref_reason_options = ["0","1"]
+   ["field_107", "field_108", "field_109", "field_110", "field_111"].each do |field|
+      if send(field).present? && !valid_reasonpref_reason_options.include?(send(field).to_s)
+        question_text = QUESTIONS[field.to_sym]
+        question_text[0] = question_text[0].downcase
+        errors.add(field.to_sym, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: question_text))
+      end
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -679,13 +679,13 @@ private
   end
 
   def validate_reasonpref_reason_values
-    valid_reasonpref_reason_options = ["0","1"]
-   ["field_107", "field_108", "field_109", "field_110", "field_111"].each do |field|
-      if send(field).present? && !valid_reasonpref_reason_options.include?(send(field).to_s)
-        question_text = QUESTIONS[field.to_sym]
-        question_text[0] = question_text[0].downcase
-        errors.add(field.to_sym, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: question_text))
-      end
+    valid_reasonpref_reason_options = %w[0 1]
+    %w[field_107 field_108 field_109 field_110 field_111].each do |field|
+      next unless send(field).present? && !valid_reasonpref_reason_options.include?(send(field).to_s)
+
+      question_text = QUESTIONS[field.to_sym]
+      question_text[0] = question_text[0].downcase
+      errors.add(field.to_sym, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: question_text))
     end
   end
 

--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -443,6 +443,7 @@ class BulkUpload::Lettings::Year2025::RowParser
 
   validate :validate_incomplete_soft_validations, on: :after_log
   validate :validate_nationality, on: :after_log
+  validate :validate_reasonpref_reason_values, on: :after_log
 
   validate :validate_nulls, on: :after_log
 
@@ -673,6 +674,17 @@ private
   def validate_nationality
     if field_45.present? && !valid_nationality_options.include?(field_45.to_s)
       errors.add(:field_45, I18n.t("#{ERROR_BASE_KEY}.nationality.invalid"))
+    end
+  end
+
+  def validate_reasonpref_reason_values
+    valid_reasonpref_reason_options = %w[0 1]
+    %w[field_107 field_108 field_109 field_110 field_111].each do |field|
+      next unless send(field).present? && !valid_reasonpref_reason_options.include?(send(field).to_s)
+
+      question_text = QUESTIONS[field.to_sym]
+      question_text[0] = question_text[0].downcase
+      errors.add(field.to_sym, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: question_text))
     end
   end
 

--- a/lib/tasks/correct_reasonpref_values.rake
+++ b/lib/tasks/correct_reasonpref_values.rake
@@ -1,0 +1,15 @@
+desc "Correct invalid BU reasonable preference values"
+task correct_reasonpref_values: :environment do
+  %w[rp_homeless rp_hardship rp_medwel rp_insan_unsat rp_dontknow].each do |field|
+    field_invalid = "#{field} != 1 AND #{field} != 0 AND #{field} is NOT NULL"
+
+    LettingsLog.filter_by_year(2024).where(field_invalid).find_each do |lettings_log|
+      lettings_log[field] = 0
+      unless lettings_log.save
+        Rails.logger.info("Failed to save reasonpref for LettingsLog with id #{lettings_log.id}: #{lettings_log.errors.full_messages}")
+      end
+    end
+
+    LettingsLog.filter_by_year(2023).where(field_invalid).update_all("#{field}": 0)
+  end
+end

--- a/spec/lib/tasks/correct_reasonpref_values_spec.rb
+++ b/spec/lib/tasks/correct_reasonpref_values_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "correct_reasonpref_values" do
+  describe ":correct_reasonpref_values", type: :task do
+    subject(:task) { Rake::Task["correct_reasonpref_values"] }
+
+    let(:organisation) { create(:organisation, rent_periods: [2]) }
+    let(:user) { create(:user, organisation:) }
+
+    before do
+      Rake.application.rake_require("tasks/correct_reasonpref_values")
+      Rake::Task.define_task(:environment)
+      task.reenable
+    end
+
+    context "when the rake task is run" do
+      context "and any of the reasonable_preference_reason options are not 1, 0 or nil" do
+        let(:bulk_upload) { create(:bulk_upload, :lettings, year: 2024, rent_type_fix_status: BulkUpload.rent_type_fix_statuses[:not_applied]) }
+
+        it "sets the options to 0" do
+          log = build(:lettings_log, :completed, reasonpref: 1, rp_homeless: -2, rp_hardship: 2, rp_medwel: 3, rp_insan_unsat: 4, rp_dontknow: 1,
+                                                 bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+
+          task.invoke
+          log.reload
+
+          expect(log.updated_at).not_to eq(initial_updated_at)
+          expect(log.status).to eq("completed")
+          expect(log.rp_homeless).to be(0)
+          expect(log.rp_hardship).to be(0)
+          expect(log.rp_medwel).to be(0)
+          expect(log.rp_insan_unsat).to be(0)
+          expect(log.rp_dontknow).to be(1)
+        end
+
+        it "updates the reasonable preference reason values on a pending log" do
+          log = build(:lettings_log, :completed, status: "pending", reasonpref: 1, rp_homeless: -2, rp_hardship: 1, rp_medwel: 3, rp_insan_unsat: 4, rp_dontknow: 2, bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+          expect(log.status).to eq("pending")
+
+          task.invoke
+          log.reload
+          expect(log.rp_homeless).to be(0)
+          expect(log.rp_hardship).to be(1)
+          expect(log.rp_medwel).to be(0)
+          expect(log.rp_insan_unsat).to be(0)
+          expect(log.rp_dontknow).to be(0)
+          expect(log.status).to eq("pending")
+          expect(log.updated_at).not_to eq(initial_updated_at)
+        end
+
+        it "does not update logs with valid values" do
+          log = build(:lettings_log, :completed, reasonpref: 1, rp_homeless: 0, rp_hardship: 1, rp_medwel: 0, rp_insan_unsat: 0, rp_dontknow: 0, bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+          expect(log.status).to eq("completed")
+
+          task.invoke
+          log.reload
+
+          expect(log.status).to eq("completed")
+          expect(log.updated_at).to eq(initial_updated_at)
+        end
+
+        it "updates the reasonable preference reason values if some of the checkbox values are valid" do
+          log = build(:lettings_log, :completed, status: "pending", reasonpref: 1, rp_homeless: 0, rp_hardship: 2, rp_medwel: 1, rp_insan_unsat: 0, rp_dontknow: 0, bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+          expect(log.status).to eq("pending")
+
+          task.invoke
+          log.reload
+          expect(log.rp_homeless).to be(0)
+          expect(log.rp_hardship).to be(0)
+          expect(log.rp_medwel).to be(1)
+          expect(log.rp_insan_unsat).to be(0)
+          expect(log.rp_dontknow).to be(0)
+          expect(log.status).to eq("pending")
+          expect(log.updated_at).not_to eq(initial_updated_at)
+        end
+
+        it "updates the reasonable preference reason values on a 2023 log" do
+          log = build(:lettings_log, :completed, startdate: Time.zone.local(2023, 6, 6), reasonpref: 1, rp_homeless: 0, rp_hardship: 2, rp_medwel: 1, rp_insan_unsat: 0, rp_dontknow: 0, bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+
+          task.invoke
+          log.reload
+
+          expect(log.updated_at).to eq(initial_updated_at)
+          expect(log.rp_hardship).to eq(0)
+        end
+
+        it "does not update and logs error if a validation triggers" do
+          log = build(:lettings_log, :completed, postcode_full: "0", reasonpref: 1, rp_homeless: 0, rp_hardship: 2, rp_medwel: 1, rp_insan_unsat: 0, rp_dontknow: 0, bulk_upload:, assigned_to: user)
+          log.save!(validate: false)
+          initial_updated_at = log.updated_at
+
+          task.invoke
+          log.reload
+
+          expect(log.updated_at).to eq(initial_updated_at)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2024/row_parser_spec.rb
@@ -1272,6 +1272,19 @@ RSpec.describe BulkUpload::Lettings::Year2024::RowParser do
           expect(parser.log.rp_dontknow).to be_nil
         end
       end
+
+      context "when some reasonable preference options are set as invalid values" do
+        let(:attributes) { setup_section_params.merge({ bulk_upload:, field_106: "2", field_107: "2", field_108: "3", field_109: "2", field_110: "3", field_111: "-4" }) }
+
+        it "adds errors" do
+          parser.valid?
+          expect(parser.errors[:field_107]).to be_present
+          expect(parser.errors[:field_108]).to be_present
+          expect(parser.errors[:field_109]).to be_present
+          expect(parser.errors[:field_110]).to be_present
+          expect(parser.errors[:field_111]).to be_present
+        end
+      end
     end
 
     describe "#field_116" do # referral

--- a/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
@@ -1083,6 +1083,19 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
           expect(parser.errors[:field_111]).to be_present
         end
       end
+
+      context "when some reasonable preference options are set as invalid values" do
+        let(:attributes) { setup_section_params.merge({ bulk_upload:, field_106: "2", field_107: "2", field_108: "3", field_109: "2", field_110: "3", field_111: "-4" }) }
+
+        it "adds errors" do
+          parser.valid?
+          expect(parser.errors[:field_107]).to be_present
+          expect(parser.errors[:field_108]).to be_present
+          expect(parser.errors[:field_109]).to be_present
+          expect(parser.errors[:field_110]).to be_present
+          expect(parser.errors[:field_111]).to be_present
+        end
+      end
     end
 
     describe "#field_116" do # referral


### PR DESCRIPTION
This adds a validation message when any reasonpref reasons are not 1, 0 or empty in bulk upload.
This also has a rake task for fixing the existing invalid values for reasonpref reasons.