### PR TITLE
CLDC-4289: Ensure numbers can be parsed to floats before totaling

### DIFF
--- a/app/frontend/controllers/numeric_question_controller.js
+++ b/app/frontend/controllers/numeric_question_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
   calculateFields () {
     const affectedField = this.element.dataset.target
     const fieldsToAdd = JSON.parse(this.element.dataset.calculated).map(x => `lettings-log-${x.replaceAll('_', '-')}-field`)
-    const valuesToAdd = fieldsToAdd.map(x => getFieldValue(x)).filter(x => x)
+    const valuesToAdd = fieldsToAdd.map(x => getFieldValue(x)).filter(x => x && !isNaN(parseFloat(x)))
     const newValue = valuesToAdd.map(x => parseFloat(x)).reduce((a, b) => a + b, 0).toFixed(2)
     const elementToUpdate = document.getElementById(affectedField)
     elementToUpdate.value = newValue

--- a/spec/features/form/progressive_total_field_spec.rb
+++ b/spec/features/form/progressive_total_field_spec.rb
@@ -58,4 +58,13 @@ RSpec.describe "Accessible Autocomplete" do
     fill_in("lettings-log-supcharg-field-error", with: 50)
     expect(find("#lettings-log-tcharge-field").value).to eq("550.00")
   end
+
+  it "does not show 'NaN' if one of the inputs is not a number", :js do
+    visit("/lettings-logs/#{lettings_log.id}/rent")
+    expect(page).to have_selector("#tcharge_div")
+    fill_in("lettings-log-brent-field", with: 5)
+    expect(find("#lettings-log-tcharge-field").value).to eq("5.00")
+    fill_in("lettings-log-pscharge-field", with: "something else")
+    expect(find("#lettings-log-tcharge-field").value).to eq("5.00")
+  end
 end


### PR DESCRIPTION
closes [CLDC-4289](https://mhclgdigital.atlassian.net/browse/CLDC-4289)

updates logic and adds a test

this logic draws from the `@fields_added = %w[brent scharge pscharge supcharg]` property of the `tcharge` questions, which eventually makes it way to this controller

see also `question_attribute_controller.rb`

[CLDC-4289]: https://mhclgdigital.atlassian.net/browse/CLDC-4289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ