### PR TITLE
CLDC-4158: Create initial 26/27 forms - sales and lettings

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -24,6 +24,11 @@ class Form
       new_logs_end_date: Time.zone.local(2026, 7, 3),
       edit_end_date: Time.zone.local(2026, 8, 1),
     },
+    2026 => {
+      submission_deadline: Time.zone.local(2027, 6, 4),
+      new_logs_end_date: Time.zone.local(2027, 7, 3),
+      edit_end_date: Time.zone.local(2027, 7, 31),
+    },
     :default => {
       submission_deadline: ->(start_year) { Time.zone.local(start_year + 1, 6, 1) },
       new_logs_end_date: ->(start_year) { Time.zone.local(start_year + 1, 12, 31) },

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -353,4 +353,8 @@ class Form
   def start_year_2025_or_later?
     start_date && start_date.year >= 2025
   end
+
+  def start_year_2026_or_later?
+    start_date && start_date.year >= 2026
+  end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,6 +1,6 @@
 class FeatureToggle
   def self.allow_future_form_use?
-    false
+    Rails.env.development? || Rails.env.review? || Rails.env.staging?
   end
 
   def self.bulk_upload_duplicate_log_check_enabled?

--- a/config/locales/forms/2026/lettings/guidance.en.yml
+++ b/config/locales/forms/2026/lettings/guidance.en.yml
@@ -1,0 +1,69 @@
+en:
+  forms:
+    2026:
+      lettings:
+        guidance:
+          finding_location:
+            title: "What is a location?"
+            content: "A location is a postcode area where supported housing is provided under a scheme. A scheme can have multiple locations, and a location can have multiple units at the same postcode."
+            scheme_changes_link_text: "Read more about schemes and locations"
+
+          finding_scheme:
+            title: "Can’t find your scheme?"
+            content: "<p>Schemes are attached to the organisation that owns the property. Check you have correctly answered question 1 \"Which organisation owns this property?\"</p>
+              <p>If your organisation’s schemes were migrated from old CORE, they may have new names and codes. Search by postcode to find your scheme.</p>"
+            view_schemes_link_text: "View your organisation’s schemes"
+
+          privacy_notice_tenant:
+            content: "Make sure the lead tenant has seen or been given access to %{privacy_notice_link} before completing this log. This is a legal requirement under data protection legislation."
+            privacy_notice_link_text: "the Ministry of Housing, Communities and Local Government (MHCLG) privacy notice"
+
+          rent_type_definitions:
+            title: "Rent type definitions"
+            content: "<p><b>Social Rent:</b> where target rents are determined through the national rent regime. This is sometimes also known as 'formula rent'.</p>
+              <p><b>Affordable Rent:</b> where up to 80% of market rent can be charged. A new supply agreement is signed with Homes England or the Greater London Authority (GLA).</p>
+              <p><b>London Affordable Rent:</b> a tenure of affordable housing available in London by the GLA. It is an affordable rent which must be set in accordance with the Regulator of Social Housing’s Affordable Rent guidance. The landlord of these homes must be registered with the Regulator of Social Housing. These are a type of Affordable Rent lettings.</p>
+              <p><b>Rent to Buy: </b> a discount of up to 20% market rent is charged for a single rental period for a minimum of 5 years. After that period, the tenant is offered first chance to purchase the property (either shared ownership or outright) at full market value. These are a type of Intermediate Rent lettings.</p>
+              <p><b>London Living Rent:</b> a tenure of affordable housing available in London by the GLA. It was introduced in Affordable Homes Programme 2016 to 2021. These are a type of Intermediate Rent lettings.</p>
+              <p><b>Other intermediate rent:</b> any other specific scheme where up to 80% of market rent can be charged. This includes schemes with reduced rent so tenants can save towards a house purchasing deposit and schemes with an in-built future opportunity to buy the property being rented.</p>"
+
+          scheme_selection:
+            data_provider:
+              content: "If you’re not sure which scheme to choose, ask a data coordinator. Find your data coordinators on the %{users_page_link}."
+              users_page_link_text: "users page"
+            data_coordinator:
+              create_scheme_link_text: "Create a new supported housing scheme"
+
+          void_date:
+            title: "What is a void date?"
+            content: "<p>Date the property was (legally or contractually) available to let, or for:</p>
+              <ul class=\"govuk-list govuk-list--bullet\">
+                <li>re-lets: the day after the previous tenant’s contract ended</li>
+                <li>new builds: the day the landlord legally first owned the property (‘completion date’)</li>
+                <li>new conversions or acquisitions: completion date, or the day after rehabilitation work ended</li>
+                <li>new leases: the day the landlord got contractual property rights and could let it out to tenants</li>
+              </ul>"
+
+          what_counts_as_income:
+            title: "What counts as income?"
+            content: "<p>You should include any income after tax from:</p>
+              <ul class=\"govuk-list govuk-list--bullet\">
+                <li>employment</li>
+                <li>pensions</li>
+                <li>Universal Credit</li>
+              </ul>
+
+              <p>Don’t include:</p>
+              <ul class=\"govuk-list govuk-list--bullet\">
+                <li>National Insurance (NI) contributions and tax</li>
+                <li>housing benefit</li>
+                <li>child benefit</li>
+                <li>council tax support</li>
+              </ul>"
+
+          address_search:
+            title: "Can’t find the address you’re looking for?"
+            content: "<ul class=\"govuk-list govuk-list--bullet\">
+                <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
+                <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
+              </ul>"

--- a/config/locales/forms/2026/lettings/household_characteristics.en.yml
+++ b/config/locales/forms/2026/lettings/household_characteristics.en.yml
@@ -1,0 +1,377 @@
+en:
+  forms:
+    2026:
+      lettings:
+        household_characteristics:
+          hhmemb:
+            page_header: ""
+            check_answer_label: "Number of household members"
+            check_answer_prompt: "Enter total number of household members"
+            hint_text: "You can provide details for a maximum of 8 people."
+            question_text: "How many people live in the household for this letting?"
+
+          age1:
+            page_header: ""
+            age1_known:
+              check_answer_label: "Lead tenant’s age"
+              check_answer_prompt: "Enter lead tenant’s age if known"
+              hint_text: "The lead tenant is the person in the household who does the most paid work. If several people do the same paid work, the lead tenant is whoever is the oldest."
+              question_text: "Do you know the lead tenant’s age?"
+            age1:
+              check_answer_label: "Lead tenant’s age"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Age"
+
+          sex1:
+            page_header: ""
+            check_answer_label: "Lead tenant’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes the lead tenant’s gender identity?"
+
+          ethnic_group:
+            page_header: ""
+            check_answer_label: "Lead tenant’s ethnic group"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the lead tenant’s ethnic group?"
+
+          ethnic:
+            ethnic_background_black:
+              page_header: ""
+              check_answer_label: "Lead tenant’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes lead tenant’s Black, African, Caribbean or Black British background?"
+            ethnic_background_asian:
+              page_header: ""
+              check_answer_label: "Lead tenant’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes lead tenant’s Asian or Asian British background?"
+            ethnic_background_arab:
+              page_header: ""
+              check_answer_label: "Lead tenant’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes the lead tenant’s Arab background?"
+            ethnic_background_mixed:
+              page_header: ""
+              check_answer_label: "Lead tenant’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes lead tenant’s Mixed or Multiple ethnic groups background?"
+            ethnic_background_white:
+              page_header: ""
+              check_answer_label: "Lead tenant’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes lead tenant’s White background?"
+
+          nationality_all:
+            page_header: ""
+            nationality_all:
+              check_answer_label: "Lead tenant’s nationality"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Enter a nationality"
+            nationality_all_group:
+              check_answer_label: "Lead tenant’s nationality"
+              check_answer_prompt: ""
+              hint_text: "If the lead tenant is a dual national of the United Kingdom and another country, enter United Kingdom. If they are a dual national of two other countries, the tenant should decide which country to enter."
+              question_text: "What is the nationality of the lead tenant?"
+
+          ecstat1:
+            page_header: ""
+            check_answer_label: "Lead tenant’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes the lead tenant’s working situation?"
+
+          details_known_2:
+            page_header: "You’ve given us the details for 1 person in the household"
+            check_answer_label: "Details known for person 2"
+            check_answer_prompt: "Tell us if you know person 2’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 2?"
+
+          relat2:
+            page_header: ""
+            check_answer_label: "Person 2 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 2 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 2 the partner of tenant 1?"
+
+          age2:
+            page_header: ""
+            age2_known:
+              check_answer_label: "Person 2’s age"
+              check_answer_prompt: "Enter person 2’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 2’s age?"
+            age2:
+              check_answer_label: "Person 2’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex2:
+            page_header: ""
+            check_answer_label: "Person 2’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 2’s gender identity?"
+
+          ecstat2:
+            page_header: ""
+            check_answer_label: "Person 2’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 2’s working situation?"
+
+          details_known_3:
+            page_header: "You’ve given us the details for 2 people in the household"
+            check_answer_label: "Details known for person 3"
+            check_answer_prompt: "Tell us if you know person 3’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 3?"
+
+          relat3:
+            page_header: ""
+            check_answer_label: "Person 3 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 3 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 3 the partner of tenant 1?"
+
+          age3:
+            page_header: ""
+            age3_known:
+              check_answer_label: "Person 3’s age"
+              check_answer_prompt: "Enter person 3’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 3’s age?"
+            age3:
+              check_answer_label: "Person 3’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex3:
+            page_header: ""
+            check_answer_label: "Person 3’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 3’s gender identity?"
+
+          ecstat3:
+            page_header: ""
+            check_answer_label: "Person 3’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 3’s working situation?"
+
+          details_known_4:
+            page_header: "You’ve given us the details for 3 people in the household"
+            check_answer_label: "Details known for person 4"
+            check_answer_prompt: "Tell us if you know person 4’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 4?"
+
+          relat4:
+            page_header: ""
+            check_answer_label: "Person 4 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 4 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 4 the partner of tenant 1?"
+
+          age4:
+            page_header: ""
+            age4_known:
+              check_answer_label: "Person 4’s age"
+              check_answer_prompt: "Enter person 4’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 4’s age?"
+            age4:
+              check_answer_label: "Person 4’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex4:
+            page_header: ""
+            check_answer_label: "Person 4’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 4’s gender identity?"
+
+          ecstat4:
+            page_header: ""
+            check_answer_label: "Person 4’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 4’s working situation?"
+
+          details_known_5:
+            page_header: "You’ve given us the details for 4 people in the household"
+            check_answer_label: "Details known for person 5"
+            check_answer_prompt: "Tell us if you know person 5’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 5?"
+
+          relat5:
+            page_header: ""
+            check_answer_label: "Person 5 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 5 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 5 the partner of tenant 1?"
+
+          age5:
+            page_header: ""
+            age5_known:
+              check_answer_label: "Person 5’s age"
+              check_answer_prompt: "Enter person 5’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 5’s age?"
+            age5:
+              check_answer_label: "Person 5’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex5:
+            page_header: ""
+            check_answer_label: "Person 5’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 5’s gender identity?"
+
+          ecstat5:
+            page_header: ""
+            check_answer_label: "Person 5’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 5’s working situation?"
+
+          details_known_6:
+            page_header: "You’ve given us the details for 5 people in the household"
+            check_answer_label: "Details known for person 6"
+            check_answer_prompt: "Tell us if you know person 6’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 6?"
+
+          relat6:
+            page_header: ""
+            check_answer_label: "Person 6 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 6 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 6 the partner of tenant 1?"
+
+          age6:
+            page_header: ""
+            age6_known:
+              check_answer_label: "Person 6’s age"
+              check_answer_prompt: "Enter person 6’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 6’s age?"
+            age6:
+              check_answer_label: "Person 6’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex6:
+            page_header: ""
+            check_answer_label: "Person 6’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 6’s gender identity?"
+
+          ecstat6:
+            page_header: ""
+            check_answer_label: "Person 6’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 6’s working situation?"
+
+          details_known_7:
+            page_header: "You’ve given us the details for 6 people in the household"
+            check_answer_label: "Details known for person 7"
+            check_answer_prompt: "Tell us if you know person 7’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 7?"
+
+          relat7:
+            page_header: ""
+            check_answer_label: "Person 7 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 7 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 7 the partner of tenant 1?"
+
+          age7:
+            page_header: ""
+            age7_known:
+              check_answer_label: "Person 7’s age"
+              check_answer_prompt: "Enter person 7’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 7’s age?"
+            age7:
+              check_answer_label: "Person 7’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex7:
+            page_header: ""
+            check_answer_label: "Person 7’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 7’s gender identity?"
+
+          ecstat7:
+            page_header: ""
+            check_answer_label: "Person 7’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 7’s working situation?"
+
+          details_known_8:
+            page_header: "You’ve given us the details for 7 people in the household"
+            check_answer_label: "Details known for person 8"
+            check_answer_prompt: "Tell us if you know person 8’s details"
+            hint_text: "You must provide details for everyone in the household if you know them."
+            question_text: "Do you know details for person 8?"
+
+          relat8:
+            page_header: ""
+            check_answer_label: "Person 8 lead tenant’s partner"
+            check_answer_prompt: "Tell us if person 8 is the lead tenant’s partner"
+            hint_text: ""
+            question_text: "Is tenant 8 the partner of tenant 1?"
+
+          age8:
+            page_header: ""
+            age8_known:
+              check_answer_label: "Person 8’s age"
+              check_answer_prompt: "Enter person 8’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 8’s age?"
+            age8:
+              check_answer_label: "Person 8’s age"
+              check_answer_prompt: ""
+              hint_text: "Answer 1 for children aged under 1 year old"
+              question_text: "Age"
+
+          sex8:
+            page_header: ""
+            check_answer_label: "Person 8’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 8’s gender identity?"
+
+          ecstat8:
+            page_header: ""
+            check_answer_label: "Person 8’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 8’s working situation?"

--- a/config/locales/forms/2026/lettings/household_needs.en.yml
+++ b/config/locales/forms/2026/lettings/household_needs.en.yml
@@ -1,0 +1,66 @@
+en:
+  forms:
+    2026:
+      lettings:
+        household_needs:
+          armedforces:
+            page_header: ""
+            check_answer_label: "Household links to UK armed forces"
+            check_answer_prompt: "Tell us if there are any household links to UK armed forces"
+            hint_text: "This excludes national service.<br><br>If there are several people in the household with links to the UK armed forces, you should answer for the regular. If there’s no regular, answer for the reserve. If there’s no reserve, answer for the spouse or civil partner."
+            question_text: "Does anybody in the household have any links to the UK armed forces?"
+
+          leftreg:
+            page_header: ""
+            check_answer_label: "Person still serving in UK armed forces"
+            check_answer_prompt: "Tell us if the person is still serving in UK armed forces"
+            hint_text: ""
+            question_text: "Is the person still serving in the UK armed forces?"
+
+          reservist:
+            page_header: ""
+            check_answer_label: "Person seriously injured or ill as result of serving in UK armed forces"
+            check_answer_prompt: "Tell us if the person is seriously injured or ill as result of serving in UK armed forces"
+            hint_text: ""
+            question_text: "Was the person seriously injured or ill as a result of serving in the UK armed forces?"
+
+          preg_occ:
+            page_header: ""
+            check_answer_label: "Anybody in household pregnant"
+            check_answer_prompt: "Tell us if anybody in the household is pregnant"
+            hint_text: ""
+            question_text: "Is anybody in the household pregnant?"
+
+          housingneeds:
+            page_header: ""
+            check_answer_label: "Anybody with disabled access needs"
+            check_answer_prompt: "Tell us if there is anybody with disabled access needs"
+            hint_text: ""
+            question_text: "Does anybody in the household have any disabled access needs?"
+
+          housingneeds_type:
+            page_header: "Disabled access needs"
+            housingneeds_type:
+              check_answer_label: "Disabled access needs"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "What type of access needs do they have?"
+            housingneeds_other:
+              check_answer_label: "Other disabled access needs"
+              check_answer_prompt: "Tell us if they have any other disabled access needs"
+              hint_text: ""
+              question_text: "Do they have any other disabled access needs?"
+
+          illness:
+            page_header: ""
+            check_answer_label: "Anybody in household with physical or mental health condition"
+            check_answer_prompt: "Tell us if anybody in the household has a physical or mental health condition"
+            hint_text: ""
+            question_text: "Does anybody in the household have a physical or mental health condition (or other illness) expected to last 12 months or more?"
+
+          condition_effects:
+            page_header: ""
+            check_answer_label: "How is person affected by condition or illness"
+            check_answer_prompt: "Select how the person is affected by their condition or illness"
+            hint_text: "Select all that apply."
+            question_text: "How is the person affected by their condition or illness?"

--- a/config/locales/forms/2026/lettings/household_situation.en.yml
+++ b/config/locales/forms/2026/lettings/household_situation.en.yml
@@ -1,0 +1,150 @@
+en:
+  forms:
+    2026:
+      lettings:
+        household_situation:
+          layear:
+            page_header: ""
+            check_answer_label: "Length of time in local authority area"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "How long has the household continuously lived in the local authority area of the new letting?"
+
+          waityear:
+            page_header: ""
+            check_answer_label: "Length of time on local authority waiting list"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "How long has the household been on the local authority housing register (or waiting list) for the area of the new letting?"
+
+          reason:
+            reason_for_leaving_last_settled_home_renewal:
+              page_header: ""
+              reason:
+                check_answer_label: "Reason for leaving last settled home"
+                check_answer_prompt: ""
+                hint_text: "You told us this letting is a renewal. We have removed some options because of this."
+                question_text: "What is the tenant’s main reason for the household leaving their last settled home?"
+              reasonother:
+                check_answer_label: ""
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What is the reason?"
+            reason_for_leaving_last_settled_home:
+              page_header: ""
+              reason:
+                check_answer_label: "Reason for leaving last settled home"
+                check_answer_prompt: ""
+                hint_text: "The tenant’s ‘last settled home’ is their last long-standing home. For tenants who were in temporary accommodation, sleeping rough or otherwise homeless, their last settled home is where they were living previously."
+                question_text: "What is the tenant’s main reason for the household leaving their last settled home?"
+              reasonother:
+                check_answer_label: ""
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What is the reason?"
+
+          prevten:
+            renewal:
+              page_header: ""
+              check_answer_label: "Where household was immediately before this letting"
+              check_answer_prompt: ""
+              hint_text:  "You told us this letting is a renewal. We have removed some options because of this.<br><br>This is where the household was the night before they moved into this new let."
+              question_text: "Where was the household immediately before this letting?"
+            not_renewal:
+              page_header: ""
+              check_answer_label: "Where household was immediately before this letting"
+              check_answer_prompt: ""
+              hint_text: "This is where the household was the night before they moved into this new let."
+              question_text: "Where was the household immediately before this letting?"
+
+          homeless:
+            page_header: ""
+            check_answer_label: "Household homeless immediately before letting"
+            check_answer_prompt: "Tell us if household homeless immediately before letting"
+            hint_text: ""
+            question_text: "Did the household experience homelessness immediately before this letting?"
+
+          previous_postcode:
+            page_header: ""
+            ppcodenk:
+              check_answer_label: "Postcode of the household’s last settled accommodation"
+              check_answer_prompt: "Enter the postcode of the household’s last settled accommodation if known"
+              hint_text: "This is the tenant’s last long-standing home. It is where the tenant was living before any period in temporary accommodation, sleeping rough or otherwise homeless."
+              question_text: "Do you know the postcode of the household’s last settled accommodation?"
+            ppostcode_full:
+              check_answer_label: "Postcode of household’s last settled accommodation"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Postcode for the previous accommodation"
+
+          previous_local_authority:
+            page_header: ""
+            previous_la_known:
+              check_answer_label: "Local authority of household’s last settled accommodation"
+              check_answer_prompt: "Enter the local authority of the buyer’s last settled accommodation if known"
+              hint_text: "This is the tenant’s last long-standing home. It is where the tenant was living before any period in temporary accommodation, sleeping rough or otherwise homeless."
+              question_text: "Do you know the local authority of the household’s last settled accommodation?"
+            prevloc:
+              check_answer_label: "Location of household’s last settled accommodation"
+              check_answer_prompt: ""
+              hint_text: "Select ‘Northern Ireland’, ‘Scotland’, ‘Wales’ or ‘Outside the UK’ if the household’s last settled home was outside England."
+              question_text: "Select a local authority"
+
+          reasonpref:
+            page_header: ""
+            check_answer_label: "Household given reasonable preference"
+            check_answer_prompt: "Tell us if the household was given reasonable preference"
+            hint_text: "Households may be given ‘reasonable preference’ for social housing under one or more specific categories by the local authority. This is also known as ‘priority need’."
+            question_text: "Was the household given ‘reasonable preference’ by the local authority?"
+
+          reasonable_preference_reason:
+            page_header: ""
+            check_answer_label: "Reason for reasonable preference"
+            check_answer_prompt: ""
+            hint_text: "Select all that apply."
+            question_text: "Why was the household given ‘reasonable preference’?"
+
+          letting_allocation:
+            page_header: ""
+            check_answer_label: "Allocation system"
+            check_answer_prompt: ""
+            hint_text: "Select all that apply."
+            question_text: "How was this letting allocated?"
+
+          referral:
+            type:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"
+            direct:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"
+            la:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"
+            prp:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"
+            hsc:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"
+            justice:
+              page_header: ""
+              check_answer_label: "Source of referral for letting"
+              check_answer_prompt: "Select source of referral"
+              hint_text: ""
+              question_text: "What was the source of referral for this letting?"

--- a/config/locales/forms/2026/lettings/income_and_benefits.en.yml
+++ b/config/locales/forms/2026/lettings/income_and_benefits.en.yml
@@ -1,0 +1,128 @@
+en:
+  forms:
+    2026:
+      lettings:
+        income_and_benefits:
+          net_income_known:
+            page_header: "Household’s combined income after tax"
+            check_answer_label: "Household’s combined total income after tax"
+            check_answer_prompt: "Tell us if you know the household’s combined total income after tax"
+            hint_text: ""
+            question_text: "Do you know the household’s combined income after tax?"
+
+          income_amount:
+            page_header: "Total household income"
+            incfreq:
+              check_answer_label: "How often the household receives this amount"
+              check_answer_prompt: "Tell us how often does the household receives this amount"
+              hint_text: ""
+              question_text: "How often does the household receive this amount?"
+            earnings:
+              check_answer_label: "Total household income"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "How much income does the household have in total?"
+
+          hb:
+            page_header: ""
+            check_answer_label: "Housing related benefits received"
+            check_answer_prompt: "Tell us if household receives housing related benefits"
+            hint_text: "This is about when the tenant is in their new let. If they are unsure about the situation for their new let and their financial and working situation hasn’t changed significantly, answer based on what housing related benefits they currently receive."
+            question_text: "Is the household likely to be receiving any of these housing related benefits?"
+
+          benefits:
+            page_header: ""
+            check_answer_label: "Household income from Universal Credit, state pension or benefit"
+            check_answer_prompt: "Tell us if household income is from Universal Credit, state pension or benefit"
+            hint_text: "This excludes child and housing benefit, council tax support and tax credits."
+            question_text: "How much of the household’s income is from Universal Credit, state pensions or benefits?"
+
+          household_charge:
+            page_header: ""
+            check_answer_label: "Does the household pay rent or charges"
+            check_answer_prompt: "Tell us if the household pay rent or charges"
+            hint_text: "If rent is charged on the property then answer ‘Yes’ to this question, even if the tenants do not pay it themselves."
+            question_text: "Does the household pay rent or other charges for the accommodation?"
+
+          period:
+            page_header: ""
+            check_answer_label: "Frequency of household rent and charges"
+            check_answer_prompt: ""
+            hint_text: "Select how often the household is charged. This may be different to how often they pay."
+            question_text: "How often does the household pay rent and other charges?"
+
+          care_home:
+            page_header: ""
+            is_carehome:
+              check_answer_label: "Care home accommodation"
+              check_answer_prompt: "Tell us if care home accommodation"
+              hint_text: ""
+              question_text: "Is this accommodation a care home?"
+            chcharge_weekly:
+              check_answer_label: "Care home charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "How much does the household pay every week?"
+            chcharge_bi_weekly:
+              check_answer_label: "Care home charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "How much does the household pay every 2 weeks?"
+            chcharge_4_weekly:
+              check_answer_label: "Care home charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "How much does the household pay every 4 weeks?"
+            chcharge_monthly:
+              check_answer_label: "Care home charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "How much does the household pay every month?"
+
+          rent_and_charges:
+            page_header: "Household rent and charges"
+            brent:
+              check_answer_label: "Basic rent"
+              check_answer_prompt: ""
+              hint_text: "This is the amount paid before any charges are added for services (for example, hot water or cleaning). Households may receive housing benefit or Universal Credit towards basic rent."
+              question_text: "What is the basic rent?"
+            scharge:
+              check_answer_label: "Service charge"
+              check_answer_prompt: ""
+              hint_text: "For example, for cleaning. Households may receive housing benefit or Universal Credit towards the service charge."
+              question_text: "What is the service charge?"
+            pscharge:
+              check_answer_label: "Personal service charge"
+              check_answer_prompt: ""
+              hint_text: "For example, for heating or hot water. This doesn’t include housing benefit or Universal Credit."
+              question_text: "What is the personal service charge?"
+            supcharg:
+              check_answer_label: "Support charge"
+              check_answer_prompt: ""
+              hint_text: "Any charges made to fund support services included in tenancy agreement."
+              question_text: "What is the support charge?"
+            tcharge:
+              check_answer_label: "Household rent and charges"
+              check_answer_prompt: ""
+              hint_text: "This is the total for rent and all charges."
+              question_text: "Total charge"
+
+          hbrentshortfall:
+            page_header: ""
+            check_answer_label: "Any outstanding amount for basic rent and charges"
+            check_answer_prompt: "Tell us if any outstanding amount for basic rent and charges"
+            hint_text: "Also known as the ‘outstanding amount’."
+            question_text: "After the household has received any housing related benefits, will they still need to pay for rent and charges?"
+
+          outstanding_amount:
+            page_header: ""
+            tshortfall_known:
+              check_answer_label: "Outstanding amount known"
+              check_answer_prompt: "Tell us if you know the outstanding amount"
+              hint_text: "You only need to give an approximate figure."
+              question_text: "Can you estimate the outstanding amount?"
+            tshortfall:
+              check_answer_label: "Estimated outstanding amount"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Estimated outstanding amount"

--- a/config/locales/forms/2026/lettings/property_information.en.yml
+++ b/config/locales/forms/2026/lettings/property_information.en.yml
@@ -1,0 +1,122 @@
+en:
+  forms:
+    2026:
+      lettings:
+        property_information:
+          first_time_property_let_as_social_housing:
+            page_header: ""
+            check_answer_label: "First time being let as social housing"
+            check_answer_prompt: "Tell us if it’s the first time being let as social housing"
+            hint_text: ""
+            question_text: "Is this the first time the property has been let as social housing?"
+
+          address_search:
+            page_header: "What is the property’s address?"
+            check_answer_label: "Address"
+            check_answer_prompt: "Enter address or UPRN"
+            hint_text: "For example, '1 Victoria Road' or '10010457355'"
+            question_text: "Enter address or UPRN"
+
+          address:
+            page_header: "What is the property’s address?"
+            address_line1:
+              check_answer_label: "Address lines 1 and 2"
+              check_answer_prompt: "Enter address lines 1 and 2"
+              hint_text: ""
+              question_text: "Address line 1"
+            address_line2:
+              check_answer_label: ""
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Address line 2 (optional)"
+            town_or_city:
+              check_answer_label: "Town or city"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Town or city"
+            county:
+              check_answer_label: "County"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "County (optional)"
+            postcode_full:
+              check_answer_label: "Postcode"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Postcode"
+
+          la:
+            page_header: ""
+            check_answer_label: "Local authority"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the property’s local authority?"
+
+          unitletas:
+            page_header: ""
+            check_answer_label: "Most recent let type"
+            check_answer_prompt: ""
+            hint_text: "This is the rent type of the previous tenancy in this property."
+            question_text: "What type was the property most recently let as?"
+
+          rsnvac:
+            page_header: ""
+            check_answer_label: "Vacancy reason"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the reason for the property being vacant?"
+
+          unittype_gn:
+            page_header: ""
+            check_answer_label: "Type of unit"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What type of unit is the property?"
+
+          builtype:
+            page_header: ""
+            check_answer_label: "Type of building"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What type of building is the property?"
+
+          wchair:
+            page_header: ""
+            check_answer_label: "Property built or adapted to wheelchair-user standards"
+            check_answer_prompt: "Tell us if the property is built or adapted to wheelchair-user standards"
+            hint_text: "This is whether someone who uses a wheelchair is able to make full use of all of the property’s rooms and facilities, including use of both inside and outside space, and entering and exiting the property."
+            question_text: "Is the property built or adapted to wheelchair-user standards?"
+
+          beds:
+            page_header: ""
+            check_answer_label: "Number of bedrooms"
+            check_answer_prompt: ""
+            hint_text: "If shared accommodation, enter the number of bedrooms occupied by this household."
+            question_text: "How many bedrooms does the property have?"
+
+          voiddate:
+            page_header: "Void date"
+            check_answer_label: "Void date"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the void date?"
+
+          property_major_repairs:
+            page_header: ""
+            majorrepairs:
+              check_answer_label: "Major repairs carried out during void period"
+              check_answer_prompt: ""
+              hint_text: "Major repairs are works that could not be reasonably carried out with a tenant living at the property. For example, structural repairs."
+              question_text: "Were any major repairs carried out during the void period?"
+            mrcdate:
+              check_answer_label: "Completion date of repairs"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "When were the repairs completed?"
+
+          sheltered:
+            page_header: ""
+            check_answer_label: "Letting is older people’s housing"
+            check_answer_prompt: "Tell us if letting is older people’s housing"
+            hint_text: "This includes retirement living, sheltered housing and extra care housing. There is no national set limit for \"older people\", please answer based on your own policies.</br></br>Extra care housing is for tenants with medium to high care and support needs, often with 24 hour access to support staff provided by an agency registered with the Care Quality Commission."
+            question_text: "Is this property older people’s housing?"

--- a/config/locales/forms/2026/lettings/setup.en.yml
+++ b/config/locales/forms/2026/lettings/setup.en.yml
@@ -1,0 +1,101 @@
+en:
+  forms:
+    2026:
+      lettings:
+        setup:
+          owning_organisation_id:
+            page_header: ""
+            check_answer_label: "Stock owner"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which organisation owns this property?"
+
+          managing_organisation_id:
+            page_header: ""
+            check_answer_label: "Managing agent"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which organisation manages this letting?"
+
+          assigned_to_id:
+            page_header: ""
+            check_answer_label: "Log owner"
+            check_answer_prompt: "Select user"
+            hint_text: ""
+            question_text: "Which user are you creating this log for?"
+
+          needstype:
+            page_header: ""
+            check_answer_label: "Needs type"
+            check_answer_prompt: ""
+            hint_text: "General needs housing includes both self-contained and shared housing without support or specific adaptations. Supported housing can include direct access hostels, group homes, residential care and nursing homes."
+            question_text: "What is the needs type?"
+
+          scheme_id:
+            page_header: "Scheme"
+            check_answer_label: "Scheme name"
+            check_answer_prompt: ""
+            hint_text: "Enter postcode or scheme name.<br><br>A supported housing scheme provides shared or self-contained housing for a particular client group, for example younger or vulnerable people."
+            question_text: "What scheme is this log for?"
+
+          location_id:
+            less_than_twenty:
+              page_header: "Location"
+              check_answer_label: "Location"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which location is this letting for?"
+            twenty_or_more:
+              page_header: "Location"
+              check_answer_label: "Location"
+              check_answer_prompt: ""
+              hint_text: '<div class="govuk-inset-text">This scheme has 20 or more locations.</div>Enter postcode or address.'
+              question_text: "Which location is this letting for?"
+
+          renewal:
+            page_header: ""
+            check_answer_label: "Property renewal"
+            check_answer_prompt: "Tell us if it’s a property renewal"
+            hint_text: "If the property was previously being used as temporary accommodation, then answer 'no'."
+            question_text: "Is this letting a renewal of social housing to the same tenant in the same property?"
+
+          startdate:
+            page_header: ""
+            check_answer_label: "Tenancy start date"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the tenancy start date?"
+
+          rent_type:
+            page_header: "Rent Type"
+            rent_type:
+              check_answer_label: "Rent type"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "What is the rent type?"
+            irproduct_other:
+              check_answer_label: "Product name"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Name of rent product"
+
+          tenancycode:
+            page_header: ""
+            check_answer_label: "Tenant code"
+            check_answer_prompt: ""
+            hint_text: "This is how you usually refer to this tenancy on your own systems."
+            question_text: "What is the tenant code?"
+
+          propcode:
+            page_header: ""
+            check_answer_label: "Property reference"
+            check_answer_prompt: ""
+            hint_text: "This is how you usually refer to this property on your own systems."
+            question_text: "What is the property reference?"
+
+          declaration:
+            page_header: "Ministry of Housing, Communities and Local Government privacy notice"
+            check_answer_label: "Tenant has seen the privacy notice"
+            check_answer_prompt: "Tell us if tenant has seen the privacy notice"
+            hint_text: ""
+            question_text: "Declaration"

--- a/config/locales/forms/2026/lettings/soft_validations.en.yml
+++ b/config/locales/forms/2026/lettings/soft_validations.en.yml
@@ -1,0 +1,157 @@
+en:
+  forms:
+    2026:
+      lettings:
+        soft_validations:
+          pregnancy_value_check:
+            no_females_pregnant_household_value_check:
+              page_header: ""
+              check_answer_label: "Pregnancy confirmation"
+              check_answer_prompt: "Confirm pregnancy answer"
+              hint_text: ""
+              question_text: "Are you sure this is correct?"
+              title_text: "You told us somebody in the household is pregnant."
+              informative_text: "You also told us that all the tenants living at the property are male."
+            females_in_soft_age_range_in_pregnant_household_value_check:
+              page_header: ""
+              check_answer_label: "Pregnancy confirmation"
+              check_answer_prompt: "Confirm pregnancy status"
+              hint_text: ""
+              question_text: "Are you sure this is correct?"
+              title_text: "You told us somebody in the household is pregnant."
+              informative_text: "You also told us that any female tenants living at the property are in the following age ranges:<ul class=\"govuk-body-l app-panel--interruption\"><li>under 16 years old</li><li>over 50 years old</li></ul>"
+
+          no_retirement_value_check:
+            page_header: ""
+            check_answer_label: "Retirement confirmation"
+            check_answer_prompt: "Confirm retirement status"
+            hint_text: ""
+            question_text: "Are you sure this person is retired?"
+            title_text: "You told us this person is aged %{age} years and retired."
+            informative_text: "The minimum expected retirement age in England is 66."
+
+          retirement_value_check:
+            page_header: ""
+            check_answer_label: "Retirement confirmation"
+            check_answer_prompt: "Confirm retirement status"
+            hint_text: ""
+            question_text: "Are you sure this person isn’t retired?"
+            title_text: "You told us this person is over 66 and not retired."
+            informative_text: "Are you sure this person isn’t retired?"
+
+          partner_under_16_value_check:
+            page_header: ""
+            check_answer_label: "Partner under 16 confirmation"
+            check_answer_prompt: "Confirm partner’s age"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us this person is aged %{age} years and has 'Partner' relationship to the lead tenant."
+            informative_text: "Are you sure this is correct?"
+
+          multiple_partners_value_check:
+            page_header: ""
+            check_answer_label: "Multiple partners confirmation"
+            check_answer_prompt: "Confirm multiple partners"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us there are more than 1 persons with 'Partner' relationship to the lead tenant."
+            informative_text: "Are you sure this is correct?"
+
+          reasonother_value_check:
+            page_header: ""
+            check_answer_label: "Reason other confirmation"
+            check_answer_prompt: "Confirm reason for leaving"
+            hint_text: ""
+            question_text: "Are you sure this doesn’t fit an existing category?"
+            title_text: "You told us that the tenant’s main reason for leaving their last settled home was %{reasonother}."
+            informative_text: "The reason you have entered looks very similar to one of the existing response categories. Please check the categories and select the appropriate one. If the existing categories are not suitable, please confirm here to move onto the next question."
+
+          referral_value_check:
+            page_header: ""
+            check_answer_label: "Referral confirmation"
+            check_answer_prompt: "Confirm referral type"
+            hint_text: ""
+            question_text: "Are you sure?"
+            title_text: "Are you sure?"
+            informative_text: "This is a general needs log, and this referral type is for supported housing."
+
+          net_income_value_check:
+            page_header: ""
+            check_answer_label: "Net income confirmation"
+            check_answer_prompt: "Confirm net income"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us that the household’s income is %{earnings} %{incfreq}."
+            informative_text: "This is %{net_income_higher_or_lower_text} than we would expect for the household’s working situation."
+
+          care_home_charges_value_check:
+            page_header: ""
+            check_answer_label: "Care home charges confirmation"
+            check_answer_prompt: "Confirm care home charges"
+            hint_text: ""
+            question_text: "Are you sure there are no care home charges?"
+            title_text: "Care home charges should be provided if this is a care home accommodation."
+            informative_text: "Are you sure there are no care home charges?"
+
+          rent_value_check:
+            page_header: ""
+            check_answer_label: "Total rent confirmation"
+            check_answer_prompt: "Confirm total rent"
+            hint_text: "Check the following:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the rent type is correct, for example affordable or social rent</li></ul>"
+            question_text:  "Are you sure this is correct?"
+            title_text: "You told us the rent is %{brent}."
+            informative_text: "This is %{higher_or_lower} than we would expect."
+
+          scharge_value_check:
+            page_header: ""
+            check_answer_label: "Service charge confirmation"
+            check_answer_prompt: "Confirm service charge"
+            hint_text: "Check the following:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the needs type</li></ul>"
+            question_text: "Are you sure?"
+            title_text: "You told us the service charge is %{scharge}."
+            informative_text: "This is higher than we would expect."
+
+          pscharge_value_check:
+            page_header: ""
+            check_answer_label: "Personal service charge confirmation"
+            check_answer_prompt: "Confirm personal service charge"
+            hint_text: "Check the following:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the needs type</li></ul>"
+            question_text: "Are you sure?"
+            title_text: "You told us the personal service charge is %{pscharge}."
+            informative_text: "This is higher than we would expect."
+
+          supcharg_value_check:
+            page_header: ""
+            check_answer_label: "Support charge confirmation"
+            check_answer_prompt: "Confirm support charge"
+            hint_text: "Check the following:<ul class=\"govuk-body-l app-panel--interruption\"><li>the decimal point</li><li>the frequency, for example every week or every calendar month</li><li>the needs type</li></ul>"
+            question_text: "Are you sure?"
+            title_text: "You told us the support charge is %{supcharg}."
+            informative_text: "This is higher than we would expect."
+
+          void_date_value_check:
+            page_header: ""
+            check_answer_label: "Void date confirmation"
+            check_answer_prompt: "Confirm void date"
+            hint_text: ""
+            question_text: "Are you sure the property has been vacant for this long?"
+            title_text: "You told us that the property has been vacant for more than 2 years."
+            informative_text: "This is longer than we would expect."
+
+          major_repairs_date_value_check:
+            page_header: ""
+            check_answer_label: "Major repairs date confirmation"
+            check_answer_prompt: "Confirm major repairs date"
+            hint_text: ""
+            question_text: "Are you sure the property has been vacant for this long?"
+            title_text: "You told us the property has been vacant for 2 years."
+            informative_text: "This is longer than we would expect."
+
+          no_address_found:
+            page_header: ""
+            check_answer_label: "No address found"
+            check_answer_prompt: "Confirm no address found"
+            hint_text: ""
+            question_text: "We could not find an address that matches your search. You can search again or continue to enter the address manually."
+            title_text: "No address found"
+            informative_text: "We could not find an address that matches your search. You can search again or continue to enter the address manually."

--- a/config/locales/forms/2026/lettings/tenancy_information.en.yml
+++ b/config/locales/forms/2026/lettings/tenancy_information.en.yml
@@ -1,0 +1,77 @@
+en:
+  forms:
+    2026:
+      lettings:
+        tenancy_information:
+          joint:
+            page_header: ""
+            check_answer_label: "Joint tenancy"
+            check_answer_prompt: "Tell us if it’s a joint tenancy"
+            hint_text: "This is where two or more people are named on the tenancy agreement"
+            question_text: "Is this a joint tenancy?"
+
+          startertenancy:
+            page_header: ""
+            check_answer_label: "Starter or introductory tenancy"
+            check_answer_prompt: "Tell us if it’s a starter or introductory tenancy"
+            hint_text: "If the tenancy has an ‘introductory period’, answer ‘yes’.<br><br>You should submit a CORE log at the beginning of the starter tenancy or introductory period, with the best information you have at the time. You do not need to submit a log when a tenant later rolls onto the main tenancy."
+            question_text: "Is this a starter tenancy?"
+
+          tenancy:
+            tenancy_type:
+              page_header: ""
+              tenancy:
+                check_answer_label: "Type of main tenancy"
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What is the type of tenancy?"
+              tenancyother:
+                check_answer_label: ""
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "Please state the tenancy type"
+            starter_tenancy_type:
+              page_header: ""
+              tenancy:
+                check_answer_label: "Type of main tenancy after the starter or introductory period has ended"
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What is the type of tenancy after the starter or introductory period has ended?"
+              tenancyother:
+                check_answer_label: ""
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "Please state the tenancy type"
+
+          tenancylength:
+            tenancy_length:
+              page_header: ""
+              check_answer_label: "Length of fixed-term tenancy"
+              check_answer_prompt: ""
+              hint_text: "Do not include the starter or introductory period."
+              question_text: "What is the length of the fixed-term tenancy to the nearest year?"
+            tenancy_length_affordable_rent:
+              page_header: ""
+              check_answer_label: "Length of fixed-term tenancy"
+              check_answer_prompt: ""
+              hint_text: "Do not include the starter or introductory period.</br></br>The minimum period is 2 years for social or affordable rent general needs logs. You do not need to submit CORE logs for these types of tenancies if they are shorter than 2 years."
+              question_text: "What is the length of the fixed-term tenancy to the nearest year?"
+            tenancy_length_intermediate_rent:
+              page_header: ""
+              check_answer_label: "Length of fixed-term tenancy"
+              check_answer_prompt: ""
+              hint_text: "Do not include the starter or introductory period.</br></br>The minimum period is 1 year for intermediate rent general needs logs. You do not need to submit CORE logs for these types of tenancies if they are shorter than 1 year."
+              question_text: "What is the length of the fixed-term tenancy to the nearest year?"
+            tenancy_length_periodic:
+              page_header: ""
+              check_answer_label: "Length of periodic tenancy"
+              check_answer_prompt: ""
+              hint_text: "As this is a periodic tenancy, this question is optional. If you do not have the information available click save and continue"
+              question_text: "What is the length of the periodic tenancy to the nearest year?"
+
+          sheltered:
+            page_header: ""
+            check_answer_label: "Letting in sheltered accommodation"
+            check_answer_prompt: "Tell us if letting is in sheltered accommodation"
+            hint_text: "Sheltered housing and special retirement housing are for tenants with low-level care and support needs. This typically provides some limited support to enable independent living, such as alarm-based assistance or a scheme manager.</br></br>Extra care housing is for tenants with medium to high care and support needs, often with 24 hour access to support staff provided by an agency registered with the Care Quality Commission."
+            question_text: "Is this letting in sheltered accommodation?"

--- a/config/locales/forms/2026/sales/guidance.en.yml
+++ b/config/locales/forms/2026/sales/guidance.en.yml
@@ -1,0 +1,53 @@
+en:
+  forms:
+    2026:
+      sales:
+        guidance:
+          shared_ownership_type_definitions:
+            title: "Shared Ownership Type Definitions"
+            content: "<p><b>Shared Ownership (old model lease):</b> Cannot be used for homes funded through the Affordable Homes Programme 2021 to 2026. Use the new model lease for these properties.</p>
+              <p><b>Shared Ownership (new model lease):</b> Homes bought using the  Affordable Homes Programme 2021 to 2026.</p>
+              <p><b>Social HomeBuy — shared ownership purchase:</b> Tenants of private registered providers purchase their home at discount on Shared Ownership terms.</p>
+              <p><b>Home Ownership for people with Long-Term Disabilities (HOLD):</b> A shared ownership sale for those with long term disabilities.</p>
+              <p><b>Older Persons Shared Ownership:</b> A type of shared ownership for those 55 years and over.</p>
+              <p><b>Rent to Buy — Shared Ownership:</b> A sale following a period of discounted rent.</p>
+              <p><b>Right to Shared Ownership (RtSO):</b> A sale of a share of a rented home to a tenant using this scheme.</p>
+              <p><b>London Living Rent — Shared Ownership:</b> A shared ownership sale following a period of discounted rent as part of the London Living Rent scheme.</p>"
+
+          discounted_ownership_type_definitions:
+            title: "Discounted Ownership Type Definitions"
+            content: "<p><b>Right to Acquire (RTA):</b>  a discounted sale of a property built or purchased after 31 March 1997 to tenants of a private registered provider.</p>
+              <p><b>Preserved Right to Buy (PRTB):</b>  a discounted sale of a property that used to be owned by a council to tenants of a private registered provider.</p>
+              <p><b>Voluntary Right to Buy (VRTB):</b>  a discounted sale to tenants in this PRP owned property, as part of a pilot scheme.</p>
+              <p><b>Right to Buy (RTB):</b>  a discounted sale to tenants in this council owned property.</p>
+              <p><b>Rent to Buy full ownership:</b> a sale on full ownership terms following a period of discounted rent.</p>
+              <p><b>Social HomeBuy for outright purchase:</b> a discounted sale to tenants of a private registered provider on full ownership terms.</p>
+              <p><b>Any other equity loan scheme:</b> any scheme, not covered elsewhere, in which a loan is used to purchase equity.</p>"
+
+          mortgage_lender:
+            title: "Can’t find the mortgage lender you’re looking for?"
+            content: "<ul class=\"govuk-list govuk-list--bullet\">
+                <li>Double check the spelling and try again</li>
+                <li>Type the first few letters to see the suggestions</li>
+                <li>Type Other and continue - we’ll ask you to type in your answer in the next question</li>
+              </ul>"
+
+          outright_sale_type_definitions:
+            title: "Outright sale type definitions"
+            content: "<p><b>Outright sale:</b> the full purchase of a property, usually with a mortgage or cash.</p>
+              <p><b>Other sale:</b> any sale which does not fit the criteria of any of the remaining options.</p>"
+
+          privacy_notice_buyer_joint_purchase:
+            content: "Make sure the buyers have seen or been given access to %{privacy_notice_link} before completing this log. This is a legal requirement under data protection legislation."
+            privacy_notice_link_text: "the Ministry of Housing, Communities and Local Government (MHCLG) privacy notice"
+
+          privacy_notice_buyer:
+            content: "Make sure the buyer has seen or been given access to %{privacy_notice_link} before completing this log. This is a legal requirement under data protection legislation."
+            privacy_notice_link_text: "the Ministry of Housing, Communities and Local Government (MHCLG) privacy notice"
+
+          address_search:
+            title: "Can’t find the address you’re looking for?"
+            content: "<ul class=\"govuk-list govuk-list--bullet\">
+                <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
+                <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
+              </ul>"

--- a/config/locales/forms/2026/sales/household_characteristics.en.yml
+++ b/config/locales/forms/2026/sales/household_characteristics.en.yml
@@ -1,0 +1,404 @@
+en:
+  forms:
+    2026:
+      sales:
+        household_characteristics:
+          age1:
+            page_header: ""
+            age1_known:
+              check_answer_label: "Buyer 1’s age"
+              check_answer_prompt: "Enter buyer 1’s age if known"
+              hint_text: "Buyer 1 is the person in the household who does the most paid work. If it’s a joint purchase and the buyers do the same amount of paid work, buyer 1 is whoever is the oldest."
+              question_text: "Do you know buyer 1’s age?"
+            age1:
+              check_answer_label: "Buyer 1’s age"
+              check_answer_prompt: "Enter buyer 1’s age"
+              hint_text: ""
+              question_text: "Age"
+
+          sex1:
+            page_header: ""
+            check_answer_label: "Buyer 1’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes buyer 1’s gender identity?"
+
+          ethnic_group:
+            page_header: ""
+            check_answer_label: "Buyer 1’s ethnic group"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is buyer 1’s ethnic group?"
+
+          ethnic:
+            ethnic_background_black:
+              page_header: ""
+              check_answer_label: "Buyer 1’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 1’s Black, African, Caribbean or Black British background?"
+            ethnic_background_asian:
+              page_header: ""
+              check_answer_label: "Buyer 1’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 1’s Asian or Asian British background?"
+            ethnic_background_arab:
+              page_header: ""
+              check_answer_label: "Buyer 1’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 1’s Arab background?"
+            ethnic_background_mixed:
+              page_header: ""
+              check_answer_label: "Buyer 1’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 1’s Mixed or Multiple ethnic groups background?"
+            ethnic_background_white:
+              page_header: ""
+              check_answer_label: "Buyer 1’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 1’s White background?"
+
+          nationality_all_group:
+            page_header: ""
+            check_answer_label: "Buyer 1’s nationality"
+            check_answer_prompt: ""
+            hint_text: "If buyer 1 is a dual national of the United Kingdom and another country, enter United Kingdom. If they are a dual national of two other countries, the buyer should decide which country to enter."
+            question_text: "What is buyer 1’s nationality?"
+
+          nationality_all:
+            page_header: ""
+            check_answer_label: "Buyer 1’s nationality"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Enter a nationality"
+
+          ecstat1:
+            page_header: ""
+            check_answer_label: "Buyer 1’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes buyer 1’s working situation?"
+
+          buy1livein:
+            page_header: ""
+            check_answer_label: "Buyer 1 lives in the property"
+            check_answer_prompt: "Tell us if buyer 1 lives in the property"
+            hint_text: ""
+            question_text: "Will buyer 1 live in the property?"
+
+          relat2:
+            buyer:
+              page_header: ""
+              check_answer_label: "Buyer 2 is the partner of buyer 1"
+              check_answer_prompt: "Tell us if buyer 2 is the partner of buyer 1"
+              hint_text: ""
+              question_text: "Is buyer 2 the partner of buyer 1?"
+            person:
+              page_header: ""
+              check_answer_label: "Person 2 is the partner of buyer 1"
+              check_answer_prompt: "Tell us if person 2 is the partner of buyer 1"
+              hint_text: ""
+              question_text: "Is person 2 the partner of buyer 1?"
+
+          age2:
+            buyer:
+              page_header: ""
+              age2_known:
+                check_answer_label: "Buyer 2’s age"
+                check_answer_prompt: "Enter buyer 2’s age if known"
+                hint_text: ""
+                question_text: "Do you know buyer 2’s age?"
+              age2:
+                check_answer_label: "Buyer 2’s age"
+                check_answer_prompt: "Enter buyer 2’s age"
+                hint_text: ""
+                question_text: "Age"
+            person:
+              page_header: ""
+              age2_known:
+                check_answer_label: "Person 2’s age"
+                check_answer_prompt: "Enter person 2’s age if known"
+                hint_text: ""
+                question_text: "Do you know person 2’s age?"
+              age2:
+                check_answer_label: "Person 2’s age"
+                check_answer_prompt: "Enter person 2’s age"
+                hint_text: ""
+                question_text: "Age"
+
+          sex2:
+            buyer:
+              page_header: ""
+              check_answer_label: "Buyer 2’s gender identity"
+              check_answer_prompt: ""
+              hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+              question_text: "Which of these best describes buyer 2’s gender identity?"
+            person:
+              page_header: ""
+              check_answer_label: "Person 2’s gender identity"
+              check_answer_prompt: ""
+              hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+              question_text: "Which of these best describes person 2’s gender identity?"
+
+          ethnic_group2:
+            page_header: ""
+            check_answer_label: "Buyer 2’s ethnic group"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is buyer 2’s ethnic group?"
+
+          ethnicbuy2:
+            ethnic_background_black:
+              page_header: ""
+              check_answer_label: "Buyer 2’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 2’s Black, African, Caribbean or Black British background?"
+            ethnic_background_asian:
+              page_header: ""
+              check_answer_label: "Buyer 2’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 2’s Asian or Asian British background?"
+            ethnic_background_arab:
+              page_header: ""
+              check_answer_label: "Buyer 2’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 2’s Arab background?"
+            ethnic_background_mixed:
+              page_header: ""
+              check_answer_label: "Buyer 2’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 2’s Mixed or Multiple ethnic groups background?"
+            ethnic_background_white:
+              page_header: ""
+              check_answer_label: "Buyer 2’s ethnic background"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of the following best describes buyer 2’s White background?"
+
+          nationality_all_buyer2_group:
+            page_header: ""
+            check_answer_label: "Buyer 2’s nationality"
+            check_answer_prompt: ""
+            hint_text: "If buyer 1 is a dual national of the United Kingdom and another country, enter United Kingdom. If they are a dual national of two other countries, the buyer should decide which country to enter."
+            question_text: "What is buyer 2’s nationality?"
+
+          nationality_all_buyer2:
+            page_header: ""
+            check_answer_label: "Buyer 2’s nationality"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Enter a nationality"
+
+          ecstat2:
+            buyer:
+              page_header: ""
+              check_answer_label: "Buyer 2’s working situation"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of these best describes buyer 2’s working situation?"
+            person:
+              page_header: ""
+              check_answer_label: "Person 2’s working situation"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Which of these best describes person 2’s working situation?"
+
+          buy2livein:
+            page_header: ""
+            check_answer_label: "Buyer 2 lives in the property"
+            check_answer_prompt: "Tell us if buyer 2 lives in the property"
+            hint_text: ""
+            question_text: "Will buyer 2 live in the property?"
+
+          hholdcount:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Number of other people living in the property"
+              check_answer_prompt: ""
+              hint_text: "Include all people living in the property who are not the buyers. In later questions you will only be asked for details about the first 4 other people for a joint purchase."
+              question_text: "Besides the buyers, how many other people live or will live in the property?"
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Number of other people living in the property"
+              check_answer_prompt: ""
+              hint_text: "Include all people living in the property who are not the buyer. In later questions you will only be asked for details about the first 5 other people for a sole purchase."
+              question_text: "Besides the buyer, how many other people live or will live in the property?"
+
+          details_known_2:
+            page_header: ""
+            check_answer_label: "Details known for person 2?"
+            check_answer_prompt: "Tell us if you know person 2’s details"
+            hint_text: ""
+            question_text: "Do you know the details for person 2?"
+
+          details_known_3:
+            page_header: ""
+            check_answer_label: "Details known for person 3?"
+            check_answer_prompt: "Tell us if you know person 3’s details"
+            hint_text: ""
+            question_text: "Do you know the details for person 3?"
+
+          relat3:
+            page_header: ""
+            check_answer_label: "Person 3 is the partner of buyer 1"
+            check_answer_prompt: "Tell us if person 3 is the partner of buyer 1"
+            hint_text: ""
+            question_text: "Is person 3 the partner of buyer 1?"
+
+          age3:
+            page_header: ""
+            age3_known:
+              check_answer_label: "Person 3’s age"
+              check_answer_prompt: "Enter person 3’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 3’s age?"
+            age3:
+              check_answer_label: "Person 3’s age"
+              check_answer_prompt: "Enter person 3’s age"
+              hint_text: ""
+              question_text: "Age"
+
+          sex3:
+            page_header: ""
+            check_answer_label: "Person 3’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 3’s gender identity?"
+
+          ecstat3:
+            page_header: ""
+            check_answer_label: "Person 3’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 3’s working situation?"
+
+          details_known_4:
+            page_header: ""
+            check_answer_label: "Details known for person 4?"
+            check_answer_prompt: "Tell us if you know person 4’s details"
+            hint_text: ""
+            question_text: "Do you know the details for person 4?"
+
+          relat4:
+            page_header: ""
+            check_answer_label: "Person 4 is the partner of buyer 1"
+            check_answer_prompt: "Tell us if person 4 is the partner of buyer 1"
+            hint_text: ""
+            question_text: "Is person 4 the partner of buyer 1?"
+
+          age4:
+            page_header: ""
+            age4_known:
+              check_answer_label: "Person 4’s age"
+              check_answer_prompt: "Enter person 4’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 4’s age?"
+            age4:
+              check_answer_label: "Person 4’s age"
+              check_answer_prompt: "Enter person 4’s age"
+              hint_text: ""
+              question_text: "Age"
+
+          sex4:
+            page_header: ""
+            check_answer_label: "Person 4’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 4’s gender identity?"
+
+          ecstat4:
+            page_header: ""
+            check_answer_label: "Person 4’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 4’s working situation?"
+
+          details_known_5:
+            page_header: ""
+            check_answer_label: "Details known for person 5?"
+            check_answer_prompt: "Tell us if you know person 5’s details"
+            hint_text: ""
+            question_text: "Do you know the details for person 5?"
+
+          relat5:
+            page_header: ""
+            check_answer_label: "Person 5 is the partner of buyer 1"
+            check_answer_prompt: "Tell us if person 5 is the partner of buyer 1"
+            hint_text: ""
+            question_text: "Is person 5 the partner of buyer 1?"
+
+          age5:
+            page_header: ""
+            age5_known:
+              check_answer_label: "Person 5’s age"
+              check_answer_prompt: "Enter person 5’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 5’s age?"
+            age5:
+              check_answer_label: "Person 5’s age"
+              check_answer_prompt: "Enter person 5’s age"
+              hint_text: ""
+              question_text: "Age"
+
+          sex5:
+            page_header: ""
+            check_answer_label: "Person 5’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 5’s gender identity?"
+
+          ecstat5:
+            page_header: ""
+            check_answer_label: "Person 5’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 5’s working situation?"
+
+          details_known_6:
+            page_header: ""
+            check_answer_label: "Details known for person 6?"
+            check_answer_prompt: "Tell us if you know person 6’s details"
+            hint_text: ""
+            question_text: "Do you know the details for person 6?"
+
+          relat6:
+            page_header: ""
+            check_answer_label: "Person 6 is the partner of buyer 1"
+            check_answer_prompt: "Tell us if person 6 is the partner of buyer 1"
+            hint_text: ""
+            question_text: "Is person 6 the partner of buyer 1?"
+
+          age6:
+            page_header: ""
+            age6_known:
+              check_answer_label: "Person 6’s age"
+              check_answer_prompt: "Enter person 6’s age if known"
+              hint_text: ""
+              question_text: "Do you know person 6’s age?"
+            age6:
+              check_answer_label: "Person 6’s age"
+              check_answer_prompt: "Enter person 6’s age"
+              hint_text: ""
+              question_text: "Age"
+
+          sex6:
+            page_header: ""
+            check_answer_label: "Person 6’s gender identity"
+            check_answer_prompt: ""
+            hint_text: "This should be however they personally choose to identify from the options below. This may or may not be the same as their biological sex or the sex they were assigned at birth."
+            question_text: "Which of these best describes person 6’s gender identity?"
+
+          ecstat6:
+            page_header: ""
+            check_answer_label: "Person 6’s working situation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which of these best describes person 6’s working situation?"

--- a/config/locales/forms/2026/sales/household_situation.en.yml
+++ b/config/locales/forms/2026/sales/household_situation.en.yml
@@ -1,0 +1,51 @@
+en:
+  forms:
+    2026:
+      sales:
+        household_situation:
+          prevten:
+            page_header: ""
+            check_answer_label: "Buyer 1’s previous tenure"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What was buyer 1’s previous tenure?"
+
+          last_accommodation:
+            page_header: ""
+            ppcodenk:
+              check_answer_label: "Postcode of buyer 1’s last settled accommodation"
+              check_answer_prompt: "Enter the postcode of the buyer’s last settled accommodation if known"
+              hint_text: "This is also known as the household’s 'last settled home'"
+              question_text: "Do you know the postcode of buyer 1’s last settled accommodation?"
+            ppostcode_full:
+              check_answer_label: "Postcode of buyer 1’s last settled accommodation"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Postcode"
+
+          last_accommodation_la:
+            page_header: ""
+            previous_la_known:
+              check_answer_label: "Local authority of buyer 1’s last settled accommodation"
+              check_answer_prompt: "Enter the local authority of the buyer’s last settled accommodation if known"
+              hint_text: "This is also known as the household’s 'last settled home'"
+              question_text: "Do you know the local authority of buyer 1’s last settled accommodation?"
+            prevloc:
+              check_answer_label: "Local authority of buyer 1’s last settled accommodation"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Select a local authority"
+
+          buy2living:
+            page_header: ""
+            check_answer_label: "Buyer 2 living at the same address"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "At the time of purchase, was buyer 2 living at the same address as buyer 1?"
+
+          prevtenbuy2:
+            page_header: ""
+            check_answer_label: "Buyer 2’s previous tenure"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What was buyer 2’s previous tenure?"

--- a/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
+++ b/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
@@ -1,0 +1,105 @@
+en:
+  forms:
+    2026:
+      sales:
+        income_benefits_and_savings:
+          buyer_1_income:
+            page_header: ""
+            income1nk:
+              check_answer_label: "Buyer 1’s gross annual income known"
+              check_answer_prompt: "Enter buyer 1’s gross annual income if known"
+              hint_text: ""
+              question_text: "Do you know buyer 1’s annual income?"
+            income1:
+              check_answer_label: "Buyer 1’s gross annual income"
+              check_answer_prompt: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              question_text: "Buyer 1’s gross annual income"
+
+          inc1mort:
+            page_header: ""
+            check_answer_label: "Buyer 1’s income used for mortgage application"
+            check_answer_prompt: "Tell us if buyer 1’s income used for a mortgage application"
+            hint_text: ""
+            question_text: "Was buyer 1’s income used for a mortgage application?"
+
+          buyer_2_income:
+            page_header: ""
+            income2nk:
+              check_answer_label: "Buyer 2’s gross annual income known"
+              check_answer_prompt: "Enter buyer 2’s gross annual income if known"
+              hint_text: ""
+              question_text: "Do you know buyer 2’s annual income?"
+            income2:
+              check_answer_label: "Buyer 2’s gross annual income"
+              check_answer_prompt: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              question_text: "Buyer 2’s gross annual income"
+
+          inc2mort:
+            page_header: ""
+            check_answer_label:  "Buyer 2’s income used for mortgage application"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Was buyer 2’s income used for a mortgage application?"
+
+          housing_benefits:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Housing related benefits buyers received before buying this property"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text:  "Were the buyers receiving any of these housing related benefits immediately before buying this property?"
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Housing related benefits buyer received before buying this property"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text:  "Was the buyer receiving any of these housing related benefits immediately before buying this property?"
+
+          savings:
+            joint_purchase:
+              page_header: ""
+              savingsnk:
+                check_answer_label:  "Buyers’ total savings"
+                check_answer_prompt: "Enter buyers’ total savings if known"
+                hint_text: ""
+                question_text: "Do you know how much the buyers had in savings before they paid any deposit for the property?"
+              savings:
+                check_answer_label: "Buyers’ total savings before any deposit paid"
+                check_answer_prompt: ""
+                hint_text: "Include any savings, investments, ISAs, premium bonds, shares, or money held in a bank or building society account."
+                question_text: "Enter their total savings to the nearest £10"
+            not_joint_purchase:
+              page_header: ""
+              savingsnk:
+                check_answer_label:  "Buyer’s total savings"
+                check_answer_prompt: "Enter buyer’s total savings if known"
+                hint_text: ""
+                question_text: "Do you know how much the buyer had in savings before they paid any deposit for the property?"
+              savings:
+                check_answer_label: "Buyer’s total savings before any deposit paid"
+                check_answer_prompt: ""
+                hint_text: "Include any savings, investments, ISAs, premium bonds, shares, or money held in a bank or building society account."
+                question_text: "Enter their total savings to the nearest £10"
+
+          prevown:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyers previously owned a property."
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Have any of the buyers previously owned a property?"
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyer previously owned a property"
+              check_answer_prompt: "Tell us if the buyer previously owned a property"
+              hint_text: ""
+              question_text: "Has the buyer previously owned a property?"
+
+          prevshared:
+            page_header: ""
+            check_answer_label: "Previous property shared ownership"
+            check_answer_prompt: "Tell us if the previous property was shared ownership"
+            hint_text: "For any buyer"
+            question_text: "Was the previous property under shared ownership?"

--- a/config/locales/forms/2026/sales/other_household_information.en.yml
+++ b/config/locales/forms/2026/sales/other_household_information.en.yml
@@ -1,0 +1,39 @@
+en:
+  forms:
+    2026:
+      sales:
+        other_household_information:
+          hhregres:
+            page_header: ""
+            check_answer_label: "Any buyer has served as regulars in the UK armed forces"
+            check_answer_prompt: "Tell us if any buyer has ever served as a regular in the UK armed forces"
+            hint_text: "A regular is somebody who has served in the Royal Navy, the Royal Marines, the Royal Airforce or Army full time and does not include reserve forces"
+            question_text: "Have any of the buyers ever served as a regular in the UK armed forces?"
+
+          hhregresstill:
+            page_header: ""
+            check_answer_label: "Buyer still serving in the UK armed forces"
+            check_answer_prompt: "Tell us if the buyer is still serving in the UK armed forces"
+            hint_text: ""
+            question_text: "Is the buyer still serving in the UK armed forces?"
+
+          armedforcesspouse:
+            page_header: ""
+            check_answer_label: "Any buyer is a spouse or civil partner of a UK armed forces regular who died in service within the last 2 years"
+            check_answer_prompt: "Tell us if any buyers are a spouse or civil partner of a UK armed forces regular who died in service within the last 2 years"
+            hint_text: ""
+            question_text: "Are any of the buyers a spouse or civil partner of a UK armed forces regular who died in service within the last 2 years?"
+
+          disabled:
+            page_header: ""
+            check_answer_label: "Household member has a disability"
+            check_answer_prompt: "Tell us if someone has a disability"
+            hint_text: "This includes any long-term health condition that has an impact on the person’s day-to-day life"
+            question_text: "Does anyone in the household consider themselves to have a disability?"
+
+          wheel:
+            page_header: ""
+            check_answer_label: "Household member uses a wheelchair"
+            check_answer_prompt: "Tell us if someone uses a wheelchair"
+            hint_text: "This can be inside or outside the home"
+            question_text: "Does anyone in the household use a wheelchair?"

--- a/config/locales/forms/2026/sales/property_information.en.yml
+++ b/config/locales/forms/2026/sales/property_information.en.yml
@@ -1,0 +1,74 @@
+en:
+  forms:
+    2026:
+      sales:
+        property_information:
+          address_search:
+            page_header: "What is the property’s address?"
+            check_answer_label: "Address"
+            check_answer_prompt: "Enter address or UPRN"
+            hint_text: "For example, '1 Victoria Road' or '10010457355'"
+            question_text: "Enter address or UPRN"
+
+          address:
+            page_header: "What is the property’s address?"
+            address_line1:
+              check_answer_label: "Address lines 1 and 2"
+              check_answer_prompt: "Enter address lines 1 and 2"
+              hint_text: ""
+              question_text: "Address line 1"
+            address_line2:
+              check_answer_label: ""
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Address line 2 (optional)"
+            town_or_city:
+              check_answer_label: "Town or city"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Town or city"
+            county:
+              check_answer_label: "County"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "County (optional)"
+            postcode_full:
+              check_answer_label: "Postcode"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Postcode"
+
+          la:
+            page_header: ""
+            check_answer_label: "Local authority"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the property’s local authority?"
+
+          beds:
+            page_header: ""
+            check_answer_label: "Number of bedrooms"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "How many bedrooms does the property have?"
+
+          proptype:
+            page_header: ""
+            check_answer_label: "Type of unit"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What type of unit is the property?"
+
+          builtype:
+            page_header: ""
+            check_answer_label: "Type of building"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What type of building is the property?"
+
+          wchair:
+            page_header: ""
+            check_answer_label: "Property built or adapted to wheelchair-user standards"
+            check_answer_prompt: "Tell us if the property is built or adapted to wheelchair-user standards"
+            hint_text: "This is whether someone who uses a wheelchair is able to make full use of all of the property’s rooms and facilities, including use of both inside and outside space, and entering and exiting the property."
+            question_text: "Is the property built or adapted to wheelchair-user standards?"

--- a/config/locales/forms/2026/sales/sale_information.en.yml
+++ b/config/locales/forms/2026/sales/sale_information.en.yml
@@ -1,0 +1,320 @@
+en:
+  forms:
+    2026:
+      sales:
+        sale_information:
+          living_before_purchase:
+            joint_purchase:
+              page_header: ""
+              proplen:
+                check_answer_label: "Number of years living in the property before purchase"
+                check_answer_prompt: ""
+                hint_text: "You should round up to the nearest year"
+                question_text: "How long did they live there?"
+              proplen_asked:
+                check_answer_label: "Buyers lived in the property before purchasing"
+                check_answer_prompt: "Tell us if buyers lived in the property before purchase"
+                hint_text: ""
+                question_text: "Did the buyers live in the property before purchasing it?"
+            not_joint_purchase:
+              page_header: ""
+              proplen:
+                check_answer_label: "Number of years living in the property before purchase"
+                check_answer_prompt: ""
+                hint_text: "You should round up to the nearest year"
+                question_text: "How long did they live there?"
+              proplen_asked:
+                check_answer_label: "Buyer lived in the property before purchasing"
+                check_answer_prompt: "Tell us if the buyer lived in the property before purchasing"
+                hint_text: ""
+                question_text: "Did the buyer live in the property before purchasing it?"
+
+          about_staircasing:
+            page_header: "About the staircasing transaction"
+            stairbought:
+              check_answer_label: "Percentage bought in this staircasing transaction"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "What percentage of the property has been bought in this staircasing transaction?"
+            stairowned:
+              joint_purchase:
+                check_answer_label: "Percentage the buyers now own in total"
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What percentage of the property do the buyers now own in total?"
+              not_joint_purchase:
+                check_answer_label: "Percentage the buyer now owns in total"
+                check_answer_prompt: ""
+                hint_text: ""
+                question_text: "What percentage of the property does the buyer now own in total?"
+
+          staircasesale:
+            page_header: ""
+            check_answer_label: "Part of a back-to-back staircasing transaction"
+            check_answer_prompt: "Tell us if this is part of a back-to-back staircasing transaction"
+            hint_text: "Back-to-back staircasing transactions are used as a way for shared owners who own less than 100% of their property to sell on the open market. It involves the shared owner purchasing the remaining share from their landlord and immediately selling 100% of the property to a buyer on the open market. The landlord is then reimbursed for the staircasing transaction through the proceeds of sale to the buyer."
+            question_text: "Is this transaction part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
+
+          firststair:
+            page_header: ""
+            check_answer_label: "First time staircasing"
+            check_answer_prompt: "Tell us if this is the first time staircasing"
+            hint_text: ""
+            question_text: "Is this the first time the shared owner has engaged in staircasing in the home?"
+
+          stairprevious:
+            page_header: "About previous staircasing transactions"
+            numstair:
+              check_answer_label: "Number of staircasing transactions"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Including this time, how many times has the shared owner engaged in staircasing in the home?"
+            initialpurchase:
+              check_answer_label: "Initial staircasing transaction"
+              check_answer_prompt: "Enter initial staircasing transaction date"
+              hint_text: ""
+              question_text: "What was the date of the initial purchase of a share in the property?"
+            lasttransaction:
+              check_answer_label: "Last staircasing transaction"
+              check_answer_prompt: "Enter last staircasing transaction date"
+              hint_text: ""
+              question_text: "What was the date of the last staircasing transaction?"
+
+          resale:
+            page_header: ""
+            check_answer_label: "Resale"
+            check_answer_prompt: "Tell us if this is a resale"
+            hint_text: "If the social landlord has previously sold the property to another buyer and is now reselling the property, select 'yes'. If this is the first time the property has been sold, select 'no'."
+            question_text: "Is this a resale?"
+
+          exchange_date:
+            page_header: ""
+            check_answer_label: "Exchange of contracts date"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the exchange of contracts date?"
+
+          handover_date:
+            page_header: ""
+            check_answer_label: "Practical completion or handover date"
+            check_answer_prompt: ""
+            hint_text: "This is the date on which the building contractor hands over responsibility for the completed property to the private registered provider (PRP)"
+            question_text: "What is the practical completion or handover date?"
+
+          la_nominations:
+            page_header: ""
+            check_answer_label: "Household rehoused under a local authority nominations agreement"
+            check_answer_prompt: "Tell us if household rehoused under a local authority nominations agreement"
+            hint_text: "A local authority nominations agreement is a written agreement between a local authority and private registered provider (PRP) that some or all of its sales vacancies are offered to local authorities for rehousing"
+            question_text: "Was the household rehoused under a 'local authority nominations agreement'?"
+
+          soctenant:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyers were registered providers, housing association or local authority tenants immediately before this sale"
+              check_answer_prompt: "Tell us if buyers were registered providers, housing association or local authority tenants"
+              hint_text: ""
+              question_text: "Were any of the buyers private registered providers, housing association or local authority tenants immediately before this sale?"
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyer was a registered provider, housing association or local authority tenant immediately before this sale"
+              check_answer_prompt: "Tell us if buyer was a registered provider, housing association or local authority tenant"
+              hint_text: ""
+              question_text: "Was the buyer a private registered provider, housing association or local authority tenant immediately before this sale?"
+
+          frombeds:
+            page_header: ""
+            check_answer_label: "Number of bedrooms in previous property"
+            check_answer_prompt: ""
+            hint_text: "A bedsit has 1 bedroom."
+            question_text: "How many bedrooms did the property have?"
+
+          fromprop:
+            page_header: ""
+            check_answer_label: "Previous property type"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What was the previous property type?"
+
+          socprevten:
+            page_header: ""
+            check_answer_label: "Previous property tenure"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What was the previous tenure of the buyer?"
+
+          value:
+            page_header: "About the price of the property"
+            value_shared_ownership:
+              check_answer_label: "Full purchase price"
+              check_answer_prompt: ""
+              hint_text: "Enter the full purchase price of the property before any discounts are applied. This is the full purchase price paid for 100% equity (this is equal to the value of the share owned by the PRP plus the value bought by the purchaser)."
+              question_text: "What was the full purchase price?"
+            value_shared_ownership_staircase:
+              check_answer_label: "Full purchase price"
+              check_answer_prompt: ""
+              hint_text: "Enter the full purchase price paid for the equity bought in this staircasing transaction (this is equal to the value of the share bought by the purchaser)."
+              question_text: "What was the full purchase price for this staircasing transaction?"
+
+          equity:
+            page_header: "About the price of the property"
+            initial_equity:
+              check_answer_label: "Initial percentage equity share"
+              check_answer_prompt: ""
+              hint_text: "Enter the amount of initial equity share held by the purchaser (for example, 25% or 50%)"
+              question_text: "What was the initial percentage share purchased?"
+            staircase_equity:
+              check_answer_label: "Initial percentage equity share"
+              check_answer_prompt: ""
+              hint_text: "Enter the amount of initial equity share held by the purchaser (for example, 25% or 50%)"
+              question_text: "What was the percentage shared purchased in the initial transaction?"
+
+          mortgageused:
+            page_header: ""
+            check_answer_label: "Mortgage used"
+            check_answer_prompt: "Tell us if a mortgage was used"
+            hint_text: ""
+            question_text: "Was a mortgage used for the purchase of this property?"
+
+          mortgage:
+            page_header: ""
+            check_answer_label: "Mortgage amount"
+            check_answer_prompt: ""
+            hint_text: "Enter the amount of mortgage agreed with the mortgage lender. Exclude any deposits or cash payments. Numeric in pounds. Rounded to the nearest pound."
+            question_text: "What is the mortgage amount?"
+
+          mortgagelender:
+            page_header: ""
+            check_answer_label: "Mortgage lender"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the name of the mortgage lender?"
+
+          mortgagelenderother:
+            page_header: ""
+            check_answer_label: "Other Mortgage Lender"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the other mortgage lender?"
+
+          mortlen:
+            page_header: ""
+            check_answer_label: "Length of mortgage"
+            check_answer_prompt: ""
+            hint_text: "You should round up to the nearest year. Value should not exceed 60 years."
+            question_text: "What is the length of the mortgage?"
+
+          extrabor:
+            page_header: ""
+            check_answer_label: "Any other borrowing"
+            check_answer_prompt: "Tell us if there is any other borrowing"
+            hint_text: ""
+            question_text: "Does this include any extra borrowing?"
+
+          deposit:
+            discounted_ownership:
+              page_header: "About the deposit"
+              check_answer_label: "Deposit amount"
+              check_answer_prompt: ""
+              hint_text: "Enter the total cash sum paid by the buyer towards the property that was not funded by the mortgage. This excludes any grant or loan."
+              question_text: "How much cash deposit was paid on the property?"
+            shared_ownership:
+              page_header: "About the deposit"
+              check_answer_label: "Deposit amount"
+              check_answer_prompt: ""
+              hint_text: "Enter the total cash sum paid by the buyer towards the property that was not funded by the mortgage."
+              question_text: "How much cash deposit was paid on the property?"
+
+          cashdis:
+            page_header: "About the deposit"
+            check_answer_label: "Cash discount through SocialHomeBuy"
+            check_answer_prompt: ""
+            hint_text: "Enter the total cash discount given on the property being purchased through the Social HomeBuy scheme"
+            question_text: "How much cash discount was given through Social HomeBuy?"
+
+          mrent:
+            page_header: ""
+            check_answer_label: "Monthly rent"
+            check_answer_prompt: ""
+            hint_text: "Amount paid before any charges"
+            question_text: "What is the basic monthly rent?"
+
+          mrent_staircasing:
+            page_header: "Monthly rent"
+            prestaircasing:
+              check_answer_label: "Monthly rent prior to staircasing"
+              check_answer_prompt: ""
+              hint_text: "Amount paid before any charges"
+              question_text: "What was the basic monthly rent prior to staircasing?"
+            poststaircasing:
+              check_answer_label: "Monthly rent after staircasing"
+              check_answer_prompt: ""
+              hint_text: "Amount paid before any charges"
+              question_text: "What is the basic monthly rent after staircasing?"
+
+          leaseholdcharges:
+            page_header: ""
+            has_mscharge:
+              check_answer_label: "Property leasehold charges"
+              check_answer_prompt: "Enter leasehold charges if any"
+              hint_text: "For example, service and management charges"
+              question_text: "Does the property have any monthly leasehold charges?"
+            mscharge:
+              check_answer_label:  "Monthly leasehold charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Enter the total monthly charge"
+
+          servicecharges:
+            page_header: ""
+            has_servicecharge:
+              check_answer_label: "Property service charges"
+              check_answer_prompt: "Enter service charges if any"
+              hint_text: "This includes any charges for day-to-day maintenance and repairs, building insurance, and any contributions to a sinking or reserved fund. It does not include estate management fees."
+              question_text: "Does the property have any service charges?"
+            servicecharge:
+              check_answer_label:  "Monthly service charges"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Enter the total monthly charge"
+
+          purchase_price:
+            discounted_ownership:
+              page_header: "About the price of the property"
+              check_answer_label: "Purchase price"
+              check_answer_prompt: ""
+              hint_text: "For all schemes, including Right to Acquire (RTA), Right to Buy (RTB), Voluntary Right to Buy (VRTB) or Preserved Right to Buy (PRTB) sales, enter the full price of the property without any discount"
+              question_text: "What is the full purchase price?"
+            outright_sale:
+              page_header: "About the price of the property"
+              check_answer_label: "Purchase price"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "What is the full purchase price?"
+
+          discount:
+            page_header: "About the price of the property"
+            check_answer_label: "Percentage discount"
+            check_answer_prompt: ""
+            hint_text: "For Right to Buy (RTB), Preserved Right to Buy (PRTB), and Voluntary Right to Buy (VRTB)</br></br>If discount capped, enter capped %</br></br>If the property is being sold to an existing tenant under the RTB, PRTB, or VRTB schemes, enter the % discount from the full market value that is being given."
+            question_text: "What was the percentage discount?"
+
+          grant:
+            page_header: "About the price of the property"
+            check_answer_label: "Amount of any loan, grant or subsidy"
+            check_answer_prompt: ""
+            hint_text: "For all schemes except Right to Buy (RTB), Preserved Right to Buy (PRTB), Voluntary Right to Buy (VRTB) and Rent to Buy"
+            question_text: "What was the amount of any loan, grant, discount or subsidy given?"
+
+          management_fee:
+            page_header: ""
+            has_management_fee:
+              check_answer_label: "Monthly estate management fee"
+              check_answer_prompt: "Tell us if the property has an estate management fee"
+              hint_text: "Estate management fees are typically used for the maintenance of communal gardens, payments, private roads, car parks and/or play areas within new build estates."
+              question_text: "Does the property have an estate management fee?"
+            management_fee:
+              check_answer_label:  "Monthly estate management fee"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "Enter the total monthly management fee"

--- a/config/locales/forms/2026/sales/setup.en.yml
+++ b/config/locales/forms/2026/sales/setup.en.yml
@@ -1,0 +1,109 @@
+en:
+  forms:
+    2026:
+      sales:
+        setup:
+          owning_organisation_id:
+            page_header: ""
+            check_answer_label: "Owning organisation"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "Which organisation owns this log?"
+
+          managing_organisation_id:
+            page_header: ""
+            check_answer_label: "Reported by"
+            check_answer_prompt: "Select reporting organisation"
+            hint_text: ""
+            question_text: "Which organisation is reporting this sale?"
+
+          assigned_to_id:
+            page_header: ""
+            check_answer_label: "Log owner"
+            check_answer_prompt: "Select user"
+            hint_text: ""
+            question_text: "Which user are you creating this log for?"
+
+          saledate:
+            page_header: ""
+            check_answer_label: "Sale completion date"
+            check_answer_prompt: ""
+            hint_text: ""
+            question_text: "What is the sale completion date?"
+
+          purchid:
+            page_header: ""
+            check_answer_label: "Purchaser code"
+            check_answer_prompt: ""
+            hint_text: "This is how you usually refer to the purchaser on your own systems."
+            question_text: "What is the purchaser code?"
+
+          ownershipsch:
+            page_header: ""
+            check_answer_label: "Purchase made under ownership scheme"
+            check_answer_prompt: "Tell us if purchase made under ownership scheme"
+            hint_text: "Sales logs are not required for outright and other sales."
+            question_text: "Select the type of sale"
+
+          staircasing:
+            page_header: ""
+            check_answer_label: "Staircasing transaction"
+            check_answer_prompt: "Tell us if it’s a staircasing transaction"
+            hint_text: "A staircasing transaction is when the household purchases more shares in their property, increasing the proportion they own and decreasing the proportion the housing association owns. Once the household purchases 100% of the shares, they own the property."
+            question_text: "Is this a staircasing transaction?"
+
+          type:
+            shared_ownership:
+              page_header: "Type of shared ownership sale"
+              check_answer_label: "Type of shared ownership sale"
+              check_answer_prompt: ""
+              hint_text: "When the purchaser buys an initial share of up to 75% of the property value and pays rent to the Private Registered Provider (PRP) on the remaining portion, or a subsequent staircasing transaction"
+              question_text: "What is the type of shared ownership sale?"
+            discounted_ownership:
+              page_header: "Type of discounted ownership sale"
+              check_answer_label: "Type of discounted ownership sale"
+              check_answer_prompt: ""
+              hint_text: ""
+              question_text: "What is the type of discounted ownership sale?"
+
+          jointpur:
+            page_header: ""
+            check_answer_label: "Joint purchase"
+            check_answer_prompt: "Tell us if joint purchase"
+            hint_text: "This is where two or more people are named as legal owners of the property after the purchase"
+            question_text: "Is this a joint purchase?"
+
+          jointmore:
+            page_header: ""
+            check_answer_label: "More than 2 joint buyers"
+            check_answer_prompt: "Tell us if there are more than 2 joint buyers"
+            hint_text: ""
+            question_text: "Are there more than 2 joint buyers of this property?"
+
+          noint:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyers interviewed in person"
+              check_answer_prompt: "Tell us if buyers interviewed in person"
+              hint_text: "You should still try to answer all questions even if the buyers weren’t interviewed in person"
+              question_text: "Were the buyers interviewed for any of the answers you will provide on this log?"
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Buyer interviewed in person"
+              check_answer_prompt: "Tell us if buyer interviewed in person"
+              hint_text: "You should still try to answer all questions even if the buyer wasn’t interviewed in person"
+              question_text: "Was the buyer interviewed for any of the answers you will provide on this log?"
+
+          privacynotice:
+            joint_purchase:
+              page_header: "Ministry of Housing, Communities and Local Government privacy notice"
+              check_answer_label: "Buyers have seen the privacy notice"
+              check_answer_prompt: "Tell us if buyers have seen the privacy notice"
+              hint_text: ""
+              question_text: "Declaration"
+            not_joint_purchase:
+              page_header: "Ministry of Housing, Communities and Local Government privacy notice"
+              check_answer_label: "Buyer has seen the privacy notice"
+              check_answer_prompt: "Tell us if buyer has seen the privacy notice"
+              hint_text: ""
+              question_text: "Declaration"

--- a/config/locales/forms/2026/sales/soft_validations.en.yml
+++ b/config/locales/forms/2026/sales/soft_validations.en.yml
@@ -1,0 +1,264 @@
+en:
+  forms:
+    2026:
+      sales:
+        soft_validations:
+          retirement_value_check:
+            max:
+              page_header: ""
+              check_answer_label: "Retirement confirmation"
+              check_answer_prompt: "Confirm person isn’t retired"
+              hint_text: ""
+              question_text: "Are you sure this person isn’t retired?"
+              title_text: "You told us this person is over 66 and not retired."
+              informative_text: "The minimum expected retirement age in England is 66."
+            min:
+              page_header: ""
+              check_answer_label: "Retirement confirmation"
+              check_answer_prompt: "Confirm person is retired"
+              hint_text: ""
+              question_text: "Are you sure this person is retired?"
+              title_text: "You told us this person is aged %{age} years and retired."
+              informative_text: "The minimum expected retirement age in England is 66."
+          old_persons_shared_ownership_value_check:
+            page_header: ""
+            check_answer_label: "Shared ownership confirmation"
+            check_answer_prompt: "Confirm shared ownership scheme"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text:
+              joint_purchase: "You told us the buyers are using the Older Persons Shared Ownership scheme."
+              not_joint_purchase: "You told us the buyer is using the Older Persons Shared Ownership scheme."
+            informative_text: "At least one buyer must be aged 65 years and over to use this scheme."
+          income1_value_check:
+            check_answer_label: "Buyer 1 income confirmation"
+            check_answer_prompt: "Confirm buyer 1 income"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            ecstat:
+              page_header: ""
+              title_text: "You told us the income of buyer 1 is %{income}."
+              informative_text: "This is %{more_or_less} than we would expect for someone in this working situation."
+            discounted:
+              page_header: ""
+              title_text: "You told us the income of buyer 1 is %{income}. This seems high for this sale type. Are you sure this is correct?"
+
+          income2_value_check:
+            check_answer_label: "Buyer 2 income confirmation"
+            check_answer_prompt: "Confirm buyer 2 income"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            ecstat:
+              page_header: ""
+              title_text: "You told us the income of buyer 2 is %{income}."
+              informative_text: "This is %{more_or_less} than we would expect for someone in this working situation."
+            discounted:
+              page_header: ""
+              title_text: "You told us the income of buyer 2 is %{income}. This seems high for this sale type. Are you sure this is correct?"
+
+          combined_income_value_check:
+            page_header: ""
+            check_answer_label: "Combined income confirmation"
+            check_answer_prompt: "Confirm combined income"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us the combined income of this household is %{combined_income}. This seems high for this sale type.  Are you sure this is correct?"
+
+          mortgage_value_check:
+            page_header: ""
+            check_answer_label: "Mortgage confirmation"
+            check_answer_prompt: "Confirm mortgage amount"
+            hint_text: ""
+            question_text: "Are you sure that the mortgage is more than 5 times the income used for the mortgage application?"
+            title_text: "You told us that the mortgage amount is %{mortgage}."
+            informative_text: "This is more than 5 times the income, which is higher than we would expect."
+
+          savings_value_check:
+            page_header: ""
+            check_answer_label: "Savings confirmation"
+            check_answer_prompt: "Confirm savings amount"
+            hint_text: ""
+            question_text: "Are you sure the savings are higher than £100,000?"
+            joint_purchase:
+              title_text: "You told us the buyers’ savings were %{savings}."
+              informative_text: "This is higher than we would expect."
+            not_joint_purchase:
+              title_text: "You told us the buyer’s savings were %{savings}."
+              informative_text: "This is higher than we would expect."
+
+          staircase_bought_value_check:
+            page_header: ""
+            check_answer_label: "Percentage bought confirmation"
+            check_answer_prompt: "Confirm percentage bought"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us that %{percentage}% was bought in this staircasing transaction."
+            informative_text: "Most staircasing transactions are less than 50%"
+
+          stairowned_value_check:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Percentage owned confirmation"
+              check_answer_prompt: "Confirm percentage owned"
+              hint_text: ""
+              question_text:  "Are you sure?"
+              title_text: "You told us that the buyers now own %{stairowned} of the property."
+              informative_text: "The maximum percentage that can be owned under the Older Persons Shared Ownership scheme is 75%, unless the property was funded outside the Affordable Homes Programme. Make sure these answers are correct."
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Percentage owned confirmation"
+              check_answer_prompt: "Confirm percentage owned"
+              hint_text: ""
+              question_text:  "Are you sure?"
+              title_text: "You told us that the buyer now owns %{stairowned} of the property."
+              informative_text: "The maximum percentage that can be owned under the Older Persons Shared Ownership scheme is 75%, unless the property was funded outside the Affordable Homes Programme. Make sure these answers are correct."
+
+          hodate_check:
+            page_header: ""
+            check_answer_label: "Practical completion or handover date check"
+            check_answer_prompt: "Confirm practical completion or handover date"
+            hint_text: ""
+            question_text:  "Are you sure?"
+            title_text: "You told us practical completion or handover date is more than 3 years before sale completion date."
+
+          value_value_check:
+            page_header: ""
+            check_answer_label: "Purchase price confirmation"
+            check_answer_prompt: "Confirm purchase price"
+            hint_text: ""
+            question_text:  "Are you sure?"
+            title_text: "You told us the purchase price is %{value}."
+            informative_text: "This is %{higher_or_lower} than we would expect."
+
+          shared_ownership_deposit_value_check:
+            page_header: ""
+            check_answer_label: "Shared ownership deposit confirmation"
+            check_answer_prompt: "Confirm shared ownership deposit"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us that the %{mortgage_deposit_and_discount_error_fields} add up to %{mortgage_deposit_and_discount_total}."
+
+          deposit_value_check:
+            joint_purchase:
+              page_header: ""
+              check_answer_label: "Deposit confirmation"
+              check_answer_prompt: "Confirm deposit amount"
+              hint_text: ""
+              question_text: "Are you sure that the deposit is this much higher than the buyer’s savings?"
+              title_text: "You told us the buyers’ deposit was %{deposit} and their savings were %{savings}."
+              informative_text: "The deposit amount is higher than we would expect for the amount of savings they have."
+            not_joint_purchase:
+              page_header: ""
+              check_answer_label: "Deposit confirmation"
+              check_answer_prompt: "Confirm deposit amount"
+              hint_text: ""
+              question_text: "Are you sure that the deposit is this much higher than the buyer’s savings?"
+              title_text: "You told us the buyer’s deposit was %{deposit} and their savings were %{savings}."
+              informative_text: "The deposit amount is higher than we would expect for the amount of savings they have."
+
+          address_search_value_check:
+            page_header: ""
+            check_answer_label: "No address found"
+            check_answer_prompt: "Confirm no address found"
+            hint_text: ""
+            question_text: ""
+            title_text: "No address found."
+            informative_text: "We could not find an address that matches your search. You can search again or continue to enter the address manually."
+
+          wheel_value_check:
+            page_header: ""
+            check_answer_label: "Household member uses a wheelchair"
+            check_answer_prompt: "Confirm household member uses a wheelchair"
+            hint_text: ""
+            question_text: "You told us that someone in the household uses a wheelchair."
+            title_text: "You told us that someone in the household uses a wheelchair."
+
+          buyer_livein_value_check:
+            buyer1:
+              page_header: ""
+              check_answer_label: "Buyer live in confirmation"
+              check_answer_prompt: "Confirm buyer 1 living situation"
+              hint_text: ""
+              question_text: "Are you sure this is correct?"
+              title_text: "You told us that buyer 1 will not live in the property."
+              informative_text: "For %{ownership_scheme} types, the buyer usually lives in the property."
+            buyer2:
+              page_header: ""
+              check_answer_label: "Buyer live in confirmation"
+              check_answer_prompt: "Confirm buyer 2 living situation"
+              hint_text: ""
+              question_text: "Are you sure this is correct?"
+              title_text: "You told us that buyer 2 will not live in the property."
+              informative_text: "For %{ownership_scheme} types, the buyer usually lives in the property."
+
+          partner_under_16_value_check:
+            page_header: ""
+            check_answer_label: "Partner under 16 confirmation"
+            check_answer_prompt: "Confirm partner’s age"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us this person is aged %{age} years and has 'Partner' relationship to buyer 1."
+            informative_text: "Are you sure this is correct?"
+
+          multiple_partners_value_check:
+            page_header: ""
+            check_answer_label: "Multiple partners confirmation"
+            check_answer_prompt: "Confirm multiple partners"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us there are more than 1 persons with 'Partner' relationship to buyer 1."
+            informative_text: "Are you sure this is correct?"
+
+          monthly_charges_value_check:
+            page_header: ""
+            check_answer_label: "Monthly charges confirmation"
+            check_answer_prompt: "Confirm monthly charges"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us that the monthly charges were %{mscharge}."
+            informative_text: "This is higher than we would expect."
+
+          extra_borrowing_value_check:
+            page_header: ""
+            check_answer_label: "Extra borrowing confirmation"
+            check_answer_prompt: "Confirm extra borrowing"
+            hint_text: ""
+            question_text: "Are you sure there is no extra borrowing?"
+            title_text: "You told us that the mortgage and deposit total is %{mortgage_and_deposit_total}."
+            informative_text: "This is higher than the purchase price minus the discount."
+
+          percentage_discount_value_check:
+            page_header: ""
+            check_answer_label: "Percentage discount confirmation"
+            check_answer_prompt: "Confirm percentage discount"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "You told us that the percentage discount is %{discount}."
+            informative_text: "This is higher than we would expect."
+
+          grant_value_check:
+            page_header: ""
+            check_answer_label: "Grant value confirmation"
+            check_answer_prompt: "Confirm grant value"
+            hint_text: ""
+            question_text: "Are you sure? Grants are usually £9,000 - £16,000"
+            title_text: "You told us that the grant amount is %{grant}."
+            informative_text: "Loans, grants and subsidies are usually between £9,000 and £16,000."
+
+          discounted_sale_value_check:
+            page_header: ""
+            check_answer_label: "Discounted sale value confirmation"
+            check_answer_prompt: "Confirm discounted sale value"
+            hint_text: ""
+            question_text: "Are you sure this is correct?"
+            title_text: "Mortgage, deposit, and grant total must equal %{value_with_discount}."
+            informative_text: "Your given mortgage, deposit and grant total is %{mortgage_deposit_and_grant_total}."
+
+          deposit_and_mortgage_value_check:
+            page_header: ""
+            check_answer_label: "Deposit and mortgage against discount confirmation"
+            check_answer_prompt: "Confirm deposit and mortgage against discount"
+            hint_text: ""
+            question_text: "Are you sure? Mortgage and deposit usually equal or are more than (value - discount)"
+            title_text: "You told us the mortgage amount was %{mortgage}, the cash deposit was %{deposit} and the discount was %{discount}."
+            informative_text: "We would expect the mortgage amount and the deposit added together to be the same as the purchase price minus the discount."

--- a/config/locales/validations/lettings/2026/bulk_upload.en.yml
+++ b/config/locales/validations/lettings/2026/bulk_upload.en.yml
@@ -1,0 +1,67 @@
+en:
+  validations:
+    lettings:
+      2026:
+        bulk_upload:
+          not_answered: "You must answer %{question}"
+          invalid_option: "Enter a valid value for %{question}"
+          invalid_number: "Enter a number for %{question}"
+          spreadsheet_dupe: "This is a duplicate of a log in your file."
+          duplicate: "This is a duplicate log."
+          blank_file: "Template is blank - The template must be filled in for us to create the logs and check if data is correct."
+          wrong_template:
+            wrong_template: "Incorrect start dates, please ensure you have used the correct template."
+            no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            over_max_column_count: "Too many columns, please ensure you have used the correct template."
+          owning_organisation:
+            not_found: "The owning organisation code is incorrect."
+            not_stock_owner: "The owning organisation code provided is for an organisation that does not own stock."
+            not_permitted:
+              not_support: "You do not have permission to add logs for this owning organisation."
+              support: "This owning organisation is not affiliated with %{org_name}."
+          managing_organisation:
+            no_relationship: "This managing organisation does not have a relationship with the owning organisation."
+            not_found: "The managing organisation code is incorrect."
+          assigned_to:
+            not_found: "User with the specified email could not be found."
+            organisation_not_related: "User must be related to owning organisation or managing organisation."
+          startdate:
+            outside_collection_window: "Enter a date within the %{year_combo} collection year, which is between 1st April %{start_year} and 31st March %{end_year}."
+            year_not_two_or_four_digits: "Tenancy start year must be 2 or 4 digits."
+          housingneeds:
+            no_and_dont_know_disabled_needs_conjunction: "No disabled access needs and don’t know disabled access needs cannot be selected together."
+            dont_know_disabled_needs_conjunction: "Don’t know disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs."
+            no_disabled_needs_conjunction: "No disabled access needs can’t be selected if you have selected fully wheelchair-accessible housing, wheelchair access to essential rooms, level access housing or other disabled access needs."
+          housingneeds_type:
+            only_one_option_permitted: "Only one disabled access need: fully wheelchair-accessible housing, wheelchair access to essential rooms or level access housing, can be selected."
+          condition_effects:
+            no_choices: "You cannot answer this question as you told us nobody in the household has a physical or mental health condition (or other illness) expected to last 12 months or more."
+          reason:
+            renewal_reason_needed: "The reason for leaving must be \"End of social or private sector tenancy - no fault\", \"End of social or private sector tenancy - evicted due to anti-social behaviour (ASB)\", \"End of social or private sector tenancy - evicted due to rent arrears\" or \"End of social or private sector tenancy - evicted for any other reason\"."
+          referral:
+            general_needs_prp_referred_by_la: "The source of the referral cannot be referred by local authority housing department for a general needs log."
+            nominated_by_local_ha_but_la: "The source of the referral cannot be Nominated by local housing authority as your organisation is a local authority."
+          scheme:
+            must_relate_to_org: "This scheme code does not belong to the owning organisation or managing organisation."
+          location:
+            must_relate_to_org: "Location code must relate to a location that is owned by the owning organisation or managing organisation."
+          age:
+            invalid: "Age of person %{person_num} must be a number or the letter R"
+          address:
+            not_found: "We could not find this address. Check the address data in your CSV file is correct and complete, or find the correct address in the service."
+            not_determined:
+              one: "There is a possible match for this address which doesn't look right. Check the address data in your CSV file is correct and complete, or confirm the address in the service."
+              multiple: "There are multiple matches for this address. Check the address data in your CSV file is correct and complete, or select the correct address in the service."
+            not_answered: "Enter either the UPRN or the full address."
+          nationality:
+            invalid: "Select a valid nationality."
+          charges:
+            missing_charges: "Please enter the %{sentence_fragment}. If there is no %{sentence_fragment}, please enter '0'."
+            related_to_missing_charge: "You must enter all these fields: basic rent, service charge, personal service charge and support charge. Please enter ‘0' for any types of charges that you don’t issue."
+          reasonpref:
+            conflict:
+              dont_know: "You cannot select 'Don't know' if any of the other reasonable preference reasons are also selected."
+              other: "You cannot select this reasonable preference reason as you've also selected 'Don't know' as a reason."
+          prevten:
+            invalid: "You said this letting is a renewal to the same tenant in the same property in the set up section. This means where the household was immediately before this letting must be \"Fixed-term local authority general needs tenancy\", \"Fixed-term private registered provider (PRP) general needs tenancy\", \"Lifetime local authority general needs tenancy\", \"Lifetime private registered provider (PRP) general needs tenancy\", \"Extra care housing\", \"Older people's housing for tenants with low support needs\" or \"Other supported housing.\""

--- a/config/locales/validations/sales/2026/bulk_upload.en.yml
+++ b/config/locales/validations/sales/2026/bulk_upload.en.yml
@@ -1,0 +1,46 @@
+en:
+  validations:
+    sales:
+      2026:
+        bulk_upload:
+          not_answered: "You must answer %{question}"
+          invalid_option: "Enter a valid value for %{question}"
+          spreadsheet_dupe: "This is a duplicate of a log in your file."
+          duplicate: "This is a duplicate log."
+          blank_file: "Template is blank - The template must be filled in for us to create the logs and check if data is correct."
+          wrong_template:
+            over_max_column_count: "Too many columns, please ensure you have used the correct template."
+            no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            wrong_template: "Incorrect sale dates, please ensure you have used the correct template."
+          numeric:
+            within_range: "%{field} must be between %{min} and %{max}."
+          owning_organisation:
+            not_found: "The owning organisation code is incorrect."
+            not_stock_owner: "The owning organisation code provided is for an organisation that does not own stock."
+            not_permitted:
+              support: "This owning organisation is not affiliated with %{name}."
+              not_support: "You do not have permission to add logs for this owning organisation."
+          assigned_to:
+            not_found: "User with the specified email could not be found."
+            organisation_not_related: "User must be related to owning organisation or managing organisation."
+            managing_organisation_not_related: "This organisation does not have a relationship with the owning organisation."
+          saledate:
+            outside_collection_window: "Enter a date within the %{year_combo} collection year, which is between 1st April %{start_year} and 31st March %{end_year}."
+            year_not_two_or_four_digits: "Sale completion year must be 2 or 4 digits."
+          ecstat1:
+            buyer_cannot_be_over_16_and_child: "Buyer 1’s age cannot be 16 or over if their working situation is child under 16."
+            buyer_cannot_be_child: "Buyer 1 cannot have a working situation of child under 16."
+          age1:
+            buyer_cannot_be_over_16_and_child: "Buyer 1’s age cannot be 16 or over if their working situation is child under 16."
+          ecstat2:
+            buyer_cannot_be_over_16_and_child: "Buyer 2’s age cannot be 16 or over if their working situation is child under 16."
+            buyer_cannot_be_child: "Buyer 2 cannot have a working situation of child under 16."
+          age2:
+            buyer_cannot_be_over_16_and_child: "Buyer 2’s age cannot be 16 or over if their working situation is child under 16."
+          address:
+            not_found: "We could not find this address. Check the address data in your CSV file is correct and complete, or select the correct address using the CORE site."
+            not_determined: "There are multiple matches for this address. Either select the correct address manually or correct the UPRN in the CSV file."
+            not_answered: "Enter either the UPRN or the full address."
+          nationality:
+            invalid: "Select a valid nationality."


### PR DESCRIPTION
closes [CLDC-4158](https://mhclgdigital.atlassian.net/browse/CLDC-4158)

re-enables the future form use on pre-prod environments

adds new locales files, copied from 2025

adds deadlines provided by Rachel

adds the vital 2026 helper for use in other tickets

tested locally, can create a 2026 log now

<img alt="2026 lettings log page" src="https://github.com/user-attachments/assets/e0c0d89c-bb49-4d27-9508-109e58184717" />


[CLDC-4158]: https://mhclgdigital.atlassian.net/browse/CLDC-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ