### PR TITLE
CLDC-4237: Fix sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -32,7 +32,9 @@ Redis.silence_deprecations = true
 
 Sidekiq.configure_server do |config|
   config.on(:startup) do
-    Sidekiq::Cron::Job.all.find_each(&:destroy)
+    # rubocop:disable Rails/FindEach
+    Sidekiq::Cron::Job.all.each(&:destroy)
+    # rubocop:enable Rails/FindEach
     unless FeatureToggle.service_moved? || FeatureToggle.service_unavailable?
       Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/sidekiq_cron_schedule.yml")
     end


### PR DESCRIPTION
bugfix for [CLDC-4237](https://mhclgdigital.atlassian.net/browse/CLDC-4237)

use each over for_each in sidekiq init

linter incorrectly assumes it is an activerecord relation

[CLDC-4237]: https://mhclgdigital.atlassian.net/browse/CLDC-4237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ