### PR TITLE
CLDC-3912 Set LA for manual address entry with BU

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -415,6 +415,7 @@ private
     self.address_line2 = address_line2_as_entered
     self.county = county_as_entered
     self.town_or_city = town_or_city_as_entered
+    self.la = la_as_entered
     self.manual_address_entry_selected = true
   end
 end

--- a/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2024/row_parser_spec.rb
@@ -1063,7 +1063,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
         end
 
         context "and all key address fields are present" do
-          let(:attributes) { setup_section_params.merge({ field_22: nil, field_23: "address line 1", field_25: "town or city", field_27: "AA1", field_28: "1AA" }) }
+          let(:attributes) { setup_section_params.merge({ field_22: nil, field_23: "address line 1", field_25: "town or city", field_27: "AA1", field_28: "1AA", field_29: "E06000023" }) }
 
           context "and an address can be found with a high enough match rating" do
             before do
@@ -1073,7 +1073,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
 
             it "does not add errors" do
               parser.valid?
-              %i[field_22 field_23 field_24 field_25 field_26 field_27 field_28].each do |field|
+              %i[field_22 field_23 field_24 field_25 field_26 field_27 field_28 field_29].each do |field|
                 expect(parser.errors[field]).to be_empty
               end
             end
@@ -1092,7 +1092,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
 
             it "does not add errors" do
               parser.valid?
-              %i[field_22 field_23 field_24 field_25 field_26 field_27 field_28].each do |field|
+              %i[field_22 field_23 field_24 field_25 field_26 field_27 field_28 field_29].each do |field|
                 expect(parser.errors[field]).to be_empty
               end
             end
@@ -1103,6 +1103,7 @@ RSpec.describe BulkUpload::Sales::Year2024::RowParser do
               expect(parser.log.address_line1).to eq("address line 1")
               expect(parser.log.town_or_city).to eq("town or city")
               expect(parser.log.postcode_full).to eq("AA1 1AA")
+              expect(parser.log.la).to eq("E06000023")
             end
           end
 

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -978,7 +978,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
         end
 
         context "and all key address fields are present" do
-          let(:attributes) { setup_section_params.merge({ field_16: nil, field_17: "address line 1", field_19: "town or city", field_21: "AA1", field_22: "1AA" }) }
+          let(:attributes) { setup_section_params.merge({ field_16: nil, field_17: "address line 1", field_19: "town or city", field_21: "AA1", field_22: "1AA", field_23: "E06000023" }) }
 
           context "and an address can be found with a high enough match rating" do
             before do
@@ -988,7 +988,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
 
             it "does not add errors" do
               parser.valid?
-              %i[field_16 field_17 field_18 field_19 field_20 field_21 field_22].each do |field|
+              %i[field_16 field_17 field_18 field_19 field_20 field_21 field_22 field_23].each do |field|
                 expect(parser.errors[field]).to be_empty
               end
             end
@@ -1007,7 +1007,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
 
             it "does not add errors" do
               parser.valid?
-              %i[field_16 field_17 field_18 field_19 field_20 field_21 field_22].each do |field|
+              %i[field_16 field_17 field_18 field_19 field_20 field_21 field_22 field_23].each do |field|
                 expect(parser.errors[field]).to be_empty
               end
             end
@@ -1018,6 +1018,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
               expect(parser.log.address_line1).to eq("address line 1")
               expect(parser.log.town_or_city).to eq("town or city")
               expect(parser.log.postcode_full).to eq("AA1 1AA")
+              expect(parser.log.la).to eq("E06000023")
             end
           end
 


### PR DESCRIPTION
The LA field was previously missed when setting the address fields for manual address entry from BU