### PR TITLE
CLDC-3876: Household characteristic ecstat of child under 16 bug fix when age changed

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -72,6 +72,7 @@ module DerivedVariables::LettingsLogVariables
       self.beds = 1
     end
 
+    clear_child_ecstat_for_age_changes!
     child_under_16_constraints!
 
     self.hhtype = household_type
@@ -239,6 +240,14 @@ private
     (2..8).each do |idx|
       if age_under_16?(idx)
         self["ecstat#{idx}"] = 9
+      end
+    end
+  end
+
+  def clear_child_ecstat_for_age_changes!
+    (2..8).each do |idx|
+      if public_send("age#{idx}_changed?") && self["ecstat#{idx}"] == 9
+        self["ecstat#{idx}"] = nil
       end
     end
   end

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -46,6 +46,7 @@ module DerivedVariables::SalesLogVariables
 
     if saledate && form.start_year_2024_or_later?
       self.soctenant = soctenant_from_prevten_values
+      clear_child_ecstat_for_age_changes!
       child_under_16_constraints!
     end
 
@@ -177,6 +178,15 @@ private
     (start_index..6).each do |idx|
       if age_under_16?(idx)
         self["ecstat#{idx}"] = 9
+      end
+    end
+  end
+
+  def clear_child_ecstat_for_age_changes!
+    start_index = joint_purchase? ? 3 : 2
+    (start_index..6).each do |idx|
+      if public_send("age#{idx}_changed?") && self["ecstat#{idx}"] == 9
+        self["ecstat#{idx}"] = nil
       end
     end
   end

--- a/spec/models/lettings_log_derived_fields_spec.rb
+++ b/spec/models/lettings_log_derived_fields_spec.rb
@@ -1206,4 +1206,24 @@ RSpec.describe LettingsLog, type: :model do
       end
     end
   end
+
+  describe "#clear_child_ecstat_for_age_changes!" do
+    it "clears the working situation of a person that was previously a child under 16" do
+      log = create(:lettings_log, :completed, age2: 13)
+      log.age2 = 17
+      expect { log.set_derived_fields! }.to change(log, :ecstat2).from(9).to(nil)
+    end
+
+    it "does not clear the working situation of a person that had an age change but is still a child under 16" do
+      log = create(:lettings_log, :completed, age2: 13)
+      log.age2 = 15
+      expect { log.set_derived_fields! }.to not_change(log, :ecstat2)
+    end
+
+    it "does not clear the working situation of a person that had an age change but is still an adult" do
+      log = create(:lettings_log, :completed, age2: 45)
+      log.age2 = 46
+      expect { log.set_derived_fields! }.to not_change(log, :ecstat2)
+    end
+  end
 end

--- a/spec/models/sales_log_derived_fields_spec.rb
+++ b/spec/models/sales_log_derived_fields_spec.rb
@@ -78,6 +78,26 @@ RSpec.describe SalesLog, type: :model do
       expect { log.set_derived_fields! }.to change(log, :mortgage).from(50_000).to(nil)
     end
 
+    describe "#clear_child_ecstat_for_age_changes!" do
+      it "clears the working situation of a person that was previously a child under 16" do
+        log = create(:sales_log, :completed, age3: 13, age4: 16, age5: 45)
+        log.age3 = 17
+        expect { log.set_derived_fields! }.to change(log, :ecstat3).from(9).to(nil)
+      end
+
+      it "does not clear the working situation of a person that had an age change but is still a child under 16" do
+        log = create(:sales_log, :completed, age3: 13, age4: 16, age5: 45)
+        log.age3 = 15
+        expect { log.set_derived_fields! }.to not_change(log, :ecstat3)
+      end
+
+      it "does not clear the working situation of a person that had an age change but is still an adult" do
+        log = create(:sales_log, :completed, age3: 13, age4: 16, age5: 45)
+        log.age5 = 46
+        expect { log.set_derived_fields! }.to not_change(log, :ecstat5)
+      end
+    end
+
     context "with a log that is not outright sales" do
       it "does not derive deposit when mortgage used is no" do
         log = build(:sales_log, :shared_ownership_setup_complete, value: 123_400, deposit: nil, mortgageused: 2)


### PR DESCRIPTION
This PR resolves an issue where users are unable to change a person’s age from under 16 to 16 or above. Currently, the form derives a working situation of “child under 16” for individuals under 16 and skips the working situation question. However, when users attempt to update the age to 16 or older, they encounter an error because the “child under 16” status is no longer valid. This fix ensures that users can successfully update the age and that the working situation question is appropriately prompted for individuals aged 16 and above.