### PR TITLE
CLDC-4298: Ensure value must be a whole number

### DIFF
--- a/app/models/form/sales/questions/purchase_price.rb
+++ b/app/models/form/sales/questions/purchase_price.rb
@@ -4,7 +4,7 @@ class Form::Sales::Questions::PurchasePrice < ::Form::Question
     @id = "value"
     @type = "numeric"
     @min = form.start_year_2026_or_later? ? 15_000 : 0
-    @step = 0.01
+    @step = form.start_year_2026_or_later? ? 1 : 0.01 # 0.01 was a mistake that was fixed in 2026
     @width = 5
     @prefix = "£"
     @ownership_sch = ownershipsch

--- a/lib/tasks/round_value_for_2026_sales_logs.rake
+++ b/lib/tasks/round_value_for_2026_sales_logs.rake
@@ -1,0 +1,12 @@
+desc "Rounds and value for sales logs in the database if they are not a whole number"
+task round_value_for_2026_sales_logs: :environment do
+  ids = SalesLog.filter_by_year(2026).where("value % 1 != 0").pluck(:id)
+  puts "Correcting #{ids.count} sales logs, #{ids}"
+
+  # find all values of mortgage that are not a whole number
+  SalesLog.filter_by_year(2026).where("value % 1 != 0").find_each do |log|
+    log.update(value: log.value.round)
+  end
+
+  puts "Done"
+end

--- a/lib/tasks/round_value_for_2026_sales_logs.rake
+++ b/lib/tasks/round_value_for_2026_sales_logs.rake
@@ -1,10 +1,9 @@
-desc "Rounds and value for sales logs in the database if they are not a whole number"
+desc "Rounds purchase price (the 'value' field) for sales logs in the database if not a whole number"
 task round_value_for_2026_sales_logs: :environment do
-  ids = SalesLog.filter_by_year(2026).where("value % 1 != 0").pluck(:id)
-  puts "Correcting #{ids.count} sales logs, #{ids}"
+  logs = SalesLog.filter_by_year(2026).where("value % 1 != 0")
+  puts "Correcting #{logs.count} sales logs, #{logs.map(&:id)}"
 
-  # find all values of mortgage that are not a whole number
-  SalesLog.filter_by_year(2026).where("value % 1 != 0").find_each do |log|
+  logs.find_each do |log|
     log.update(value: log.value.round)
   end
 


### PR DESCRIPTION
closes [CLDC-4298](https://mhclgdigital.atlassian.net/browse/CLDC-4298)

the `@step` property for purchase_price was incorrectly set to 0.01, allowing for non whole numbers to be input

this is fixed for 2026

we should also run the attached script post release to round all logs with an incorrect value value to the nearest whole number

<img alt="image" src="https://github.com/user-attachments/assets/e267b5e3-d41c-4ba4-b79f-cc27eef720f5" />

[CLDC-4298]: https://mhclgdigital.atlassian.net/browse/CLDC-4298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ