### PR TITLE
CLDC-3938 Log invalid BU row numbers

### DIFF
--- a/app/services/bulk_upload/lettings/validator.rb
+++ b/app/services/bulk_upload/lettings/validator.rb
@@ -55,8 +55,10 @@ class BulkUpload::Lettings::Validator
     row_parsers.each do |row_parser|
       row_parser.log.blank_invalid_non_setup_fields!
     end
-    if any_logs_invalid?
+
+    if invalid_row_numbers.any?
       Sentry.capture_message("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      Rails.logger.error("Lettings bulk upload #{bulk_upload.id} blocked due to invalid logs after blanking on rows #{invalid_row_numbers}")
       "logs_invalid"
     end
   end
@@ -101,8 +103,8 @@ private
     end
   end
 
-  def any_logs_invalid?
-    row_parsers.any? { |row_parser| row_parser.log.invalid? }
+  def invalid_row_numbers
+    row_parsers.each_with_index.map { |row_parser, index| index + row_offset + 1 if row_parser.log.invalid? }.compact
   end
 
   def csv_parser

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -56,8 +56,9 @@ class BulkUpload::Sales::Validator
       row_parser.log.blank_invalid_non_setup_fields!
     end
 
-    if any_logs_invalid?
+    if invalid_row_numbers.any?
       Sentry.capture_message("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      Rails.logger.error("Sales bulk upload #{bulk_upload.id} blocked due to invalid logs after blanking on rows #{invalid_row_numbers}")
       "logs_invalid"
     end
   end
@@ -98,8 +99,8 @@ private
     end
   end
 
-  def any_logs_invalid?
-    row_parsers.any? { |row_parser| row_parser.log.invalid? }
+  def invalid_row_numbers
+    row_parsers.each_with_index.map { |row_parser, index| index + row_offset + 1 if row_parser.log.invalid? }.compact
   end
 
   def csv_parser

--- a/app/services/bulk_upload/sales/validator.rb
+++ b/app/services/bulk_upload/sales/validator.rb
@@ -57,7 +57,7 @@ class BulkUpload::Sales::Validator
     end
 
     if invalid_row_numbers.any?
-      Sentry.capture_message("Bulk upload log creation blocked due to invalid logs after blanking non setup fields: #{bulk_upload.id}.")
+      Sentry.capture_message("Bulk upload #{bulk_upload.id} had log creation blocked due to invalid logs after blanking non setup fields. First invalid row number: #{invalid_row_numbers.first}.")
       Rails.logger.error("Sales bulk upload #{bulk_upload.id} blocked due to invalid logs after blanking on rows #{invalid_row_numbers}")
       "logs_invalid"
     end


### PR DESCRIPTION
This will help debug the alerts we've been seeing when bulk uploads fails with rows that are still invalid.