### PR TITLE
CLDC-4306: Correct sales Q70 still serving options for 2026

### DIFF
--- a/app/models/form/sales/questions/buyer_still_serving.rb
+++ b/app/models/form/sales/questions/buyer_still_serving.rb
@@ -3,17 +3,27 @@ class Form::Sales::Questions::BuyerStillServing < ::Form::Question
     super
     @id = "hhregresstill"
     @type = "radio"
-    @answer_options = ANSWER_OPTIONS
+    @answer_options = answer_options
     @question_number = get_question_number_from_hash(QUESTION_NUMBER_FROM_YEAR)
   end
 
-  ANSWER_OPTIONS = {
-    "4" => { "value" => "Yes" },
-    "5" => { "value" => "No" },
-    "6" => { "value" => "Buyer prefers not to say" },
-    "divider" => { "value" => true },
-    "7" => { "value" => "Don’t know" },
-  }.freeze
+  def answer_options
+    if form.start_year_2026_or_later?
+      {
+        "4" => { "value" => "Yes" },
+        "5" => { "value" => "No - they left up to and including 2 years ago" },
+        "6" => { "value" => "No - they left more than 2 years ago" },
+      }.freeze
+    else
+      {
+        "4" => { "value" => "Yes" },
+        "5" => { "value" => "No" },
+        "6" => { "value" => "Buyer prefers not to say" },
+        "divider" => { "value" => true },
+        "7" => { "value" => "Don’t know" },
+      }.freeze
+    end
+  end
 
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 63, 2024 => 65, 2025 => 62, 2026 => 70 }.freeze
 end

--- a/spec/models/form/sales/pages/buyer_still_serving_spec.rb
+++ b/spec/models/form/sales/pages/buyer_still_serving_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Pages::BuyerStillServing, type: :model do
+  include CollectionTimeHelper
+
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1))) }
+  let(:subsection) { instance_double(Form::Subsection, form: instance_double(Form, start_date: current_collection_start_date, start_year_2026_or_later?: true)) }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)

--- a/spec/models/form/sales/questions/buyer_still_serving_spec.rb
+++ b/spec/models/form/sales/questions/buyer_still_serving_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Questions::BuyerStillServing, type: :model do
+  include CollectionTimeHelper
+
   subject(:question) { described_class.new(question_id, question_definition, page) }
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
+  let(:start_year_2026_or_later?) { true }
+  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: current_collection_start_date, start_year_2026_or_later?: start_year_2026_or_later?))) }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -23,13 +26,29 @@ RSpec.describe Form::Sales::Questions::BuyerStillServing, type: :model do
     expect(question.derived?(nil)).to be false
   end
 
-  it "has the correct answer_options" do
-    expect(question.answer_options).to eq({
-      "4" => { "value" => "Yes" },
-      "5" => { "value" => "No" },
-      "6" => { "value" => "Buyer prefers not to say" },
-      "divider" => { "value" => true },
-      "7" => { "value" => "Don’t know" },
-    })
+  context "when 2025", metadata: { year: 25 } do
+    let(:start_year_2026_or_later?) { false }
+
+    it "has the correct answer_options" do
+      expect(question.answer_options).to eq({
+        "4" => { "value" => "Yes" },
+        "5" => { "value" => "No" },
+        "6" => { "value" => "Buyer prefers not to say" },
+        "divider" => { "value" => true },
+        "7" => { "value" => "Don’t know" },
+      })
+    end
+  end
+
+  context "when 2026", metadata: { year: 26 } do
+    let(:start_year_2026_or_later?) { true }
+
+    it "has the correct answer_options" do
+      expect(question.answer_options).to eq({
+        "4" => { "value" => "Yes" },
+        "5" => { "value" => "No - they left up to and including 2 years ago" },
+        "6" => { "value" => "No - they left more than 2 years ago" },
+      })
+    end
   end
 end


### PR DESCRIPTION
closes [CLDC-4306](https://mhclgdigital.atlassian.net/browse/CLDC-4306)

uses correct options as defined in the paper form

<img alt="q70 web ui" src="https://github.com/user-attachments/assets/a18543cf-3f68-47b1-8f48-2c1b35440098" />

<img alt="q70 paper form" src="https://github.com/user-attachments/assets/88b355b3-b9a3-4ed0-865b-4a2c89afbf3e" />


[CLDC-4306]: https://mhclgdigital.atlassian.net/browse/CLDC-4306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ