### PR TITLE
CLDC-4105: Ensure hhmemb is not >8 for validation

### DIFF
--- a/app/models/validations/soft_validations.rb
+++ b/app/models/validations/soft_validations.rb
@@ -288,6 +288,8 @@ private
   end
 
   def at_least_one_person_working_situation_is_illness?
+    return if hhmemb.present? && hhmemb > 8
+
     person_count = hhmemb || 8
 
     (1..person_count).any? { |n| public_send("ecstat#{n}") == 8 }


### PR DESCRIPTION
bugfix for [CLDC-4105](https://mhclgdigital.atlassian.net/browse/CLDC-4105)

otherwise the send to ecstatn will fail

this can happen whilst running validation checks

[CLDC-4105]: https://mhclgdigital.atlassian.net/browse/CLDC-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ