### PR TITLE
CLDC-3898 Correctly route to manual address entry for new builds

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -89,13 +89,7 @@ module DerivedVariables::LettingsLogVariables
         self.manual_address_entry_selected = true
       end
 
-      if changed_from_newbuild?
-        self.manual_address_entry_selected = if address_answered_without_uprn?
-                                               true
-                                             else
-                                               false
-                                             end
-      end
+      self.manual_address_entry_selected = address_answered_without_uprn? if changed_from_newbuild?
     end
 
     self.uprn_known = 0 if address_answered_without_uprn?

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -84,8 +84,7 @@ module DerivedVariables::LettingsLogVariables
 
     set_housingneeds_fields if housingneeds?
     if form.start_year_2025_or_later? && is_general_needs?
-      if changed_to_newbuild?
-        self.uprn = nil
+      if changed_to_newbuild? && uprn.nil?
         self.manual_address_entry_selected = true
       end
 

--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -83,12 +83,26 @@ module DerivedVariables::LettingsLogVariables
     end
 
     set_housingneeds_fields if housingneeds?
+    if form.start_year_2025_or_later? && is_general_needs?
+      if changed_to_newbuild?
+        self.uprn = nil
+        self.manual_address_entry_selected = true
+      end
+
+      if changed_from_newbuild?
+        self.manual_address_entry_selected = if address_answered_without_uprn?
+                                               true
+                                             else
+                                               false
+                                             end
+      end
+    end
 
     self.uprn_known = 0 if address_answered_without_uprn?
 
     if uprn_known&.zero?
       self.uprn = nil
-      if uprn_known_was == 1
+      if uprn_known_was == 1 && (rsnvac != 15 || !form.start_year_2025_or_later?)
         self.address_line1 = nil
         self.address_line2 = nil
         self.town_or_city = nil

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -740,6 +740,14 @@ class LettingsLog < Log
     "lettings_log"
   end
 
+  def changed_to_newbuild?
+    rsnvac == 15 && rsnvac_was != 15
+  end
+
+  def changed_from_newbuild?
+    rsnvac != 15 && rsnvac_was == 15
+  end
+
 private
 
   def reset_invalid_unresolved_log_fields!

--- a/spec/models/lettings_log_spec.rb
+++ b/spec/models/lettings_log_spec.rb
@@ -954,7 +954,7 @@ RSpec.describe LettingsLog do
                  uprn: "1")
         end
 
-        it "clears the uprn and keeps the address fields" do
+        it "keeps the uprn" do
           expect(address_lettings_log.manual_address_entry_selected).to eq(false)
           expect(address_lettings_log.uprn).to eq("1")
           expect(address_lettings_log.address_line1).to eq("1, Test Street")
@@ -962,13 +962,13 @@ RSpec.describe LettingsLog do
           expect(address_lettings_log.postcode_full).to eq("AA1 1AA")
 
           address_lettings_log.update!(rsnvac: 15)
-          expect(address_lettings_log.manual_address_entry_selected).to eq(true)
+          expect(address_lettings_log.manual_address_entry_selected).to eq(false)
           expect(address_lettings_log.address_line1).to eq("1, Test Street")
           expect(address_lettings_log.town_or_city).to eq("Test Town")
           expect(address_lettings_log.postcode_full).to eq("AA1 1AA")
-          expect(address_lettings_log.uprn_selection).to eq(nil)
-          expect(address_lettings_log.uprn).to eq(nil)
-          expect(address_lettings_log.uprn_known).to eq(0)
+          expect(address_lettings_log.uprn_selection).to eq("1")
+          expect(address_lettings_log.uprn).to eq("1")
+          expect(address_lettings_log.uprn_known).to eq(1)
         end
       end
 

--- a/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
             field_128: "1",
             field_129: "34.56",
 
-            field_16: "15",
+            field_16: "17",
             field_30: now.day.to_s,
             field_31: now.month.to_s,
             field_32: now.strftime("%g"),

--- a/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
             field_128: "1",
             field_129: "34.56",
 
-            field_16: "17",
+            field_16: "15",
             field_30: now.day.to_s,
             field_31: now.month.to_s,
             field_32: now.strftime("%g"),


### PR DESCRIPTION
We don't always get the up to date data from our addresses API when it comes to new built properties. In the cases where the property is a new build, by default we will route to manual address entry. There is still an option to search for an address instead