### PR TITLE
CLDC-4290: filter address responses to England only

### DIFF
--- a/app/services/address_client.rb
+++ b/app/services/address_client.rb
@@ -46,6 +46,7 @@ private
       key: ENV["OS_DATA_KEY"],
       maxresults: @options[:maxresults] || 10,
       minmatch: @options[:minmatch] || 0.4,
+      fq: ["COUNTRY_CODE:E"],
     }
     uri.query = URI.encode_www_form(params)
     uri.to_s

--- a/app/services/uprn_client.rb
+++ b/app/services/uprn_client.rb
@@ -49,6 +49,7 @@ private
       uprn:,
       key: ENV["OS_DATA_KEY"],
       dataset: %w[DPA LPI].join(","),
+      fq: ["COUNTRY_CODE:E"],
     }
     uri.query = URI.encode_www_form(params)
     uri.to_s

--- a/spec/models/form/lettings/questions/address_search_spec.rb
+++ b/spec/models/form/lettings/questions/address_search_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Form::Lettings::Questions::AddressSearch, type: :model do
         ],
       }.to_json
 
-      WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=123")
+      WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=123")
              .to_return(status: 200, body:, headers: {})
     end
 

--- a/spec/models/form/sales/questions/address_search_spec.rb
+++ b/spec/models/form/sales/questions/address_search_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Form::Sales::Questions::AddressSearch, type: :model do
         ],
       }.to_json
 
-      WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=123")
+      WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=123")
              .to_return(status: 200, body:, headers: {})
     end
 

--- a/spec/request_helper.rb
+++ b/spec/request_helper.rb
@@ -18,14 +18,14 @@ module RequestHelper
            .to_return(status: 200, body: "{\"status\":200,\"result\":{\"postcode\":\"ZZ1 1ZZ\",\"admin_district\":\"Westminster\",\"codes\":{\"admin_district\":\"E09000033\"}}}", headers: {})
 
     body = { results: [{ DPA: { UPRN: "10033558653" } }] }.to_json
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key&maxresults=10&minmatch=0.4&query=Address%20line%201,%20SW1A%201AA")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key&maxresults=10&minmatch=0.4&query=Address%20line%201,%20SW1A%201AA")
            .to_return(status: 200, body:, headers: {})
     body = { results: [{ DPA: { "POSTCODE": "SW1A 1AA", "POST_TOWN": "London", "PO_BOX_NUMBER": "The Mall, City Of Westminster" } }] }.to_json
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key&uprn=1")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key&uprn=1")
            .to_return(status: 200, body:, headers: {})
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key&uprn=10033558653")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key&uprn=10033558653")
            .to_return(status: 200, body:, headers: {})
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=10033558653")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=10033558653")
            .to_return(status: 200, body:, headers: {})
 
     WebMock.stub_request(:post, /api.notifications.service.gov.uk\/v2\/notifications\/email/)
@@ -45,7 +45,7 @@ module RequestHelper
       ],
     }.to_json
 
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=1")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=1")
     .to_return(status: 200, body:, headers: {})
 
     body = {
@@ -61,7 +61,7 @@ module RequestHelper
       ],
     }.to_json
 
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key&uprn=121")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key&uprn=121")
      .to_return(status: 200, body:, headers: {})
 
     body = {
@@ -76,7 +76,7 @@ module RequestHelper
       ],
     }.to_json
 
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=123")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=123")
     .to_return(status: 200, body:, headers: {})
 
     body = {
@@ -91,13 +91,13 @@ module RequestHelper
       ],
     }.to_json
 
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=12")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=12")
     .to_return(status: 200, body:, headers: {})
 
-    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=1234567890123")
+    WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=1234567890123")
     .to_return(status: 404, body: "", headers: {})
 
-    template = Addressable::Template.new "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.4&query={+address_query}"
+    template = Addressable::Template.new "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.4&query={+address_query}"
     WebMock.stub_request(:get, template)
       .to_return do |request|
         address = request.uri.query_values["query"].split(",")

--- a/spec/requests/address_search_controller_spec.rb
+++ b/spec/requests/address_search_controller_spec.rb
@@ -152,9 +152,9 @@ RSpec.describe AddressSearchController, type: :request do
         before do
           body = { results: [{ DPA: { "ADDRESS": "100, Test Street", "UPRN": "100" } }] }.to_json
           uprn_body = { results: [{ DPA: nil }] }.to_json
-          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=100")
+          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=100")
                  .to_return(status: 200, body:, headers: {})
-          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=100")
+          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=100")
                  .to_return(status: 200, body: uprn_body, headers: {})
         end
 
@@ -170,9 +170,9 @@ RSpec.describe AddressSearchController, type: :request do
         before do
           body = { results: [{ DPA: nil }] }.to_json
           uprn_body = { results: [{ DPA: { "ADDRESS": "321, Test Street", UPRN: "321" } }] }.to_json
-          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=321")
+          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=321")
                  .to_return(status: 200, body:, headers: {})
-          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=321")
+          WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=321")
                  .to_return(status: 200, body: uprn_body, headers: {})
         end
 
@@ -199,9 +199,9 @@ RSpec.describe AddressSearchController, type: :request do
       before do
         address_body = { results: [{ DPA: { "ADDRESS": "Path not taken", UPRN: "111" } }] }.to_json
         uprn_body = { results: [{ DPA: { "ADDRESS": "2, Test Street", UPRN: "123456" } }] }.to_json
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=123456")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=123456")
                .to_return(status: 200, body: address_body, headers: {})
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=123456")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=123456")
                .to_return(status: 200, body: uprn_body, headers: {})
       end
 
@@ -217,9 +217,9 @@ RSpec.describe AddressSearchController, type: :request do
       before do
         address_body = { results: [{ DPA: { "ADDRESS": "70, Test Street", UPRN: "123777" } }] }.to_json
         uprn_body = { results: [{ DPA: { "ADDRESS": "Path not taken", UPRN: "111" } }] }.to_json
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=70,")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=70,")
                .to_return(status: 200, body: address_body, headers: {})
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=70,")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=70,")
                .to_return(status: 200, body: uprn_body, headers: {})
       end
 
@@ -235,9 +235,9 @@ RSpec.describe AddressSearchController, type: :request do
       before do
         address_body = { results: [{ DPA: { "ADDRESS": "111, Test Street", UPRN: "123777" } }] }.to_json
         uprn_body = { results: [{ DPA: { "ADDRESS": "70 Bean Road", UPRN: "111" } }] }.to_json
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=111")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.2&query=111")
                .to_return(status: 200, body: address_body, headers: {})
-        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=111")
+        WebMock.stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=111")
                .to_return(status: 200, body: uprn_body, headers: {})
       end
 

--- a/spec/services/address_client_spec.rb
+++ b/spec/services/address_client_spec.rb
@@ -8,7 +8,7 @@ describe AddressClient do
   end
 
   def stub_api_request(body:, status: 200)
-    stub_request(:get, "https://api.os.uk/search/places/v1/find?key=OS_DATA_KEY&maxresults=10&minmatch=0.4&query=123")
+    stub_request(:get, "https://api.os.uk/search/places/v1/find?fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&maxresults=10&minmatch=0.4&query=123")
     .to_return(status:, body:, headers: {})
   end
 

--- a/spec/services/exports/lettings_log_export_service_spec.rb
+++ b/spec/services/exports/lettings_log_export_service_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Exports::LettingsLogExportService do
       before do
         Timecop.freeze(start_time)
         Singleton.__init__(FormHandler)
-        stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=100023336956")
+        stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=100023336956")
          .to_return(status: 200, body: '{"status":200,"results":[{"DPA":{
           "PO_BOX_NUMBER": "fake",
       "ORGANISATION_NAME": "org",

--- a/spec/services/uprn_client_spec.rb
+++ b/spec/services/uprn_client_spec.rb
@@ -8,7 +8,7 @@ describe UprnClient do
   end
 
   def stub_api_request(body:, status: 200)
-    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA,LPI&key=OS_DATA_KEY&uprn=123")
+    stub_request(:get, "https://api.os.uk/search/places/v1/uprn?dataset=DPA%2CLPI&fq=COUNTRY_CODE%3AE&key=OS_DATA_KEY&uprn=123")
     .to_return(status:, body:, headers: {})
   end
 


### PR DESCRIPTION
Closes [CLDC-4290](https://mhclgdigital.atlassian.net/browse/CLDC-4290).

Address search before:
<img width="850" height="719" alt="image" src="https://github.com/user-attachments/assets/488278bf-71ce-4b8f-9693-66505be23e51" />


Address search after:
<img width="870" height="653" alt="image" src="https://github.com/user-attachments/assets/4ce64393-7427-4f5a-befd-af07c2b61a00" />


UPRN search in Wales before:
<img width="925" height="583" alt="image" src="https://github.com/user-attachments/assets/9f96e41d-7410-4bff-b28f-f53294ca2972" />

UPRN search in Wales after:
<img width="969" height="520" alt="image" src="https://github.com/user-attachments/assets/835934cf-a55d-445c-adbc-0ae1e7887eac" />

UPRN in search in England unchanged:
<img width="829" height="592" alt="image" src="https://github.com/user-attachments/assets/ad3933dc-512d-4825-829c-a903eea45842" />


[CLDC-4290]: https://mhclgdigital.atlassian.net/browse/CLDC-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ