### PR TITLE
CLDC-4060: Reset 2FA when user is deactivated

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,7 @@ class User < ApplicationRecord
       initial_confirmation_sent: false,
       reactivate_with_organisation:,
       unconfirmed_email: nil,
+      second_factor_attempts_count: 0,
     )
   end
 


### PR DESCRIPTION
closes [CLDC-4060](https://mhclgdigital.atlassian.net/browse/CLDC-4060)

as requested by CORE, allows CORE to always reset a user by deactivating/reactivating them

[CLDC-4060]: https://mhclgdigital.atlassian.net/browse/CLDC-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ