### PR TITLE
CLDC-2594: Deactivated user login custom error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,7 +271,14 @@ class User < ApplicationRecord
   end
 
   def valid_for_authentication?
-    super && active?
+    super && account_is_active?
+  end
+
+  def account_is_active?
+    unless active?
+      throw(:warden, message: :inactive_account)
+    end
+    true
   end
 
   def editable_duplicate_lettings_logs_sets

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,7 @@ en:
       timeout: "Your session expired. Sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You must confirm your email address before continuing."
+      inactive_account: "Your account has been deactivated. Ask a data coordinator at your organisation to reactivate your account. Contact the helpdesk if you don't know who your data coordinator is."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions."


### PR DESCRIPTION
# Description
adds a check upon login for whether they are an active user or not

uses agreed wording

# Screenshots
![image](https://github.com/user-attachments/assets/ef4dd58f-3539-4e12-8e01-2e39c176f261)
