### PR TITLE
CLDC-3919: Sales BU Decimal numbers rounding errors

### DIFF
--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -252,8 +252,8 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_84, :integer
   attribute :field_85, :integer
   attribute :field_86, :integer
-  attribute :field_87, :integer
-  attribute :field_88, :integer
+  attribute :field_87, :decimal
+  attribute :field_88, :decimal
   attribute :field_89, :integer
 
   attribute :field_90, :integer

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -269,7 +269,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_99, :integer
   attribute :field_100, :integer
   attribute :field_101, :decimal
-  attribute :field_102, :integer
+  attribute :field_102, :decimal
   attribute :field_103, :integer
   attribute :field_104, :decimal
   attribute :field_105, :integer

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -293,7 +293,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_121, :integer
   attribute :field_122, :integer
   attribute :field_123, :decimal
-  attribute :field_124, :integer
+  attribute :field_124, :decimal
   attribute :field_125, :decimal
   attribute :field_126, :integer
   attribute :field_127, :decimal
@@ -301,7 +301,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_128, :integer
   attribute :field_129, :integer
   attribute :field_130, :decimal
-  attribute :field_131, :integer
+  attribute :field_131, :decimal
 
   validates :field_4,
             presence: {

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -278,7 +278,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_108, :integer
 
   attribute :field_109, :decimal
-  attribute :field_110, :integer
+  attribute :field_110, :decimal
   attribute :field_111, :decimal
   attribute :field_112, :decimal
   attribute :field_113, :integer

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -268,7 +268,7 @@ class BulkUpload::Sales::Year2024::RowParser
 
   attribute :field_99, :integer
   attribute :field_100, :integer
-  attribute :field_101, :integer
+  attribute :field_101, :decimal
   attribute :field_102, :integer
   attribute :field_103, :integer
   attribute :field_104, :integer
@@ -282,7 +282,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_111, :decimal
   attribute :field_112, :decimal
   attribute :field_113, :integer
-  attribute :field_114, :integer
+  attribute :field_114, :decimal
   attribute :field_115, :integer
   attribute :field_116, :integer
   attribute :field_117, :integer
@@ -294,7 +294,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_122, :integer
   attribute :field_123, :integer
   attribute :field_124, :integer
-  attribute :field_125, :integer
+  attribute :field_125, :decimal
   attribute :field_126, :integer
   attribute :field_127, :integer
 

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -277,7 +277,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_107, :integer
   attribute :field_108, :integer
 
-  attribute :field_109, :integer
+  attribute :field_109, :decimal
   attribute :field_110, :integer
   attribute :field_111, :decimal
   attribute :field_112, :decimal
@@ -292,7 +292,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_120, :string
   attribute :field_121, :integer
   attribute :field_122, :integer
-  attribute :field_123, :integer
+  attribute :field_123, :decimal
   attribute :field_124, :integer
   attribute :field_125, :decimal
   attribute :field_126, :integer
@@ -300,7 +300,7 @@ class BulkUpload::Sales::Year2024::RowParser
 
   attribute :field_128, :integer
   attribute :field_129, :integer
-  attribute :field_130, :integer
+  attribute :field_130, :decimal
   attribute :field_131, :integer
 
   validates :field_4,

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -284,7 +284,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_113, :integer
   attribute :field_114, :decimal
   attribute :field_115, :integer
-  attribute :field_116, :integer
+  attribute :field_116, :decimal
   attribute :field_117, :integer
   attribute :field_118, :decimal
 

--- a/app/services/bulk_upload/sales/year2024/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2024/row_parser.rb
@@ -271,7 +271,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_101, :decimal
   attribute :field_102, :integer
   attribute :field_103, :integer
-  attribute :field_104, :integer
+  attribute :field_104, :decimal
   attribute :field_105, :integer
   attribute :field_106, :string
   attribute :field_107, :integer
@@ -286,7 +286,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_115, :integer
   attribute :field_116, :integer
   attribute :field_117, :integer
-  attribute :field_118, :integer
+  attribute :field_118, :decimal
 
   attribute :field_119, :integer
   attribute :field_120, :string
@@ -296,7 +296,7 @@ class BulkUpload::Sales::Year2024::RowParser
   attribute :field_124, :integer
   attribute :field_125, :decimal
   attribute :field_126, :integer
-  attribute :field_127, :integer
+  attribute :field_127, :decimal
 
   attribute :field_128, :integer
   attribute :field_129, :integer

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -242,7 +242,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_89, :integer
   attribute :field_90, :integer
   attribute :field_91, :decimal
-  attribute :field_92, :integer
+  attribute :field_92, :decimal
   attribute :field_93, :decimal
   attribute :field_94, :decimal
   attribute :field_95, :decimal

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -239,7 +239,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_86, :decimal
   attribute :field_87, :decimal
   attribute :field_88, :integer
-  attribute :field_89, :integer
+  attribute :field_89, :decimal
   attribute :field_90, :integer
   attribute :field_91, :decimal
   attribute :field_92, :decimal
@@ -269,7 +269,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_114, :integer
   attribute :field_115, :decimal
   attribute :field_116, :integer
-  attribute :field_117, :integer
+  attribute :field_117, :decimal
   attribute :field_118, :integer
   attribute :field_119, :integer
   attribute :field_120, :decimal

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -241,7 +241,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_88, :integer
   attribute :field_89, :integer
   attribute :field_90, :integer
-  attribute :field_91, :integer
+  attribute :field_91, :decimal
   attribute :field_92, :integer
   attribute :field_93, :decimal
   attribute :field_94, :decimal
@@ -272,7 +272,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_117, :integer
   attribute :field_118, :integer
   attribute :field_119, :integer
-  attribute :field_120, :integer
+  attribute :field_120, :decimal
   attribute :field_121, :integer
 
   validates :field_1,

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -267,7 +267,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_112, :integer
   attribute :field_113, :integer
   attribute :field_114, :integer
-  attribute :field_115, :integer
+  attribute :field_115, :decimal
   attribute :field_116, :integer
   attribute :field_117, :integer
   attribute :field_118, :integer

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -236,7 +236,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_83, :integer
   attribute :field_84, :integer
   attribute :field_85, :integer
-  attribute :field_86, :integer
+  attribute :field_86, :decimal
   attribute :field_87, :decimal
   attribute :field_88, :integer
   attribute :field_89, :integer
@@ -258,14 +258,14 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_104, :integer
   attribute :field_105, :integer
   attribute :field_106, :integer
-  attribute :field_107, :integer
+  attribute :field_107, :decimal
   attribute :field_108, :decimal
   attribute :field_109, :integer
   attribute :field_110, :decimal
   attribute :field_111, :decimal
 
   attribute :field_112, :integer
-  attribute :field_113, :integer
+  attribute :field_113, :decimal
   attribute :field_114, :integer
   attribute :field_115, :decimal
   attribute :field_116, :integer

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -261,7 +261,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_107, :integer
   attribute :field_108, :decimal
   attribute :field_109, :integer
-  attribute :field_110, :integer
+  attribute :field_110, :decimal
   attribute :field_111, :decimal
 
   attribute :field_112, :integer

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -247,8 +247,8 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_94, :decimal
   attribute :field_95, :decimal
 
-  attribute :field_96, :integer
-  attribute :field_97, :integer
+  attribute :field_96, :decimal
+  attribute :field_97, :decimal
   attribute :field_98, :integer
   attribute :field_99, :integer
   attribute :field_100, :integer

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -237,7 +237,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_84, :integer
   attribute :field_85, :integer
   attribute :field_86, :integer
-  attribute :field_87, :integer
+  attribute :field_87, :decimal
   attribute :field_88, :integer
   attribute :field_89, :integer
   attribute :field_90, :integer
@@ -259,7 +259,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_105, :integer
   attribute :field_106, :integer
   attribute :field_107, :integer
-  attribute :field_108, :integer
+  attribute :field_108, :decimal
   attribute :field_109, :integer
   attribute :field_110, :integer
   attribute :field_111, :decimal

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -273,7 +273,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_118, :integer
   attribute :field_119, :integer
   attribute :field_120, :decimal
-  attribute :field_121, :integer
+  attribute :field_121, :decimal
 
   validates :field_1,
             presence: {


### PR DESCRIPTION
This PR was initially intended to fix the issue where users were unable to upload bulk uploads with discount percentages to 1 decimal place. However, I discovered other fields that we currently allow in the service to be entered as decimals, which would also benefit from this fix. I used the scheme.rb and question models to verify that they accept decimals. I've separated out each group of changes should we need to revert any.