### PR TITLE
CLDC-3870: Ask number of bedrooms when changing answer to non bedsit

### DIFF
--- a/app/models/derived_variables/lettings_log_variables.rb
+++ b/app/models/derived_variables/lettings_log_variables.rb
@@ -71,6 +71,9 @@ module DerivedVariables::LettingsLogVariables
     if form.start_year_2024_or_later? && is_bedsit?
       self.beds = 1
     end
+    if bedsit_changed_to_not_bedsit? # make user answer num of bedrooms again
+      self.beds = nil
+    end
 
     clear_child_ecstat_for_age_changes!
     child_under_16_constraints!

--- a/app/models/derived_variables/sales_log_variables.rb
+++ b/app/models/derived_variables/sales_log_variables.rb
@@ -83,6 +83,9 @@ module DerivedVariables::SalesLogVariables
     if form.start_year_2025_or_later? && is_bedsit?
       self.beds = 1
     end
+    if bedsit_changed_to_not_bedsit? # make user answer num of bedrooms again
+      self.beds = nil
+    end
 
     self.nationality_all = nationality_all_group if nationality_uk_or_prefers_not_to_say?
     self.nationality_all_buyer2 = nationality_all_buyer2_group if nationality2_uk_or_prefers_not_to_say?

--- a/app/models/lettings_log.rb
+++ b/app/models/lettings_log.rb
@@ -399,6 +399,10 @@ class LettingsLog < Log
     form.start_year_2024_or_later? && is_bedsit?
   end
 
+  def bedsit_changed_to_not_bedsit?
+    unittype_gn_changed? && unittype_gn_was == 2
+  end
+
   def is_shared_housing?
     # 4: Shared flat or maisonette
     # 9: Shared house

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -386,6 +386,10 @@ class SalesLog < Log
     form.start_year_2025_or_later? && is_bedsit?
   end
 
+  def bedsit_changed_to_not_bedsit?
+    proptype_changed? && proptype_was == 2
+  end
+
   def shared_ownership_scheme?
     ownershipsch == 1
   end

--- a/spec/models/lettings_log_derived_fields_spec.rb
+++ b/spec/models/lettings_log_derived_fields_spec.rb
@@ -1232,4 +1232,20 @@ RSpec.describe LettingsLog, type: :model do
       expect { log.set_derived_fields! }.to not_change(log, :ecstat2)
     end
   end
+
+  describe "deriving num of bedrooms from whether property is bedsit" do
+    it "sets num of bedrooms to 1 when property is a bedsit" do
+      log.unittype_gn = 2
+      expect { log.set_derived_fields! }.to change(log, :beds).to 1
+    end
+
+    it "sets num of bedrooms to nil when property is change from a bedsit" do
+      log.unittype_gn = 2
+      log.set_derived_fields!
+      log.clear_changes_information
+
+      log.unittype_gn = 1
+      expect { log.set_derived_fields! }.to change(log, :beds).to nil
+    end
+  end
 end

--- a/spec/models/sales_log_derived_fields_spec.rb
+++ b/spec/models/sales_log_derived_fields_spec.rb
@@ -186,5 +186,23 @@ RSpec.describe SalesLog, type: :model do
         end
       end
     end
+
+    describe "deriving num of bedrooms from whether property is bedsit" do
+      let(:log) { create(:sales_log, :completed) }
+
+      it "sets num of bedrooms to 1 when property is a bedsit" do
+        log.proptype = 2
+        expect { log.set_derived_fields! }.to change(log, :beds).to 1
+      end
+
+      it "sets num of bedrooms to nil when property is change from a bedsit" do
+        log.proptype = 2
+        log.set_derived_fields!
+        log.clear_changes_information
+
+        log.proptype = 1
+        expect { log.set_derived_fields! }.to change(log, :beds).to nil
+      end
+    end
   end
 end


### PR DESCRIPTION
closes [CLDC-3870](https://mhclgdigital.atlassian.net/browse/CLDC-3870)

when changing to a non bedsit answer nil the number of bedrooms answer is set to nil

this is as we previously assumed 1 bedroom if they are a bedsit, we shouldn't assume 1 if they switch to a different property type

adds some verifying tests (as well for the bedsit assumption)

[CLDC-3870]: https://mhclgdigital.atlassian.net/browse/CLDC-3870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ