### PR TITLE
CLDC-3864 change boolean export for cpl cap chr accessible_register

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -74,11 +74,6 @@ module Exports
       attribute_hash["voiddate"] = lettings_log.voiddate&.iso8601
       attribute_hash["discarded_at"] = lettings_log.discarded_at&.iso8601
 
-      attribute_hash["cbl"] = 2 if attribute_hash["cbl"]&.zero?
-      attribute_hash["cap"] = 2 if attribute_hash["cap"]&.zero?
-      attribute_hash["chr"] = 2 if attribute_hash["chr"]&.zero?
-      attribute_hash["accessible_register"] = 2 if attribute_hash["accessible_register"]&.zero?
-
       # Age refused
       (1..8).each do |index|
         attribute_hash["age#{index}"] = -9 if attribute_hash["age#{index}_known"] == 1

--- a/spec/fixtures/exports/general_needs_log.xml
+++ b/spec/fixtures/exports/general_needs_log.xml
@@ -54,9 +54,9 @@
     <waityear>7</waityear>
     <postcode_full>NW1 5TY</postcode_full>
     <reasonpref>1</reasonpref>
-    <cbl>2</cbl>
+    <cbl>0</cbl>
     <chr>1</chr>
-    <cap>2</cap>
+    <cap>0</cap>
     <reasonother/>
     <housingneeds_a>1</housingneeds_a>
     <housingneeds_b>0</housingneeds_b>

--- a/spec/fixtures/exports/general_needs_log_23_24.xml
+++ b/spec/fixtures/exports/general_needs_log_23_24.xml
@@ -54,9 +54,9 @@
     <waityear>7</waityear>
     <postcode_full>SE2 6RT</postcode_full>
     <reasonpref>1</reasonpref>
-    <cbl>2</cbl>
+    <cbl>0</cbl>
     <chr>1</chr>
-    <cap>2</cap>
+    <cap>0</cap>
     <reasonother/>
     <housingneeds_a>1</housingneeds_a>
     <housingneeds_b>0</housingneeds_b>

--- a/spec/fixtures/exports/general_needs_log_24_25.xml
+++ b/spec/fixtures/exports/general_needs_log_24_25.xml
@@ -52,9 +52,9 @@
     <waityear>7</waityear>
     <postcode_full>AA1 1AA</postcode_full>
     <reasonpref>1</reasonpref>
-    <cbl>2</cbl>
+    <cbl>0</cbl>
     <chr>1</chr>
-    <cap>2</cap>
+    <cap>0</cap>
     <reasonother/>
     <housingneeds_a>1</housingneeds_a>
     <housingneeds_b>0</housingneeds_b>
@@ -151,7 +151,7 @@
     <scharge_value_check/>
     <pscharge_value_check/>
     <duplicate_set_id/>
-    <accessible_register>2</accessible_register>
+    <accessible_register>0</accessible_register>
     <nationality_all>826</nationality_all>
     <address_line1_as_entered>address line 1 as entered</address_line1_as_entered>
     <address_line2_as_entered>address line 2 as entered</address_line2_as_entered>

--- a/spec/fixtures/exports/supported_housing_logs.xml
+++ b/spec/fixtures/exports/supported_housing_logs.xml
@@ -53,9 +53,9 @@
     <waityear>7</waityear>
     <postcode_full>SW1A 2AA</postcode_full>
     <reasonpref>1</reasonpref>
-    <cbl>2</cbl>
+    <cbl>0</cbl>
     <chr>1</chr>
-    <cap>2</cap>
+    <cap>0</cap>
     <reasonother/>
     <housingneeds_a>1</housingneeds_a>
     <housingneeds_b>0</housingneeds_b>


### PR DESCRIPTION
I've removed the mapping for these variables, so they will now export to 0.

As per the ticket we will need to re-export the 2024 logs after releasing this.