### PR TITLE
CLDC-4212, CLDC-4213, CLDC-4214: Add 0.1% tolerance to all calculations that involve %s of a value

### DIFF
--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -268,10 +268,20 @@ class SalesLog < Log
     value * equity / 100
   end
 
-  def expected_shared_ownership_deposit_value_range
-    return unless value && equity
+  def expected_shared_ownership_deposit_value_tolerance
+    return 1 unless value && equity
 
-    (value * ((equity - 0.1) / 100)..value * ((equity + 0.1) / 100))
+    # we found that a simple tolerance was not quite what we wanted here.
+    # CORE wants it so if a user say, has a 66.6% equity then can enter either 66.6% or 66.7%
+    # so in 2026 we base our tolerance off of a discount 0.1% higher or lower
+    if form.start_year_2026_or_later?
+      lower_bound = value * ((equity - 0.1) / 100)
+      upper_bound = value * ((equity + 0.1) / 100)
+
+      (upper_bound - lower_bound) / 2
+    else
+      1
+    end
   end
 
   def stairbought_part_of_value
@@ -474,13 +484,20 @@ class SalesLog < Log
     value - discount_amount
   end
 
-  def value_with_discount_range
-    return if value.blank?
-    return (value..value) if discount.nil?
+  def value_with_discount_tolerance
+    return 1 if value.blank? || discount.nil?
 
-    discount_amount_lower_bound = value * (discount - 0.1) / 100
-    discount_amount_upper_bound = value * (discount + 0.1) / 100
-    (value - discount_amount_upper_bound..value - discount_amount_lower_bound)
+    # we found that a simple tolerance was not quite what we wanted here.
+    # CORE wants it so if a user say, has a 66.6% discount then can enter either 66.6% or 66.7%
+    # so in 2026 we base our tolerance off of a discount 0.1% higher or lower
+    if form.start_year_2026_or_later?
+      discount_amount_lower_bound = value * (discount - 0.1) / 100
+      discount_amount_upper_bound = value * (discount + 0.1) / 100
+
+      (discount_amount_upper_bound - discount_amount_lower_bound) / 2
+    else
+      discount ? value * 0.05 / 100 : 1
+    end
   end
 
   def mortgage_deposit_and_grant_total

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -271,8 +271,8 @@ class SalesLog < Log
   def expected_shared_ownership_deposit_value_tolerance
     return 1 unless value && equity
 
-    # we found that a simple tolerance was not quite what we wanted here.
-    # CORE wants it so if a user say, has a 66.6% equity then can enter either 66.6% or 66.7%
+    # we found that a fixed tolerance was not quite what we wanted here.
+    # CORE wants it so if a user say, has a 66.666% equity they can enter either 66.6% or 66.7% (or 66.5%)
     # so in 2026 we base our tolerance off of a discount 0.1% higher or lower
     if form.start_year_2026_or_later?
       lower_bound = value * ((equity - 0.1) / 100)

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -268,6 +268,12 @@ class SalesLog < Log
     value * equity / 100
   end
 
+  def expected_shared_ownership_deposit_value_range
+    return unless value && equity
+
+    (value * ((equity - 0.1) / 100)..value * ((equity + 0.1) / 100))
+  end
+
   def stairbought_part_of_value
     return unless value && stairbought
 
@@ -466,6 +472,15 @@ class SalesLog < Log
 
     discount_amount = discount ? value * discount / 100 : 0
     value - discount_amount
+  end
+
+  def value_with_discount_range
+    return if value.blank?
+    return (value..value) if discount.nil?
+
+    discount_amount_lower_bound = value * (discount - 0.1) / 100
+    discount_amount_upper_bound = value * (discount + 0.1) / 100
+    (value - discount_amount_upper_bound..value - discount_amount_lower_bound)
   end
 
   def mortgage_deposit_and_grant_total

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -80,10 +80,7 @@ module Validations::Sales::SaleInformationValidations
     return unless record.mortgage || record.mortgageused == 2 || record.mortgageused == 3
     return unless record.discount || record.grant || record.type == 29
 
-    # When a percentage discount is used, a percentage tolerance is needed to account for rounding errors
-    tolerance = record.discount ? record.value * 0.05 / 100 : 1
-
-    if over_tolerance?(record.mortgage_deposit_and_grant_total, record.value_with_discount, tolerance, strict: !record.discount.nil?) && record.discounted_ownership_sale?
+    if mortgage_deposit_and_grant_total_is_over_discount_tolerance?(record) && record.discounted_ownership_sale?
       deposit_and_grant_sentence = record.grant.present? ? ", cash deposit (#{record.field_formatted_as_currency('deposit')}), and grant (#{record.field_formatted_as_currency('grant')})" : " and cash deposit (#{record.field_formatted_as_currency('deposit')})"
       discount_sentence = record.discount.present? ? " (#{record.field_formatted_as_currency('value')}) subtracted by the sum of the full purchase price (#{record.field_formatted_as_currency('value')}) multiplied by the percentage discount (#{record.discount}%)" : ""
       %i[mortgageused mortgage value deposit discount grant].each do |field|
@@ -207,7 +204,7 @@ module Validations::Sales::SaleInformationValidations
     if record.mortgage_used?
       return unless record.mortgage
 
-      if over_tolerance?(record.mortgage_deposit_and_discount_total, record.expected_shared_ownership_deposit_value, 1)
+      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.mortgage_deposit_and_discount_total, record)
         %i[mortgage value deposit cashdis equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_used_socialhomebuy",
                                           mortgage: record.field_formatted_as_currency("mortgage"),
@@ -228,7 +225,7 @@ module Validations::Sales::SaleInformationValidations
                                                                  expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     elsif record.mortgage_not_used?
-      if over_tolerance?(record.deposit_and_discount_total, record.expected_shared_ownership_deposit_value, 1)
+      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.deposit_and_discount_total, record)
         %i[mortgageused value deposit cashdis equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_not_used_socialhomebuy",
                                           deposit_and_discount_total: record.field_formatted_as_currency("deposit_and_discount_total"),
@@ -253,7 +250,7 @@ module Validations::Sales::SaleInformationValidations
     if record.mortgage_used?
       return unless record.mortgage
 
-      if over_tolerance?(record.mortgage_and_deposit_total, record.expected_shared_ownership_deposit_value, 1)
+      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.mortgage_and_deposit_total, record)
         %i[mortgage value deposit equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_used",
                                           mortgage: record.field_formatted_as_currency("mortgage"),
@@ -272,7 +269,7 @@ module Validations::Sales::SaleInformationValidations
                                                                  expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     elsif record.mortgage_not_used?
-      if over_tolerance?(record.deposit, record.expected_shared_ownership_deposit_value, 1)
+      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.deposit, record)
         %i[mortgageused value deposit equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_not_used",
                                           deposit: record.field_formatted_as_currency("deposit"),
@@ -393,6 +390,25 @@ module Validations::Sales::SaleInformationValidations
     if record.firststair == 2 && record.numstair < 2
       record.errors.add :numstair, I18n.t("validations.sales.sale_information.numstair.must_be_greater_than_one")
       record.errors.add :firststair, I18n.t("validations.sales.sale_information.firststair.cannot_be_no")
+    end
+  end
+
+  def total_is_over_expected_shared_ownership_deposit_tolerance?(total, record)
+    if record.form.start_year_2026_or_later?
+      !record.expected_shared_ownership_deposit_value_range.cover?(total)
+    else
+      over_tolerance?(total, record.expected_shared_ownership_deposit_value, 1)
+    end
+  end
+
+  def mortgage_deposit_and_grant_total_is_over_discount_tolerance?(record)
+    if record.form.start_year_2026_or_later?
+      !record.value_with_discount_range.cover?(record.mortgage_deposit_and_grant_total)
+    else
+      # we found that this tolerance still wasn't working for us, so for post 2026 we just calculate a range for 0.1% higher and lower.
+      # this means we can be certain an answer 0.1% higher or lower will always be accepted without needed to backsolve for the tolerance
+      tolerance = record.discount ? record.value * 0.05 / 100 : 1
+      over_tolerance?(record.mortgage_deposit_and_grant_total, record.value_with_discount, tolerance, strict: record.discount.present?)
     end
   end
 

--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -80,7 +80,9 @@ module Validations::Sales::SaleInformationValidations
     return unless record.mortgage || record.mortgageused == 2 || record.mortgageused == 3
     return unless record.discount || record.grant || record.type == 29
 
-    if mortgage_deposit_and_grant_total_is_over_discount_tolerance?(record) && record.discounted_ownership_sale?
+    tolerance = record.value_with_discount_tolerance
+
+    if over_tolerance?(record.mortgage_deposit_and_grant_total, record.value_with_discount, tolerance, strict: !record.discount.nil? || record.form.start_year_2026_or_later?) && record.discounted_ownership_sale?
       deposit_and_grant_sentence = record.grant.present? ? ", cash deposit (#{record.field_formatted_as_currency('deposit')}), and grant (#{record.field_formatted_as_currency('grant')})" : " and cash deposit (#{record.field_formatted_as_currency('deposit')})"
       discount_sentence = record.discount.present? ? " (#{record.field_formatted_as_currency('value')}) subtracted by the sum of the full purchase price (#{record.field_formatted_as_currency('value')}) multiplied by the percentage discount (#{record.discount}%)" : ""
       %i[mortgageused mortgage value deposit discount grant].each do |field|
@@ -201,10 +203,12 @@ module Validations::Sales::SaleInformationValidations
   def check_non_staircasing_socialhomebuy_mortgage(record)
     return unless record.cashdis
 
+    tolerance = record.expected_shared_ownership_deposit_value_tolerance
+
     if record.mortgage_used?
       return unless record.mortgage
 
-      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.mortgage_deposit_and_discount_total, record)
+      if over_tolerance?(record.mortgage_deposit_and_discount_total, record.expected_shared_ownership_deposit_value, tolerance, strict: record.form.start_year_2026_or_later?)
         %i[mortgage value deposit cashdis equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_used_socialhomebuy",
                                           mortgage: record.field_formatted_as_currency("mortgage"),
@@ -225,7 +229,7 @@ module Validations::Sales::SaleInformationValidations
                                                                  expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     elsif record.mortgage_not_used?
-      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.deposit_and_discount_total, record)
+      if over_tolerance?(record.deposit_and_discount_total, record.expected_shared_ownership_deposit_value, tolerance, strict: record.form.start_year_2026_or_later?)
         %i[mortgageused value deposit cashdis equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_not_used_socialhomebuy",
                                           deposit_and_discount_total: record.field_formatted_as_currency("deposit_and_discount_total"),
@@ -247,10 +251,12 @@ module Validations::Sales::SaleInformationValidations
   end
 
   def check_non_staircasing_non_socialhomebuy_mortgage(record)
+    tolerance = record.expected_shared_ownership_deposit_value_tolerance
+
     if record.mortgage_used?
       return unless record.mortgage
 
-      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.mortgage_and_deposit_total, record)
+      if over_tolerance?(record.mortgage_and_deposit_total, record.expected_shared_ownership_deposit_value, tolerance, strict: record.form.start_year_2026_or_later?)
         %i[mortgage value deposit equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_used",
                                           mortgage: record.field_formatted_as_currency("mortgage"),
@@ -269,7 +275,7 @@ module Validations::Sales::SaleInformationValidations
                                                                  expected_shared_ownership_deposit_value: record.field_formatted_as_currency("expected_shared_ownership_deposit_value")).html_safe
       end
     elsif record.mortgage_not_used?
-      if total_is_over_expected_shared_ownership_deposit_tolerance?(record.deposit, record)
+      if over_tolerance?(record.deposit, record.expected_shared_ownership_deposit_value, tolerance, strict: record.form.start_year_2026_or_later?)
         %i[mortgageused value deposit equity].each do |field|
           record.errors.add field, I18n.t("validations.sales.sale_information.#{field}.non_staircasing_mortgage.mortgage_not_used",
                                           deposit: record.field_formatted_as_currency("deposit"),
@@ -390,25 +396,6 @@ module Validations::Sales::SaleInformationValidations
     if record.firststair == 2 && record.numstair < 2
       record.errors.add :numstair, I18n.t("validations.sales.sale_information.numstair.must_be_greater_than_one")
       record.errors.add :firststair, I18n.t("validations.sales.sale_information.firststair.cannot_be_no")
-    end
-  end
-
-  def total_is_over_expected_shared_ownership_deposit_tolerance?(total, record)
-    if record.form.start_year_2026_or_later?
-      !record.expected_shared_ownership_deposit_value_range.cover?(total)
-    else
-      over_tolerance?(total, record.expected_shared_ownership_deposit_value, 1)
-    end
-  end
-
-  def mortgage_deposit_and_grant_total_is_over_discount_tolerance?(record)
-    if record.form.start_year_2026_or_later?
-      !record.value_with_discount_range.cover?(record.mortgage_deposit_and_grant_total)
-    else
-      # we found that this tolerance still wasn't working for us, so for post 2026 we just calculate a range for 0.1% higher and lower.
-      # this means we can be certain an answer 0.1% higher or lower will always be accepted without needed to backsolve for the tolerance
-      tolerance = record.discount ? record.value * 0.05 / 100 : 1
-      over_tolerance?(record.mortgage_deposit_and_grant_total, record.value_with_discount, tolerance, strict: record.discount.present?)
     end
   end
 

--- a/app/models/validations/sales/soft_validations.rb
+++ b/app/models/validations/sales/soft_validations.rb
@@ -117,6 +117,7 @@ module Validations::Sales::SoftValidations
 
   def mortgage_plus_deposit_less_than_discounted_value?
     return unless mortgage && deposit && value && discount
+    return if form.start_year_2026_or_later?
 
     discounted_value = value * (100 - discount) / 100
     mortgage + deposit < discounted_value

--- a/spec/models/validations/sales/sale_information_validations_spec.rb
+++ b/spec/models/validations/sales/sale_information_validations_spec.rb
@@ -663,6 +663,46 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
         expect(record.errors["grant"]).to be_empty
       end
     end
+
+    context "with year 2026", :aggregate_failures do
+      let(:saledate) { Time.zone.local(2026, 4, 1) }
+
+      context "when mortgage and deposit is exact" do
+        let(:record) { FactoryBot.build(:sales_log, saledate:, mortgage: 85_000, deposit: 5_000, value: 100_000, discount: 10, ownershipsch: 2, type: 9) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_discounted_ownership_value(record)
+          expect(record.errors["mortgage"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["discount"]).to be_empty
+        end
+      end
+
+      context "when mortgage and deposit is within 0.1% discount tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, saledate:, mortgage: 85_000, deposit: 5_000, value: 100_000, discount: 10.1, ownershipsch: 2, type: 9) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_discounted_ownership_value(record)
+          expect(record.errors["mortgage"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["discount"]).to be_empty
+        end
+      end
+
+      context "when mortgage and deposit is outside 0.1% discount tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, saledate:, mortgage: 85_000, deposit: 5_000, value: 100_000, discount: 10.2, ownershipsch: 2, type: 9) }
+
+        it "adds an error" do
+          sale_information_validator.validate_discounted_ownership_value(record)
+          expect(record.errors["mortgage"]).not_to be_empty
+          expect(record.errors["value"]).not_to be_empty
+          expect(record.errors["deposit"]).not_to be_empty
+          expect(record.errors["discount"]).not_to be_empty
+        end
+      end
+    end
   end
 
   describe "#validate_outright_sale_value_matches_mortgage_plus_deposit" do
@@ -1168,6 +1208,82 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
           expect(record.errors["equity"]).to be_empty
           expect(record.errors["cashdis"]).to be_empty
           expect(record.errors["type"]).to be_empty
+        end
+      end
+    end
+
+    context "with year 2026", :aggregate_failures do
+      let(:saledate) { Time.zone.local(2026, 4, 1) }
+
+      context "when mortgage and deposit is exact" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 1, mortgage: 10_000, staircase: 2, deposit: 5_000, value: 100_000, equity: 15, ownershipsch: 1, type: 30, saledate:) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgage"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["equity"]).to be_empty
+        end
+      end
+
+      context "when mortgage and deposit is within 0.1% equity tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 1, mortgage: 10_000, staircase: 2, deposit: 5_000, value: 100_000, equity: 15.1, ownershipsch: 1, type: 30, saledate:) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgage"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["equity"]).to be_empty
+        end
+      end
+
+      context "when mortgage and deposit is outside 0.1% equity tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 1, mortgage: 10_000, staircase: 2, deposit: 5_000, value: 100_000, equity: 15.2, ownershipsch: 1, type: 30, saledate:) }
+
+        it "adds an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgage"]).not_to be_empty
+          expect(record.errors["value"]).not_to be_empty
+          expect(record.errors["deposit"]).not_to be_empty
+          expect(record.errors["equity"]).not_to be_empty
+        end
+      end
+
+      context "when deposit (no mortgage) is exact" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 2, staircase: 2, deposit: 15_000, value: 100_000, equity: 15, ownershipsch: 1, type: 30, saledate:) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgageused"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["equity"]).to be_empty
+        end
+      end
+
+      context "when deposit (no mortgage) is within 0.1% equity tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 2, staircase: 2, deposit: 15_000, value: 100_000, equity: 15.1, ownershipsch: 1, type: 30, saledate:) }
+
+        it "does not add an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgageused"]).to be_empty
+          expect(record.errors["value"]).to be_empty
+          expect(record.errors["deposit"]).to be_empty
+          expect(record.errors["equity"]).to be_empty
+        end
+      end
+
+      context "when deposit (no mortgage) is outside 0.1% equity tolerance" do
+        let(:record) { FactoryBot.build(:sales_log, mortgageused: 2, staircase: 2, deposit: 15_000, value: 100_000, equity: 15.2, ownershipsch: 1, type: 30, saledate:) }
+
+        it "adds an error" do
+          sale_information_validator.validate_non_staircasing_mortgage(record)
+          expect(record.errors["mortgageused"]).not_to be_empty
+          expect(record.errors["value"]).not_to be_empty
+          expect(record.errors["deposit"]).not_to be_empty
+          expect(record.errors["equity"]).not_to be_empty
         end
       end
     end


### PR DESCRIPTION
closes [CLDC-4212](https://mhclgdigital.atlassian.net/browse/CLDC-4212), [CLDC-4213](https://mhclgdigital.atlassian.net/browse/CLDC-4213), [CLDC-4214](https://mhclgdigital.atlassian.net/browse/CLDC-4214)

as far as I can tell there are two validations to edit here:

- SO initial purchase: value, equity, deposit, mortgage
- discounted ownership: value, discount, deposit, mortgage

SO staircasing is not edited at all since as far as I can see this validation is unused since 2025. in 2025 we stopped asking deposit for staircasing. see [CLDC-3758](https://mhclgdigital.atlassian.net/browse/CLDC-3758) 128ac5d57ad719d36705cefaa6936d38dd15dfcc

these now explicitly run a range between the calculation if equity was 0.1% higher and 0.1% lower. I think there could be a way to reuse the existing tolerance calculation but this felt like it'd become hard to understand later. better to do explicitly.

<details><summary>screenshots</summary>
initial purchase within 0.1%
<img alt="initial purchase within 0.1%" src="https://github.com/user-attachments/assets/bcdc05cb-a31b-4bc2-8dc2-188fc17b7d62" />

initial purchase over bounds
<img alt="initial purchase over bounds" src="https://github.com/user-attachments/assets/b2507fc3-4666-448f-878a-cf146c0e8ad3" />

discounted ownership within 0.1%
<img alt="discounted ownership within 0.1%" src="https://github.com/user-attachments/assets/45bb8ecd-0abc-46d6-bbe0-b53027e99e7f" />

discounted ownership over bounds
<img alt="discounted ownership over bounds" src="https://github.com/user-attachments/assets/5b068127-d117-46a1-bb6a-c5444a345035" />
</details>

[CLDC-4212]: https://mhclgdigital.atlassian.net/browse/CLDC-4212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLDC-4213]: https://mhclgdigital.atlassian.net/browse/CLDC-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLDC-4214]: https://mhclgdigital.atlassian.net/browse/CLDC-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CLDC-3758]: https://mhclgdigital.atlassian.net/browse/CLDC-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ