### PR TITLE
CLDC-NONE: Add a manual runner pipeline that can redeploy review app code

### DIFF
--- a/.github/workflows/manual_review_code_pipeline.yml
+++ b/.github/workflows/manual_review_code_pipeline.yml
@@ -1,12 +1,12 @@
 name: Manual review app code pipeline
 
 concurrency:
-  group: review-${{ inputs.key }}
+  group: review-${{ inputs.review_app_key }}
 
 on:
   workflow_dispatch:
     inputs:
-      review-app-key:
+      review_app_key:
         required: true
         type: string
         description: "The review app ID to deploy code for."
@@ -22,8 +22,8 @@ jobs:
     with:
       aws_account_id: 837698168072
       aws_role_prefix: core-dev
-      aws_task_prefix: core-review-${{ inputs.key }}
-      concurrency_tag: ${{ inputs.key }}
+      aws_task_prefix: core-review-${{ inputs.review_app_key }}
+      concurrency_tag: ${{ inputs.review_app_key }}
       environment: review
     permissions:
       id-token: write

--- a/.github/workflows/manual_review_code_pipeline.yml
+++ b/.github/workflows/manual_review_code_pipeline.yml
@@ -1,0 +1,29 @@
+name: Manual review app code pipeline
+
+concurrency:
+  group: review-${{ inputs.key }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      review-app-key:
+        required: true
+        type: string
+        description: "The review app ID to deploy code for."
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  code:
+    name: Deploy review app code
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws_account_id: 837698168072
+      aws_role_prefix: core-dev
+      aws_task_prefix: core-review-${{ inputs.key }}
+      concurrency_tag: ${{ inputs.key }}
+      environment: review
+    permissions:
+      id-token: write


### PR DESCRIPTION
will give us a reliable method to redeploy code

this will push a docker image to ECR which can fix issues when the image expires

replaces rerunning the review app pipeline which is sometimes not possible