### PR TITLE
CLDC-4312: Fix broken purchase price soft validation

### DIFF
--- a/app/models/form/sales/questions/property_number_of_bedrooms.rb
+++ b/app/models/form/sales/questions/property_number_of_bedrooms.rb
@@ -11,5 +11,9 @@ class Form::Sales::Questions::PropertyNumberOfBedrooms < ::Form::Question
     @question_number = get_question_number_from_hash(QUESTION_NUMBER_FROM_YEAR)
   end
 
+  def derived?(log)
+    log.is_bedsit?
+  end
+
   QUESTION_NUMBER_FROM_YEAR = { 2023 => 11, 2024 => 18, 2025 => 17, 2026 => 18 }.freeze
 end

--- a/spec/models/form/sales/questions/property_number_of_bedrooms_spec.rb
+++ b/spec/models/form/sales/questions/property_number_of_bedrooms_spec.rb
@@ -19,8 +19,22 @@ RSpec.describe Form::Sales::Questions::PropertyNumberOfBedrooms, type: :model do
     expect(question.type).to eq("numeric")
   end
 
-  it "is not marked as derived" do
-    expect(question.derived?(nil)).to be false
+  describe "#derived?" do
+    context "when the log is a bedsit" do
+      let(:log) { build(:sales_log, proptype: 2) }
+
+      it "is marked as derived" do
+        expect(question.derived?(log)).to be true
+      end
+    end
+
+    context "when the log is not a bedsit" do
+      let(:log) { build(:sales_log, proptype: 1) }
+
+      it "is not marked as derived" do
+        expect(question.derived?(log)).to be false
+      end
+    end
   end
 
   it "has the correct min" do


### PR DESCRIPTION
Closes [CLDC-4312](https://mhclgdigital.atlassian.net/browse/CLDC-4312).

This bug was present because for bedsits, beds is a derived value (1).
But the beds question was not marked as derived in this case, so on submission, `beds` was having its value automatically cleared by `reset_free_user_input_questions_if_not_routed`.

This then meant the soft vaildation question (`value_value_check`) was not routed, so its value was also cleared (as its `depends_on` requires beds to be present).

`set_derived_fields!` then runs after and re-derives beds = 1.

This led to the behaviour where it looked like nothing was happening when confirming the soft validaiton. The good news is the beds value being re-derived means logs won't have lost data if they hit this state. I've confirmed this is the case with the rails console and a test staging log.

The equivalent lettings beds q is already marked as derived so this bug was sales-only.

[CLDC-4312]: https://mhclgdigital.atlassian.net/browse/CLDC-4312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ