### PR TITLE
CLDC-3911 Limit CSV variables to those defined in or before year

### DIFF
--- a/app/services/csv/lettings_log_csv_service.rb
+++ b/app/services/csv/lettings_log_csv_service.rb
@@ -284,8 +284,7 @@ module Csv
     end
 
     def lettings_log_definitions
-      CsvVariableDefinition.lettings.group_by { |record| [record.variable, record.definition] }
-                           .map { |_, options|
+      CsvVariableDefinition.lettings.group_by(&:variable).map { |_, options|
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 

--- a/app/services/csv/lettings_log_csv_service.rb
+++ b/app/services/csv/lettings_log_csv_service.rb
@@ -285,12 +285,12 @@ module Csv
 
     def lettings_log_definitions
       CsvVariableDefinition.lettings.group_by { |record| [record.variable, record.definition] }
-                           .map do |_, options|
+                           .map { |_, options|
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 
         options.select { |opt| opt.year < @year }.max_by(&:year)
-      end
+      }.compact
     end
 
     def insert_derived_and_related_attributes(ordered_questions)

--- a/app/services/csv/lettings_log_csv_service.rb
+++ b/app/services/csv/lettings_log_csv_service.rb
@@ -289,7 +289,7 @@ module Csv
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 
-        options.max_by(&:year)
+        options.select { |opt| opt.year < @year }.max_by(&:year)
       end
     end
 

--- a/app/services/csv/sales_log_csv_service.rb
+++ b/app/services/csv/sales_log_csv_service.rb
@@ -179,8 +179,7 @@ module Csv
     end
 
     def sales_log_definitions
-      CsvVariableDefinition.sales.group_by { |record| [record.variable, record.definition] }
-                           .map { |_, options|
+      CsvVariableDefinition.sales.group_by(&:variable).map { |_, options|
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 

--- a/app/services/csv/sales_log_csv_service.rb
+++ b/app/services/csv/sales_log_csv_service.rb
@@ -184,7 +184,7 @@ module Csv
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 
-        options.max_by(&:year)
+        options.select { |opt| opt.year < @year }.max_by(&:year)
       end
     end
 

--- a/app/services/csv/sales_log_csv_service.rb
+++ b/app/services/csv/sales_log_csv_service.rb
@@ -180,12 +180,12 @@ module Csv
 
     def sales_log_definitions
       CsvVariableDefinition.sales.group_by { |record| [record.variable, record.definition] }
-                           .map do |_, options|
+                           .map { |_, options|
         exact_match = options.find { |definition| definition.year == @year }
         next exact_match if exact_match
 
         options.select { |opt| opt.year < @year }.max_by(&:year)
-      end
+      }.compact
     end
 
     def insert_derived_and_related_attributes(ordered_questions)


### PR DESCRIPTION
Previously we could have eg a variable defined in 2023 and 2025 but not 2024, and the 2025 one would be used for 2024.

They are grouped by both name and description so this is not actually as important as if they'd been grouped only by name like I initially thought, but worth resolving anyway.