### PR TITLE
CLDC-4340: Account for nil location name on location select

### DIFF
--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -30,16 +30,8 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
 
     scheme_location_ids = lettings_log.scheme.locations.visible.confirmed.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
-                  .sort_by { |_, v|
-                    if v["hint"].present?
-                      name = v["hint"]
-                      name_text = name&.match(/[a-zA-Z].*/).to_s
-                      number = name&.match(/\d+/).to_s.to_i
-                      [0, name_text, number]
-                    else
-                      [1, v["value"]]
-                    end
-                  }.to_h
+                  .sort_by { |_, v| v["value"] }
+                  .to_h
   end
 
   def hidden_in_check_answers?(lettings_log, _current_user = nil)

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -31,8 +31,9 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
     scheme_location_ids = lettings_log.scheme.locations.visible.confirmed.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
                   .sort_by { |_, v|
-                    name = v["hint"].match(/[a-zA-Z].*/).to_s
-                    number = v["hint"].match(/\d+/).to_s.to_i
+                    name_or_postcode = v["hint"] || v["value"] # name can be nil, postcode is never nil
+                    name = name_or_postcode.match(/[a-zA-Z].*/).to_s
+                    number = name_or_postcode.match(/\d+/).to_s.to_i
                     [name, number]
                   }.to_h
   end

--- a/app/models/form/lettings/questions/location_id.rb
+++ b/app/models/form/lettings/questions/location_id.rb
@@ -31,10 +31,14 @@ class Form::Lettings::Questions::LocationId < ::Form::Question
     scheme_location_ids = lettings_log.scheme.locations.visible.confirmed.pluck(:id)
     answer_options.select { |k, _v| scheme_location_ids.include?(k.to_i) }
                   .sort_by { |_, v|
-                    name_or_postcode = v["hint"] || v["value"] # name can be nil, postcode is never nil
-                    name = name_or_postcode.match(/[a-zA-Z].*/).to_s
-                    number = name_or_postcode.match(/\d+/).to_s.to_i
-                    [name, number]
+                    if v["hint"].present?
+                      name = v["hint"]
+                      name_text = name&.match(/[a-zA-Z].*/).to_s
+                      number = name&.match(/\d+/).to_s.to_i
+                      [0, name_text, number]
+                    else
+                      [1, v["value"]]
+                    end
                   }.to_h
   end
 

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -142,41 +142,28 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
 
       context "and some locations start with numbers" do
         before do
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 5), name: "2 Abe Road")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 6), name: "1 Abe Road")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 7), name: "1 Lake Lane")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 8), name: "3 Abe Road")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 9), name: "2 Lake Lane")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 10), name: "Smith Avenue")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 11), name: "Abacus Road")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 12), name: "Hawthorne Road")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 5), name: "2 Abe Road", postcode: "AA1 1AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 6), name: "1 Abe Road", postcode: "AA1 2AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 7), name: "1 Lake Lane", postcode: "AA1 3AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 8), name: "3 Abe Road", postcode: "AA1 4AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 9), name: "2 Lake Lane", postcode: "AA1 5AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 10), name: "Smith Avenue", postcode: "AA1 6AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 11), name: "Abacus Road", postcode: "AA1 7AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 12), name: "Hawthorne Road", postcode: "AA1 8AA")
           lettings_log.update!(scheme:)
         end
 
-        it "orders the locations by name then numerically" do
+        it "orders the locations by postcode" do
           expect(question.displayed_answer_options(lettings_log).values.map { |v| v["hint"] }).to eq([
-            "Abacus Road",
-            "1 Abe Road",
             "2 Abe Road",
-            "3 Abe Road",
-            "Hawthorne Road",
+            "1 Abe Road",
             "1 Lake Lane",
+            "3 Abe Road",
             "2 Lake Lane",
             "Smith Avenue",
+            "Abacus Road",
+            "Hawthorne Road",
           ])
-        end
-      end
-
-      context "and some locations don't have names" do
-        before do
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 7), name: "other name", postcode: "AA1 1AA")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 6), name: nil, postcode: "AA1 1AB")
-          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 5), name: "A", postcode: "AA1 1AC")
-          lettings_log.update!(scheme:)
-        end
-
-        it "uses the postcode as a fallback" do
-          expect(question.displayed_answer_options(lettings_log).values.map { |v| v["value"] }).to eq(["AA1 1AC", "AA1 1AB", "AA1 1AA"])
         end
       end
     end

--- a/spec/models/form/lettings/questions/location_id_spec.rb
+++ b/spec/models/form/lettings/questions/location_id_spec.rb
@@ -166,6 +166,19 @@ RSpec.describe Form::Lettings::Questions::LocationId, type: :model do
           ])
         end
       end
+
+      context "and some locations don't have names" do
+        before do
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 7), name: "other name", postcode: "AA1 1AA")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 6), name: nil, postcode: "AA1 1AB")
+          FactoryBot.create(:location, scheme:, startdate: Time.utc(2022, 5, 5), name: "A", postcode: "AA1 1AC")
+          lettings_log.update!(scheme:)
+        end
+
+        it "uses the postcode as a fallback" do
+          expect(question.displayed_answer_options(lettings_log).values.map { |v| v["value"] }).to eq(["AA1 1AC", "AA1 1AB", "AA1 1AA"])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
closes [CLDC-4340](https://mhclgdigital.atlassian.net/browse/CLDC-4340)

there was a bug in the sort function that would always try and sort by the name which can be nil

this is only used visually for ordering the options on the page so doesn't need to be very precise

use postcode as a fallback, which should never be nil

<img alt="locations select page with a location without a name set" src="https://github.com/user-attachments/assets/142f7d07-f6e8-4d86-8b90-914f55c74959" />

[CLDC-4340]: https://mhclgdigital.atlassian.net/browse/CLDC-4340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ