### PR TITLE
CLDC-4147: Add working situation hint

### DIFF
--- a/config/locales/forms/2026/lettings/household_characteristics.en.yml
+++ b/config/locales/forms/2026/lettings/household_characteristics.en.yml
@@ -127,7 +127,7 @@ en:
             page_header: ""
             check_answer_label: "Person 2’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 2’s working situation?"
 
           details_known_3:
@@ -168,7 +168,7 @@ en:
             page_header: ""
             check_answer_label: "Person 3’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 3’s working situation?"
 
           details_known_4:
@@ -209,7 +209,7 @@ en:
             page_header: ""
             check_answer_label: "Person 4’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 4’s working situation?"
 
           details_known_5:
@@ -250,7 +250,7 @@ en:
             page_header: ""
             check_answer_label: "Person 5’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 5’s working situation?"
 
           details_known_6:
@@ -291,7 +291,7 @@ en:
             page_header: ""
             check_answer_label: "Person 6’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 6’s working situation?"
 
           details_known_7:
@@ -332,7 +332,7 @@ en:
             page_header: ""
             check_answer_label: "Person 7’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 7’s working situation?"
 
           details_known_8:
@@ -373,5 +373,5 @@ en:
             page_header: ""
             check_answer_label: "Person 8’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 8’s working situation?"

--- a/config/locales/forms/2026/lettings/household_characteristics.en.yml
+++ b/config/locales/forms/2026/lettings/household_characteristics.en.yml
@@ -86,7 +86,7 @@ en:
             page_header: ""
             check_answer_label: "Lead tenant’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes the lead tenant’s working situation?"
 
           details_known_2:
@@ -127,7 +127,7 @@ en:
             page_header: ""
             check_answer_label: "Person 2’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 2’s working situation?"
 
           details_known_3:
@@ -168,7 +168,7 @@ en:
             page_header: ""
             check_answer_label: "Person 3’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 3’s working situation?"
 
           details_known_4:
@@ -209,7 +209,7 @@ en:
             page_header: ""
             check_answer_label: "Person 4’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 4’s working situation?"
 
           details_known_5:
@@ -250,7 +250,7 @@ en:
             page_header: ""
             check_answer_label: "Person 5’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 5’s working situation?"
 
           details_known_6:
@@ -291,7 +291,7 @@ en:
             page_header: ""
             check_answer_label: "Person 6’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 6’s working situation?"
 
           details_known_7:
@@ -332,7 +332,7 @@ en:
             page_header: ""
             check_answer_label: "Person 7’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 7’s working situation?"
 
           details_known_8:
@@ -373,5 +373,5 @@ en:
             page_header: ""
             check_answer_label: "Person 8’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 8’s working situation?"

--- a/config/locales/forms/2026/sales/household_characteristics.en.yml
+++ b/config/locales/forms/2026/sales/household_characteristics.en.yml
@@ -202,13 +202,13 @@ en:
               page_header: ""
               check_answer_label: "Buyer 2’s working situation"
               check_answer_prompt: ""
-              hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+              hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
               question_text: "Which of these best describes buyer 2’s working situation?"
             person:
               page_header: ""
               check_answer_label: "Person 2’s working situation"
               check_answer_prompt: ""
-              hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+              hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
               question_text: "Which of these best describes person 2’s working situation?"
 
           buy2livein:
@@ -277,7 +277,7 @@ en:
             page_header: ""
             check_answer_label: "Person 3’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 3’s working situation?"
 
           details_known_4:
@@ -318,7 +318,7 @@ en:
             page_header: ""
             check_answer_label: "Person 4’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 4’s working situation?"
 
           details_known_5:
@@ -359,7 +359,7 @@ en:
             page_header: ""
             check_answer_label: "Person 5’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 5’s working situation?"
 
           details_known_6:
@@ -400,5 +400,5 @@ en:
             page_header: ""
             check_answer_label: "Person 6’s working situation"
             check_answer_prompt: ""
-            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
+            hint_text: "People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 6’s working situation?"

--- a/config/locales/forms/2026/sales/household_characteristics.en.yml
+++ b/config/locales/forms/2026/sales/household_characteristics.en.yml
@@ -80,7 +80,7 @@ en:
             page_header: ""
             check_answer_label: "Buyer 1’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes buyer 1’s working situation?"
 
           buy1livein:
@@ -202,13 +202,13 @@ en:
               page_header: ""
               check_answer_label: "Buyer 2’s working situation"
               check_answer_prompt: ""
-              hint_text: ""
+              hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
               question_text: "Which of these best describes buyer 2’s working situation?"
             person:
               page_header: ""
               check_answer_label: "Person 2’s working situation"
               check_answer_prompt: ""
-              hint_text: ""
+              hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
               question_text: "Which of these best describes person 2’s working situation?"
 
           buy2livein:
@@ -277,7 +277,7 @@ en:
             page_header: ""
             check_answer_label: "Person 3’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 3’s working situation?"
 
           details_known_4:
@@ -318,7 +318,7 @@ en:
             page_header: ""
             check_answer_label: "Person 4’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 4’s working situation?"
 
           details_known_5:
@@ -359,7 +359,7 @@ en:
             page_header: ""
             check_answer_label: "Person 5’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 5’s working situation?"
 
           details_known_6:
@@ -400,5 +400,5 @@ en:
             page_header: ""
             check_answer_label: "Person 6’s working situation"
             check_answer_prompt: ""
-            hint_text: ""
+            hint_text: "This is the household member who does the most paid work. If several people do the same amount of paid work, it's the oldest household member. People providing informal care for family and friends who are not in formal employment (but may receive carer's allowance) should answer 'Not seeking work'."
             question_text: "Which of these best describes person 6’s working situation?"


### PR DESCRIPTION
closes [CLDC-4147](https://mhclgdigital.atlassian.net/browse/CLDC-4147)

adds hint text as required by CORE

<details><summary>screenshots</summary>
## lettings
<img alt="q36" src="https://github.com/user-attachments/assets/90a919e1-daa6-4066-8eed-7d6ad464590d" />

<img alt="q40" src="https://github.com/user-attachments/assets/ac98d1be-d5c1-420d-8167-9e1843629f6b" />
</details>

[CLDC-4147]: https://mhclgdigital.atlassian.net/browse/CLDC-4147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ