### PR TITLE
CLDC-4271: Rework BU error hiding logic

### DIFF
--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -679,10 +679,17 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
-            error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
-            errors.add(field, message: error_message, category: :soft_validation)
+          error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
+
+          # skip if an existing error with the same message on the same question.
+          # this is needed since a single soft validation will appear in n places on the flow
+          # and a soft validation contains m interruption screen question IDs.
+          # without this filter we'd add n * m errors
+          next unless errors.none? do |e|
+            e.options[:message] == error_message && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute)
           end
+
+          errors.add(field, message: error_message, category: :soft_validation)
         end
       end
     end

--- a/app/services/bulk_upload/lettings/year2026/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2026/row_parser.rb
@@ -717,10 +717,17 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
-            error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
-            errors.add(field, message: error_message, category: :soft_validation)
+          error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
+
+          # skip if an existing error with the same message on the same question.
+          # this is needed since a single soft validation will appear in n places on the flow
+          # and a soft validation contains m interruption screen question IDs.
+          # without this filter we'd add n * m errors
+          next unless errors.none? do |e|
+            e.options[:message] == error_message && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute)
           end
+
+          errors.add(field, message: error_message, category: :soft_validation)
         end
       end
     end

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -1475,10 +1475,17 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
-            error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
-            errors.add(field, message: error_message, category: :soft_validation)
+          error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
+
+          # skip if an existing error with the same message on the same question.
+          # this is needed since a single soft validation will appear in n places on the flow
+          # and a soft validation contains m interruption screen question IDs.
+          # without this filter we'd add n * m errors
+          next unless errors.none? do |e|
+            e.options[:message] == error_message && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute)
           end
+
+          errors.add(field, message: error_message, category: :soft_validation)
         end
       end
     end

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -1515,10 +1515,17 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
-            error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
-            errors.add(field, message: error_message, category: :soft_validation)
+          error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
+
+          # skip if an existing error with the same message on the same question.
+          # this is needed since a single soft validation will appear in n places on the flow
+          # and a soft validation contains m interruption screen question IDs.
+          # without this filter we'd add n * m errors
+          next unless errors.none? do |e|
+            e.options[:message] == error_message && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute)
           end
+
+          errors.add(field, message: error_message, category: :soft_validation)
         end
       end
     end


### PR DESCRIPTION
# pending CORE confirmation on how the BU parser should work

closes [CLDC-4271](https://mhclgdigital.atlassian.net/browse/CLDC-4271)

make the BU parser logic consistent across sales & lettings

right now it works like:
- lettings: only add soft validation error to that question if there are no other errors
- sales: only add soft validation error to that question if there are no other soft validation errors

not sure that either of these two approaches are quite correct. in the following report it's sensible to have two soft validations on the same question:

<img alt="bu with two errors on ap2 lead tenants age" src="https://github.com/user-attachments/assets/aafc0305-31fa-4ba6-ba9a-6a459b28c4ef" />

the code below will only skip adding the error if there's already one on the same question with the same text. this should make all meaningful soft validation errors shown

[CLDC-4271]: https://mhclgdigital.atlassian.net/browse/CLDC-4271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ