### PR TITLE
CLDC-4035: Improve our handling of commas in price inputs

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -160,6 +160,9 @@ private
           result[option] = 1 if question_params.include?(option)
         end
       elsif question.type != "date"
+        if question.strip_commas
+          question_params = question_params.delete(",")
+        end
         result[question.id] = question_params
       end
 

--- a/app/models/form/lettings/questions/brent_4_weekly.rb
+++ b/app/models/form/lettings/questions/brent_4_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::Brent4Weekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 4 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 95, 2024 => 94, 2025 => 92 }.freeze

--- a/app/models/form/lettings/questions/brent_bi_weekly.rb
+++ b/app/models/form/lettings/questions/brent_bi_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::BrentBiWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 2 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 95, 2024 => 94, 2025 => 92 }.freeze

--- a/app/models/form/lettings/questions/brent_monthly.rb
+++ b/app/models/form/lettings/questions/brent_monthly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::BrentMonthly < ::Form::Question
     @prefix = "£"
     @suffix = " every month"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 95, 2024 => 94, 2025 => 92 }.freeze

--- a/app/models/form/lettings/questions/brent_weekly.rb
+++ b/app/models/form/lettings/questions/brent_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::BrentWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every week"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 95, 2024 => 94, 2025 => 92 }.freeze

--- a/app/models/form/lettings/questions/chcharge_4_weekly.rb
+++ b/app/models/form/lettings/questions/chcharge_4_weekly.rb
@@ -10,6 +10,7 @@ class Form::Lettings::Questions::Chcharge4Weekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 4 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 94, 2024 => 93 }.freeze

--- a/app/models/form/lettings/questions/chcharge_bi_weekly.rb
+++ b/app/models/form/lettings/questions/chcharge_bi_weekly.rb
@@ -10,6 +10,7 @@ class Form::Lettings::Questions::ChchargeBiWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 2 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 94, 2024 => 93 }.freeze

--- a/app/models/form/lettings/questions/chcharge_monthly.rb
+++ b/app/models/form/lettings/questions/chcharge_monthly.rb
@@ -10,6 +10,7 @@ class Form::Lettings::Questions::ChchargeMonthly < ::Form::Question
     @prefix = "£"
     @suffix = " every month"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 94, 2024 => 93 }.freeze

--- a/app/models/form/lettings/questions/chcharge_weekly.rb
+++ b/app/models/form/lettings/questions/chcharge_weekly.rb
@@ -10,6 +10,7 @@ class Form::Lettings::Questions::ChchargeWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every week"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 94, 2024 => 93 }.freeze

--- a/app/models/form/lettings/questions/earnings.rb
+++ b/app/models/form/lettings/questions/earnings.rb
@@ -16,6 +16,7 @@ class Form::Lettings::Questions::Earnings < ::Form::Question
       { "label" => " every year", "depends_on" => { "incfreq" => 3 } },
     ]
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 88, 2024 => 87 }.freeze

--- a/app/models/form/lettings/questions/pscharge_4_weekly.rb
+++ b/app/models/form/lettings/questions/pscharge_4_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::Pscharge4Weekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 4 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 97, 2024 => 96, 2025 => 94 }.freeze

--- a/app/models/form/lettings/questions/pscharge_bi_weekly.rb
+++ b/app/models/form/lettings/questions/pscharge_bi_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::PschargeBiWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 2 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 97, 2024 => 96, 2025 => 94 }.freeze

--- a/app/models/form/lettings/questions/pscharge_monthly.rb
+++ b/app/models/form/lettings/questions/pscharge_monthly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::PschargeMonthly < ::Form::Question
     @prefix = "£"
     @suffix = " every month"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 97, 2024 => 96, 2025 => 94 }.freeze

--- a/app/models/form/lettings/questions/pscharge_weekly.rb
+++ b/app/models/form/lettings/questions/pscharge_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::PschargeWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every week"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 97, 2024 => 96, 2025 => 94 }.freeze

--- a/app/models/form/lettings/questions/scharge_4_weekly.rb
+++ b/app/models/form/lettings/questions/scharge_4_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::Scharge4Weekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 4 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 96, 2024 => 95, 2025 => 93 }.freeze

--- a/app/models/form/lettings/questions/scharge_bi_weekly.rb
+++ b/app/models/form/lettings/questions/scharge_bi_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SchargeBiWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 2 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 96, 2024 => 95, 2025 => 93 }.freeze

--- a/app/models/form/lettings/questions/scharge_monthly.rb
+++ b/app/models/form/lettings/questions/scharge_monthly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SchargeMonthly < ::Form::Question
     @prefix = "£"
     @suffix = " every month"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 96, 2024 => 95, 2025 => 93 }.freeze

--- a/app/models/form/lettings/questions/scharge_weekly.rb
+++ b/app/models/form/lettings/questions/scharge_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SchargeWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every week"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 96, 2024 => 95, 2025 => 93 }.freeze

--- a/app/models/form/lettings/questions/supcharg_4_weekly.rb
+++ b/app/models/form/lettings/questions/supcharg_4_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::Supcharg4Weekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 4 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 98, 2024 => 97, 2025 => 95 }.freeze

--- a/app/models/form/lettings/questions/supcharg_bi_weekly.rb
+++ b/app/models/form/lettings/questions/supcharg_bi_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SupchargBiWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every 2 weeks"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 98, 2024 => 97, 2025 => 95 }.freeze

--- a/app/models/form/lettings/questions/supcharg_monthly.rb
+++ b/app/models/form/lettings/questions/supcharg_monthly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SupchargMonthly < ::Form::Question
     @prefix = "£"
     @suffix = " every month"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 98, 2024 => 97, 2025 => 95 }.freeze

--- a/app/models/form/lettings/questions/supcharg_weekly.rb
+++ b/app/models/form/lettings/questions/supcharg_weekly.rb
@@ -13,6 +13,7 @@ class Form::Lettings::Questions::SupchargWeekly < ::Form::Question
     @prefix = "£"
     @suffix = " every week"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 98, 2024 => 97, 2025 => 95 }.freeze

--- a/app/models/form/lettings/questions/tcharge_4_weekly.rb
+++ b/app/models/form/lettings/questions/tcharge_4_weekly.rb
@@ -14,5 +14,6 @@ class Form::Lettings::Questions::Tcharge4Weekly < ::Form::Question
     @requires_js = true
     @fields_added = %w[brent scharge pscharge supcharg]
     @hidden_in_check_answers = true
+    @strip_commas = true
   end
 end

--- a/app/models/form/lettings/questions/tcharge_bi_weekly.rb
+++ b/app/models/form/lettings/questions/tcharge_bi_weekly.rb
@@ -14,5 +14,6 @@ class Form::Lettings::Questions::TchargeBiWeekly < ::Form::Question
     @requires_js = true
     @fields_added = %w[brent scharge pscharge supcharg]
     @hidden_in_check_answers = true
+    @strip_commas = true
   end
 end

--- a/app/models/form/lettings/questions/tcharge_monthly.rb
+++ b/app/models/form/lettings/questions/tcharge_monthly.rb
@@ -14,5 +14,6 @@ class Form::Lettings::Questions::TchargeMonthly < ::Form::Question
     @requires_js = true
     @fields_added = %w[brent scharge pscharge supcharg]
     @hidden_in_check_answers = true
+    @strip_commas = true
   end
 end

--- a/app/models/form/lettings/questions/tcharge_weekly.rb
+++ b/app/models/form/lettings/questions/tcharge_weekly.rb
@@ -14,5 +14,6 @@ class Form::Lettings::Questions::TchargeWeekly < ::Form::Question
     @requires_js = true
     @fields_added = %w[brent scharge pscharge supcharg]
     @hidden_in_check_answers = true
+    @strip_commas = true
   end
 end

--- a/app/models/form/lettings/questions/tshortfall.rb
+++ b/app/models/form/lettings/questions/tshortfall.rb
@@ -22,6 +22,7 @@ class Form::Lettings::Questions::Tshortfall < ::Form::Question
       { "label" => " every week for 53 weeks", "depends_on" => { "period" => 10 } },
     ]
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 100, 2024 => 99, 2025 => 97 }.freeze

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -8,7 +8,7 @@ class Form::Question
                 :top_guidance_partial, :bottom_guidance_partial, :prefix, :suffix,
                 :requires_js, :fields_added, :derived, :check_answers_card_number,
                 :unresolved_hint_text, :question_number, :hide_question_number_on_page,
-                :plain_label, :error_label
+                :plain_label, :error_label, :strip_commas
 
   def initialize(id, hsh, page)
     @id = id
@@ -45,6 +45,7 @@ class Form::Question
       @plain_label = hsh["plain_label"]
       @error_label = hsh["error_label"]
       @disable_clearing_if_not_routed_or_dynamic_answer_options = hsh["disable_clearing_if_not_routed_or_dynamic_answer_options"]
+      @strip_commas = hsh["strip_commas"] || false
     end
   end
 

--- a/app/models/form/sales/questions/buyer1_income.rb
+++ b/app/models/form/sales/questions/buyer1_income.rb
@@ -11,6 +11,7 @@ class Form::Sales::Questions::Buyer1Income < ::Form::Question
     @prefix = "£"
     @check_answers_card_number = 1
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 67, 2024 => 69, 2025 => 66 }.freeze

--- a/app/models/form/sales/questions/buyer2_income.rb
+++ b/app/models/form/sales/questions/buyer2_income.rb
@@ -11,6 +11,7 @@ class Form::Sales::Questions::Buyer2Income < ::Form::Question
     @prefix = "£"
     @check_answers_card_number = 2
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 69, 2024 => 71, 2025 => 68 }.freeze

--- a/app/models/form/sales/questions/deposit_amount.rb
+++ b/app/models/form/sales/questions/deposit_amount.rb
@@ -13,6 +13,7 @@ class Form::Sales::Questions::DepositAmount < ::Form::Question
     @optional = optional
     @top_guidance_partial = top_guidance_partial
     @copy_key = copy_key
+    @strip_commas = true
   end
 
   def derived?(log)

--- a/app/models/form/sales/questions/deposit_discount.rb
+++ b/app/models/form/sales/questions/deposit_discount.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::DepositDiscount < ::Form::Question
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
     @top_guidance_partial = "financial_calculations_shared_ownership"
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 96, 2024 => 97, 2025 => 86 }.freeze

--- a/app/models/form/sales/questions/grant.rb
+++ b/app/models/form/sales/questions/grant.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::Grant < ::Form::Question
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
     @top_guidance_partial = "financial_calculations_discounted_ownership"
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 101, 2024 => 102, 2025 => 104 }.freeze

--- a/app/models/form/sales/questions/leasehold_charges.rb
+++ b/app/models/form/sales/questions/leasehold_charges.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::LeaseholdCharges < ::Form::Question
     @copy_key = "sales.sale_information.leaseholdcharges.mscharge"
     @ownershipsch = ownershipsch
     @question_number = QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.fetch(form.start_date.year, QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.max_by { |k, _v| k }.last)[ownershipsch]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP = {

--- a/app/models/form/sales/questions/management_fee.rb
+++ b/app/models/form/sales/questions/management_fee.rb
@@ -9,6 +9,7 @@ class Form::Sales::Questions::ManagementFee < ::Form::Question
     @width = 5
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2025 => 89 }.freeze

--- a/app/models/form/sales/questions/monthly_rent.rb
+++ b/app/models/form/sales/questions/monthly_rent.rb
@@ -8,6 +8,7 @@ class Form::Sales::Questions::MonthlyRent < ::Form::Question
     @width = 5
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 97, 2024 => 98, 2025 => 87 }.freeze

--- a/app/models/form/sales/questions/monthly_rent_after_staircasing.rb
+++ b/app/models/form/sales/questions/monthly_rent_after_staircasing.rb
@@ -9,6 +9,7 @@ class Form::Sales::Questions::MonthlyRentAfterStaircasing < ::Form::Question
     @width = 5
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2025 => 101 }.freeze

--- a/app/models/form/sales/questions/monthly_rent_before_staircasing.rb
+++ b/app/models/form/sales/questions/monthly_rent_before_staircasing.rb
@@ -9,6 +9,7 @@ class Form::Sales::Questions::MonthlyRentBeforeStaircasing < ::Form::Question
     @width = 5
     @prefix = "£"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2025 => 100 }.freeze

--- a/app/models/form/sales/questions/mortgage_amount.rb
+++ b/app/models/form/sales/questions/mortgage_amount.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::MortgageAmount < ::Form::Question
     @ownershipsch = ownershipsch
     @question_number = QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.fetch(form.start_date.year, QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.max_by { |k, _v| k }.last)[ownershipsch]
     @top_guidance_partial = top_guidance_partial
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP = {

--- a/app/models/form/sales/questions/purchase_price.rb
+++ b/app/models/form/sales/questions/purchase_price.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::PurchasePrice < ::Form::Question
     @ownership_sch = ownershipsch
     @question_number = QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.fetch(form.start_date.year, QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP.max_by { |k, _v| k }.last)[ownershipsch]
     @top_guidance_partial = top_guidance_partial
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR_AND_OWNERSHIP = {

--- a/app/models/form/sales/questions/savings.rb
+++ b/app/models/form/sales/questions/savings.rb
@@ -9,6 +9,7 @@ class Form::Sales::Questions::Savings < ::Form::Question
     @step = 10
     @min = 0
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 72, 2024 => 74, 2025 => 71 }.freeze

--- a/app/models/form/sales/questions/service_charge.rb
+++ b/app/models/form/sales/questions/service_charge.rb
@@ -9,6 +9,7 @@ class Form::Sales::Questions::ServiceCharge < ::Form::Question
     @prefix = "£"
     @copy_key = "sales.sale_information.servicecharges.servicecharge"
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @strip_commas = true
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2025 => 88 }.freeze

--- a/app/models/form/sales/questions/value.rb
+++ b/app/models/form/sales/questions/value.rb
@@ -10,6 +10,7 @@ class Form::Sales::Questions::Value < ::Form::Question
     @prefix = "£"
     @question_number = question_number_from_year[form.start_date.year] || question_number_from_year[question_number_from_year.keys.max]
     @top_guidance_partial = "financial_calculations_shared_ownership"
+    @strip_commas = true
   end
 
   def question_number_from_year


### PR DESCRIPTION
add the option to ignore commas in a price field (or other numeric/text fields)

happy to hear alterative implementations for this - there is no unifying currency type for questions so settled on a general parameter for this behaviour, though could look into making a specific currency type that ignores commas by default