### PR TITLE
CLDC-4078: Optimise UPRN & Address lookup logic

### DIFF
--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -915,6 +915,7 @@ private
   def should_process_uprn_change?
     return unless uprn
     return unless startdate
+    return if skip_uprn_lookup
 
     uprn_changed? || startdate_changed?
   end
@@ -923,6 +924,7 @@ private
     return unless uprn_selection || select_best_address_match
     return unless startdate
     return unless form.start_year_2024_or_later?
+    return if skip_address_lookup
 
     if select_best_address_match
       address_line1_input.present? && postcode_full_input.present?

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -435,6 +435,7 @@ class SalesLog < Log
   def should_process_uprn_change?
     return unless uprn
     return unless saledate
+    return if skip_uprn_lookup
 
     uprn_changed? || saledate_changed?
   end
@@ -443,6 +444,7 @@ class SalesLog < Log
     return unless uprn_selection || select_best_address_match
     return unless saledate
     return unless form.start_year_2024_or_later?
+    return if skip_address_lookup
 
     if select_best_address_match
       address_line1_input.present? && postcode_full_input.present?


### PR DESCRIPTION
closes [CLDC-4078](https://mhclgdigital.atlassian.net/browse/CLDC-4078)

specifically, during bulk uploads an object is validated many times before saving

dirty checks only reset on save meaning after setting the UPRN the process_uprn_change code would run on every validation, leading to many calls

to solve this, add a flag to the log which blocks further UPRN calls if it tries to set the uprn twice to the same value. if different values are returned then continue checking

this offers a tradeoff between number of api calls and also should not break existing functionality

in testing found the following gains. for one bulk upload log:
- if doing a uprn lookup, api calls reduced from 16 per log to 4 per log
- if doing an address lookup, api calls reduced from 8 per log to 4 per log

I think the minimum per log is 2 (since we 'create' the log twice, once for validation and once when all are valid and we add to the db), so only way to get to 2 is to allow for uprn to only be set once which feels risky

[CLDC-4078]: https://mhclgdigital.atlassian.net/browse/CLDC-4078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ