### PR TITLE
CLDC-4355: Add hyphens to housing-related

### DIFF
--- a/config/locales/forms/2025/lettings/income_and_benefits.en.yml
+++ b/config/locales/forms/2025/lettings/income_and_benefits.en.yml
@@ -25,10 +25,10 @@ en:
 
           hb:
             page_header: ""
-            check_answer_label: "Housing related benefits received"
-            check_answer_prompt: "Tell us if household receives housing related benefits"
-            hint_text: "This is about when the tenant is in their new let. If they are unsure about the situation for their new let and their financial and working situation hasn’t changed significantly, answer based on what housing related benefits they currently receive."
-            question_text: "Is the household likely to be receiving any of these housing related benefits?"
+            check_answer_label: "Housing-related benefits received"
+            check_answer_prompt: "Tell us if household receives housing-related benefits"
+            hint_text: "This is about when the tenant is in their new let. If they are unsure about the situation for their new let and their financial and working situation hasn’t changed significantly, answer based on what housing-related benefits they currently receive."
+            question_text: "Is the household likely to be receiving any of these housing-related benefits?"
 
           benefits:
             page_header: ""
@@ -112,7 +112,7 @@ en:
             check_answer_label: "Any outstanding amount for basic rent and charges"
             check_answer_prompt: "Tell us if any outstanding amount for basic rent and charges"
             hint_text: "Also known as the ‘outstanding amount’."
-            question_text: "After the household has received any housing related benefits, will they still need to pay for rent and charges?"
+            question_text: "After the household has received any housing-related benefits, will they still need to pay for rent and charges?"
 
           outstanding_amount:
             page_header: ""

--- a/config/locales/forms/2025/sales/income_benefits_and_savings.en.yml
+++ b/config/locales/forms/2025/sales/income_benefits_and_savings.en.yml
@@ -46,16 +46,16 @@ en:
           housing_benefits:
             joint_purchase:
               page_header: ""
-              check_answer_label: "Housing related benefits buyers received before buying this property"
+              check_answer_label: "Housing-related benefits buyers received before buying this property"
               check_answer_prompt: ""
               hint_text: ""
-              question_text:  "Were the buyers receiving any of these housing related benefits immediately before buying this property?"
+              question_text:  "Were the buyers receiving any of these housing-related benefits immediately before buying this property?"
             not_joint_purchase:
               page_header: ""
-              check_answer_label: "Housing related benefits buyer received before buying this property"
+              check_answer_label: "Housing-related benefits buyer received before buying this property"
               check_answer_prompt: ""
               hint_text: ""
-              question_text:  "Was the buyer receiving any of these housing related benefits immediately before buying this property?"
+              question_text:  "Was the buyer receiving any of these housing-related benefits immediately before buying this property?"
 
           savings:
             joint_purchase:

--- a/config/locales/forms/2026/lettings/income_and_benefits.en.yml
+++ b/config/locales/forms/2026/lettings/income_and_benefits.en.yml
@@ -25,10 +25,10 @@ en:
 
           hb:
             page_header: ""
-            check_answer_label: "Housing related benefits received"
-            check_answer_prompt: "Tell us if household receives housing related benefits"
-            hint_text: "This is about when the tenant is in their new let. If they are unsure about the situation for their new let and their financial and working situation hasn’t changed significantly, answer based on what housing related benefits they currently receive."
-            question_text: "Is the household likely to be receiving any of these housing related benefits?"
+            check_answer_label: "Housing-related benefits received"
+            check_answer_prompt: "Tell us if household receives housing-related benefits"
+            hint_text: "This is about when the tenant is in their new let. If they are unsure about the situation for their new let and their financial and working situation hasn’t changed significantly, answer based on what housing-related benefits they currently receive."
+            question_text: "Is the household likely to be receiving any of these housing-related benefits?"
 
           benefits:
             page_header: ""
@@ -112,7 +112,7 @@ en:
             check_answer_label: "Any outstanding amount for basic rent and charges"
             check_answer_prompt: "Tell us if any outstanding amount for basic rent and charges"
             hint_text: "Also known as the ‘outstanding amount’."
-            question_text: "After the household has received any housing related benefits, will they still need to pay for rent and charges?"
+            question_text: "After the household has received any housing-related benefits, will they still need to pay for rent and charges?"
 
           outstanding_amount:
             page_header: ""

--- a/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
+++ b/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
@@ -46,16 +46,16 @@ en:
           housing_benefits:
             joint_purchase:
               page_header: ""
-              check_answer_label: "Housing related benefits buyers received before buying this property"
+              check_answer_label: "Housing-related benefits buyers received before buying this property"
               check_answer_prompt: ""
               hint_text: ""
-              question_text:  "Were the buyers receiving any of these housing related benefits immediately before buying this property?"
+              question_text:  "Were the buyers receiving any of these housing-related benefits immediately before buying this property?"
             not_joint_purchase:
               page_header: ""
-              check_answer_label: "Housing related benefits buyer received before buying this property"
+              check_answer_label: "Housing-related benefits buyer received before buying this property"
               check_answer_prompt: ""
               hint_text: ""
-              question_text:  "Was the buyer receiving any of these housing related benefits immediately before buying this property?"
+              question_text:  "Was the buyer receiving any of these housing-related benefits immediately before buying this property?"
 
           savings:
             joint_purchase:


### PR DESCRIPTION
closes [CLDC-4355](https://mhclgdigital.atlassian.net/browse/CLDC-4355)

fixes all instances of "housing related" I could find to be "housing-related"

<details><summary>screenshots</summary>
<img alt="lettings-housing-benefit-question" src="https://github.com/user-attachments/assets/b6636227-2b4e-4230-9ed0-fa925a68a472" />
<img alt="lettings-outstanding-question" src="https://github.com/user-attachments/assets/d19dbc90-31cd-4c42-9aef-9e76a84000bf" />
<img alt="sales-housing-benefits-joint" src="https://github.com/user-attachments/assets/ebafdb09-0199-4abf-833e-4db9fb05a753" />
<img alt="sales-housing-benefits-not-joint" src="https://github.com/user-attachments/assets/037834c9-05ff-4be5-909c-850be55e44ff" />
</details>


[CLDC-4355]: https://mhclgdigital.atlassian.net/browse/CLDC-4355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ