### PR TITLE
CLDC-4142: Add CYA override for gender_same_as_sex

### DIFF
--- a/app/models/form/lettings/questions/gender_same_as_sex.rb
+++ b/app/models/form/lettings/questions/gender_same_as_sex.rb
@@ -7,6 +7,7 @@ class Form::Lettings::Questions::GenderSameAsSex < ::Form::Question
     @conditional_for = { "gender_description#{person_index}" => [2] }
     @person_index = person_index
     @question_number = question_number
+    @inferred_check_answers_value = [{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }]
   end
 
   def answer_options

--- a/spec/models/form/lettings/questions/gender_same_as_sex_spec.rb
+++ b/spec/models/form/lettings/questions/gender_same_as_sex_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -72,7 +72,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -102,7 +102,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -132,7 +132,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -162,7 +162,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -192,7 +192,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -222,7 +222,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do
@@ -252,7 +252,7 @@ RSpec.describe Form::Lettings::Questions::GenderSameAsSex, type: :model do
     end
 
     it "has the correct inferred_check_answers_value" do
-      expect(question.inferred_check_answers_value).to be_nil
+      expect(question.inferred_check_answers_value).to eq([{ "condition" => { "gender_same_as_sex#{person_index}" => 2 }, "value" => "No" }])
     end
 
     it "has the correct question number" do


### PR DESCRIPTION
improvement for [CLDC-4142](https://mhclgdigital.atlassian.net/browse/CLDC-4142)

it's clearer for 'No' here as the below question in CYA talks above gender identity description

as requested by client

<img alt="household characteristics cya page person 2" src="https://github.com/user-attachments/assets/f154845d-6ac4-4905-8da6-614a8332a513" />


[CLDC-4142]: https://mhclgdigital.atlassian.net/browse/CLDC-4142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ