### PR TITLE
CLDC-4157: Remove nursing care from scheme level of support

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -264,7 +264,7 @@ class Scheme < ApplicationRecord
     Scheme.registered_under_care_acts.keys.map { |key, _| OpenStruct.new(id: key, name: key.to_s) }
   end
 
-  def support_level_options_with_hints
+  def self.support_level_options_with_hints
     hints = {
       "Low level": "Staff visiting once a week, fortnightly or less.",
       "Medium level": "Staff on site daily or making frequent visits with some out-of-hours cover.",
@@ -273,7 +273,7 @@ class Scheme < ApplicationRecord
     Scheme.support_types.keys.excluding("Missing").excluding("Floating support").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints[key.to_sym]) }
   end
 
-  def intended_length_of_stay_options_with_hints
+  def self.intended_length_of_stay_options_with_hints
     hints = {
       "Very short stay": "Up to one month.",
       "Short stay": "Up to one year.",

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -170,7 +170,6 @@ class Scheme < ApplicationRecord
     "Low level": 2,
     "Medium level": 3,
     "High level": 4,
-    "Nursing care in a care home": 5,
     "Floating support": 6,
   }.freeze
 
@@ -280,7 +279,6 @@ class Scheme < ApplicationRecord
       "Short stay": "Up to one year.",
       "Medium stay": "More than one year but with an expectation to move on.",
       "Permanent": "Provides a home for life with no requirement for the tenant to move.",
-
     }
     Scheme.intended_stays.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints[key.to_sym]) }
   end

--- a/app/views/schemes/support.html.erb
+++ b/app/views/schemes/support.html.erb
@@ -12,23 +12,15 @@
       <%= render partial: "organisations/headings", locals: { main: "What support does this scheme provide?", sub: @scheme.service_name } %>
       <%= govuk_inset_text(text: "Only update a scheme if you’re fixing an error. If the scheme is changing,  create a new scheme.") if @scheme.confirmed? %>
 
-      <% support_level_options_hints = { "Low level": "Staff visiting once a week, fortnightly or less.", "Medium level": "Staff on site daily or making frequent visits with some out-of-hours cover.", "High level": "Intensive level of staffing provided on a 24-hour basis." } %>
-
-      <% support_level_options_with_hints = Scheme.support_types.keys.excluding("Missing").excluding("Floating support").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: support_level_options_hints[key.to_sym]) } %>
-
       <%= f.govuk_collection_radio_buttons :support_type,
-                                           support_level_options_with_hints,
+                                           Scheme.support_level_options_with_hints,
                                            :id,
                                            :name,
                                            :description,
                                            legend: { text: "Level of support given", size: "m" } %>
 
-      <% intended_length_of_stay_options_hints = { "Very short stay": "Up to one month.", "Short stay": "Up to one year.", "Medium stay": "More than one year but with an expectation to move on.", "Permanent": "Provides a home for life with no requirement for the tenant to move." } %>
-
-      <% intended_length_of_stay_options_with_hints = Scheme.intended_stays.keys.excluding("Missing").map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: intended_length_of_stay_options_hints[key.to_sym]) } %>
-
       <%= f.govuk_collection_radio_buttons :intended_stay,
-                                           intended_length_of_stay_options_with_hints,
+                                           Scheme.intended_length_of_stay_options_with_hints,
                                            :id,
                                            :name,
                                            :description,

--- a/lib/tasks/update_schemes_logs_impacted_by_nursing_level_removal.rake
+++ b/lib/tasks/update_schemes_logs_impacted_by_nursing_level_removal.rake
@@ -1,5 +1,5 @@
 desc "Update schemes that had a level of support of 'Nursing' to be incomplete, and mark all logs that use that scheme as incomplete"
-task update_scheme_registered_under_care_value: :environment do
+task update_schemes_logs_impacted_by_nursing_level_removal: :environment do
   ActiveRecord::Base.transaction do
     impacted_schemes = Scheme.where(support_type: 5)
     impacted_logs = LettingsLog.filter_by_year_or_later(2025).where(scheme: impacted_schemes)

--- a/lib/tasks/update_schemes_logs_impacted_by_nursing_level_removal.rake
+++ b/lib/tasks/update_schemes_logs_impacted_by_nursing_level_removal.rake
@@ -1,0 +1,10 @@
+desc "Update schemes that had a level of support of 'Nursing' to be incomplete, and mark all logs that use that scheme as incomplete"
+task update_scheme_registered_under_care_value: :environment do
+  ActiveRecord::Base.transaction do
+    impacted_schemes = Scheme.where(support_type: 5)
+    impacted_logs = LettingsLog.filter_by_year_or_later(2025).where(scheme: impacted_schemes)
+
+    impacted_schemes.update!(support_type: nil, confirmed: false)
+    impacted_logs.update!(scheme: nil)
+  end
+end

--- a/spec/factories/scheme.rb
+++ b/spec/factories/scheme.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     service_name { "#{Faker::Name.name}'s Housing & Co." }
     sensitive { Faker::Number.within(range: 0..1) }
     registered_under_care_act { 1 }
-    support_type { [0, 2, 3, 4, 5].sample }
+    support_type { [0, 2, 3, 4].sample }
     scheme_type { 4 }
     arrangement_type { "D" }
     intended_stay { %w[M P S V X].sample }


### PR DESCRIPTION
closes [CLDC-4157](https://mhclgdigital.atlassian.net/browse/CLDC-4157)

removes support type option 5 from the enum. this removes it from the schemes page automatically

include a script to automatically set all impacted schemes to invalid and all impacted logs to incomplete, ready for LAs to fill in again

[CLDC-4157]: https://mhclgdigital.atlassian.net/browse/CLDC-4157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ