### PR TITLE
CLDC-4046: Remove forcing on Q84 based on Q76 answer

### DIFF
--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -31,10 +31,6 @@ module Validations::HouseholdValidations
     validate_other_field(record, 20, :reason, :reasonother)
 
     if record.is_reason_permanently_decanted?
-      if record.referral_type.present? && !record.is_from_prp_only_housing_register_or_waiting_list?
-        record.errors.add :referral_type, I18n.t("validations.lettings.household.referral_type.leaving_last_settled_home.reason_permanently_decanted")
-      end
-
       if record.referral.present? && !record.is_internal_transfer?
         record.errors.add :referral, I18n.t("validations.lettings.household.referral.leaving_last_settled_home.reason_permanently_decanted")
         record.errors.add :reason, I18n.t("validations.lettings.household.reason.leaving_last_settled_home.not_internal_transfer")

--- a/app/models/validations/household_validations.rb
+++ b/app/models/validations/household_validations.rb
@@ -30,13 +30,6 @@ module Validations::HouseholdValidations
     end
     validate_other_field(record, 20, :reason, :reasonother)
 
-    if record.is_reason_permanently_decanted?
-      if record.referral.present? && !record.is_internal_transfer?
-        record.errors.add :referral, I18n.t("validations.lettings.household.referral.leaving_last_settled_home.reason_permanently_decanted")
-        record.errors.add :reason, I18n.t("validations.lettings.household.reason.leaving_last_settled_home.not_internal_transfer")
-      end
-    end
-
     return unless record.form.start_year_2024_or_later?
 
     if record.reason == 20 && PHRASES_INDICATING_HOMELESSNESS_REGEX.match?(record.reasonother)

--- a/config/locales/validations/lettings/household.en.yml
+++ b/config/locales/validations/lettings/household.en.yml
@@ -106,7 +106,3 @@ en:
             reason_permanently_decanted: "Answer must be internal transfer as the tenant was permanently decanted from another property owned by this landlord."
           la_general_needs:
             internal_transfer: "Answer cannot be internal transfer as it’s the same landlord on the tenancy agreement and the household had either a fixed-term or lifetime local authority general needs tenancy immediately before this letting."
-
-        referral_type:
-          leaving_last_settled_home:
-            reason_permanently_decanted: "Answer must be from a PRP-only housing register or waiting list (no local authority involvement) as the tenant was permanently decanted from another property owned by this landlord."

--- a/config/locales/validations/lettings/household.en.yml
+++ b/config/locales/validations/lettings/household.en.yml
@@ -28,7 +28,6 @@ en:
         reason:
           leaving_last_settled_home:
             dont_know_required: "Answer must be ‘don’t know’ as you told us you don’t know the tenant’s main reason for leaving."
-            not_internal_transfer: "Answer cannot be ‘permanently decanted from another property owned by this landlord’ as you told us the source of referral for this tenancy was not an internal transfer."
             other_not_settled: "Please give the reason for the tenant leaving their last settled home. This is where they were living before they became homeless, were living in temporary accommodation or sleeping rough."
 
         condition_effects:
@@ -102,7 +101,5 @@ en:
 
         referral:
           prevten_invalid: "Answer cannot be internal transfer as the household situation immediately before this letting was %{prevten}."
-          leaving_last_settled_home:
-            reason_permanently_decanted: "Answer must be internal transfer as the tenant was permanently decanted from another property owned by this landlord."
           la_general_needs:
             internal_transfer: "Answer cannot be internal transfer as it’s the same landlord on the tenancy agreement and the household had either a fixed-term or lifetime local authority general needs tenancy immediately before this letting."

--- a/spec/models/validations/household_validations_spec.rb
+++ b/spec/models/validations/household_validations_spec.rb
@@ -116,17 +116,17 @@ RSpec.describe Validations::HouseholdValidations do
     end
 
     context "when referral is not internal transfer" do
-      it "cannot be permanently decanted from another property owned by this landlord" do
+      it "can be permanently decanted from another property owned by this landlord" do
         record.reason = 1
         record.referral_type = 1
         record.referral = 2
         household_validator.validate_reason_for_leaving_last_settled_home(record)
         expect(record.errors["reason"])
-          .to include(match(I18n.t("validations.lettings.household.reason.leaving_last_settled_home.not_internal_transfer")))
+          .to be_empty
         expect(record.errors["referral"])
-          .to include(match(I18n.t("validations.lettings.household.referral.leaving_last_settled_home.reason_permanently_decanted")))
+          .to be_empty
         expect(record.errors["referral_type"])
-          .to include(match(I18n.t("validations.lettings.household.referral_type.leaving_last_settled_home.reason_permanently_decanted")))
+          .to be_empty
       end
     end
 


### PR DESCRIPTION
closes [CLDC-4046](https://mhclgdigital.atlassian.net/browse/CLDC-4046)

exact request:
> Please allow "Permanently decanted from another property owned by this landlord" from Q76 (reason) as an option regardless of what is chosen for Q84 (referral).

fairly certain this fulfils the request (right now we only allow decanted for Q76 with one option for Q84)

[CLDC-4046]: https://mhclgdigital.atlassian.net/browse/CLDC-4046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ