### PR TITLE
CLDC-3904 remove default from relat mapping

### DIFF
--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -1473,6 +1473,17 @@ private
     %w[0] + GlobalConstants::COUNTRIES_ANSWER_OPTIONS.keys # 0 is "Prefers not to say"
   end
 
+  def validate_relat_fields
+    %i[field_34 field_42 field_46 field_50 field_54].each do |field|
+      value = send(field)
+      next if value.blank?
+
+      unless (1..3).cover?(value)
+        errors.add(field, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: format_ending(QUESTIONS[field])))
+      end
+    end
+  end
+
   def bulk_upload_organisation
     Organisation.find(bulk_upload.organisation_id)
   end

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -806,31 +806,11 @@ private
     attributes["sex5"] = field_52
     attributes["sex6"] = field_56
 
-    attributes["relat2"] = if field_34 == 1
-                             "P"
-                           else
-                             (field_34 == 2 ? "X" : "R")
-                           end
-    attributes["relat3"] = if field_42 == 1
-                             "P"
-                           else
-                             (field_42 == 2 ? "X" : "R")
-                           end
-    attributes["relat4"] = if field_46 == 1
-                             "P"
-                           else
-                             (field_46 == 2 ? "X" : "R")
-                           end
-    attributes["relat5"] = if field_50 == 1
-                             "P"
-                           else
-                             (field_50 == 2 ? "X" : "R")
-                           end
-    attributes["relat6"] = if field_54 == 1
-                             "P"
-                           else
-                             (field_54 == 2 ? "X" : "R")
-                           end
+    attributes["relat2"] = relationship_from_is_partner(field_34)
+    attributes["relat3"] = relationship_from_is_partner(field_42)
+    attributes["relat4"] = relationship_from_is_partner(field_46)
+    attributes["relat5"] = relationship_from_is_partner(field_50)
+    attributes["relat6"] = relationship_from_is_partner(field_54)
 
     attributes["ecstat1"] = field_32
     attributes["ecstat2"] = field_39
@@ -1041,6 +1021,17 @@ private
 
   def person_6_present?
     field_55.present? || field_56.present? || field_54.present?
+  end
+
+  def relationship_from_is_partner(is_partner)
+    case is_partner
+    when 1
+      "P"
+    when 2
+      "X"
+    when 3
+      "R"
+    end
   end
 
   def details_known?(person_n)

--- a/db/migrate/20250219122817_add_manual_address_entry_selected_to_logs.rb
+++ b/db/migrate/20250219122817_add_manual_address_entry_selected_to_logs.rb
@@ -1,6 +1,6 @@
 class AddManualAddressEntrySelectedToLogs < ActiveRecord::Migration[7.2]
   def change
-    add_column :sales_logs, :manual_address_entry_selected, :boolean, default: false
-    add_column :lettings_logs, :manual_address_entry_selected, :boolean, default: false
+    remove_column :sales_logs, :manual_address_entry_selected, :boolean, default: false
+    remove_column :lettings_logs, :manual_address_entry_selected, :boolean, default: false
   end
 end

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
       field_31: "28",
       field_32: "1",
       field_33: "1",
-      field_34: "R",
+      field_34: "3",
       field_35: "32",
       field_36: "F",
       field_37: "17",

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -1145,6 +1145,52 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
       end
     end
 
+    describe "relationship field mappings" do
+      [
+        %w[field_34 relat2 2],
+        %w[field_42 relat3 3],
+        %w[field_46 relat4 4],
+        %w[field_49 relat5 5],
+        %w[field_54 relat6 6],
+      ].each do |input_field, relationship_attribute, person_num|
+        describe input_field.to_s do
+          context "when #{input_field} is 1" do
+            let(:attributes) { setup_section_params.merge({ input_field.to_sym => "1", field_41: "5" }) }
+
+            it "sets relationship to P" do
+              expect(parser.log.public_send(relationship_attribute)).to eq("P")
+            end
+          end
+
+          context "when #{input_field} is 2" do
+            let(:attributes) { setup_section_params.merge({ input_field.to_sym => "2", field_41: "5" }) }
+
+            it "sets relationship to X" do
+              expect(parser.log.public_send(relationship_attribute)).to eq("X")
+            end
+          end
+
+          context "when #{input_field} is 3" do
+            let(:attributes) { setup_section_params.merge({ input_field.to_sym => "3", field_41: "5" }) }
+
+            it "sets relationship to R" do
+              expect(parser.log.public_send(relationship_attribute)).to eq("R")
+            end
+          end
+
+          context "when #{input_field} is 4" do
+            let(:attributes) { setup_section_params.merge({ input_field.to_sym => "4", field_41: "5" }) }
+
+            it "gives a validation error" do
+              parser.valid?
+              validation_message = "You must answer person #{person_num} is the partner of buyer 1."
+              expect(parser.errors[input_field]).to include validation_message
+            end
+          end
+        end
+      end
+    end
+
     describe "field_39" do # ecstat2
       context "when buyer 2 has no age but has ecstat as child" do
         let(:attributes) { valid_attributes.merge({ field_35: nil, field_39: "9" }) }

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -1150,7 +1150,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
         %w[field_34 relat2 2],
         %w[field_42 relat3 3],
         %w[field_46 relat4 4],
-        %w[field_49 relat5 5],
+        %w[field_50 relat5 5],
         %w[field_54 relat6 6],
       ].each do |input_field, relationship_attribute, person_num|
         describe input_field.to_s do


### PR DESCRIPTION
Adjust relation mapping which was mapping to R by default. This mapping happens before we validate that the answer is a valid radio option, so it should not do this. It now maps 1,2,3 correctly and gives a validation error for other inputs.