### PR TITLE
CLDC-3938 set ppostcode on postcode change to fix bu bug

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -714,9 +714,17 @@ class LettingsLog < Log
 
   def process_postcode_changes!
     self.postcode_full = upcase_and_remove_whitespace(postcode_full)
+
+    if is_renewal?
+      self.ppostcode_full = upcase_and_remove_whitespace(postcode_full)
+    end
+
     return if postcode_full.blank?
 
     self.postcode_known = 1
+    if is_renewal?
+      self.ppcodenk = 0
+    end
     inferred_la = get_inferred_la(postcode_full)
     self.is_la_inferred = inferred_la.present?
     self.la = inferred_la if inferred_la.present?

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -649,6 +649,7 @@ class LettingsLog < Log
     super
 
     self.postcode_known = nil if errors.attribute_names.include? :postcode_full
+    self.ppcodenk = nil if errors.attribute_names.include? :ppostcode_full
 
     if errors.of_kind?(:earnings, :under_hard_min)
       self.incfreq = nil

--- a/app/models/validations/local_authority_validations.rb
+++ b/app/models/validations/local_authority_validations.rb
@@ -1,6 +1,8 @@
 module Validations::LocalAuthorityValidations
   def validate_previous_accommodation_postcode(record)
     postcode = record.ppostcode_full
+    return unless postcode
+
     if record.previous_postcode_known? && (postcode.blank? || !postcode.match(POSTCODE_REGEXP))
       error_message = I18n.t("validations.postcode")
       record.errors.add :ppostcode_full, :wrong_format, message: error_message

--- a/spec/models/lettings_log_derived_fields_spec.rb
+++ b/spec/models/lettings_log_derived_fields_spec.rb
@@ -1016,11 +1016,13 @@ RSpec.describe LettingsLog, type: :model do
       postcode = "SW1A 1AA"
       log.assign_attributes(postcode_known: 1, postcode_full: postcode, renewal: 1)
 
-      expect { log.send :process_postcode_changes! }.to change(log, :la).to(expected_la)
-      expect { log.set_derived_fields! }
-        .to change(log, :ppostcode_full).to(postcode)
+      expect { log.send :process_postcode_changes! }
+        .to change(log, :la).to(expected_la)
+        .and change(log, :ppostcode_full).to(postcode)
         .and change(log, :ppcodenk).to(0)
-        .and change(log, :prevloc).to(expected_la)
+
+      expect { log.set_derived_fields! }
+        .to change(log, :prevloc).to(expected_la)
     end
 
     it "clears values for previous location and related fields when log is a renewal and current values are cleared" do


### PR DESCRIPTION
We've been seeing ppostcode errors in some situations where they don't apply, and bulk upload logs that were invalid even after blanking. 

They seem to arise when it's a renewal, uprn is nil and manual_address_entry is false. 

On single logs, we can get errors when hitting "Clear address and search instead" as this sets manual_address_entry to false, which can be the final condition needed to hit this issue.

On bulk uploads, we can get a sentry error from logs that are invalid even after blanking non-setup fields.
I think the flow that causes previous postcodes to be cleared on renewals was:

> Currently before_validation of a lettings log that's a renewal and the uprn is nil and manual_address_entry isn’t selected (ie a bulk upload), we
> 
> 1.set `postcode_full` to nil, because uprn is nil (and manual_address_entry isn’t selected)
> 2. set `ppostcode_full` to `postcode_full`, because it’s a renewal. But this is now nil. 
> 3. use the address to set `uprn` and use `uprn` to set `postcode_full`
> 
> Then we throw an error on ppostcode because `ppcodenk` is still 0, but `ppostcode_full` is nil. Furthermore, if we then blank invalid non setup fields, we clear `ppcodenk` to nil, but then set it right back to 0 when we then call `log.valid?`, causing the log to be invalid.