### PR TITLE
CLDC-3896: Remove "Answer" button from soft validation check errors page

### DIFF
--- a/app/helpers/check_errors_helper.rb
+++ b/app/helpers/check_errors_helper.rb
@@ -2,7 +2,7 @@ module CheckErrorsHelper
   include GovukLinkHelper
 
   def check_errors_answer_text(question, log)
-    question.displayed_as_answered?(log) ? "Change" : "Answer"
+    question.displayed_as_answered?(log) ? "Change" : ""
   end
 
   def check_errors_answer_link(log, question, page, applicable_questions)

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -50,7 +50,7 @@
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   <% if !question.displayed_as_answered?(@log) || question.subsection.id == "setup" %>
-                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) %>
+                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) unless question.unanswered?(@log)%>
                   <% else %>
                     <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
                   <% end %>

--- a/app/views/form/check_errors.html.erb
+++ b/app/views/form/check_errors.html.erb
@@ -50,7 +50,7 @@
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   <% if !question.displayed_as_answered?(@log) || question.subsection.id == "setup" %>
-                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) unless question.unanswered?(@log)%>
+                    <%= govuk_link_to check_errors_answer_text(question, @log), check_errors_answer_link(@log, question, @page, applicable_questions) unless question.unanswered?(@log) %>
                   <% else %>
                     <input type="submit" value="Clear" class="govuk-body govuk-link submit-button-link" name="<%= question.id %>">
                   <% end %>

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe CheckErrorsController, type: :request do
         it "displays correct clear links" do
           expect(page).to have_content("Make sure these answers are correct")
           expect(page).to have_link(lettings_log.form.get_question("hhmemb", lettings_log).check_answer_prompt, href: "/lettings-logs/#{lettings_log.id}/household-members?referrer=check_answers_new_answer", class: "govuk-link govuk-link--no-visited-state")
-          expect(page).to have_link("Answer")
+          expect(page).to have_link("Enter total number of household members")
           expect(lettings_log.reload.earnings).to eq(nil)
         end
       end
@@ -350,7 +350,7 @@ RSpec.describe CheckErrorsController, type: :request do
         it "displays correct clear links" do
           expect(page).to have_content("Make sure these answers are correct")
           expect(page).to have_link(sales_log.form.get_question("income1", sales_log).check_answer_prompt, href: "/sales-logs/#{sales_log.id}/buyer-1-income?referrer=check_answers_new_answer", class: "govuk-link govuk-link--no-visited-state")
-          expect(page).to have_link("Answer")
+          expect(page).to have_link("Enter buyer 1’s gross annual income")
           expect(sales_log.reload.income1).to eq(nil)
         end
       end


### PR DESCRIPTION
We recently changed how users are asked to answer unanswered questions, instead of placeholder text and and "Answer" button to the right we now have descriptive prompts. This PR aims to remove the "Answer" button from a view that was missed. The descriptive prompt link is already in place.