### PR TITLE
CLDC-4082: Allow for an unresolved log to redirect to the correct location page

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -86,7 +86,11 @@ class Form
   end
 
   def next_page_id(page, log, current_user, ignore_answered: false)
-    return page.next_unresolved_page_id || :check_answers if log.unresolved
+    if log.unresolved
+      return log.scheme_has_large_number_of_locations? ? "location_search" : "location" if page.next_unresolved_page_id == :location_or_location_search
+
+      return page.next_unresolved_page_id || :check_answers
+    end
 
     page_ids = page.subsection.pages.map(&:id)
     page_index = page_ids.index(page.id)

--- a/app/models/form/lettings/pages/scheme.rb
+++ b/app/models/form/lettings/pages/scheme.rb
@@ -6,7 +6,7 @@ class Form::Lettings::Pages::Scheme < ::Form::Page
         "needstype" => 2,
       },
     ]
-    @next_unresolved_page_id = "location"
+    @next_unresolved_page_id = :location_or_location_search
   end
 
   def questions


### PR DESCRIPTION
closes https://mhclgdigital.atlassian.net/browse/closes CLDC-4082

previously would always go to location, causing issues for schemes with many locations which should send to location_search page