### PR TITLE
CLDC-4038: Specify correct questions related to incorrect housingneeds

### DIFF
--- a/app/services/bulk_upload/lettings/year2024/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2024/row_parser.rb
@@ -1070,7 +1070,7 @@ private
       leftreg: %i[field_76],
       reservist: %i[field_77],
       preg_occ: %i[field_78],
-      housingneeds: %i[field_78],
+      housingneeds: %i[field_79 field_80 field_81 field_82 field_83 field_84],
 
       illness: %i[field_85],
 


### PR DESCRIPTION
for the housingneeds question, specifies which fields in the data export relate to it, in this case it should be fields 79-84

![image](https://github.com/user-attachments/assets/95c6771a-7927-4a28-9769-2b17952c63af)
