### PR TITLE
CLDC-4226: Unionise org filter scope

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -52,8 +52,8 @@ class Log < ApplicationRecord
   scope :imported_2023, -> { imported.filter_by_year(2023) }
   # TODO: CLDC-4273: use .union in filter_by_organisation rather than raw SQL
   scope :filter_by_organisation, lambda { |orgs, _user = nil|
-    owned = where(owning_organisation: orgs).select(:id)
-    managed = where(managing_organisation: orgs).select(:id)
+    owned = unscoped { where(owning_organisation: orgs).select(:id) }
+    managed = unscoped { where(managing_organisation: orgs).select(:id) }
 
     where("#{table_name}.id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
   }

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -50,6 +50,7 @@ class Log < ApplicationRecord
   scope :has_old_form_id, -> { where.not(old_form_id: nil) }
   scope :imported_2023_with_old_form_id, -> { imported.filter_by_year(2023).has_old_form_id }
   scope :imported_2023, -> { imported.filter_by_year(2023) }
+  # TODO: CLDC-4273: use .union in filter_by_organisation rather than raw SQL
   scope :filter_by_organisation, lambda { |orgs, _user = nil|
     owned   = unscoped.where(owning_organisation: orgs).select(:id)
     managed = unscoped.where(managing_organisation: orgs).select(:id)

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -50,7 +50,12 @@ class Log < ApplicationRecord
   scope :has_old_form_id, -> { where.not(old_form_id: nil) }
   scope :imported_2023_with_old_form_id, -> { imported.filter_by_year(2023).has_old_form_id }
   scope :imported_2023, -> { imported.filter_by_year(2023) }
-  scope :filter_by_organisation, ->(org, _user = nil) { where(owning_organisation: org).or(where(managing_organisation: org)) }
+  scope :filter_by_organisation, lambda { |orgs, _user = nil|
+    owned   = unscoped.where(owning_organisation: orgs).select(:id)
+    managed = unscoped.where(managing_organisation: orgs).select(:id)
+
+    where("#{table_name}.id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
+  }
   scope :filter_by_owning_organisation, ->(owning_organisation, _user = nil) { where(owning_organisation:) }
   scope :filter_by_managing_organisation, ->(managing_organisation, _user = nil) { where(managing_organisation:) }
   scope :filter_by_user_text_search, ->(param, user) { where(assigned_to: User.visible(user).search_by(param)) }

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -52,10 +52,10 @@ class Log < ApplicationRecord
   scope :imported_2023, -> { imported.filter_by_year(2023) }
   # TODO: CLDC-4273: use .union in filter_by_organisation rather than raw SQL
   scope :filter_by_organisation, lambda { |orgs, _user = nil|
-    owned   = unscoped.where(owning_organisation: orgs).select(:id)
-    managed = unscoped.where(managing_organisation: orgs).select(:id)
+    owned = where(owning_organisation: orgs).select(:id)
+    managed = where(managing_organisation: orgs).select(:id)
 
-    where("#{table_name}.id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
+    where("id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
   }
   scope :filter_by_owning_organisation, ->(owning_organisation, _user = nil) { where(owning_organisation:) }
   scope :filter_by_managing_organisation, ->(managing_organisation, _user = nil) { where(managing_organisation:) }

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -55,7 +55,7 @@ class Log < ApplicationRecord
     owned = where(owning_organisation: orgs).select(:id)
     managed = where(managing_organisation: orgs).select(:id)
 
-    where("id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
+    where("#{table_name}.id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
   }
   scope :filter_by_owning_organisation, ->(owning_organisation, _user = nil) { where(owning_organisation:) }
   scope :filter_by_managing_organisation, ->(managing_organisation, _user = nil) { where(managing_organisation:) }


### PR DESCRIPTION
Closes [CLDC-4226](https://mhclgdigital.atlassian.net/browse/CLDC-4226).

The migration that the previous PR for this ticket applied has been successfully applied, but the prod db is still unable to use it. I've done some further investigation and the POSTGRES is still making the inefficient scanning choice it was making before this migration, which comes down to the `filter_by_organisations` scope. This has an `.or` on managing and owning orgs, which is the key restriction preventing the new indices from being used. So, the solution is to use a UNION instead. Our current version of rails doesn't allow `.union` so I've done this in raw SQL but it's a simple enough query.

```
org = Organisation.find(1032)
orgs = org.absorbed_organisations + [org]
years = [2024, 2025, 2026]

# OLD (OR)
old_scope = LettingsLog.visible
  .where(owning_organisation: orgs).or(LettingsLog.visible.where(managing_organisation: orgs))
  .filter_by_years_or_nil(years.dup)
  .order(id: :desc).limit(20)

puts "=== OLD (OR) ==="
t = Time.now
old_ids = old_scope.pluck(:id)
old_time = Time.now - t
puts "IDs: #{old_ids}"
puts "Time: #{old_time}s"

# NEW (ANY(ARRAY(UNION))) — hardcoded
owned   = LettingsLog.where(owning_organisation: orgs).select(:id)
managed = LettingsLog.where(managing_organisation: orgs).select(:id)
new_scope = LettingsLog.visible
  .where("id = ANY(ARRAY(#{owned.to_sql} UNION #{managed.to_sql}))")
  .filter_by_years_or_nil(years.dup)
  .order(id: :desc).limit(20)

puts
puts "=== NEW (ANY(ARRAY(UNION))) ==="
t = Time.now
new_ids = new_scope.pluck(:id)
new_time = Time.now - t
puts "IDs: #{new_ids}"
puts "Time: #{new_time}s"

puts
puts "IDs match: #{old_ids == new_ids}"
puts "Speedup: #{(old_time / new_time).round(0)}x"
```
Returns the following, so we can be confident this will work on prod. I've also confirmed the IDs returned are the same; the outputs of the old vs new scope are identical.

```
=== OLD (OR) ===
IDs: [1013652, 1013569, 1013063, 983308, 789628, 789590, 789464, 789338, 789221, 788895]
Time: 43.271396378s

=== NEW (ANY(ARRAY(UNION))) ===
IDs: [1013652, 1013569, 1013063, 983308, 789628, 789590, 789464, 789338, 789221, 788895]
Time: 0.024607612s

IDs match: true
Speedup: 1758x
```

[CLDC-4226]: https://mhclgdigital.atlassian.net/browse/CLDC-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ