### PR TITLE
CLDC-4221: Add 2026 collection deadlines

### DIFF
--- a/app/helpers/collection_deadline_helper.rb
+++ b/app/helpers/collection_deadline_helper.rb
@@ -6,13 +6,13 @@ module CollectionDeadlineHelper
       first_quarter_deadline: Time.zone.local(2025, 7, 11),
       second_quarter_deadline: Time.zone.local(2025, 10, 10),
       third_quarter_deadline: Time.zone.local(2026, 1, 16),
-      fourth_quarter_deadline: Time.zone.local(2026, 6, 5), # Same as submission deadline
+      fourth_quarter_deadline: Form::DEADLINES[2025][:submission_deadline],
     },
     2026 => {
       first_quarter_deadline: Time.zone.local(2026, 7, 10),
       second_quarter_deadline: Time.zone.local(2026, 10, 9),
       third_quarter_deadline: Time.zone.local(2027, 1, 15),
-      fourth_quarter_deadline: Time.zone.local(2027, 6, 4), # Same as submission deadline
+      fourth_quarter_deadline: Form::DEADLINES[2026][:submission_deadline],
     },
   }.freeze
 

--- a/app/helpers/collection_deadline_helper.rb
+++ b/app/helpers/collection_deadline_helper.rb
@@ -2,17 +2,17 @@ module CollectionDeadlineHelper
   include CollectionTimeHelper
 
   QUARTERLY_DEADLINES = {
-    2024 => {
-      first_quarter_deadline: Time.zone.local(2024, 7, 12),
-      second_quarter_deadline: Time.zone.local(2024, 10, 11),
-      third_quarter_deadline: Time.zone.local(2025, 1, 10),
-      fourth_quarter_deadline: Time.zone.local(2025, 6, 6), # Same as submission deadline
-    },
     2025 => {
       first_quarter_deadline: Time.zone.local(2025, 7, 11),
       second_quarter_deadline: Time.zone.local(2025, 10, 10),
       third_quarter_deadline: Time.zone.local(2026, 1, 16),
       fourth_quarter_deadline: Time.zone.local(2026, 6, 5), # Same as submission deadline
+    },
+    2026 => {
+      first_quarter_deadline: Time.zone.local(2026, 7, 10),
+      second_quarter_deadline: Time.zone.local(2026, 10, 9),
+      third_quarter_deadline: Time.zone.local(2027, 1, 15),
+      fourth_quarter_deadline: Time.zone.local(2027, 6, 4), # Same as submission deadline
     },
   }.freeze
 

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Home Page Features" do
   end
 
   describe "_upcoming_deadlines" do
-    let(:current_collection_year) { 2024 }
-    let(:next_collection_year) { 2025 }
+    let(:current_collection_year) { 2025 }
+    let(:next_collection_year) { 2026 }
 
     context "when visiting during the current collection year" do
       before do
@@ -28,11 +28,11 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct text for quarters" do
         Timecop.freeze(Time.zone.local(current_collection_year, 4, 1)) do
           visit root_path
-          find("span.govuk-details__summary-text", text: "Quarterly cut-off dates for 2024 to 2025").click
-          expect(page).to have_content("Q1 - Friday 12 July 2024")
-          expect(page).to have_content("Q2 - Friday 11 October 2024")
-          expect(page).to have_content("Q3 - Friday 10 January 2025")
-          expect(page).to have_content("End of year deadline - Friday 6 June 2025")
+          find("span.govuk-details__summary-text", text: "Quarterly cut-off dates for 2025 to 2026").click
+          expect(page).to have_content("Q1 - Friday 11 July 2025")
+          expect(page).to have_content("Q2 - Friday 10 October 2025")
+          expect(page).to have_content("Q3 - Friday 16 January 2026")
+          expect(page).to have_content("End of year deadline - Friday 5 June 2026")
         end
         Timecop.return
       end
@@ -40,7 +40,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q1" do
         Timecop.freeze(Time.zone.local(current_collection_year, 4, 1)) do
           visit root_path
-          expect(page).to have_content("Q1 - Friday 12 July 2024")
+          expect(page).to have_content("Q1 - Friday 11 July 2025")
         end
         Timecop.return
       end
@@ -48,7 +48,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q2" do
         Timecop.freeze(Time.zone.local(current_collection_year, 8, 1)) do
           visit root_path
-          expect(page).to have_content("Q2 - Friday 11 October 2024")
+          expect(page).to have_content("Q2 - Friday 10 October 2025")
         end
         Timecop.return
       end
@@ -56,7 +56,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q3" do
         Timecop.freeze(Time.zone.local(current_collection_year, 11, 1)) do
           visit root_path
-          expect(page).to have_content("Q3 - Friday 10 January 2025")
+          expect(page).to have_content("Q3 - Friday 16 January 2026")
         end
         Timecop.return
       end
@@ -74,11 +74,11 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct text for quarters" do
         Timecop.freeze(Time.zone.local(next_collection_year, 4, 1)) do
           visit root_path
-          find("span.govuk-details__summary-text", text: "Quarterly cut-off dates for 2025 to 2026").click
-          expect(page).to have_content("Q1 - Friday 11 July 2025")
-          expect(page).to have_content("Q2 - Friday 10 October 2025")
-          expect(page).to have_content("Q3 - Friday 16 January 2026")
-          expect(page).to have_content("End of year deadline - Friday 5 June 2026")
+          find("span.govuk-details__summary-text", text: "Quarterly cut-off dates for 2026 to 2027").click
+          expect(page).to have_content("Q1 - Friday 10 July 2026")
+          expect(page).to have_content("Q2 - Friday 9 October 2026")
+          expect(page).to have_content("Q3 - Friday 15 January 2027")
+          expect(page).to have_content("End of year deadline - Friday 4 June 2027")
         end
         Timecop.return
       end
@@ -86,7 +86,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q1" do
         Timecop.freeze(Time.zone.local(next_collection_year, 4, 1)) do
           visit root_path
-          expect(page).to have_content("Q1 - Friday 11 July 2025")
+          expect(page).to have_content("Q1 - Friday 10 July 2026")
         end
         Timecop.return
       end
@@ -94,7 +94,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q2" do
         Timecop.freeze(Time.zone.local(next_collection_year, 8, 1)) do
           visit root_path
-          expect(page).to have_content("Q2 - Friday 10 October 2025")
+          expect(page).to have_content("Q2 - Friday 9 October 2026")
         end
         Timecop.return
       end
@@ -102,7 +102,7 @@ RSpec.describe "Home Page Features" do
       scenario "displays correct current quarter as Q3" do
         Timecop.freeze(Time.zone.local(next_collection_year, 11, 1)) do
           visit root_path
-          expect(page).to have_content("Q3 - Friday 16 January 2026")
+          expect(page).to have_content("Q3 - Friday 15 January 2027")
         end
         Timecop.return
       end

--- a/spec/helpers/collection_deadline_helper_spec.rb
+++ b/spec/helpers/collection_deadline_helper_spec.rb
@@ -5,25 +5,25 @@ RSpec.describe CollectionDeadlineHelper do
   let(:user) { create(:user, :data_coordinator) }
 
   describe "#quarter_for_date" do
-    it "returns correct cutoff date for the first quarter of 2024/25" do
-      quarter = quarter_for_date(date: Time.zone.local(2024, 4, 1))
-      expect(quarter.cutoff_date).to eq(Time.zone.local(2024, 7, 12))
-      expect(quarter.quarter_start_date).to eq(Time.zone.local(2024, 4, 1))
-      expect(quarter.quarter_end_date).to eq(Time.zone.local(2024, 6, 30))
+    it "returns correct cutoff date for the first quarter of 2025/26" do
+      quarter = quarter_for_date(date: Time.zone.local(2025, 4, 1))
+      expect(quarter.cutoff_date).to eq(Time.zone.local(2025, 7, 11))
+      expect(quarter.quarter_start_date).to eq(Time.zone.local(2025, 4, 1))
+      expect(quarter.quarter_end_date).to eq(Time.zone.local(2025, 6, 30))
     end
 
-    it "returns correct cutoff date for the second quarter of 2024/25" do
-      quarter = quarter_for_date(date: Time.zone.local(2024, 9, 30))
-      expect(quarter.cutoff_date).to eq(Time.zone.local(2024, 10, 11))
-      expect(quarter.quarter_start_date).to eq(Time.zone.local(2024, 7, 1))
-      expect(quarter.quarter_end_date).to eq(Time.zone.local(2024, 9, 30))
+    it "returns correct cutoff date for the second quarter of 2025/26" do
+      quarter = quarter_for_date(date: Time.zone.local(2025, 9, 30))
+      expect(quarter.cutoff_date).to eq(Time.zone.local(2025, 10, 10))
+      expect(quarter.quarter_start_date).to eq(Time.zone.local(2025, 7, 1))
+      expect(quarter.quarter_end_date).to eq(Time.zone.local(2025, 9, 30))
     end
 
-    it "returns correct cutoff date for the third quarter of 2024/25" do
-      quarter = quarter_for_date(date: Time.zone.local(2024, 10, 25))
-      expect(quarter.cutoff_date).to eq(Time.zone.local(2025, 1, 10))
-      expect(quarter.quarter_start_date).to eq(Time.zone.local(2024, 10, 1))
-      expect(quarter.quarter_end_date).to eq(Time.zone.local(2024, 12, 31))
+    it "returns correct cutoff date for the third quarter of 2025/26" do
+      quarter = quarter_for_date(date: Time.zone.local(2025, 10, 25))
+      expect(quarter.cutoff_date).to eq(Time.zone.local(2026, 1, 16))
+      expect(quarter.quarter_start_date).to eq(Time.zone.local(2025, 10, 1))
+      expect(quarter.quarter_end_date).to eq(Time.zone.local(2025, 12, 31))
     end
   end
 end

--- a/spec/helpers/tasklist_helper_spec.rb
+++ b/spec/helpers/tasklist_helper_spec.rb
@@ -232,20 +232,20 @@ RSpec.describe TasklistHelper do
     end
 
     context "when today is the deadline for log with sale/start date" do
-      let(:log) { build(:sales_log, saledate: Time.zone.local(2025, 2, 1)) }
+      let(:log) { build(:sales_log, saledate: Time.zone.local(2026, 2, 1)) }
 
       it "returns the overdue text" do
-        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2025, 6, 6))
-        expect(deadline_text(log)).to include("Upcoming Q4 deadline: 6 June 2025.")
+        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2026, 6, 5))
+        expect(deadline_text(log)).to include("Upcoming Q4 deadline: 5 June 2026.")
       end
     end
 
     context "when today is after the deadline for log with sale/start date" do
-      let(:log) { build(:sales_log, saledate: Time.zone.local(2025, 2, 1)) }
+      let(:log) { build(:sales_log, saledate: Time.zone.local(2026, 2, 1)) }
 
       it "returns the overdue text" do
-        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2025, 6, 7))
-        expect(deadline_text(log)).to include("Overdue: Q4 deadline 6 June 2025.")
+        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2026, 6, 6))
+        expect(deadline_text(log)).to include("Overdue: Q4 deadline 5 June 2026.")
       end
     end
   end

--- a/spec/requests/start_controller_spec.rb
+++ b/spec/requests/start_controller_spec.rb
@@ -322,41 +322,41 @@ RSpec.describe StartController, type: :request do
         end
       end
 
-      context "and 2023 collection window is open for editing" do
+      context "and 2024 collection window is open for editing" do
         before do
-          create(:collection_resource, :additional, year: 2023, log_type: "sales", display_name: "sales additional resource (2023 to 2024)")
-          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 4, 1))
+          create(:collection_resource, :additional, year: 2024, log_type: "sales", display_name: "sales additional resource (2024 to 2025)")
+          allow(Time).to receive(:now).and_return(Time.zone.local(2025, 4, 1))
         end
 
-        it "displays correct resources for 2023/24 and 2024/25 collection years" do
+        it "displays correct resources for 2024/25 and 2025/26 collection years" do
           get root_path
+          expect(page).to have_content("Lettings 25/26")
           expect(page).to have_content("Lettings 24/25")
-          expect(page).to have_content("Lettings 23/24")
+          expect(page).to have_content("Lettings 2025 to 2026")
           expect(page).to have_content("Lettings 2024 to 2025")
-          expect(page).to have_content("Lettings 2023 to 2024")
+          expect(page).to have_content("Sales 25/26")
           expect(page).to have_content("Sales 24/25")
-          expect(page).to have_content("Sales 23/24")
+          expect(page).to have_content("Sales 2025 to 2026")
           expect(page).to have_content("Sales 2024 to 2025")
-          expect(page).to have_content("Sales 2023 to 2024")
-          expect(page).to have_content("Download the sales additional resource (2023 to 2024)")
+          expect(page).to have_content("Download the sales additional resource (2024 to 2025)")
         end
       end
 
-      context "and 2023 collection window is closed for editing" do
+      context "and 2024 collection window is closed for editing" do
         before do
-          allow(Time).to receive(:now).and_return(Time.zone.local(2024, 12, 1))
+          allow(Time).to receive(:now).and_return(Time.zone.local(2025, 12, 1))
         end
 
         it "displays correct resources" do
           get root_path
-          expect(page).to have_content("Lettings 24/25")
-          expect(page).not_to have_content("Lettings 23/24")
-          expect(page).to have_content("Lettings 2024 to 2025")
-          expect(page).not_to have_content("Lettings 2023 to 2024")
-          expect(page).to have_content("Sales 24/25")
-          expect(page).not_to have_content("Sales 23/24")
-          expect(page).to have_content("Sales 2024 to 2025")
-          expect(page).not_to have_content("Sales 2023 to 2024")
+          expect(page).to have_content("Lettings 25/26")
+          expect(page).not_to have_content("Lettings 24/25")
+          expect(page).to have_content("Lettings 2025 to 2026")
+          expect(page).not_to have_content("Lettings 2024 to 2025")
+          expect(page).to have_content("Sales 25/26")
+          expect(page).not_to have_content("Sales 24/25")
+          expect(page).to have_content("Sales 2025 to 2026")
+          expect(page).not_to have_content("Sales 2024 to 2025")
         end
       end
 


### PR DESCRIPTION
closes [CLDC-4221](https://mhclgdigital.atlassian.net/browse/CLDC-4221)

adds collection deadline dates for 26/27

removes the 24/25 dates as they aren't used any more

I've tested this locally and it looks fine by adding an initializer that uses timecop.travel to 1st april 2026

<img alt="2026 deadlines" src="https://github.com/user-attachments/assets/e5bffdcc-adae-4473-999f-6ef4d9880fe5" />

[CLDC-4221]: https://mhclgdigital.atlassian.net/browse/CLDC-4221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ