### PR TITLE
CLDC-4200: Add household characteristics household members CYA label

### DIFF
--- a/app/components/check_answers_summary_list_card_component.html.erb
+++ b/app/components/check_answers_summary_list_card_component.html.erb
@@ -1,8 +1,8 @@
 <% if applicable_questions.first %>
   <div class="govuk-summary-card govuk-!-margin-bottom-6">
-    <% if applicable_questions.first.check_answers_card_number != 0 && applicable_questions.first.check_answers_card_number.present? %>
+    <% if check_answers_card_label(applicable_questions.first).present? %>
       <div class="govuk-summary-card__title-wrapper">
-        <h3 class="govuk-summary-card__title"><%= check_answers_card_title(applicable_questions.first) %></h3>
+        <h3 class="govuk-summary-card__title"><%= check_answers_card_label(applicable_questions.first) %></h3>
       </div>
     <% end %>
 

--- a/app/components/check_answers_summary_list_card_component.rb
+++ b/app/components/check_answers_summary_list_card_component.rb
@@ -22,7 +22,10 @@ class CheckAnswersSummaryListCardComponent < ViewComponent::Base
     [question.question_number_string, question.check_answer_label.to_s.presence || question.header.to_s].compact.join(" - ")
   end
 
-  def check_answers_card_title(question)
+  def check_answers_card_label(question)
+    return question.check_answers_card_title if question.check_answers_card_title.present?
+    return unless question.check_answers_card_number.present? && question.check_answers_card_number != 0
+
     return "Lead tenant" if question.form.type == "lettings" && question.check_answers_card_number == 1
     return "Buyer #{question.check_answers_card_number}" if question.check_answers_card_number <= number_of_buyers
 

--- a/app/models/form/lettings/questions/hhmemb.rb
+++ b/app/models/form/lettings/questions/hhmemb.rb
@@ -9,6 +9,7 @@ class Form::Lettings::Questions::Hhmemb < ::Form::Question
     @min = 1
     @step = 1
     @question_number = QUESTION_NUMBER_FROM_YEAR[form.start_date.year] || QUESTION_NUMBER_FROM_YEAR[QUESTION_NUMBER_FROM_YEAR.keys.max]
+    @check_answers_card_title = "Household" if form.start_year_2026_or_later?
   end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 31, 2024 => 30 }.freeze

--- a/app/models/form/question.rb
+++ b/app/models/form/question.rb
@@ -6,7 +6,7 @@ class Form::Question
                 :conditional_for, :readonly, :answer_options, :page,
                 :inferred_answers, :hidden_in_check_answers, :inferred_check_answers_value,
                 :top_guidance_partial, :bottom_guidance_partial, :prefix, :suffix,
-                :requires_js, :fields_added, :derived, :check_answers_card_number,
+                :requires_js, :fields_added, :derived, :check_answers_card_number, :check_answers_card_title,
                 :unresolved_hint_text, :question_number, :hide_question_number_on_page,
                 :plain_label, :error_label, :strip_commas
 

--- a/spec/models/form/lettings/pages/household_members_spec.rb
+++ b/spec/models/form/lettings/pages/household_members_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Form::Lettings::Pages::HouseholdMembers, type: :model do
+  include CollectionTimeHelper
+
+  subject(:page) { described_class.new(page_id, page_definition, subsection) }
+
+  let(:page_id) { nil }
+  let(:page_definition) { nil }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form, start_date: current_collection_start_date, start_year_2026_or_later?: true) }
+
+  before do
+    allow(subsection).to receive(:form).and_return(form)
+  end
+
+  it "has correct subsection" do
+    expect(page.subsection).to eq(subsection)
+  end
+
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(%w[hhmemb])
+  end
+
+  it "has the correct id" do
+    expect(page.id).to eq("household_members")
+  end
+
+  it "has the correct description" do
+    expect(page.description).to be_nil
+  end
+end

--- a/spec/models/form/lettings/questions/hhmemb_spec.rb
+++ b/spec/models/form/lettings/questions/hhmemb_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Form::Lettings::Questions::Hhmemb, type: :model do
+  include CollectionTimeHelper
+
+  subject(:question) { described_class.new(nil, question_definition, page) }
+
+  let(:question_definition) { nil }
+  let(:page) { instance_double(Form::Page) }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:start_year_2026_or_later?) { false }
+  let(:form) { instance_double(Form, start_date: current_collection_start_date, start_year_2026_or_later?: start_year_2026_or_later?) }
+
+  before do
+    allow(page).to receive(:subsection).and_return(subsection)
+    allow(subsection).to receive(:form).and_return(form)
+  end
+
+  it "has correct page" do
+    expect(question.page).to eq(page)
+  end
+
+  it "has the correct type" do
+    expect(question.type).to eq("numeric")
+  end
+
+  it "is not marked as derived" do
+    expect(question.derived?(nil)).to be false
+  end
+
+  it "has the correct id" do
+    expect(question.id).to eq("hhmemb")
+  end
+
+  it "has the correct check_answers_card_number" do
+    expect(question.check_answers_card_number).to eq(0)
+  end
+
+  context "when in 2025", { year: 25 } do
+    it "does not have check answers card title" do
+      expect(question.check_answers_card_title).to be_nil
+    end
+
+    it "has the correct question number" do
+      expect(question.question_number).to eq(30)
+    end
+  end
+
+  context "when in 2026", { year: 26 } do
+    let(:start_year_2026_or_later?) { true }
+
+    it "has correct check answers card title" do
+      expect(question.check_answers_card_title).to eq("Household")
+    end
+
+    it "has the correct question number" do
+      expect(question.question_number).to eq(30)
+    end
+  end
+end


### PR DESCRIPTION
closes [CLDC-4200](https://mhclgdigital.atlassian.net/browse/CLDC-4200)

adds scope in CORE to have a custom label for a CYA section

precise wording TBC

<img alt="household characteristics cya" src="https://github.com/user-attachments/assets/fa2ef17a-40da-425f-81f5-97a632d1ef0a" />

doesn't impact 2025 logs or sales

[CLDC-4200]: https://mhclgdigital.atlassian.net/browse/CLDC-4200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ