### PR TITLE
CLDC-3981: Add a filter for the sale type

### DIFF
--- a/app/controllers/sales_logs_filters_controller.rb
+++ b/app/controllers/sales_logs_filters_controller.rb
@@ -3,7 +3,7 @@ class SalesLogsFiltersController < ApplicationController
   before_action -> { sales_filter_manager.serialize_filters_to_session }, if: :current_user
   before_action :authenticate_user!
 
-  %w[years status assigned_to owned_by managed_by].each do |filter|
+  %w[years status salestype assigned_to owned_by managed_by].each do |filter|
     define_method(filter) do
       @filter_type = "sales_logs"
       @filter = filter
@@ -18,7 +18,7 @@ class SalesLogsFiltersController < ApplicationController
     end
   end
 
-  %w[status assigned_to owned_by managed_by].each do |filter|
+  %w[status salestype assigned_to owned_by managed_by].each do |filter|
     define_method("update_#{filter}") do
       @filter_type = "sales_logs"
 

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -70,6 +70,14 @@ module FiltersHelper
     }.freeze
   end
 
+  def salestype_filters
+    {
+      "1" => "Shared ownership",
+      "2" => "Discounted ownership",
+      "3" => "Outright or other sale",
+    }.freeze
+  end
+
   def location_status_filters
     {
       "incomplete" => "Incomplete",
@@ -210,6 +218,13 @@ module FiltersHelper
     [1, 2].all? { |needstype| current_user.lettings_logs.visible.where(needstype:).count.positive? }
   end
 
+  def logs_for_multiple_salestypes_present?(organisation)
+    return true if current_user.support? && organisation.blank?
+    return [1, 2, 3].count { |ownershipsch| organisation.sales_logs.visible.where(ownershipsch:).count.positive? } > 1 if current_user.support?
+
+    [1, 2, 3].count { |ownershipsch| current_user.sales_logs.visible.where(ownershipsch:).count.positive? } > 1
+  end
+
   def non_support_with_multiple_owning_orgs?
     return true if current_user.organisation.stock_owners.count > 1
     return true if current_user.organisation.stock_owners.count.positive? && current_user.organisation.holds_own_stock?
@@ -227,6 +242,10 @@ module FiltersHelper
 
   def user_or_org_lettings_path?
     request.path.include?("/lettings-logs")
+  end
+
+  def user_or_org_sales_path?
+    request.path.include?("/sales-logs")
   end
 
   def specific_organisation_path?

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -261,6 +261,7 @@ module FiltersHelper
       { id: "years", label: "Collection year", value: formatted_years_filter(session_filters) },
       { id: "status", label: "Status", value: formatted_status_filter(session_filters) },
       filter_type == "lettings_logs" ? { id: "needstype", label: "Needs type", value: formatted_needstype_filter(session_filters) } : nil,
+      filter_type == "sales_logs" ? { id: "salestype", label: "Sales type", value: formatted_salestype_filter(session_filters) } : nil,
       { id: "assigned_to", label: "Assigned to", value: formatted_assigned_to_filter(session_filters) },
       { id: "owned_by", label: "Owned by", value: formatted_owned_by_filter(session_filters, filter_type) },
       { id: "managed_by", label: "Managed by", value: formatted_managed_by_filter(session_filters, filter_type) },
@@ -335,6 +336,12 @@ private
     return unanswered_filter_value if session_filters["needstypes"].blank?
 
     session_filters["needstypes"].map { |needstype| needstype_filters[needstype] }.to_sentence
+  end
+
+  def formatted_salestype_filter(session_filters)
+    return unanswered_filter_value if session_filters["salestypes"].blank?
+
+    session_filters["salestypes"].map { |salestype| salestype_filters[salestype] }.to_sentence
   end
 
   def formatted_assigned_to_filter(session_filters)

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -45,6 +45,13 @@ class SalesLog < Log
     query.all
   }
   scope :filter_by_purchaser_code, ->(purchid) { where("purchid ILIKE ?", "%#{purchid}%") }
+  scope :filter_by_salestype, ->(salestype) { where(ownershipsch: salestype) }
+  scope :filter_by_salestypes, lambda { |salestypes, _user = nil|
+    first_salestype = salestypes.shift
+    query = filter_by_salestype(first_salestype)
+    salestypes.each { |salestype| query = query.or(filter_by_salestype(salestype)) }
+    query.all
+  }
   scope :search_by, lambda { |param|
     sanitized_param = ActiveRecord::Base.sanitize_sql(param)
     param_without_spaces = sanitized_param.delete(" ")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,9 +228,9 @@ class User < ApplicationRecord
 
   def logs_filters(specific_org: false)
     if (support? && !specific_org) || organisation.has_managing_agents? || organisation.has_stock_owners?
-      %w[years status needstypes assigned_to user owning_organisation managing_organisation bulk_upload_id user_text_search owning_organisation_text_search managing_organisation_text_search]
+      %w[years status needstypes salestypes assigned_to user owning_organisation managing_organisation bulk_upload_id user_text_search owning_organisation_text_search managing_organisation_text_search]
     else
-      %w[years status needstypes assigned_to user bulk_upload_id user_text_search]
+      %w[years status needstypes salestypes assigned_to user bulk_upload_id user_text_search]
     end
   end
 

--- a/app/views/filters/salestype.html.erb
+++ b/app/views/filters/salestype.html.erb
@@ -1,0 +1,20 @@
+<%= form_with html: { method: :get }, url: update_csv_filters_url(@filter_type, @filter, @organisation_id) do |f| %>
+    <%= render partial: "filters/checkbox_filter",
+               locals: {
+                         f:,
+                         options: salestype_filters,
+                         label: "Sales type",
+                         category: "salestypes",
+                         size: "l",
+                       } %>
+
+  <% if request.params["search"].present? %>
+    <%= f.hidden_field :search, value: request.params["search"] %>
+  <% end %>
+  <%= f.hidden_field :codes_only, value: request.params["codes_only"] %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Save changes" %>
+    <%= govuk_button_link_to "Cancel", cancel_csv_filters_update_url(@filter_type, request.params["search"], request.params["codes_only"], @organisation_id), secondary: true %>
+  </div>
+<% end %>

--- a/app/views/logs/_log_filters.html.erb
+++ b/app/views/logs/_log_filters.html.erb
@@ -55,6 +55,17 @@
                          size: "s",
                        } %>
           <% end %>
+
+          <% if logs_for_multiple_salestypes_present?(@organisation) && user_or_org_sales_path? %>
+            <%= render partial: "filters/checkbox_filter",
+                       locals: {
+                         f:,
+                         options: salestype_filters,
+                         label: "Sales type",
+                         category: "salestypes",
+                         size: "s",
+                       } %>
+          <% end %>
         <% end %>
 
         <%= render partial: "filters/radio_filter",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,7 +197,7 @@ Rails.application.routes.draw do
         get "lettings-logs/filters/#{filter}", to: "lettings_logs_filters#organisation_#{filter.underscore}"
         get "lettings-logs/filters/update-#{filter}", to: "lettings_logs_filters#update_organisation_#{filter.underscore}"
       end
-      %w[years status assigned-to owned-by managed-by].each do |filter|
+      %w[years status salestype assigned-to owned-by managed-by].each do |filter|
         get "sales-logs/filters/#{filter}", to: "sales_logs_filters#organisation_#{filter.underscore}"
         get "sales-logs/filters/update-#{filter}", to: "sales_logs_filters#update_organisation_#{filter.underscore}"
       end
@@ -327,7 +327,7 @@ Rails.application.routes.draw do
       post "delete-logs-confirmation", to: "delete_logs#delete_sales_logs_confirmation"
       delete "delete-logs", to: "delete_logs#discard_sales_logs"
 
-      %w[years status assigned-to owned-by managed-by].each do |filter|
+      %w[years status salestype assigned-to owned-by managed-by].each do |filter|
         get "filters/#{filter}", to: "sales_logs_filters##{filter.underscore}"
         get "filters/update-#{filter}", to: "sales_logs_filters#update_#{filter.underscore}"
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe User, type: :model do
         end
 
         it "can filter lettings logs by user, year and status" do
-          expect(user.logs_filters).to match_array(%w[years status needstypes assigned_to user bulk_upload_id user_text_search])
+          expect(user.logs_filters).to match_array(%w[years status needstypes salestypes assigned_to user bulk_upload_id user_text_search])
         end
       end
 
@@ -174,7 +174,7 @@ RSpec.describe User, type: :model do
         end
 
         it "can filter lettings logs by user, year, status, managing_organisation and owning_organisation" do
-          expect(user.logs_filters).to match_array(%w[years status needstypes assigned_to user managing_organisation owning_organisation bulk_upload_id managing_organisation_text_search owning_organisation_text_search user_text_search])
+          expect(user.logs_filters).to match_array(%w[years status needstypes salestypes assigned_to user managing_organisation owning_organisation bulk_upload_id managing_organisation_text_search owning_organisation_text_search user_text_search])
         end
 
         it "can filter schemes by status and owning_organisation" do
@@ -219,7 +219,7 @@ RSpec.describe User, type: :model do
       end
 
       it "can filter lettings logs by user, year, status, managing_organisation and owning_organisation" do
-        expect(user.logs_filters).to match_array(%w[years status needstypes assigned_to user owning_organisation managing_organisation bulk_upload_id managing_organisation_text_search owning_organisation_text_search user_text_search])
+        expect(user.logs_filters).to match_array(%w[years status needstypes salestypes assigned_to user owning_organisation managing_organisation bulk_upload_id managing_organisation_text_search owning_organisation_text_search user_text_search])
       end
 
       it "can filter bulk uploads by year, uploaded_by and uploading_organisation " do

--- a/spec/requests/sales_logs_controller_spec.rb
+++ b/spec/requests/sales_logs_controller_spec.rb
@@ -981,12 +981,13 @@ RSpec.describe SalesLogsController, type: :request do
 
         it "allows updating log filters" do
           expect(page).to have_content("Check your filters")
-          expect(page).to have_link("Change", count: 5)
+          expect(page).to have_link("Change", count: 6)
           expect(page).to have_link("Change", href: "/sales-logs/filters/years?codes_only=false&referrer=check_answers&search=#{search_term}")
           expect(page).to have_link("Change", href: "/sales-logs/filters/assigned-to?codes_only=false&referrer=check_answers&search=#{search_term}")
           expect(page).to have_link("Change", href: "/sales-logs/filters/owned-by?codes_only=false&referrer=check_answers&search=#{search_term}")
           expect(page).to have_link("Change", href: "/sales-logs/filters/managed-by?codes_only=false&referrer=check_answers&search=#{search_term}")
           expect(page).to have_link("Change", href: "/sales-logs/filters/status?codes_only=false&referrer=check_answers&search=#{search_term}")
+          expect(page).to have_link("Change", href: "/sales-logs/filters/salestype?codes_only=false&referrer=check_answers&search=#{search_term}")
         end
 
         it "has a hidden field with the search term" do


### PR DESCRIPTION
Adds a filter to the `/sales-logs` page for a sale type filter

also adds it to the CSV filter flow

<details>
<summary>screenshots</summary>
<img src="https://github.com/user-attachments/assets/9ea55167-3c06-4129-a0ae-b7740516d8e8" alt="sales log view"/>
<img src="https://github.com/user-attachments/assets/3fef8775-c194-45ce-abf9-8ab1a2f445a6" alt="sales filters view"/>
</details>
