### PR TITLE
CLDC-4304: Update person known page copy for 2026

### DIFF
--- a/app/views/form/headers/_person_2_known_page.erb
+++ b/app/views/form/headers/_person_2_known_page.erb
@@ -1,1 +1,5 @@
-You have given us the details for 0 of the <%= log.hholdcount %> other people in the household
+<% if log.form.start_year_2026_or_later? %>
+  You have given us the details for 1 of the <%= log.hholdcount %> people in the household
+<% else %>
+  You have given us the details for 0 of the <%= log.hholdcount %> other people in the household
+<% end %>

--- a/app/views/form/headers/_person_3_known_page.erb
+++ b/app/views/form/headers/_person_3_known_page.erb
@@ -1,1 +1,5 @@
-You have given us the details for <%= log.joint_purchase? ? 0 : 1 %> of the <%= log.hholdcount %> other people in the household
+<% if log.form.start_year_2026_or_later? %>
+  You have given us the details for 2 of the <%= log.hholdcount %> people in the household
+<% else %>
+  You have given us the details for <%= log.joint_purchase? ? 0 : 1 %> of the <%= log.hholdcount %> other people in the household
+<% end %>

--- a/app/views/form/headers/_person_4_known_page.erb
+++ b/app/views/form/headers/_person_4_known_page.erb
@@ -1,1 +1,5 @@
-You have given us the details for <%= log.joint_purchase? ? 1 : 2 %> of the <%= log.hholdcount %> other people in the household
+<% if log.form.start_year_2026_or_later? %>
+  You have given us the details for 3 of the <%= log.hholdcount %> people in the household
+<% else %>
+  You have given us the details for <%= log.joint_purchase? ? 1 : 2 %> of the <%= log.hholdcount %> other people in the household
+<% end %>

--- a/app/views/form/headers/_person_5_known_page.erb
+++ b/app/views/form/headers/_person_5_known_page.erb
@@ -1,1 +1,5 @@
-You have given us the details for <%= log.joint_purchase? ? 2 : 3 %> of the <%= log.hholdcount %> other people in the household
+<% if log.form.start_year_2026_or_later? %>
+  You have given us the details for 4 of the <%= log.hholdcount %> people in the household
+<% else %>
+  You have given us the details for <%= log.joint_purchase? ? 2 : 3 %> of the <%= log.hholdcount %> other people in the household
+<% end %>

--- a/app/views/form/headers/_person_6_known_page.erb
+++ b/app/views/form/headers/_person_6_known_page.erb
@@ -1,1 +1,5 @@
-You have given us the details for <%= log.joint_purchase? ? 3 : 4 %> of the <%= log.hholdcount %> other people in the household
+<% if log.form.start_year_2026_or_later? %>
+  You have given us the details for 5 of the <%= log.hholdcount %> people in the household
+<% else %>
+  You have given us the details for <%= log.joint_purchase? ? 3 : 4 %> of the <%= log.hholdcount %> other people in the household
+<% end %>


### PR DESCRIPTION
closes [CLDC-4304](https://mhclgdigital.atlassian.net/browse/CLDC-4304)

to account for this question now being total person count

I'm pretty certain what we want now is that the logic is simpler, person 3 page is shown for the 3rd person regardless of if it's a joint purchase or not. joint purchase only impacts seeing the person 2 page or not

<details><summary>screenshots</summary>
<img alt="person-2-known" src="https://github.com/user-attachments/assets/476d34d7-59bd-4993-b0ee-1790e0efb346" />
<img alt="person-3-known" src="https://github.com/user-attachments/assets/b564b8df-94c6-4bfc-8a3d-fc20bca0fd41" />
<img alt="person-4-known" src="https://github.com/user-attachments/assets/b1b55717-73f1-4792-8fdd-d419252b0961" />
<img alt="person-5-known" src="https://github.com/user-attachments/assets/2437fc1b-8a8d-41b8-93ae-19867d47c712" />
<img alt="person-6-known" src="https://github.com/user-attachments/assets/e21b7f6b-d411-43ff-b2e9-bdd2a81c9e10" />
</details>

[CLDC-4304]: https://mhclgdigital.atlassian.net/browse/CLDC-4304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ