### PR TITLE
CLDC-4308: Align hb answer option copy

### DIFF
--- a/app/models/form/sales/questions/housing_benefits.rb
+++ b/app/models/form/sales/questions/housing_benefits.rb
@@ -12,7 +12,7 @@ class Form::Sales::Questions::HousingBenefits < ::Form::Question
   ANSWER_OPTIONS = {
     "2" => { "value" => "Housing benefit" },
     "3" => { "value" => "Universal Credit housing element" },
-    "1" => { "value" => "Neither housing benefit or Universal Credit housing element" },
+    "1" => { "value" => "Neither" },
     "divider" => { "value" => true },
     "4" => { "value" => "Don’t know " },
   }.freeze

--- a/spec/models/form/sales/questions/housing_benefits_spec.rb
+++ b/spec/models/form/sales/questions/housing_benefits_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Form::Sales::Questions::HousingBenefits, type: :model do
       "2" => { "value" => "Housing benefit" },
       "3" => { "value" => "Universal Credit housing element" },
       "divider" => { "value" => true },
-      "1" => { "value" => "Neither housing benefit or Universal Credit housing element" },
+      "1" => { "value" => "Neither" },
       "4" => { "value" => "Don’t know " },
     })
   end


### PR DESCRIPTION
Closes [CLDC-4308](https://mhclgdigital.atlassian.net/browse/CLDC-4308).

Simple copy update to align with the paper form.
New copy:
<img width="928" height="556" alt="image" src="https://github.com/user-attachments/assets/62441494-f3a0-40a1-ba6b-542219333f97" />


[CLDC-4308]: https://mhclgdigital.atlassian.net/browse/CLDC-4308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ