### PR TITLE
CLDC-4028: Ensure logs will update when an organisation name change is created

### DIFF
--- a/app/services/exports/lettings_log_export_service.rb
+++ b/app/services/exports/lettings_log_export_service.rb
@@ -58,10 +58,10 @@ module Exports
 
       # these must be separate as activerecord struggles to join to two different name change tables in the same query
       ids.concat(
-        relation.left_joins(owning_organisation: :organisation_name_changes).where(owning_organisation: { organisation_name_changes: { created_at: range } }).pluck(:id),
+        relation.left_joins(owning_organisation: :organisation_name_changes).where(owning_organisation: { organisation_name_changes: { updated_at: range } }).pluck(:id),
       )
       ids.concat(
-        relation.left_joins(managing_organisation: :organisation_name_changes).where(managing_organisation: { organisation_name_changes: { created_at: range } }).pluck(:id),
+        relation.left_joins(managing_organisation: :organisation_name_changes).where(managing_organisation: { organisation_name_changes: { updated_at: range } }).pluck(:id),
       )
 
       LettingsLog.where(id: ids)

--- a/app/services/exports/sales_log_export_service.rb
+++ b/app/services/exports/sales_log_export_service.rb
@@ -55,6 +55,14 @@ module Exports
               )
               .pluck(:id)
 
+      # these must be separate as activerecord struggles to join to two different name change tables in the same query
+      ids.concat(
+        relation.left_joins(owning_organisation: :organisation_name_changes).where(owning_organisation: { organisation_name_changes: { updated_at: range } }).pluck(:id),
+      )
+      ids.concat(
+        relation.left_joins(managing_organisation: :organisation_name_changes).where(managing_organisation: { organisation_name_changes: { updated_at: range } }).pluck(:id),
+      )
+
       SalesLog.where(id: ids)
     end
 

--- a/app/services/exports/user_export_service.rb
+++ b/app/services/exports/user_export_service.rb
@@ -33,7 +33,7 @@ module Exports
                 relation.where.not(organisations: { updated_at: nil }).where(organisations: { updated_at: range }),
               )
               .or(
-                relation.where(organisation_name_changes: { created_at: range }),
+                relation.where(organisation_name_changes: { updated_at: range }),
               )
               .pluck(:id)
 

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -550,6 +550,22 @@ RSpec.describe Exports::LettingsLogExportService do
 
         export_service.export_xml_lettings_logs(collection_year: current_collection_start_year)
       end
+
+      it "does export the lettings log if owning_organisation name change is created" do
+        create(:organisation_name_change, organisation: owning_organisation)
+
+        expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args)
+
+        export_service.export_xml_lettings_logs(collection_year: current_collection_start_year)
+      end
+
+      it "does export the lettings log if managing_organisation name change is created" do
+        create(:organisation_name_change, organisation: managing_organisation)
+
+        expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args)
+
+        export_service.export_xml_lettings_logs(collection_year: current_collection_start_year)
+      end
     end
   end
 

--- a/spec/services/exports/sales_log_export_service_spec.rb
+++ b/spec/services/exports/sales_log_export_service_spec.rb
@@ -491,6 +491,22 @@ RSpec.describe Exports::SalesLogExportService do
 
         export_service.export_xml_sales_logs(collection_year: current_collection_start_year)
       end
+
+      it "does export the sales log if owning_organisation name change is created" do
+        create(:organisation_name_change, organisation: owning_organisation)
+
+        expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args)
+
+        export_service.export_xml_sales_logs(collection_year: current_collection_start_year)
+      end
+
+      it "does export the sales log if managing_organisation name change is created" do
+        create(:organisation_name_change, organisation: managing_organisation)
+
+        expect(storage_service).to receive(:write_file).with(expected_zip_filename, any_args)
+
+        export_service.export_xml_sales_logs(collection_year: current_collection_start_year)
+      end
     end
   end
 end


### PR DESCRIPTION
closes [CLDC-4028](https://mhclgdigital.atlassian.net/browse/CLDC-4028)

this could lead to redundant exports if the name change does not impact the log at its startdate (which we put into the log), but it'd be more difficult to query this way so fine to be safe here

```ruby
attribute_hash["owningorgid"] = lettings_log.owning_organisation.old_visible_id || (lettings_log.owning_organisation.id + LOG_ID_OFFSET)
attribute_hash["owningorgname"] = lettings_log.owning_organisation.name(date: lettings_log.startdate)
attribute_hash["hcnum"] = lettings_log.owning_organisation.housing_registration_no
```

could look into further improving the query if the name change would cause a name change at the start date of the log but this feels quite tricky to do (needs to be both before log start date but not overwritten by a future name change)

also query name changes by updated_at rather than created_at. shouldn't really matter as we don't expect name changes to be updated but worth being safe in case we need to update a name change for maintenance reasons

[CLDC-4028]: https://mhclgdigital.atlassian.net/browse/CLDC-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ