### PR TITLE
CLDC-4066: Increase our resilience to an OS Places outage

### DIFF
--- a/app/frontend/controllers/address_search_controller.js
+++ b/app/frontend/controllers/address_search_controller.js
@@ -4,10 +4,10 @@ import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 
 const options = []
 
-let latestQueryId = 0;
+let latestQueryId = 0
 
 const sleep = (ms) => {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 const fetchOptions = async (query, searchUrl) => {
@@ -19,11 +19,11 @@ const fetchOptions = async (query, searchUrl) => {
   // this is because this API has periods of high latency if OS Places has an outage
   // making too many requests can overwhelm the number of threads available on the server
   // which can in turn cause a site wide outage
-  latestQueryId++;
-  const myQueryId = latestQueryId;
-  await sleep(500);
+  latestQueryId++
+  const myQueryId = latestQueryId
+  await sleep(500)
   if (myQueryId !== latestQueryId) {
-    throw new Error('Outdated query, ignoring result.');
+    throw new Error('Outdated query, ignoring result.')
   }
 
   try {

--- a/app/frontend/controllers/address_search_controller.js
+++ b/app/frontend/controllers/address_search_controller.js
@@ -4,10 +4,28 @@ import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 
 const options = []
 
+let latestQueryId = 0;
+
+const sleep = (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 const fetchOptions = async (query, searchUrl) => {
   if (query.length < 2) {
     throw new Error('Query must be at least 2 characters long.')
   }
+
+  // implement a debounce
+  // this is because this API has periods of high latency if OS Places has an outage
+  // making too many requests can overwhelm the number of threads available on the server
+  // which can in turn cause a site wide outage
+  latestQueryId++;
+  const myQueryId = latestQueryId;
+  await sleep(500);
+  if (myQueryId !== latestQueryId) {
+    throw new Error('Outdated query, ignoring result.');
+  }
+
   try {
     const response = await fetch(`${searchUrl}?query=${encodeURIComponent(query.trim())}`)
     return await response.json()

--- a/app/services/address_client.rb
+++ b/app/services/address_client.rb
@@ -35,7 +35,7 @@ private
     client.use_ssl = true
     client.verify_mode = OpenSSL::SSL::VERIFY_PEER
     client.max_retries = 3
-    client.read_timeout = 30 # seconds
+    client.read_timeout = 15 # seconds
     client
   end
 

--- a/app/services/uprn_client.rb
+++ b/app/services/uprn_client.rb
@@ -39,7 +39,7 @@ private
     client.use_ssl = true
     client.verify_mode = OpenSSL::SSL::VERIFY_PEER
     client.max_retries = 3
-    client.read_timeout = 30 # seconds
+    client.read_timeout = 20 # seconds
     client
   end
 

--- a/app/services/uprn_client.rb
+++ b/app/services/uprn_client.rb
@@ -39,7 +39,7 @@ private
     client.use_ssl = true
     client.verify_mode = OpenSSL::SSL::VERIFY_PEER
     client.max_retries = 3
-    client.read_timeout = 20 # seconds
+    client.read_timeout = 15 # seconds
     client
   end
 


### PR DESCRIPTION
closes [CLDC-4066](https://mhclgdigital.atlassian.net/browse/CLDC-4066)

helps the app be much more resilient when OS Places API has periods of slow responses

adds a debounce to the address search. requests will wait 0.5 seconds and only the last request will be sent. previously a request would be sent for every keypress which was quite wasteful

reduces the max wait time for OS Places API requests from 90 seconds to 45

both of these changes should help the app not be susceptible to all threads being stuck waiting on OS Places API requests which could cause an outage

[CLDC-4066]: https://mhclgdigital.atlassian.net/browse/CLDC-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ