### PR TITLE
CLDC-4044: Allow unconfirmed but logged in (reconfirmed) users to be reinvited

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,6 +167,11 @@ class User < ApplicationRecord
     update!(
       active: true,
       reactivate_with_organisation: false,
+      # resetting these fields ensures that the 'resend confirmation instructions' button shows
+      # we have this button be based on sign in date than confirmation status to ensure that the
+      # user has successfully completed the entire login flow before we hide the button
+      last_sign_in_at: nil,
+      last_sign_in_ip: nil,
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,11 +167,6 @@ class User < ApplicationRecord
     update!(
       active: true,
       reactivate_with_organisation: false,
-      # resetting these fields ensures that the 'resend confirmation instructions' button shows
-      # we have this button be based on sign in date than confirmation status to ensure that the
-      # user has successfully completed the entire login flow before we hide the button
-      last_sign_in_at: nil,
-      last_sign_in_ip: nil,
     )
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -154,6 +154,9 @@
       <div class="govuk-button-group">
         <% if @user.active? %>
           <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
+          <%# Some users are confirmed but have no sign in date, since logging in is a separate step that happens after confirmation %>
+          <%# Some users are unconfirmed but have a sign in date, since deactivating an account will unconfirm but not reset login date %>
+          <%# So, allow both cases to receive invite links %>
           <% if current_user.support? && (@user.last_sign_in_at.nil? || !@user.confirmed?) %>
             <%= govuk_button_to "Resend invite link", resend_invite_user_path(@user), secondary: true %>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -154,7 +154,7 @@
       <div class="govuk-button-group">
         <% if @user.active? %>
           <%= govuk_button_link_to "Deactivate user", deactivate_user_path(@user), warning: true %>
-          <% if current_user.support? && @user.last_sign_in_at.nil? %>
+          <% if current_user.support? && (@user.last_sign_in_at.nil? || !@user.confirmed?) %>
             <%= govuk_button_to "Resend invite link", resend_invite_user_path(@user), secondary: true %>
           <% end %>
         <% else %>

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -608,6 +608,19 @@ RSpec.describe "User Features" do
         click_button("Resend invite link")
       end
     end
+
+    context "when reactivating a user" do
+      let!(:other_user) { create(:user, name: "Other name", active: false, organisation: user.organisation, last_sign_in_at: Time.zone.now, confirmed_at: nil) }
+
+      it "allows for reactivation email to be resent" do
+        allow(user).to receive(:need_two_factor_authentication?).and_return(false)
+        sign_in(user)
+        visit(user_path(other_user))
+        click_link("Reactivate user")
+        click_button("I’m sure – reactivate this user")
+        expect(page).to have_button("Resend invite link")
+      end
+    end
   end
 
   context "when the user is a customer support person" do


### PR DESCRIPTION
closes [CLDC-4044](https://mhclgdigital.atlassian.net/browse/CLDC-4044)

this is to ensure that the code considers them a fresh user

specifically, ensures that the "Resend invite link" button will show

[CLDC-4044]: https://mhclgdigital.atlassian.net/browse/CLDC-4044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ