### PR TITLE
CLDC-4246: Reapply starter tenancy type copy updates

### DIFF
--- a/config/locales/forms/2025/lettings/tenancy_information.en.yml
+++ b/config/locales/forms/2025/lettings/tenancy_information.en.yml
@@ -21,27 +21,27 @@ en:
             tenancy_type:
               page_header: ""
               tenancy:
-                check_answer_label: "Type of main tenancy"
+                check_answer_label: "Type of tenancy"
                 check_answer_prompt: ""
                 hint_text: ""
                 question_text: "What is the type of tenancy?"
               tenancyother:
-                check_answer_label: ""
+                check_answer_label: "Type of tenancy (other)"
                 check_answer_prompt: ""
                 hint_text: ""
-                question_text: "Please state the tenancy type"
+                question_text: "Please state the type of tenancy"
             starter_tenancy_type:
               page_header: ""
               tenancy:
-                check_answer_label: "Type of main tenancy after the starter or introductory period has ended"
+                check_answer_label: "Type of tenancy"
                 check_answer_prompt: ""
-                hint_text: ""
-                question_text: "What is the type of tenancy after the starter or introductory period has ended?"
+                hint_text: "This is for the main tenancy after any starter or introductory period."
+                question_text: "What is the type of tenancy?"
               tenancyother:
-                check_answer_label: ""
+                check_answer_label: "Type of tenancy (other)"
                 check_answer_prompt: ""
                 hint_text: ""
-                question_text: "Please state the tenancy type"
+                question_text: "Please state the type of tenancy"
 
           tenancylength:
             tenancy_length:

--- a/config/locales/forms/2026/lettings/tenancy_information.en.yml
+++ b/config/locales/forms/2026/lettings/tenancy_information.en.yml
@@ -21,27 +21,27 @@ en:
             tenancy_type:
               page_header: ""
               tenancy:
-                check_answer_label: "Type of main tenancy"
+                check_answer_label: "Type of tenancy"
                 check_answer_prompt: ""
                 hint_text: ""
                 question_text: "What is the type of tenancy?"
               tenancyother:
-                check_answer_label: ""
+                check_answer_label: "Type of tenancy (other)"
                 check_answer_prompt: ""
                 hint_text: ""
-                question_text: "Please state the tenancy type"
+                question_text: "Please state the type of tenancy"
             starter_tenancy_type:
               page_header: ""
               tenancy:
-                check_answer_label: "Type of main tenancy after the starter or introductory period has ended"
+                check_answer_label: "Type of tenancy"
                 check_answer_prompt: ""
-                hint_text: ""
-                question_text: "What is the type of tenancy after the starter or introductory period has ended?"
+                hint_text: "This is for the main tenancy after any starter or introductory period."
+                question_text: "What is the type of tenancy?"
               tenancyother:
-                check_answer_label: ""
+                check_answer_label: "Type of tenancy (other)"
                 check_answer_prompt: ""
                 hint_text: ""
-                question_text: "Please state the tenancy type"
+                question_text: "Please state the type of tenancy"
 
           tenancylength:
             tenancy_length:


### PR DESCRIPTION
Closes [CLDC-4246](https://mhclgdigital.atlassian.net/browse/CLDC-4246). 

Previous PR for this changeset: https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/pull/3229

Was previously on main but has since been reverted to allow a release without these changes. This PR re-applies them.
This reverts commit 384435fdc64a4ca49ec0c7efb0ddbfdcf5193e72.


[CLDC-4246]: https://mhclgdigital.atlassian.net/browse/CLDC-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ