### PR TITLE
CLDC-4179: Amend sales duplicate log check

### DIFF
--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -18,6 +18,7 @@ class SalesLog < Log
   include Validations::Sales::SoftValidations
   include Validations::SoftValidations
   include MoneyFormattingHelper
+  include CollectionTimeHelper
 
   self.inheritance_column = :_type_disabled
 
@@ -37,6 +38,8 @@ class SalesLog < Log
   belongs_to :managing_organisation, class_name: "Organisation", optional: true
 
   scope :filter_by_year, ->(year) { where(saledate: Time.zone.local(year.to_i, 4, 1)...Time.zone.local(year.to_i + 1, 4, 1)) }
+  scope :filter_by_year_or_later, ->(year) { where("sales_logs.saledate >= ?", Time.zone.local(year.to_i, 4, 1)) }
+  scope :filter_by_year_or_earlier, ->(year) { where("sales_logs.saledate < ?", Time.zone.local(year.to_i + 1, 4, 1)) }
   scope :filter_by_years_or_nil, lambda { |years, _user = nil|
     first_year = years.shift
     query = filter_by_year(first_year)
@@ -69,12 +72,14 @@ class SalesLog < Log
   }
   scope :age1_answered, -> { where.not(age1: nil).or(where(age1_known: [1, 2])) }
   scope :ecstat1_answered, -> { where.not(ecstat1: nil).or(where("saledate >= ?", Time.zone.local(2025, 4, 1))) }
+  scope :sex1_answered, -> { where.not(sex1: nil).filter_by_year_or_earlier(2025).or(where.not(sexrab1: nil).filter_by_year_or_later(2026)) }
+  scope :address_answered, -> { where.not(postcode_full: nil).where.not(address_line1: nil).or(where.not(uprn: nil)) }
   scope :duplicate_logs, lambda { |log|
     visible.where(log.slice(*DUPLICATE_LOG_ATTRIBUTES))
     .where.not(id: log.id)
     .where.not(saledate: nil)
-    .where.not(sex1: nil)
-    .where.not(postcode_full: nil)
+    .sex1_answered
+    .address_answered
     .ecstat1_answered
     .age1_answered
   }
@@ -84,8 +89,8 @@ class SalesLog < Log
     scope = visible
     .group(*DUPLICATE_LOG_ATTRIBUTES)
     .where.not(saledate: nil)
-    .where.not(sex1: nil)
-    .where.not(postcode_full: nil)
+    .sex1_answered
+    .address_answered
     .age1_answered
     .ecstat1_answered
     .having("COUNT(*) > 1")
@@ -98,7 +103,7 @@ class SalesLog < Log
   }
 
   OPTIONAL_FIELDS = %w[purchid othtype buyers_organisations].freeze
-  DUPLICATE_LOG_ATTRIBUTES = %w[owning_organisation_id purchid saledate age1_known age1 sex1 ecstat1 postcode_full].freeze
+  DUPLICATE_LOG_ATTRIBUTES = %w[owning_organisation_id purchid saledate age1_known age1 sex1 sexrab1 ecstat1 postcode_full uprn address_line1].freeze
 
   def lettings?
     false
@@ -502,10 +507,12 @@ class SalesLog < Log
     ["owning_organisation_id",
      "saledate",
      "purchid",
+     "address_line1",
+     "postcode_full",
+     "uprn",
      "age1",
-     "sex1",
      "ecstat1",
-     uprn.blank? ? "postcode_full" : "uprn"].compact
+     form.start_year_2026_or_later? ? "sexrab1" : "sex1"].compact
   end
 
   def soctenant_is_inferred?

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -533,6 +533,8 @@ class BulkUpload::Sales::Year2025::RowParser
       "field_2",  # saledate
       "field_3",  # saledate
       "field_7",  # purchaser_code
+      "field_16", # uprn
+      "field_17", # address_line1
       "field_21", # postcode
       "field_22", # postcode
       "field_28", # age1
@@ -1287,6 +1289,8 @@ private
       ecstat1
       owning_organisation
       postcode_full
+      uprn
+      address_line1
       purchid
     ]
   end
@@ -1457,6 +1461,8 @@ private
       errors.add(:field_1, error_message) # Sale completion date
       errors.add(:field_2, error_message) # Sale completion date
       errors.add(:field_3, error_message) # Sale completion date
+      errors.add(:field_16, error_message) # UPRN
+      errors.add(:field_17, error_message) # Address line 1
       errors.add(:field_21, error_message) # Postcode
       errors.add(:field_22, error_message) # Postcode
       errors.add(:field_28, error_message) # Buyer 1 age

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -536,6 +536,8 @@ class BulkUpload::Sales::Year2026::RowParser
       "field_2",  # saledate
       "field_3",  # saledate
       "field_7",  # purchaser_code
+      "field_16", # uprn
+      "field_17", # address_line1
       "field_21", # postcode
       "field_22", # postcode
       "field_28", # age1
@@ -1291,6 +1293,8 @@ private
       ecstat1
       owning_organisation
       postcode_full
+      uprn
+      address_line1
       purchid
     ]
   end
@@ -1461,6 +1465,8 @@ private
       errors.add(:field_1, error_message) # Sale completion date
       errors.add(:field_2, error_message) # Sale completion date
       errors.add(:field_3, error_message) # Sale completion date
+      errors.add(:field_16, error_message) # UPRN
+      errors.add(:field_17, error_message) # Address line 1
       errors.add(:field_21, error_message) # Postcode
       errors.add(:field_22, error_message) # Postcode
       errors.add(:field_28, error_message) # Buyer 1 age

--- a/spec/factories/sales_log.rb
+++ b/spec/factories/sales_log.rb
@@ -67,6 +67,7 @@ FactoryBot.define do
       sexrab1 { "F" }
       sex1 { "F" }
       ecstat1 { 1 }
+      address_line1 { "same address line 1" }
       postcode_full { "A1 1AA" }
       noint { 2 }
       uprn_known { 0 }

--- a/spec/features/sales_log_spec.rb
+++ b/spec/features/sales_log_spec.rb
@@ -352,16 +352,6 @@ RSpec.describe "Sales Log Features" do
   end
 
   context "when a log becomes a duplicate" do
-    before do
-      Timecop.freeze(Time.zone.local(2024, 3, 3))
-      Singleton.__init__(FormHandler)
-    end
-
-    after do
-      Timecop.return
-      Singleton.__init__(FormHandler)
-    end
-
     context "and updating duplicate log" do
       let(:user) { create(:user, :data_coordinator) }
       let(:sales_log) { create(:sales_log, :duplicate, assigned_to: user) }

--- a/spec/requests/duplicate_logs_controller_spec.rb
+++ b/spec/requests/duplicate_logs_controller_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe DuplicateLogsController, type: :request do
               expect(page).to have_content("- Buyer 1’s gender identity", count: 3)
               expect(page).to have_content("- Buyer 1’s working situation", count: 3)
               expect(page).to have_content("- Postcode", count: 3)
-              expect(page).to have_link("Change", count: 21)
+              expect(page).to have_content("- Address line 1", count: 3)
+              expect(page).to have_link("Change", count: 24)
               expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?first_remaining_duplicate_id=#{duplicate_logs[0].id}&organisation_id=#{sales_log.owning_organisation_id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
               expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&organisation_id=#{sales_log.owning_organisation_id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
               expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&organisation_id=#{sales_log.owning_organisation_id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
@@ -216,7 +217,8 @@ RSpec.describe DuplicateLogsController, type: :request do
                 expect(page).to have_content("- Buyer 1’s gender identity", count: 1)
                 expect(page).to have_content("- Buyer 1’s working situation", count: 1)
                 expect(page).to have_content("- Postcode", count: 1)
-                expect(page).to have_link("Change", count: 7)
+                expect(page).to have_content("- Address line 1", count: 1)
+                expect(page).to have_link("Change", count: 8)
                 expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=interruption_screen")
               end
 
@@ -242,7 +244,8 @@ RSpec.describe DuplicateLogsController, type: :request do
                 expect(page).to have_content("- Buyer 1’s gender identity", count: 1)
                 expect(page).to have_content("- Buyer 1’s working situation", count: 1)
                 expect(page).to have_content("- Postcode", count: 1)
-                expect(page).to have_link("Change", count: 7)
+                expect(page).to have_content("- Address line 1", count: 1)
+                expect(page).to have_link("Change", count: 8)
                 expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=interruption_screen")
               end
 
@@ -377,7 +380,8 @@ RSpec.describe DuplicateLogsController, type: :request do
               expect(page).to have_content("- Buyer 1’s gender identity", count: 3)
               expect(page).to have_content("- Buyer 1’s working situation", count: 3)
               expect(page).to have_content("- Postcode", count: 3)
-              expect(page).to have_link("Change", count: 18)
+              expect(page).to have_content("- Address line 1", count: 3)
+              expect(page).to have_link("Change", count: 21)
               expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?first_remaining_duplicate_id=#{duplicate_logs[0].id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
               expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[0].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
               expect(page).to have_link("Change", href: "/sales-logs/#{duplicate_logs[1].id}/purchaser-code?first_remaining_duplicate_id=#{sales_log.id}&original_log_id=#{sales_log.id}&referrer=duplicate_logs")
@@ -405,7 +409,8 @@ RSpec.describe DuplicateLogsController, type: :request do
                 expect(page).to have_content("- Buyer 1’s gender identity", count: 1)
                 expect(page).to have_content("- Buyer 1’s working situation", count: 1)
                 expect(page).to have_content("- Postcode", count: 1)
-                expect(page).to have_link("Change", count: 6)
+                expect(page).to have_content("- Address line 1", count: 1)
+                expect(page).to have_link("Change", count: 7)
                 expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=interruption_screen")
               end
 
@@ -431,7 +436,8 @@ RSpec.describe DuplicateLogsController, type: :request do
                 expect(page).to have_content("- Buyer 1’s gender identity", count: 1)
                 expect(page).to have_content("- Buyer 1’s working situation", count: 1)
                 expect(page).to have_content("- Postcode", count: 1)
-                expect(page).to have_link("Change", count: 6)
+                expect(page).to have_content("- Address line 1", count: 1)
+                expect(page).to have_link("Change", count: 7)
                 expect(page).to have_link("Change", href: "/sales-logs/#{sales_log.id}/purchaser-code?original_log_id=#{sales_log.id}&referrer=interruption_screen")
               end
 

--- a/spec/services/bulk_upload/sales/validator_spec.rb
+++ b/spec/services/bulk_upload/sales/validator_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe BulkUpload::Sales::Validator do
       end
 
       it "creates errors" do
-        expect { validator.call }.to change(BulkUploadError.where(category: :setup, error: "This is a duplicate of a log in your file."), :count).by(20)
+        expect { validator.call }.to change(BulkUploadError.where(category: :setup, error: "This is a duplicate of a log in your file."), :count).by(24)
       end
     end
   end

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -784,6 +784,8 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
           :field_1, # Sale completion date
           :field_2, # Sale completion date
           :field_3, # Sale completion date
+          :field_16, # UPRN
+          :field_17, # Address line 1
           :field_21, # Postcode
           :field_22, # Postcode
           :field_28, # Buyer 1 age
@@ -814,6 +816,8 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
           :field_1, # Sale completion date
           :field_2, # Sale completion date
           :field_3, # Sale completion date
+          :field_16, # UPRN
+          :field_17, # Address line 1
           :field_21, # Postcode
           :field_22, # Postcode
           :field_28, # Buyer 1 age

--- a/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
@@ -785,6 +785,8 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
           :field_1, # Sale completion date
           :field_2, # Sale completion date
           :field_3, # Sale completion date
+          :field_16, # UPRN
+          :field_17, # Address line 1
           :field_21, # Postcode
           :field_22, # Postcode
           :field_28, # Buyer 1 age
@@ -815,6 +817,8 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
           :field_1, # Sale completion date
           :field_2, # Sale completion date
           :field_3, # Sale completion date
+          :field_16, # UPRN
+          :field_17, # Address line 1
           :field_21, # Postcode
           :field_22, # Postcode
           :field_28, # Buyer 1 age


### PR DESCRIPTION
closes [CLDC-4179](https://mhclgdigital.atlassian.net/browse/CLDC-4179)

see also #3179 and #3205 for lettings log equivalent changes

makes the same set of changes for sales logs

- use new sexrab1 question for 2026. keep using sex1 for 2025
- add uprn and address_line1 to duplicate fields

in both the frontend UI and BU

<details><summary>screenshots</summary>
bulk upload duplicate error
<img alt="bulk upload duplicate error" src="https://github.com/user-attachments/assets/161ff4f8-4d0b-4e7b-9b92-a8d73c241ac1" />

duplicate logs 2025 manual address
<img alt="duplicate logs 2025 manual address" src="https://github.com/user-attachments/assets/c0710878-ca79-482d-8119-6a543b5c6c47" />

duplicate logs 2025 uprn entered
<img alt="duplicate logs 2025 uprn entered" src="https://github.com/user-attachments/assets/586cc32a-6306-4342-8bec-bbfdfcd10e4b" />

duplicate logs 2026 manual address
<img alt="duplicate logs 2026 manual address" src="https://github.com/user-attachments/assets/5482695a-b72e-422b-856e-9b51269d836a" />

duplicate logs 2026 uprn entered
<img alt="duplicate logs 2026 uprn entered" src="https://github.com/user-attachments/assets/25f1e9b9-f547-48f8-ac1f-01ae47cda961" />
</details>

[CLDC-4179]: https://mhclgdigital.atlassian.net/browse/CLDC-4179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ