### PR TITLE
CLDC-4164: Update purchase price minimum to £15,000 for 2026 onwards

### DIFF
--- a/app/models/form/sales/questions/purchase_price.rb
+++ b/app/models/form/sales/questions/purchase_price.rb
@@ -3,7 +3,7 @@ class Form::Sales::Questions::PurchasePrice < ::Form::Question
     super(id, hsh, page)
     @id = "value"
     @type = "numeric"
-    @min = 0
+    @min = form.start_year_2026_or_later? ? 15_000 : 0
     @step = 0.01
     @width = 5
     @prefix = "£"


### PR DESCRIPTION
closes [CLDC-4164](https://mhclgdigital.atlassian.net/browse/CLDC-4164)

updates the minimum value validation for the purchase price question (Q80) to be at least £15,000 for forms starting in 2026 or later

for earlier years, the minimum remains £0 (no minimum)

[CLDC-4164]: https://mhclgdigital.atlassian.net/browse/CLDC-4164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ