### PR TITLE
CLDC-3897 Re-export merged users

### DIFF
--- a/app/services/exports/user_export_service.rb
+++ b/app/services/exports/user_export_service.rb
@@ -28,7 +28,7 @@ module Exports
     def retrieve_resources(recent_export, full_update, _year)
       if !full_update && recent_export
         params = { from: recent_export.started_at, to: @start_time }
-        User.where("(updated_at >= :from AND updated_at <= :to)", params)
+        User.where("(updated_at >= :from AND updated_at <= :to) OR (values_updated_at IS NOT NULL AND values_updated_at >= :from AND values_updated_at <= :to)", params)
       else
         params = { to: @start_time }
         User.where("updated_at <= :to", params)

--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -62,7 +62,7 @@ private
   def merge_users(merging_organisation)
     users_to_merge = users_to_merge(merging_organisation)
     @merged_users[merging_organisation.name] = users_to_merge.map { |user| { name: user.name, email: user.email } }
-    users_to_merge.update_all(organisation_id: @absorbing_organisation.id)
+    users_to_merge.update_all(organisation_id: @absorbing_organisation.id, values_updated_at: Time.zone.now)
   end
 
   def merge_schemes_and_locations(merging_organisation)

--- a/db/migrate/20250305092900_add_values_updated_at_to_user.rb
+++ b/db/migrate/20250305092900_add_values_updated_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddValuesUpdatedAtToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :values_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_25_180643) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_05_092900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -852,6 +852,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_25_180643) do
     t.boolean "reactivate_with_organisation"
     t.datetime "discarded_at"
     t.string "phone_extension"
+    t.datetime "values_updated_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -31,10 +31,12 @@ RSpec.describe Merge::MergeOrganisationsService do
         expect(Rails.logger).to receive(:info).with("\t#{merging_organisation.data_protection_officers.first.name} (#{merging_organisation.data_protection_officers.first.email})")
         expect(Rails.logger).to receive(:info).with("\tfake name (fake@email.com)")
         expect(Rails.logger).to receive(:info).with("New schemes from fake org:")
+        expect(merging_organisation_user.values_updated_at).to be_nil
         merge_organisations_service.call
 
         merging_organisation_user.reload
         expect(merging_organisation_user.organisation).to eq(absorbing_organisation)
+        expect(merging_organisation_user.values_updated_at).not_to be_nil
       end
 
       it "sets merge date on merged organisation" do


### PR DESCRIPTION
We use `update_all` to update users when they get moved into another organisation during a merge, which means `updated_at` values don't get updated.
We use `updated_at` values to determine which users need to be re-exported
This PR adds `values_updated_at` to track any manual updates (same as we do in lettings logs) and trigger the re-export