### PR TITLE
CLDC-4215: Don't run validate_discounted_ownership_value if mortgageused is 3

### DIFF
--- a/app/models/validations/sales/sale_information_validations.rb
+++ b/app/models/validations/sales/sale_information_validations.rb
@@ -77,7 +77,7 @@ module Validations::Sales::SaleInformationValidations
   def validate_discounted_ownership_value(record)
     return unless record.saledate && record.form.start_year_2024_or_later?
     return unless record.value && record.deposit && record.ownershipsch
-    return unless record.mortgage || record.mortgageused == 2 || record.mortgageused == 3
+    return unless record.mortgage || record.mortgageused == 2
     return unless record.discount || record.grant || record.type == 29
 
     tolerance = record.value_with_discount_tolerance

--- a/spec/models/validations/sales/sale_information_validations_spec.rb
+++ b/spec/models/validations/sales/sale_information_validations_spec.rb
@@ -703,6 +703,18 @@ RSpec.describe Validations::Sales::SaleInformationValidations do
         end
       end
     end
+
+    context "when mortgageused is don't know" do
+      let(:record) { FactoryBot.build(:sales_log, :saledate_today, mortgageused: 3, deposit: 10_000, value: 100_000, discount: 10, ownershipsch: 2, type: 9) }
+
+      it "does not add an error" do
+        sale_information_validator.validate_discounted_ownership_value(record)
+        expect(record.errors["mortgage"]).to be_empty
+        expect(record.errors["value"]).to be_empty
+        expect(record.errors["deposit"]).to be_empty
+        expect(record.errors["discount"]).to be_empty
+      end
+    end
   end
 
   describe "#validate_outright_sale_value_matches_mortgage_plus_deposit" do


### PR DESCRIPTION
I don't think this should have ever been turned on. if we don't know the mortgage we can't assume info in this check

technically this could be a breaking change as it is not gated to 26/27 but:
- 24/25 logs are read only. this change only makes existing invalid logs valid, but there shouldn't be any invalid 24/25 logs anyway. it won't break any existing logs
- 25/26 logs do not have a don't know option visible for discounted ownership
- 26/27 logs are fine to update

so I think it's better to not add a 2026 check if its not needed. keeps the logic cleaner

cya page where the numbers dont add up but its fine as mortgage isn't known
<img src="https://github.com/user-attachments/assets/e79b651b-835f-4677-adf5-b02375667508" />