### PR TITLE
CLDC-4145: Update major repairs hint text

### DIFF
--- a/config/locales/forms/2026/lettings/property_information.en.yml
+++ b/config/locales/forms/2026/lettings/property_information.en.yml
@@ -106,7 +106,7 @@ en:
             majorrepairs:
               check_answer_label: "Major repairs carried out during void period"
               check_answer_prompt: ""
-              hint_text: "Major repairs are works that could not be reasonably carried out with a tenant living at the property. For example, structural repairs."
+              hint_text: "Major repairs are works which could not reasonably be carried out with a tenant in occupation, and which need to be carried out in a property while it is vacant. They are works that have prevented the re-letting of the property because of their scale and extent. They involve remedial works that are necessary for the property to remain habitable and include structural repairs, site works and service installations."
               question_text: "Were any major repairs carried out during the void period?"
             mrcdate:
               check_answer_label: "Completion date of repairs"


### PR DESCRIPTION
closes [CLDC-4145](https://mhclgdigital.atlassian.net/browse/CLDC-4145)

to test, answer log is not a renewal and give the following property information answers

<img alt="required answers" src="https://github.com/user-attachments/assets/8e5af8a0-6d1b-4c48-a5d5-4f5c2a84836f" />

new wording
<img alt="q24 hint text" src="https://github.com/user-attachments/assets/889c8a11-b390-46c9-b2f4-62110a4226c6" />


[CLDC-4145]: https://mhclgdigital.atlassian.net/browse/CLDC-4145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ