### PR TITLE
CLDC-4338: remove test logs button on staging

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -28,7 +28,7 @@ class FeatureToggle
   end
 
   def self.create_test_logs_enabled?
-    Rails.env.development? || Rails.env.review? || Rails.env.staging?
+    Rails.env.development? || Rails.env.review?
   end
 
   def self.sales_export_enabled?


### PR DESCRIPTION
Closes [CLDC-4338](https://mhclgdigital.atlassian.net/browse/CLDC-4338).

Removes the test log buttons from staging so that staging more accurately mirror prod now our go-live testing is complete.

DO NOT MERGE until after go-live.

[CLDC-4338]: https://mhclgdigital.atlassian.net/browse/CLDC-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ