### PR TITLE
CLDC-4155: Update reason for leaving hint text

### DIFF
--- a/config/locales/forms/2026/lettings/household_situation.en.yml
+++ b/config/locales/forms/2026/lettings/household_situation.en.yml
@@ -35,7 +35,7 @@ en:
               reason:
                 check_answer_label: "Reason for leaving last settled home"
                 check_answer_prompt: ""
-                hint_text: "The tenant’s ‘last settled home’ is their last long-standing home. For tenants who were in temporary accommodation, sleeping rough or otherwise homeless, their last settled home is where they were living previously."
+                hint_text: "The tenant’s ‘last settled home’ is their last long-standing home. For tenants who were in temporary accommodation, sleeping rough or otherwise homeless, their last settled home is where they were living immediately before that period."
                 question_text: "What is the tenant’s main reason for the household leaving their last settled home?"
               reasonother:
                 check_answer_label: ""


### PR DESCRIPTION
closes [CLDC-4155](https://mhclgdigital.atlassian.net/browse/CLDC-4155)

updates hint text as required on ticket

<img alt="q76 reason for leaving hint text" src="https://github.com/user-attachments/assets/07f1b3c6-8130-4b9e-9743-50ab2da9bfc0" />

[CLDC-4155]: https://mhclgdigital.atlassian.net/browse/CLDC-4155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ