### PR TITLE
CLDC-4303: Add UPRN guidance to address search

### DIFF
--- a/app/views/form/guidance/_address_search.html.erb
+++ b/app/views/form/guidance/_address_search.html.erb
@@ -2,6 +2,10 @@
   <%= I18n.t("forms.#{@log.form.start_date.year}.#{@log.form.type}.guidance.address_search.content").html_safe %>
 <% end %>
 
+<%= govuk_details(summary_text: I18n.t("forms.#{@log.form.start_date.year}.#{@log.form.type}.guidance.address_uprn.title")) do %>
+  <%= I18n.t("forms.#{@log.form.start_date.year}.#{@log.form.type}.guidance.address_uprn.content").html_safe %>
+<% end %>
+
 <div class="govuk-button-group">
   <%= govuk_link_to "Enter the address manually instead", address_manual_input_path(@log.log_type, @log.id), class: "govuk-button govuk-button--secondary" %>
 </div>

--- a/config/locales/forms/2024/lettings/guidance.en.yml
+++ b/config/locales/forms/2024/lettings/guidance.en.yml
@@ -68,3 +68,8 @@ en:
                 <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
+
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"

--- a/config/locales/forms/2024/sales/guidance.en.yml
+++ b/config/locales/forms/2024/sales/guidance.en.yml
@@ -51,3 +51,8 @@ en:
                 <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
+
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"

--- a/config/locales/forms/2025/lettings/guidance.en.yml
+++ b/config/locales/forms/2025/lettings/guidance.en.yml
@@ -67,3 +67,8 @@ en:
                 <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
+
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"

--- a/config/locales/forms/2025/sales/guidance.en.yml
+++ b/config/locales/forms/2025/sales/guidance.en.yml
@@ -51,3 +51,8 @@ en:
                 <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
+
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"

--- a/config/locales/forms/2026/lettings/guidance.en.yml
+++ b/config/locales/forms/2026/lettings/guidance.en.yml
@@ -68,6 +68,11 @@ en:
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
 
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"
+
           needs_type:
             title: "What does each need type mean?"
             content: "General needs housing includes both self-contained and shared housing without support or specific adaptations.<br><br>Supported housing is housing with special design facilities or features targeted at a specific client group requiring support, for example housing designed for older people, sheltered accommodation, extra care housing. It can include direct access hostels, group homes, and purpose-built self-contained housing. We do not require CORE logs for residential care or nursing homes."

--- a/config/locales/forms/2026/sales/guidance.en.yml
+++ b/config/locales/forms/2026/sales/guidance.en.yml
@@ -50,3 +50,8 @@ en:
                 <li>Some properties may not be available yet e.g. new builds; you might need to enter them manually instead</li>
                 <li>For UPRN (Unique Property Reference Number), please enter the full value exactly</li>
               </ul>"
+
+          address_uprn:
+            title: "What is a UPRN?"
+            content: "<p>The Unique Property Reference Number (UPRN) is a unique number system created by Ordnance Survey and used by housing providers and various industries across the UK. An example is 0010457355.</p>
+              <p>The UPRN may not be the same as the property reference assigned by your organisation.</p>"


### PR DESCRIPTION
closes [CLDC-4303](https://mhclgdigital.atlassian.net/browse/CLDC-4303)

adds a dropdown to the address search page

adds copy for all years this could be viewable in

<img alt="q16 address search lettings with uprn dropdown" src="https://github.com/user-attachments/assets/5a5bfa24-83d8-4b41-bbd0-74e3381af6aa" />


[CLDC-4303]: https://mhclgdigital.atlassian.net/browse/CLDC-4303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ