### PR TITLE
CLDC-4119: Add UPRN & address line 1 to 2025 bulk upload duplicate check

### DIFF
--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -555,6 +555,8 @@ class BulkUpload::Lettings::Year2025::RowParser
       "field_10", # startdate
       "field_13", # tenancycode
       !general_needs? ? :field_6.to_s : nil, # location
+      !supported_housing? ? "field_18" : nil,  # uprn
+      !supported_housing? ? "field_19" : nil,  # address line 1
       !supported_housing? ? "field_23" : nil,  # postcode
       !supported_housing? ? "field_24" : nil,  # postcode
       "field_42", # age1
@@ -718,6 +720,8 @@ private
       "ecstat1",
       "owning_organisation",
       "tcharge",
+      !supported_housing? ? "uprn" : nil,
+      !supported_housing? ? "address_line1" : nil,
       !supported_housing? ? "postcode_full" : nil,
       !general_needs? ? "location" : nil,
       "tenancycode",
@@ -1000,6 +1004,8 @@ private
       errors.add(:field_13, error_message) # tenancycode
       errors.add(:field_6, error_message) if !general_needs? && :field_6.present? # location
       errors.add(:field_5, error_message) if !general_needs? && :field_6.blank? # add to Scheme field as unclear whether log uses New or Old CORE ids
+      errors.add(:field_18, error_message) unless supported_housing? # uprn
+      errors.add(:field_19, error_message) unless supported_housing? # address_line1
       errors.add(:field_23, error_message) unless supported_housing? # postcode_full
       errors.add(:field_24, error_message) unless supported_housing? # postcode_full
       errors.add(:field_25, error_message) unless supported_housing? # la

--- a/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
@@ -291,6 +291,8 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
                 :field_9, # startdate
                 :field_10, # startdate
                 :field_13, # tenancycode
+                :field_18, # uprn
+                :field_19, # address_line1
                 :field_23, # postcode_full
                 :field_24, # postcode_full
                 :field_25, # postcode_full


### PR DESCRIPTION
missed work for [CLDC-4119](https://mhclgdigital.atlassian.net/browse/CLDC-4119) #3179 

adds the agreed duplicate checking for 2025 logs.

note the UI flow dupe checking already accounts for 2025 logs correctly so no changes needed there

[CLDC-4119]: https://mhclgdigital.atlassian.net/browse/CLDC-4119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ