### PR TITLE
CLDC-4039: Fix merge functionality not working

### DIFF
--- a/app/services/merge/merge_organisations_service.rb
+++ b/app/services/merge/merge_organisations_service.rb
@@ -102,7 +102,11 @@ private
         location_to_set = scheme_to_set.locations.find_by(name: lettings_log.location&.name, postcode: lettings_log.location&.postcode)
 
         lettings_log.scheme = scheme_to_set if scheme_to_set.present?
-        lettings_log.location = location_to_set if location_to_set.present?
+        # in some cases the lettings_log location is nil even if scheme is present (they're two different questions).
+        # in certain cases the location_to_set query can find a location in the scheme with nil values for name and postcode,
+        # so we can end up setting the location to non nil.
+        # hence the extra check here
+        lettings_log.location = location_to_set if location_to_set.present? && lettings_log.location.present?
       end
       lettings_log.owning_organisation = @absorbing_organisation
       lettings_log.managing_organisation = @absorbing_organisation if lettings_log.managing_organisation == merging_organisation

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -715,12 +715,16 @@ RSpec.describe Merge::MergeOrganisationsService do
             create(:location, scheme:)
             incomplete_lettings_log = build(:lettings_log, scheme:, owning_organisation: merging_organisation, startdate: Time.zone.today)
             incomplete_lettings_log.save!(validate: false)
-            expect(Rails.logger).not_to receive(:error)
 
+            # if the location is overwritten with the nil one above, it will fail validation
+            # since a rollback will occur incomplete_lettings_log will not change so there's nothing to verify later
+            # so instead we verify that no rollback occurs
+            expect(Rails.logger).not_to receive(:error)
             merge_organisations_service.call
 
             incomplete_lettings_log.reload
 
+            # also ensure it wasn't overwritten with a valid location
             expect(incomplete_lettings_log.location).to be_nil
           end
 

--- a/spec/services/merge/merge_organisations_service_spec.rb
+++ b/spec/services/merge/merge_organisations_service_spec.rb
@@ -708,7 +708,7 @@ RSpec.describe Merge::MergeOrganisationsService do
           end
 
           it "does not change the lettings log location" do
-            create(:scheme, owning_organisation: merging_organisation)
+            scheme = create(:scheme, owning_organisation: merging_organisation)
             create(:location, scheme:, name: nil, postcode: nil)
             # necessary to have a couple valid locations else the scheme will be invalid
             create(:location, scheme:)
@@ -1595,8 +1595,6 @@ RSpec.describe Merge::MergeOrganisationsService do
           expect(new_absorbing_organisation.available_from.to_date).to eq(Time.zone.today)
         end
       end
-
-      context "and "
     end
 
     context "when merging multiple organisations into a new organisation" do


### PR DESCRIPTION
catches a case where the location could be edited from a non nil value to a nil one, as the guard clause only checks if scheme is null

adds a verifying test