### PR TITLE
CLDC-4033: Improve flow for unconfirmed users

### DIFF
--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -66,7 +66,7 @@ protected
     resource.need_two_factor_authentication?(request) ? :updated_2FA : :updated
   end
 
-  def after_sending_reset_password_instructions_path_for(_resource)
+  def after_sending_reset_password_instructions_path_for(resource)
     account_password_reset_confirmation_path(email: params.dig("user", "email"), unconfirmed: resource.initial_confirmation_sent && !resource.confirmed?)
   end
 

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -67,7 +67,7 @@ protected
   end
 
   def after_sending_reset_password_instructions_path_for(_resource)
-    account_password_reset_confirmation_path(email: params.dig("user", "email"), unconfirmed: !resource.confirmed?)
+    account_password_reset_confirmation_path(email: params.dig("user", "email"), unconfirmed: resource.initial_confirmation_sent && !resource.confirmed?)
   end
 
   def after_resetting_password_path_for(resource)

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -4,6 +4,7 @@ class Auth::PasswordsController < Devise::PasswordsController
   def reset_confirmation
     self.resource = resource_class.new
     @email = params["email"]
+    @unconfirmed = params["unconfirmed"] == "true"
     if @email.blank?
       resource.errors.add :email, I18n.t("validations.email.blank")
       render "devise/passwords/new", status: :unprocessable_entity
@@ -66,7 +67,7 @@ protected
   end
 
   def after_sending_reset_password_instructions_path_for(_resource)
-    account_password_reset_confirmation_path(email: params.dig("user", "email"))
+    account_password_reset_confirmation_path(email: params.dig("user", "email"), unconfirmed: !resource.confirmed?)
   end
 
   def after_resetting_password_path_for(resource)

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -66,7 +66,7 @@ protected
     resource.need_two_factor_authentication?(request) ? :updated_2FA : :updated
   end
 
-  def after_sending_reset_password_instructions_path_for(resource)
+  def after_sending_reset_password_instructions_path_for(_resource_name)
     account_password_reset_confirmation_path(email: params.dig("user", "email"), unconfirmed: resource.initial_confirmation_sent && !resource.confirmed?)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -358,6 +358,14 @@ class User < ApplicationRecord
     end
   end
 
+  def send_reset_password_instructions
+    if confirmed?
+      super
+    else
+      send_confirmation_instructions
+    end
+  end
+
 protected
 
   # Checks whether a password is needed or not. For validations only.

--- a/app/views/devise/passwords/reset_resend_confirmation.html.erb
+++ b/app/views/devise/passwords/reset_resend_confirmation.html.erb
@@ -6,7 +6,11 @@
       <%= content_for(:title) %>
     </h1>
 
-    <p class="govuk-body">We’ve sent a link to reset your password to <strong><%= @email %></strong>.</p>
+    <% if @unconfirmed %>
+      <p class="govuk-body">We’ve sent a link to confirm your email address to <strong><%= @email %></strong>. This will complete your registration onto the CORE service.</p>
+    <% else %>
+      <p class="govuk-body">We’ve sent a link to reset your password to <strong><%= @email %></strong>.</p>
+    <% end %>
     <p class="govuk-body">You’ll only receive this link if your email address already exists in our system.</p>
     <p class="govuk-body">If you don’t receive the email within 5 minutes, check your spam or junk folders. Try again if you still haven’t received the email.</p>
   </div>


### PR DESCRIPTION
send confirmation email if user is unconfirmed rather than password reset email

show text provided by CORE in this case as the regular password reset screen may be unclear

solves [CLDC-4033](https://mhclgdigital.atlassian.net/browse/CLDC-4033)

<img width="758" height="430" alt="image" src="https://github.com/user-attachments/assets/34ddcfbb-1548-415a-b0c1-9b94ac766cb2" />


[CLDC-4033]: https://mhclgdigital.atlassian.net/browse/CLDC-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ