### PR TITLE
CLDC-4362: Add 'Don't know' to Q70 still serving

### DIFF
--- a/app/models/form/sales/questions/buyer_still_serving.rb
+++ b/app/models/form/sales/questions/buyer_still_serving.rb
@@ -13,6 +13,8 @@ class Form::Sales::Questions::BuyerStillServing < ::Form::Question
         "4" => { "value" => "Yes" },
         "5" => { "value" => "No - they left up to and including 2 years ago" },
         "6" => { "value" => "No - they left more than 2 years ago" },
+        "divider" => { "value" => true },
+        "7" => { "value" => "Don’t know" },
       }.freeze
     else
       {

--- a/app/models/form/sales/questions/buyer_still_serving.rb
+++ b/app/models/form/sales/questions/buyer_still_serving.rb
@@ -14,7 +14,7 @@ class Form::Sales::Questions::BuyerStillServing < ::Form::Question
         "5" => { "value" => "No - they left up to and including 2 years ago" },
         "6" => { "value" => "No - they left more than 2 years ago" },
         "divider" => { "value" => true },
-        "7" => { "value" => "Don’t know" },
+        "9" => { "value" => "Don’t know" },
       }.freeze
     else
       {

--- a/spec/models/form/sales/questions/buyer_still_serving_spec.rb
+++ b/spec/models/form/sales/questions/buyer_still_serving_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Form::Sales::Questions::BuyerStillServing, type: :model do
         "5" => { "value" => "No - they left up to and including 2 years ago" },
         "6" => { "value" => "No - they left more than 2 years ago" },
         "divider" => { "value" => true },
-        "7" => { "value" => "Don’t know" },
+        "9" => { "value" => "Don’t know" },
       })
     end
   end

--- a/spec/models/form/sales/questions/buyer_still_serving_spec.rb
+++ b/spec/models/form/sales/questions/buyer_still_serving_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe Form::Sales::Questions::BuyerStillServing, type: :model do
         "4" => { "value" => "Yes" },
         "5" => { "value" => "No - they left up to and including 2 years ago" },
         "6" => { "value" => "No - they left more than 2 years ago" },
+        "divider" => { "value" => true },
+        "7" => { "value" => "Don’t know" },
       })
     end
   end


### PR DESCRIPTION
closes [CLDC-4362](https://mhclgdigital.atlassian.net/browse/CLDC-4362)

adds missing Don't know option that was still wanted for 26/27 

options added in #3248 



[CLDC-4362]: https://mhclgdigital.atlassian.net/browse/CLDC-4362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ