### PR TITLE
CLDC-4309: Add copy for staircasing transaction mortgage used

### DIFF
--- a/app/models/form/sales/questions/mortgageused.rb
+++ b/app/models/form/sales/questions/mortgageused.rb
@@ -6,6 +6,12 @@ class Form::Sales::Questions::Mortgageused < ::Form::Question
     @answer_options = ANSWER_OPTIONS
     @ownershipsch = ownershipsch
     @question_number = get_question_number_from_hash(QUESTION_NUMBER_FROM_YEAR_AND_SECTION, value_key: form.start_year_2025_or_later? ? subsection.id : ownershipsch)
+    sub_copy_key = if subsection.id == "shared_ownership_staircasing_transaction"
+                     "staircase_equity"
+                   else
+                     "non_staircase_equity"
+                   end
+    @copy_key = "#{form.type}.#{subsection.copy_key}.#{@id}.#{sub_copy_key}" if form.start_year_2026_or_later?
     @top_guidance_partial = top_guidance_partial
   end
 

--- a/config/locales/forms/2026/sales/sale_information.en.yml
+++ b/config/locales/forms/2026/sales/sale_information.en.yml
@@ -171,10 +171,16 @@ en:
 
           mortgageused:
             page_header: ""
-            check_answer_label: "Mortgage used"
-            check_answer_prompt: "Tell us if a mortgage was used"
-            hint_text: ""
-            question_text: "Was a mortgage used for the purchase of this property?"
+            staircase_equity:
+              check_answer_label: "Mortgage used"
+              check_answer_prompt: "Tell us if a mortgage was used"
+              hint_text: ""
+              question_text: "Was a mortgage used for this staircasing transaction?"
+            non_staircase_equity:
+              check_answer_label: "Mortgage used"
+              check_answer_prompt: "Tell us if a mortgage was used"
+              hint_text: ""
+              question_text: "Was a mortgage used for the purchase of this property?"
 
           mortgage:
             page_header: ""

--- a/spec/models/form/sales/questions/mortgageused_spec.rb
+++ b/spec/models/form/sales/questions/mortgageused_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
   let(:start_year_2025_or_later?) { true }
   let(:start_year_2026_or_later?) { true }
   let(:subsection_id) { "shared_ownership_initial_purchase" }
-  let(:form) { instance_double(Form, start_date: saledate, start_year_2024_or_later?: start_year_2024_or_later?, start_year_2025_or_later?: start_year_2025_or_later?, start_year_2026_or_later?: start_year_2026_or_later?) }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form:, id: subsection_id)) }
+  let(:form) { instance_double(Form, type: "sales", start_date: saledate, start_year_2024_or_later?: start_year_2024_or_later?, start_year_2025_or_later?: start_year_2025_or_later?, start_year_2026_or_later?: start_year_2026_or_later?) }
+  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form:, id: subsection_id, copy_key: subsection_id)) }
 
   context "when it is a shared ownership scheme" do
     let(:ownershipsch) { 1 }
@@ -120,6 +120,10 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
         expect(question.question_number).to eq 106
       end
 
+      it "has the correct copy_key" do
+        expect(question.copy_key).to eq "sales.discounted_ownership_scheme.mortgageused"
+      end
+
       it "does not show the don't know option" do
         expect_the_question_not_to_show_dont_know
       end
@@ -134,6 +138,11 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
 
       context "and it is a staircasing transaction" do
         let(:staircase) { 1 }
+        let(:subsection_id) { "shared_ownership_staircasing_transaction" }
+
+        it "has the correct copy_key" do
+          expect(question.copy_key).to eq "sales.shared_ownership_staircasing_transaction.mortgageused"
+        end
 
         it "shows the don't know option" do
           expect_the_question_to_show_dont_know
@@ -150,9 +159,14 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
 
       context "and it is not a staircasing transaction" do
         let(:staircase) { 2 }
+        let(:subsection_id) { "shared_ownership_initial_purchase" }
 
         it "does not show the don't know option" do
           expect_the_question_not_to_show_dont_know
+        end
+
+        it "has the correct copy_key" do
+          expect(question.copy_key).to eq "sales.shared_ownership_initial_purchase.mortgageused"
         end
       end
     end
@@ -167,6 +181,10 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
 
       it "shows the correct question number" do
         expect(question.question_number).to eq 116
+      end
+
+      it "has the correct copy_key" do
+        expect(question.copy_key).to eq "sales.discounted_ownership_scheme.mortgageused.non_staircase_equity"
       end
 
       it "shows the don't know option" do
@@ -185,6 +203,10 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
           expect(question.question_number).to eq 107
         end
 
+        it "has the correct copy_key" do
+          expect(question.copy_key).to eq "sales.shared_ownership_staircasing_transaction.mortgageused.staircase_equity"
+        end
+
         it "shows the don't know option" do
           expect_the_question_to_show_dont_know
         end
@@ -196,6 +218,10 @@ RSpec.describe Form::Sales::Questions::Mortgageused, type: :model do
 
         it "shows the correct question number" do
           expect(question.question_number).to eq 90
+        end
+
+        it "has the correct copy_key" do
+          expect(question.copy_key).to eq "sales.shared_ownership_initial_purchase.mortgageused.non_staircase_equity"
         end
 
         it "shows the don't know option" do


### PR DESCRIPTION
closes [CLDC-4309](https://mhclgdigital.atlassian.net/browse/CLDC-4309)

uses different copy keys for different flows

<img alt="q90" src="https://github.com/user-attachments/assets/750addc2-6c32-4110-90c1-c9e1dffa9c38" />
<img alt="q107" src="https://github.com/user-attachments/assets/0261677c-baa8-43d9-ac85-ce214990034e" />
<img alt="q116" src="https://github.com/user-attachments/assets/185b9221-6edf-44f4-8444-ed4305808b6d" />

[CLDC-4309]: https://mhclgdigital.atlassian.net/browse/CLDC-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ