### PR TITLE
CLDC-4314: Monthly service charge soft validation redirect bug

### DIFF
--- a/app/models/form/sales/subsections/shared_ownership_initial_purchase.rb
+++ b/app/models/form/sales/subsections/shared_ownership_initial_purchase.rb
@@ -40,7 +40,7 @@ class Form::Sales::Subsections::SharedOwnershipInitialPurchase < ::Form::Subsect
       Form::Sales::Pages::SharedOwnershipDepositValueCheck.new("shared_ownership_deposit_value_check", nil, self),
       Form::Sales::Pages::MonthlyRent.new(nil, nil, self),
       Form::Sales::Pages::ServiceCharge.new("service_charge", nil, self),
-      Form::Sales::Pages::MonthlyChargesValueCheck.new("monthly_charges_shared_ownership_value_check", nil, self),
+      Form::Sales::Pages::MonthlyChargesValueCheck.new("monthly_charges_initial_purchase_value_check", nil, self),
       Form::Sales::Pages::EstateManagementFee.new("estate_management_fee", nil, self),
     ].compact
   end

--- a/app/models/form/sales/subsections/shared_ownership_staircasing_transaction.rb
+++ b/app/models/form/sales/subsections/shared_ownership_staircasing_transaction.rb
@@ -27,7 +27,7 @@ class Form::Sales::Subsections::SharedOwnershipStaircasingTransaction < ::Form::
       Form::Sales::Pages::MonthlyRentStaircasing.new(nil, nil, self),
       (Form::Sales::Pages::ServiceChargeStaircasing.new("service_charge_staircasing", nil, self) if form.start_year_2026_or_later?),
       (Form::Sales::Pages::ServiceChargeChanged.new(nil, nil, self) if form.start_year_2026_or_later?),
-      Form::Sales::Pages::MonthlyChargesValueCheck.new("monthly_charges_shared_ownership_value_check", nil, self),
+      Form::Sales::Pages::MonthlyChargesValueCheck.new("monthly_charges_staircasing_value_check", nil, self),
     ].compact
   end
 

--- a/spec/models/form/sales/subsections/shared_ownership_initial_purchase_spec.rb
+++ b/spec/models/form/sales/subsections/shared_ownership_initial_purchase_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipInitialPurchase, type: :
           shared_ownership_deposit_value_check
           monthly_rent
           service_charge
-          monthly_charges_shared_ownership_value_check
+          monthly_charges_initial_purchase_value_check
           estate_management_fee
         ],
       )
@@ -102,7 +102,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipInitialPurchase, type: :
           shared_ownership_deposit_value_check
           monthly_rent
           service_charge
-          monthly_charges_shared_ownership_value_check
+          monthly_charges_initial_purchase_value_check
           estate_management_fee
         ],
       )
@@ -145,7 +145,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipInitialPurchase, type: :
           shared_ownership_deposit_value_check
           monthly_rent
           service_charge
-          monthly_charges_shared_ownership_value_check
+          monthly_charges_initial_purchase_value_check
           estate_management_fee
         ],
       )

--- a/spec/models/form/sales/subsections/shared_ownership_staircasing_transaction_spec.rb
+++ b/spec/models/form/sales/subsections/shared_ownership_staircasing_transaction_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipStaircasingTransaction, 
           staircase_mortgage_used_shared_ownership
           monthly_rent_staircasing_owned
           monthly_rent_staircasing
-          monthly_charges_shared_ownership_value_check
+          monthly_charges_staircasing_value_check
         ],
       )
     end
@@ -78,7 +78,7 @@ RSpec.describe Form::Sales::Subsections::SharedOwnershipStaircasingTransaction, 
           monthly_rent_staircasing
           service_charge_staircasing
           service_charge_changed
-          monthly_charges_shared_ownership_value_check
+          monthly_charges_staircasing_value_check
         ],
       )
     end


### PR DESCRIPTION
Closes [CLDC-4314](https://mhclgdigital.atlassian.net/browse/CLDC-4314).

URL conflict was causing neither of these two soft validations to be visitable by the user. Not a bug we've introduced this year but good to fix nonetheless.

[CLDC-4314]: https://mhclgdigital.atlassian.net/browse/CLDC-4314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ