### PR TITLE
CLDC-NONE: Add a test to ensure future logs are completed

### DIFF
--- a/app/helpers/collection_time_helper.rb
+++ b/app/helpers/collection_time_helper.rb
@@ -50,6 +50,10 @@ module CollectionTimeHelper
     next_collection_start_year + 1
   end
 
+  def next_collection_start_date
+    current_collection_start_date + 1.year
+  end
+
   def previous_collection_start_year
     current_collection_start_year - 1
   end

--- a/spec/shared/shared_log_examples.rb
+++ b/spec/shared/shared_log_examples.rb
@@ -8,14 +8,14 @@ RSpec.shared_examples "shared log examples" do |log_type|
     [
       {
         start_date: :current_collection_start_date,
-        label: "current year",
+        label: "current",
       },
       {
         start_date: :next_collection_start_date,
-        label: "next year",
+        label: "next",
       },
     ].each do |scenario|
-      context "when creating a log for #{scenario[:label]}" do
+      context "when creating a log for #{scenario[:label]} year" do
         around do |example|
           start_date = Timecop.return { send(scenario[:start_date]) }
 
@@ -30,8 +30,8 @@ RSpec.shared_examples "shared log examples" do |log_type|
         let(:completed_log) { create(log_type, :completed) }
 
         it "is set to not started for an empty #{log_type} log" do
-          expect(empty_log.not_started?).to be(true)
           expect(empty_log.in_progress?).to be(false)
+          expect(empty_log.not_started?).to be(true)
           expect(empty_log.completed?).to be(false)
           expect(empty_log.deleted?).to be(false)
         end

--- a/spec/shared/shared_log_examples.rb
+++ b/spec/shared/shared_log_examples.rb
@@ -2,30 +2,57 @@ require "rails_helper"
 
 # rubocop:disable RSpec/AnyInstance
 RSpec.shared_examples "shared log examples" do |log_type|
+  include CollectionTimeHelper
+
   describe "status" do
-    let(:empty_log) { create(log_type) }
-    let(:in_progress_log) { create(log_type, :in_progress) }
-    let(:completed_log) { create(log_type, :completed) }
+    [
+      {
+        start_date: :current_collection_start_date,
+        label: "current year",
+      },
+      {
+        start_date: :next_collection_start_date,
+        label: "next year",
+      },
+    ].each do |scenario|
+      context "when creating a log for #{scenario[:label]}" do
+        around do |example|
+          start_date = Timecop.return { send(scenario[:start_date]) }
 
-    it "is set to not started for an empty #{log_type} log" do
-      expect(empty_log.not_started?).to be(true)
-      expect(empty_log.in_progress?).to be(false)
-      expect(empty_log.completed?).to be(false)
-      expect(empty_log.deleted?).to be(false)
-    end
+          Timecop.freeze(start_date) do
+            Singleton.__init__(FormHandler)
+            example.run
+          end
+        end
 
-    it "is set to in progress for a started #{log_type} log" do
-      expect(in_progress_log.in_progress?).to be(true)
-      expect(in_progress_log.not_started?).to be(false)
-      expect(in_progress_log.completed?).to be(false)
-      expect(in_progress_log.deleted?).to be(false)
-    end
+        let(:empty_log) { create(log_type) }
+        let(:in_progress_log) { create(log_type, :in_progress) }
+        let(:completed_log) { create(log_type, :completed) }
 
-    it "is set to completed for a completed #{log_type} log" do
-      expect(completed_log.in_progress?).to be(false)
-      expect(completed_log.not_started?).to be(false)
-      expect(completed_log.completed?).to be(true)
-      expect(completed_log.deleted?).to be(false)
+        it "is set to not started for an empty #{log_type} log" do
+          expect(empty_log.not_started?).to be(true)
+          expect(empty_log.in_progress?).to be(false)
+          expect(empty_log.completed?).to be(false)
+          expect(empty_log.deleted?).to be(false)
+        end
+
+        it "is set to in progress for a started #{log_type} log" do
+          expect(in_progress_log.in_progress?).to be(true)
+          expect(in_progress_log.not_started?).to be(false)
+          expect(in_progress_log.completed?).to be(false)
+          expect(in_progress_log.deleted?).to be(false)
+        end
+
+        # if this test starts failing, likely because a new question has been added
+        # and the :completed trait in spec/factories/lettings_log.rb (or sales_log.rb)
+        # needs to be updated to set the database col with that questions answer
+        it "is set to completed for a completed #{log_type} log" do
+          expect(completed_log.in_progress?).to be(false)
+          expect(completed_log.not_started?).to be(false)
+          expect(completed_log.completed?).to be(true)
+          expect(completed_log.deleted?).to be(false)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
adds a test that the factory traits for future logs work as expected

noticed this has been something we've been missing a lot when adding new questions. feels best to make sure this is tested as we go along, otherwise it'll cause a headache at form release time