### PR TITLE
CLDC-4095: Add errors on all net income fields

### DIFF
--- a/app/models/validations/financial_validations.rb
+++ b/app/models/validations/financial_validations.rb
@@ -20,6 +20,8 @@ module Validations::FinancialValidations
       is_partner_or_main = relationship == "P" || n == 1
       if is_employed && is_partner_or_main && record.benefits == 1
         record.errors.add :benefits, I18n.t("validations.lettings.financial.benefits.part_or_full_time")
+        record.errors.add "ecstat#{n}", I18n.t("validations.lettings.financial.ecstat.part_or_full_time")
+        record.errors.add "relat#{n}", I18n.t("validations.lettings.financial.relat.part_or_full_time", person_num: n) if n > 1
       end
     end
   end

--- a/config/locales/validations/lettings/financial.en.yml
+++ b/config/locales/validations/lettings/financial.en.yml
@@ -24,6 +24,9 @@ en:
         ecstat:
           earnings_over_hard_max: "The household’s income of %{earnings} %{frequency} is too high given the household’s working situation."
           earnings_under_hard_min: "The household’s income of %{earnings} %{frequency} is too low given the household’s working situation."
+          part_or_full_time: "Answer cannot be ‘full-time’ or ‘part-time’ if ‘all’ household income is from Universal Credit, state pensions or benefits."
+        relat:
+          part_or_full_time: "Tenant %{person_num} cannot be the partner of tenant 1 if ‘all’ household income is from Universal Credit, state pensions or benefits and tenant %{person_num} works full-time or part-time."
         age:
           earnings_over_hard_max: "The household’s income of %{earnings} %{frequency} is too high for the number of adults. Change either the household income or the age of the tenants."
         incfreq:

--- a/spec/models/validations/financial_validations_spec.rb
+++ b/spec/models/validations/financial_validations_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Validations::FinancialValidations do
         record.ecstat1 = 1
         financial_validator.validate_net_income_uc_proportion(record)
         expect(record.errors["benefits"]).to include(match I18n.t("validations.lettings.financial.benefits.part_or_full_time"))
+        expect(record.errors["ecstat1"]).to include(match I18n.t("validations.lettings.financial.ecstat.part_or_full_time"))
       end
 
       it "validates that the lead tenant is not in part time employment" do
@@ -47,6 +48,7 @@ RSpec.describe Validations::FinancialValidations do
         record.ecstat1 = 2
         financial_validator.validate_net_income_uc_proportion(record)
         expect(record.errors["benefits"]).to include(match I18n.t("validations.lettings.financial.benefits.part_or_full_time"))
+        expect(record.errors["ecstat1"]).to include(match I18n.t("validations.lettings.financial.ecstat.part_or_full_time"))
       end
 
       it "expects that the lead tenant is not in full-time or part-time employment" do
@@ -54,6 +56,7 @@ RSpec.describe Validations::FinancialValidations do
         record.ecstat1 = 4
         financial_validator.validate_net_income_uc_proportion(record)
         expect(record.errors["benefits"]).to be_empty
+        expect(record.errors["ecstat1"]).to be_empty
       end
 
       it "validates that the tenant’s partner is not in full time employment" do
@@ -62,6 +65,8 @@ RSpec.describe Validations::FinancialValidations do
         record.relat2 = "P"
         financial_validator.validate_net_income_uc_proportion(record)
         expect(record.errors["benefits"]).to include(match I18n.t("validations.lettings.financial.benefits.part_or_full_time"))
+        expect(record.errors["ecstat2"]).to include(match I18n.t("validations.lettings.financial.ecstat.part_or_full_time"))
+        expect(record.errors["relat2"]).to include(match I18n.t("validations.lettings.financial.relat.part_or_full_time", person_num: 2))
       end
 
       it "expects that the tenant’s partner is not in full-time or part-time employment" do
@@ -70,6 +75,8 @@ RSpec.describe Validations::FinancialValidations do
         record.relat2 = "P"
         financial_validator.validate_net_income_uc_proportion(record)
         expect(record.errors["benefits"]).to be_empty
+        expect(record.errors["ecstat2"]).to be_empty
+        expect(record.errors["relat2"]).to be_empty
       end
     end
   end


### PR DESCRIPTION
closes [CLDC-4095](https://mhclgdigital.atlassian.net/browse/CLDC-4095)

ensures errors are added to ecstatn and relatn where appropriate

<details>
ecstat1
<img alt="ecstat1 error" src="https://github.com/user-attachments/assets/fb08bd2a-1761-4dbd-98d7-7da61121ab48" />

ecstat2
<img alt="ecstat2 error" src="https://github.com/user-attachments/assets/2558ca83-c24c-435c-b6b7-e7268b97da25" />

relat2
<img alt="relat2 error" src="https://github.com/user-attachments/assets/2cee3fb6-e408-4ee7-8050-665377cbf6c9" />
</details>




[CLDC-4095]: https://mhclgdigital.atlassian.net/browse/CLDC-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ