### PR TITLE
CLDC-4041: Apply html_safe to managing agent contact link

### DIFF
--- a/app/views/organisation_relationships/add_managing_agent.html.erb
+++ b/app/views/organisation_relationships/add_managing_agent.html.erb
@@ -31,7 +31,7 @@
     <%= govuk_list [
       "Double check the spelling and try again",
       "Type the first few letters to see the suggestions",
-      "If you still can't find it, #{govuk_link_to('contact the MHCLG service desk', GlobalConstants::HELPDESK_URL, rel: 'noreferrer noopener', target: '_blank')}",
+      "If you still can't find it, #{govuk_link_to('contact the MHCLG service desk', GlobalConstants::HELPDESK_URL, rel: 'noreferrer noopener', target: '_blank')}".html_safe,
       ], type: :bullet %>
   <% end %>
 <% end %>


### PR DESCRIPTION
closes [CLDC-4041](https://mhclgdigital.atlassian.net/browse/CLDC-4041)

else it won't be shown as a link on the page

looks to have been caused by 151a443cf6045472fc3dda6b5d0f4b4d74d3146a, which swapped a bunch of components to use functions in the markup rather than raw html tags

<img alt="add managing agent page with fixed link" src="https://github.com/user-attachments/assets/0ec6d7e1-cb0c-423a-8a08-17997a8388f9" />

[CLDC-4041]: https://mhclgdigital.atlassian.net/browse/CLDC-4041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ