### PR TITLE
Escape HTML in tests so they can handle test names with apostrophes

### DIFF
--- a/spec/helpers/tab_nav_helper_spec.rb
+++ b/spec/helpers/tab_nav_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TabNavHelper do
   describe "#org_cell" do
     it "returns the users org name and role separated by a newline character" do
       expected_html = "#{organisation.name}\n<span class=\"app-!-colour-muted\">Data provider</span>"
-      expect(org_cell(current_user)).to match(expected_html)
+      expect(CGI.unescapeHTML(org_cell(current_user))).to match(expected_html)
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe TabNavHelper do
   describe "#scheme_cell" do
     it "returns the scheme link service name and primary user group separated by a newline character" do
       expected_html = "<a class=\"govuk-link\" href=\"/schemes/#{scheme.id}\">#{scheme.service_name}</a>\n<span class=\"govuk-visually-hidden\">Scheme</span>"
-      expect(scheme_cell(scheme)).to match(expected_html)
+      expect(CGI.unescapeHTML(scheme_cell(scheme))).to match(expected_html)
     end
   end
 end

--- a/spec/requests/bulk_upload_lettings_results_controller_spec.rb
+++ b/spec/requests/bulk_upload_lettings_results_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe BulkUploadLettingsResultsController, type: :request do
         get "/lettings-logs/bulk-upload-results/#{bulk_upload.id}/summary"
 
         expect(response.body).to include("This error report is out of date.")
-        expect(response.body).to include("Some logs in this upload are assigned to #{other_user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
+        expect(CGI.unescapeHTML(response.body)).to include("Some logs in this upload are assigned to #{other_user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
       end
     end
 

--- a/spec/requests/bulk_upload_sales_results_controller_spec.rb
+++ b/spec/requests/bulk_upload_sales_results_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BulkUploadSalesResultsController, type: :request do
           get "/sales-logs/bulk-upload-results/#{bulk_upload.id}/summary"
 
           expect(response.body).to include("This error report is out of date.")
-          expect(response.body).to include("Some logs in this upload are assigned to #{user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
+          expect(CGI.unescapeHTML(response.body)).to include("Some logs in this upload are assigned to #{user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
         end
       end
 
@@ -113,7 +113,7 @@ RSpec.describe BulkUploadSalesResultsController, type: :request do
         get "/sales-logs/bulk-upload-results/#{bulk_upload.id}/summary"
 
         expect(response.body).to include("This error report is out of date.")
-        expect(response.body).to include("Some logs in this upload are assigned to #{other_user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
+        expect(CGI.unescapeHTML(response.body)).to include("Some logs in this upload are assigned to #{other_user.name}, who has moved to a different organisation since this file was uploaded. Upload the file again to get an accurate error report.")
       end
     end
 


### PR DESCRIPTION
Our library Faker generates random names which occasionally include apostrophes (typically Somebody O'Something).

This can lead to spurious test failures such as here https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/actions/runs/13901573241/job/38894405433 where the page correctly displays the expected test, but the test fails because it's comparing the html encoded page to the raw expected string name, and so the message shown "Some message about Emanuel O&#39;Keefe" fails to match the expected "Some message about Emanuel O'Keefe".

We already htmlunescape the response body in some tests, but not everywhere. I've copied this approach to the other examples I saw where we look for a Faker name in a response body.

I also ran all the tests with the factory username hard coded with an apostrophe, and got no failures. The only other place we use Faker::Name.name is in test scheme names, but these have an apostrophe hard coded in the factory already