### PR TITLE
CLDC-4177: use prefers not to say text in cya page

### DIFF
--- a/app/models/form/sales/questions/person_sex_registered_at_birth.rb
+++ b/app/models/form/sales/questions/person_sex_registered_at_birth.rb
@@ -16,4 +16,12 @@ class Form::Sales::Questions::PersonSexRegisteredAtBirth < ::Form::Question
   }.freeze
 
   QUESTION_NUMBER_FROM_YEAR = { 2026 => 0 }.freeze
+
+  def label_from_value(value, _log = nil, _user = nil)
+    return unless value
+
+    return "Prefers not to say" if value == "R"
+
+    super
+  end
 end

--- a/app/models/form/sales/questions/sex_registered_at_birth1.rb
+++ b/app/models/form/sales/questions/sex_registered_at_birth1.rb
@@ -16,4 +16,12 @@ class Form::Sales::Questions::SexRegisteredAtBirth1 < ::Form::Question
   }.freeze
 
   QUESTION_NUMBER_FROM_YEAR = { 2026 => 0 }.freeze
+
+  def label_from_value(value, _log = nil, _user = nil)
+    return unless value
+
+    return "Prefers not to say" if value == "R"
+
+    super
+  end
 end

--- a/app/models/form/sales/questions/sex_registered_at_birth2.rb
+++ b/app/models/form/sales/questions/sex_registered_at_birth2.rb
@@ -17,4 +17,12 @@ class Form::Sales::Questions::SexRegisteredAtBirth2 < ::Form::Question
   }.freeze
 
   QUESTION_NUMBER_FROM_YEAR = { 2026 => 0 }.freeze
+
+  def label_from_value(value, _log = nil, _user = nil)
+    return unless value
+
+    return "Prefers not to say" if value == "R"
+
+    super
+  end
 end


### PR DESCRIPTION
Final tweak for this ticket after getting confirmation from Rachel, we now uses the generic "Prefers not to say" text in all CYA pages (and csv downloads) rather than "Tenant/Person prefers not to say".


Screenshots:
<img width="879" height="574" alt="image" src="https://github.com/user-attachments/assets/2127dd4b-3c89-4157-a186-a4fe33c502a5" />

<img width="870" height="650" alt="image" src="https://github.com/user-attachments/assets/6e2f32b6-6826-4f5b-a193-062dd1fef521" />

<img width="881" height="989" alt="image" src="https://github.com/user-attachments/assets/3ba7f34e-a349-4c3e-91ad-3432bce0e278" />

<img width="160" height="54" alt="image" src="https://github.com/user-attachments/assets/031507f4-5159-468e-8ea1-847a9b1337cc" />


