### PR TITLE
CLDC-NONE: Add dev container to access infrastructure

### DIFF
--- a/aws-devcontainer/.devcontainer/Dockerfile
+++ b/aws-devcontainer/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM homebrew/brew
+
+RUN brew install aws-vault && brew install awscli
+RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && sudo dpkg -i session-manager-plugin.deb
+
+ENV AWS_VAULT_BACKEND=file
+ENV AWS_VAULT_FILE_DIR=./vault
+ENV AWS_CONFIG_FILE=./config

--- a/aws-devcontainer/.devcontainer/devcontainer.json
+++ b/aws-devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "CORE aws-vault",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/aws-devcontainer/.gitignore
+++ b/aws-devcontainer/.gitignore
@@ -1,0 +1,2 @@
+config
+vault/*

--- a/aws-devcontainer/README.md
+++ b/aws-devcontainer/README.md
@@ -2,4 +2,4 @@
 
 Sets up aws CLI & aws-vault CLI, as well as config storage.
 
-See internal documentation for further description on configuring this with our infrastructure.
+See [internal documentation](https://softwiretech.atlassian.net/wiki/spaces/Support/pages/21648277643/CORE+AWS+Tasks#Accessing-a-database) for further description on configuring this with our infrastructure.

--- a/aws-devcontainer/README.md
+++ b/aws-devcontainer/README.md
@@ -1,0 +1,5 @@
+# CORE AWS/AWS-vault dev container
+
+Sets up aws CLI & aws-vault CLI, as well as config storage.
+
+See internal documentation for further description on configuring this with our infrastructure.

--- a/aws-devcontainer/config.template
+++ b/aws-devcontainer/config.template
@@ -1,0 +1,3 @@
+[default]
+region=eu-west-2
+output=json


### PR DESCRIPTION
adds a dev container that configures aws and aws-vault for use on connecting to CORE infrastructure

makes rampup a little more straightforward

updated [internal documentation](https://softwiretech.atlassian.net/wiki/spaces/Support/pages/21648277643/CORE+AWS+Tasks#Accessing-a-database) to account