### PR TITLE
CLDC-None: Re-run the most recent migration to update schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -373,8 +373,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_111741) do
     t.integer "partner_under_16_value_check"
     t.integer "multiple_partners_value_check"
     t.bigint "created_by_id"
-    t.integer "referral_type"
     t.boolean "manual_address_entry_selected", default: false
+    t.integer "referral_type"
     t.index ["assigned_to_id"], name: "index_lettings_logs_on_assigned_to_id"
     t.index ["bulk_upload_id"], name: "index_lettings_logs_on_bulk_upload_id"
     t.index ["created_by_id"], name: "index_lettings_logs_on_created_by_id"
@@ -504,7 +504,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_111741) do
     t.date "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["organisation_id", "startdate"], name: "index_org_name_changes_on_org_id_and_startdate", unique: true
+    t.index ["organisation_id", "startdate", "discarded_at"], name: "index_org_name_changes_on_org_id_startdate_discarded_at", unique: true
     t.index ["organisation_id"], name: "index_organisation_name_changes_on_organisation_id"
   end
 
@@ -894,6 +894,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_111741) do
   add_foreign_key "local_authority_links", "local_authorities"
   add_foreign_key "local_authority_links", "local_authorities", column: "linked_local_authority_id"
   add_foreign_key "locations", "schemes"
+  add_foreign_key "organisation_name_changes", "organisations"
   add_foreign_key "organisation_relationships", "organisations", column: "child_organisation_id"
   add_foreign_key "organisation_relationships", "organisations", column: "parent_organisation_id"
   add_foreign_key "organisations", "organisations", column: "absorbing_organisation_id"


### PR DESCRIPTION
## Summary

@oscar-richardson-softwire [noticed](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/3144#discussion_r2709224919) in my PR for CLDC-4177 that there were unexpected changes made to the database schema file when I ran my new migration.

Upon reviewing the recent migrations, we spotted that the unexpected changes correspond to part of the migration immediately prior to my new one: "20250416111741_create_organisation_name_changes".

I think that capturing the changes in a separate PR better records that this is a deficit unrelated to ticket CLDC-4177.

### Hypothesis

Back in April 2025 when this migration was created, the developer:

1. Created the migration with the new table "organisation_name_changes", but without the foreign-key relationship to the table "organisation" and without the index on the "discarded_at" column.
2. Ran their migration.
3. Retroactively updated the migration by adding in the aforementioned FK and Index.
4. Did not re-run the migration.

## Changes

I have dropped and re-created my database using the migrations, rather than by creating it from the schema file. Doing it in this way has resulted in the changes to schema that you can see here in this PR.