### PR TITLE
CLDC-4307: Move buyer income hint text to income known qs

### DIFF
--- a/config/locales/forms/2025/sales/income_benefits_and_savings.en.yml
+++ b/config/locales/forms/2025/sales/income_benefits_and_savings.en.yml
@@ -8,12 +8,12 @@ en:
             income1nk:
               check_answer_label: "Buyer 1’s gross annual income known"
               check_answer_prompt: "Enter buyer 1’s gross annual income if known"
-              hint_text: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
               question_text: "Do you know buyer 1’s annual income?"
             income1:
               check_answer_label: "Buyer 1’s gross annual income"
               check_answer_prompt: ""
-              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              hint_text: ""
               question_text: "Buyer 1’s gross annual income"
 
           inc1mort:
@@ -28,12 +28,12 @@ en:
             income2nk:
               check_answer_label: "Buyer 2’s gross annual income known"
               check_answer_prompt: "Enter buyer 2’s gross annual income if known"
-              hint_text: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
               question_text: "Do you know buyer 2’s annual income?"
             income2:
               check_answer_label: "Buyer 2’s gross annual income"
               check_answer_prompt: ""
-              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              hint_text: ""
               question_text: "Buyer 2’s gross annual income"
 
           inc2mort:

--- a/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
+++ b/config/locales/forms/2026/sales/income_benefits_and_savings.en.yml
@@ -8,12 +8,12 @@ en:
             income1nk:
               check_answer_label: "Buyer 1’s gross annual income known"
               check_answer_prompt: "Enter buyer 1’s gross annual income if known"
-              hint_text: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
               question_text: "Do you know buyer 1’s annual income?"
             income1:
               check_answer_label: "Buyer 1’s gross annual income"
               check_answer_prompt: ""
-              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              hint_text: ""
               question_text: "Buyer 1’s gross annual income"
 
           inc1mort:
@@ -28,12 +28,12 @@ en:
             income2nk:
               check_answer_label: "Buyer 2’s gross annual income known"
               check_answer_prompt: "Enter buyer 2’s gross annual income if known"
-              hint_text: ""
+              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
               question_text: "Do you know buyer 2’s annual income?"
             income2:
               check_answer_label: "Buyer 2’s gross annual income"
               check_answer_prompt: ""
-              hint_text: "Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments."
+              hint_text: ""
               question_text: "Buyer 2’s gross annual income"
 
           inc2mort:

--- a/spec/models/form/sales/questions/buyer1_income_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_known_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Questions::Buyer1IncomeKnown, type: :model do
+  include CollectionTimeHelper
   subject(:question) { described_class.new(question_id, question_definition, page) }
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
+  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: collection_start_date_for_year(current_collection_start_year)))) }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -38,5 +39,9 @@ RSpec.describe Form::Sales::Questions::Buyer1IncomeKnown, type: :model do
 
   it "has the correct check_answers_card_number" do
     expect(question.check_answers_card_number).to eq(1)
+  end
+
+  it "has the correct hint_text" do
+    expect(question.hint_text).to eq("Provide the gross annual income (i.e. salary before tax) plus the annual amount of benefits, Universal Credit or pensions, and income from investments.")
   end
 end

--- a/spec/models/form/sales/questions/buyer1_income_known_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_known_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe Form::Sales::Questions::Buyer1IncomeKnown, type: :model do
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: collection_start_date_for_year(current_collection_start_year)))) }
+  let(:page) { instance_double(Form::Page) }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form, start_date: current_collection_start_date) }
+
+  before do
+    allow(page).to receive(:subsection).and_return(subsection)
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct page" do
     expect(question.page).to eq(page)

--- a/spec/models/form/sales/questions/buyer1_income_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Questions::Buyer1Income, type: :model do
+  include CollectionTimeHelper
   subject(:question) { described_class.new(question_id, question_definition, page) }
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: Time.zone.local(2023, 4, 1)))) }
+  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: collection_start_date_for_year(current_collection_start_year)))) }
 
   it "has correct page" do
     expect(question.page).to eq(page)
@@ -45,5 +46,9 @@ RSpec.describe Form::Sales::Questions::Buyer1Income, type: :model do
 
   it "has correct max" do
     expect(question.max).to eq(999_999)
+  end
+
+  it "has the correct hint_text" do
+    expect(question.hint_text).to eq("")
   end
 end

--- a/spec/models/form/sales/questions/buyer1_income_spec.rb
+++ b/spec/models/form/sales/questions/buyer1_income_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe Form::Sales::Questions::Buyer1Income, type: :model do
 
   let(:question_id) { nil }
   let(:question_definition) { nil }
-  let(:page) { instance_double(Form::Page, subsection: instance_double(Form::Subsection, form: instance_double(Form, start_date: collection_start_date_for_year(current_collection_start_year)))) }
+  let(:page) { instance_double(Form::Page) }
+  let(:subsection) { instance_double(Form::Subsection) }
+  let(:form) { instance_double(Form, start_date: current_collection_start_date) }
+
+  before do
+    allow(page).to receive(:subsection).and_return(subsection)
+    allow(subsection).to receive(:form).and_return(form)
+  end
 
   it "has correct page" do
     expect(question.page).to eq(page)


### PR DESCRIPTION
Closes [CLDC-4307](https://mhclgdigital.atlassian.net/browse/CLDC-4307).

Screenshots:
26/27:
<img width="1006" height="487" alt="image" src="https://github.com/user-attachments/assets/7c43d3d5-a689-4666-94cb-2f2f455e0c49" />
<img width="906" height="577" alt="image" src="https://github.com/user-attachments/assets/2687b807-9687-4e45-99f3-4d3efed251d3" />
25/26:
<img width="895" height="482" alt="image" src="https://github.com/user-attachments/assets/967ea160-50a2-48b7-9888-cb92c0066611" />
<img width="1043" height="562" alt="image" src="https://github.com/user-attachments/assets/6ec8c0a7-81da-4dcb-8654-c60f36e77cf1" />


[CLDC-4307]: https://mhclgdigital.atlassian.net/browse/CLDC-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ