### PR TITLE
CLDC-4129: Add a default option for location search

### DIFF
--- a/app/models/form/lettings/questions/location_id_search.rb
+++ b/app/models/form/lettings/questions/location_id_search.rb
@@ -16,7 +16,7 @@ class Form::Lettings::Questions::LocationIdSearch < ::Form::Question
   end
 
   def answer_options
-    answer_opts = {}
+    answer_opts = { "" => "Select an option" }
     return answer_opts unless ActiveRecord::Base.connected?
 
     Location.visible.started_in_2_weeks.select(:id, :postcode, :name).each_with_object(answer_opts) do |location, hsh|
@@ -29,7 +29,7 @@ class Form::Lettings::Questions::LocationIdSearch < ::Form::Question
     return {} unless lettings_log.scheme
 
     scheme_location_ids = lettings_log.scheme.locations.visible.confirmed.pluck(:id)
-    answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }.to_h
+    answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) or k == "" }.to_h
   end
 
   def hidden_in_check_answers?(lettings_log, _current_user = nil)


### PR DESCRIPTION
closes [CLDC-4129](https://mhclgdigital.atlassian.net/browse/CLDC-4129)

prevents the first option from being selected by default

<img alt="empty search" src="https://github.com/user-attachments/assets/29303cd6-5583-4e60-b2ce-dbd3cefd7ba2" />

<img alt="search with location" src="https://github.com/user-attachments/assets/aa0d2c4e-bbec-45c3-9d26-bbc0f8102f96" />


[CLDC-4129]: https://mhclgdigital.atlassian.net/browse/CLDC-4129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ