### PR TITLE
CLDC-4363: Fix tests failing 31st June

### DIFF
--- a/app/helpers/collection_time_helper.rb
+++ b/app/helpers/collection_time_helper.rb
@@ -29,6 +29,10 @@ module CollectionTimeHelper
     Time.zone.local(current_collection_start_year, 4, 1)
   end
 
+  def current_collection_after_crossover_start_date
+    Form::DEADLINES[current_collection_start_year][:edit_end_date] + 1.day
+  end
+
   def collection_end_date(date)
     Time.zone.local(collection_start_year_for_date(date) + 1, 3, 31).end_of_day
   end

--- a/spec/models/form/sales/pages/property_building_type_spec.rb
+++ b/spec/models/form/sales/pages/property_building_type_spec.rb
@@ -1,12 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Pages::PropertyBuildingType, type: :model do
+  include CollectionTimeHelper
+
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:form) { instance_double(Form, start_date: Time.zone.local(2024, 4, 1)) }
+  let(:form) { instance_double(Form, start_date: current_collection_start_date) }
   let(:subsection) { instance_double(Form::Subsection, enabled?: true, form:) }
+  let(:saledate) { current_collection_start_date }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -24,45 +27,21 @@ RSpec.describe Form::Sales::Pages::PropertyBuildingType, type: :model do
     expect(page.description).to be_nil
   end
 
-  context "with form year 2024" do
-    let(:form) { Form.new(nil, 2024, [], "sales") }
-    let(:saledate) { Time.zone.local(2024, 4, 1) }
+  context "with a staircasing log" do
+    let(:form) { Form.new(nil, current_collection_start_year, [], "sales") }
+    let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
 
-    context "with a staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
-    end
-
-    context "with a non-staircasing log" do
-      let(:log) { build(:sales_log, staircase: nil, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
+    it "is not routed to" do
+      expect(page.routed_to?(log, nil)).to be false
     end
   end
 
-  context "with form year 2025" do
-    let(:form) { Form.new(nil, 2025, [], "sales") }
-    let(:saledate) { Time.zone.local(2025, 4, 1) }
+  context "with a non-staircasing log" do
+    let(:form) { Form.new(nil, current_collection_start_year, [], "sales") }
+    let(:log) { build(:sales_log, staircase: nil, saledate:) }
 
-    context "with a staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
-
-      it "is not routed to" do
-        expect(page.routed_to?(log, nil)).to be false
-      end
-    end
-
-    context "with a non-staircasing log" do
-      let(:log) { build(:sales_log, staircase: nil, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
+    it "is routed to" do
+      expect(page.routed_to?(log, nil)).to be true
     end
   end
 end

--- a/spec/models/form/sales/pages/property_wheelchair_accessible_spec.rb
+++ b/spec/models/form/sales/pages/property_wheelchair_accessible_spec.rb
@@ -1,12 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Form::Sales::Pages::PropertyWheelchairAccessible, type: :model do
+  include CollectionTimeHelper
+
   subject(:page) { described_class.new(page_id, page_definition, subsection) }
 
   let(:page_id) { nil }
   let(:page_definition) { nil }
-  let(:form) { instance_double(Form, start_year_2024_or_later?: false, start_date: Time.zone.local(2023, 4, 1)) }
+  let(:form) { instance_double(Form, start_year_2024_or_later?: true, start_date: current_collection_start_date) }
   let(:subsection) { instance_double(Form::Subsection, enabled?: true, form:) }
+  let(:saledate) { current_collection_start_date }
 
   it "has correct subsection" do
     expect(page.subsection).to eq(subsection)
@@ -24,45 +27,21 @@ RSpec.describe Form::Sales::Pages::PropertyWheelchairAccessible, type: :model do
     expect(page.description).to be_nil
   end
 
-  context "with form year 2024" do
-    let(:form) { Form.new(nil, 2024, [], "sales") }
-    let(:saledate) { Time.zone.local(2024, 4, 1) }
+  context "with a staircasing log" do
+    let(:form) { Form.new(nil, current_collection_start_year, [], "sales") }
+    let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
 
-    context "with a staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
-    end
-
-    context "with a non-staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 2, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
+    it "is not routed to" do
+      expect(page.routed_to?(log, nil)).to be false
     end
   end
 
-  context "with form year 2025" do
-    let(:form) { Form.new(nil, 2025, [], "sales") }
-    let(:saledate) { Time.zone.local(2025, 4, 1) }
+  context "with a non-staircasing log" do
+    let(:form) { Form.new(nil, current_collection_start_year, [], "sales") }
+    let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 2, saledate:) }
 
-    context "with a staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 1, saledate:) }
-
-      it "is not routed to" do
-        expect(page.routed_to?(log, nil)).to be false
-      end
-    end
-
-    context "with a non-staircasing log" do
-      let(:log) { build(:sales_log, :shared_ownership_setup_complete, staircase: 2, saledate:) }
-
-      it "is routed to" do
-        expect(page.routed_to?(log, nil)).to be true
-      end
+    it "is routed to" do
+      expect(page.routed_to?(log, nil)).to be true
     end
   end
 end

--- a/spec/models/lettings_log_derived_fields_spec.rb
+++ b/spec/models/lettings_log_derived_fields_spec.rb
@@ -111,45 +111,6 @@ RSpec.describe LettingsLog, type: :model do
   end
 
   describe "deriving household member fields" do
-    context "when it is 2024", metadata: { year: 24 } do
-      let(:startdate) { collection_start_date_for_year(2024) }
-
-      before do
-        log.assign_attributes(
-          relat2: "X",
-          relat3: "C",
-          relat4: "X",
-          relat5: "C",
-          relat7: "C",
-          relat8: "X",
-          age1: 22,
-          age2: 16,
-          age4: 60,
-          age6: 88,
-          age7: 14,
-          age8: 42,
-        )
-
-        log.set_derived_fields!
-      end
-
-      it "correctly derives totchild" do
-        expect(log.totchild).to eq 3
-      end
-
-      it "correctly derives totelder" do
-        expect(log.totelder).to eq 2
-      end
-
-      it "correctly derives totadult" do
-        expect(log.totadult).to eq 3
-      end
-
-      it "correctly derives economic status for tenants under 16" do
-        expect(log.ecstat7).to eq 9
-      end
-    end
-
     context "when it is 2025", metadata: { year: 25 } do
       let(:startdate) { collection_start_date_for_year(2025) }
 

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Validations::DateValidations do
+  include CollectionTimeHelper
+
   subject(:date_validator) { validator_class.new }
 
   let(:validator_class) { Class.new { include Validations::DateValidations } }
@@ -54,44 +56,22 @@ RSpec.describe Validations::DateValidations do
       expect(record.errors["mrcdate"]).to be_empty
     end
 
-    context "with 2024 logs or earlier" do
-      it "cannot be more than 10 years before the tenancy start date" do
-        record.startdate = Time.zone.local(2024, 4, 1)
-        record.mrcdate = Time.zone.local(2014, 1, 31)
-        date_validator.validate_property_major_repairs(record)
-        expect(record.errors["mrcdate"])
-          .to include(match I18n.t("validations.lettings.date.mrcdate.ten_years_before_tenancy_start"))
-        expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_mrc_date"))
-      end
-
-      it "must be within 10 years of the tenancy start date" do
-        record.startdate = Time.zone.local(2024, 2, 1)
-        record.mrcdate = Time.zone.local(2014, 2, 1)
-        date_validator.validate_property_major_repairs(record)
-        expect(record.errors["mrcdate"]).to be_empty
-        expect(record.errors["startdate"]).to be_empty
-      end
+    it "cannot be more than 20 years before the tenancy start date" do
+      record.startdate = current_collection_start_date
+      record.mrcdate = current_collection_start_date - 20.years - 1.day
+      date_validator.validate_property_major_repairs(record)
+      expect(record.errors["mrcdate"])
+        .to include(match I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start"))
+      expect(record.errors["startdate"])
+        .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date"))
     end
 
-    context "with 2025 logs or later" do
-      it "cannot be more than 20 years before the tenancy start date" do
-        record.startdate = Time.zone.local(2026, 2, 1)
-        record.mrcdate = Time.zone.local(2006, 1, 31)
-        date_validator.validate_property_major_repairs(record)
-        expect(record.errors["mrcdate"])
-          .to include(match I18n.t("validations.lettings.date.mrcdate.twenty_years_before_tenancy_start"))
-        expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_mrc_date"))
-      end
-
-      it "must be within 20 years of the tenancy start date" do
-        record.startdate = Time.zone.local(2026, 2, 1)
-        record.mrcdate = Time.zone.local(2006, 2, 1)
-        date_validator.validate_property_major_repairs(record)
-        expect(record.errors["mrcdate"]).to be_empty
-        expect(record.errors["startdate"]).to be_empty
-      end
+    it "can be within 20 years of the tenancy start date" do
+      record.startdate = current_collection_start_date
+      record.mrcdate = current_collection_start_date - 20.years
+      date_validator.validate_property_major_repairs(record)
+      expect(record.errors["mrcdate"]).to be_empty
+      expect(record.errors["startdate"]).to be_empty
     end
 
     context "when reason for vacancy is first let of property" do
@@ -148,45 +128,23 @@ RSpec.describe Validations::DateValidations do
       expect(record.errors["voiddate"]).to be_empty
     end
 
-    context "with 2024 logs or earlier" do
-      it "cannot be more than 10 years before the tenancy start date" do
-        record.startdate = Time.zone.local(2024, 4, 1)
-        record.voiddate = Time.zone.local(2014, 1, 31)
-        date_validator.validate_property_void_date(record)
-        expect(record.errors["voiddate"])
-          .to include(match I18n.t("validations.lettings.date.void_date.ten_years_before_tenancy_start"))
-        expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.lettings.date.startdate.ten_years_after_void_date"))
-      end
-
-      it "must be within 10 years of the tenancy start date" do
-        record.startdate = Time.zone.local(2024, 2, 1)
-        record.voiddate = Time.zone.local(2014, 2, 1)
-        date_validator.validate_property_void_date(record)
-        expect(record.errors["voiddate"]).to be_empty
-        expect(record.errors["startdate"]).to be_empty
-      end
+    it "cannot be more than 20 years before the tenancy start date" do
+      record.startdate = current_collection_start_date
+      record.voiddate = current_collection_start_date - 20.years - 1.day
+      date_validator.validate_property_void_date(record)
+      date_validator.validate_startdate(record)
+      expect(record.errors["voiddate"])
+        .to include(match I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start"))
+      expect(record.errors["startdate"])
+        .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date"))
     end
 
-    context "with 2025 logs or later" do
-      it "cannot be more than 20 years before the tenancy start date" do
-        record.startdate = Time.zone.local(2026, 2, 1)
-        record.voiddate = Time.zone.local(2006, 1, 31)
-        date_validator.validate_property_void_date(record)
-        date_validator.validate_startdate(record)
-        expect(record.errors["voiddate"])
-          .to include(match I18n.t("validations.lettings.date.void_date.twenty_years_before_tenancy_start"))
-        expect(record.errors["startdate"])
-          .to include(match I18n.t("validations.lettings.date.startdate.twenty_years_after_void_date"))
-      end
-
-      it "must be within 20 years of the tenancy start date" do
-        record.startdate = Time.zone.local(2026, 2, 1)
-        record.voiddate = Time.zone.local(2006, 2, 1)
-        date_validator.validate_property_void_date(record)
-        expect(record.errors["voiddate"]).to be_empty
-        expect(record.errors["startdate"]).to be_empty
-      end
+    it "can be within 20 years of the tenancy start date" do
+      record.startdate = current_collection_start_date
+      record.mrcdate = current_collection_start_date - 20.years - 1.day
+      date_validator.validate_property_void_date(record)
+      expect(record.errors["voiddate"]).to be_empty
+      expect(record.errors["startdate"]).to be_empty
     end
 
     context "when major repairs have been carried out" do

--- a/spec/models/validations/date_validations_spec.rb
+++ b/spec/models/validations/date_validations_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Validations::DateValidations do
 
     it "can be within 20 years of the tenancy start date" do
       record.startdate = current_collection_start_date
-      record.mrcdate = current_collection_start_date - 20.years - 1.day
+      record.voiddate = current_collection_start_date - 20.years
       date_validator.validate_property_void_date(record)
       expect(record.errors["voiddate"]).to be_empty
       expect(record.errors["startdate"]).to be_empty

--- a/spec/models/validations/sales/soft_validations_spec.rb
+++ b/spec/models/validations/sales/soft_validations_spec.rb
@@ -30,57 +30,8 @@ RSpec.describe Validations::Sales::SoftValidations do
         expect(record).not_to be_income2_outside_soft_range_for_ecstat
       end
 
-      context "when log year is before 2025" do
-        let(:record) { build(:sales_log, saledate: Time.zone.local(2024, 12, 25)) }
-
-        it "does not trigger for low income1 if ecstat1 has no soft min" do
-          record.income1 = 50
-          record.ecstat1 = 4
-          expect(record).not_to be_income1_outside_soft_range_for_ecstat
-        end
-
-        it "returns true if income1 is below soft min for ecstat1" do
-          record.income1 = 4500
-          record.ecstat1 = 1
-          expect(record).to be_income1_outside_soft_range_for_ecstat
-        end
-
-        it "returns false if income1 is >= soft min for ecstat1" do
-          record.income1 = 1500
-          record.ecstat1 = 2
-          expect(record).not_to be_income1_outside_soft_range_for_ecstat
-        end
-
-        it "does not trigger for income2 if ecstat2 has no soft min" do
-          record.income2 = 50
-          record.ecstat2 = 8
-          expect(record).not_to be_income2_outside_soft_range_for_ecstat
-        end
-
-        it "returns true if income2 is below soft min for ecstat2" do
-          record.income2 = 999
-          record.ecstat2 = 3
-          expect(record).to be_income2_outside_soft_range_for_ecstat
-        end
-
-        it "returns false if income2 is >= soft min for ecstat2" do
-          record.income2 = 2500
-          record.ecstat2 = 5
-          expect(record).not_to be_income2_outside_soft_range_for_ecstat
-        end
-
-        it "does not trigger for being over maxima" do
-          record.ecstat1 = 1
-          record.income1 = 200_000
-          record.ecstat2 = 2
-          record.income2 = 100_000
-          expect(record).not_to be_income1_outside_soft_range_for_ecstat
-          expect(record).not_to be_income2_outside_soft_range_for_ecstat
-        end
-      end
-
       context "when log year is 2025" do
-        let(:record) { build(:sales_log, saledate: Time.zone.local(2025, 12, 25)) }
+        let(:record) { build(:sales_log, saledate: collection_start_date_for_year(2025)) }
 
         it "returns true if income1 is below soft min for ecstat1" do
           record.income1 = 13_399

--- a/spec/requests/collection_resources_controller_spec.rb
+++ b/spec/requests/collection_resources_controller_spec.rb
@@ -734,7 +734,7 @@ RSpec.describe CollectionResourcesController, type: :request do
   end
 
   describe "GET #edit_additional_collection_resource" do
-    let(:collection_resource) { create(:collection_resource, :additional, year: 2025, log_type: "sales", short_display_name: "additional resource", download_filename: "additional.pdf") }
+    let(:collection_resource) { create(:collection_resource, :additional, year: current_collection_start_year, log_type: "sales", short_display_name: "additional resource", download_filename: "additional.pdf") }
 
     context "when user is not signed in" do
       it "redirects to the sign in page" do
@@ -773,7 +773,7 @@ RSpec.describe CollectionResourcesController, type: :request do
       let(:user) { create(:user, :support) }
 
       before do
-        allow(Time.zone).to receive(:today).and_return(Time.zone.local(2025, 1, 8))
+        allow(Time.zone).to receive(:today).and_return(current_collection_after_crossover_start_date)
         allow(user).to receive(:need_two_factor_authentication?).and_return(false)
         sign_in user
       end
@@ -786,7 +786,7 @@ RSpec.describe CollectionResourcesController, type: :request do
         it "displays update collection resources page content" do
           get collection_resource_edit_path(collection_resource)
 
-          expect(page).to have_content("Sales 2025 to 2026")
+          expect(page).to have_content("Sales #{current_collection_start_year} to #{current_collection_end_year}")
           expect(page).to have_content("Change the additional resource")
           expect(page).to have_content("This file will be available for all users to download.")
           expect(page).to have_content("Upload file")

--- a/spec/services/csv/lettings_log_csv_service_spec.rb
+++ b/spec/services/csv/lettings_log_csv_service_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "rake"
 
 RSpec.describe Csv::LettingsLogCsvService do
+  include CollectionTimeHelper
+
   subject(:task) { Rake::Task["data_import:add_variable_definitions"] }
 
   before do
@@ -16,7 +18,7 @@ RSpec.describe Csv::LettingsLogCsvService do
     let(:user) { create(:user, :support, email: "s.port@jeemayle.com") }
     let(:service) { described_class.new(user:, export_type:, year:) }
     let(:export_type) { "labels" }
-    let(:year) { 2024 }
+    let(:year) { current_collection_start_year }
     let(:csv) { CSV.parse(service.prepare_csv(LettingsLog.where(id: logs.map(&:id)))) }
     let(:logs) { [log] }
     let(:definition_line) { csv.first }
@@ -572,199 +574,6 @@ RSpec.describe Csv::LettingsLogCsvService do
 
             it "exports the CSV with all values correct" do
               expected_content = CSV.read("spec/fixtures/files/lettings_log_csv_export_non_support_codes_25.csv")
-              values_to_delete = %w[id]
-              values_to_delete.each do |attribute|
-                index = attribute_line.index(attribute)
-                content_line[index] = nil
-              end
-              expect(csv).to eq expected_content
-            end
-          end
-        end
-      end
-
-      context "when the requested log year is 2024" do
-        let(:year) { 2024 }
-        let(:organisation) { create(:organisation, provider_type: "LA", name: "MHCLG") }
-        let(:log) do
-          create(
-            :lettings_log,
-            :ignore_validation_errors,
-            created_by: user,
-            assigned_to: user,
-            created_at: Time.zone.local(2024, 4, 1),
-            updated_at: Time.zone.local(2024, 4, 1),
-            owning_organisation: organisation,
-            managing_organisation: organisation,
-            needstype: 1,
-            renewal: 0,
-            startdate: Time.zone.local(2024, 4, 1),
-            rent_type: 1,
-            tenancycode: "HIJKLMN",
-            propcode: "ABCDEFG",
-            declaration: 1,
-            address_line1: "Address line 1",
-            town_or_city: "London",
-            postcode_full: "NW9 5LL",
-            la: "E09000003",
-            is_la_inferred: false,
-            address_line1_as_entered: "address line 1 as entered",
-            address_line2_as_entered: "address line 2 as entered",
-            town_or_city_as_entered: "town or city as entered",
-            county_as_entered: "county as entered",
-            postcode_full_as_entered: "AB1 2CD",
-            la_as_entered: "la as entered",
-            first_time_property_let_as_social_housing: 0,
-            unitletas: 2,
-            rsnvac: 6,
-            unittype_gn: 7,
-            builtype: 1,
-            wchair: 1,
-            beds: 3,
-            voiddate: Time.zone.local(2024, 3, 30),
-            majorrepairs: 1,
-            mrcdate: Time.zone.local(2024, 3, 31),
-            joint: 3,
-            startertenancy: 1,
-            tenancy: 4,
-            tenancylength: 2,
-            hhmemb: 4,
-            age1_known: 0,
-            age1: 35,
-            sex1: "F",
-            ethnic_group: 0,
-            ethnic: 2,
-            nationality_all: 36,
-            ecstat1: 0,
-            details_known_2: 0,
-            relat2: "P",
-            age2_known: 0,
-            age2: 32,
-            sex2: "M",
-            ecstat2: 6,
-            details_known_3: 1,
-            details_known_4: 0,
-            relat4: "R",
-            age4_known: 1,
-            sex4: "R",
-            ecstat4: 10,
-            armedforces: 1,
-            leftreg: 4,
-            reservist: 1,
-            preg_occ: 2,
-            housingneeds: 1,
-            housingneeds_type: 0,
-            housingneeds_a: 1,
-            housingneeds_b: 0,
-            housingneeds_c: 0,
-            housingneeds_f: 0,
-            housingneeds_g: 0,
-            housingneeds_h: 0,
-            housingneeds_other: 0,
-            illness: 1,
-            illness_type_1: 0,
-            illness_type_2: 1,
-            illness_type_3: 0,
-            illness_type_4: 0,
-            illness_type_5: 0,
-            illness_type_6: 0,
-            illness_type_7: 0,
-            illness_type_8: 0,
-            illness_type_9: 0,
-            illness_type_10: 0,
-            layear: 2,
-            waityear: 7,
-            reason: 4,
-            prevten: 6,
-            homeless: 1,
-            ppcodenk: 1,
-            ppostcode_full: "TN23 6LZ",
-            previous_la_known: 1,
-            prevloc: "E07000105",
-            reasonpref: 1,
-            rp_homeless: 0,
-            rp_insan_unsat: 1,
-            rp_medwel: 0,
-            rp_hardship: 0,
-            rp_dontknow: 0,
-            cbl: 0,
-            chr: 1,
-            cap: 0,
-            accessible_register: 0,
-            referral: 2,
-            net_income_known: 0,
-            incref: 0,
-            incfreq: 1,
-            earnings: 268,
-            hb: 6,
-            has_benefits: 1,
-            benefits: 1,
-            period: 2,
-            brent: 200,
-            scharge: 50,
-            pscharge: 40,
-            supcharg: 35,
-            tcharge: 325,
-            hbrentshortfall: 1,
-            tshortfall_known: 1,
-            tshortfall: 12,
-          )
-        end
-
-        context "when exporting with human readable labels" do
-          let(:export_type) { "labels" }
-
-          context "when the current user is a support user" do
-            let(:user) { create(:user, :support, organisation:, email: "s.port@jeemayle.com") }
-
-            it "exports the CSV with 2024 ordering and all values correct" do
-              expected_content = CSV.read("spec/fixtures/files/lettings_log_csv_export_labels_24.csv")
-              values_to_delete = %w[id]
-              values_to_delete.each do |attribute|
-                index = attribute_line.index(attribute)
-                content_line[index] = nil
-              end
-              expect(csv).to eq expected_content
-            end
-          end
-
-          context "when the current user is not a support user" do
-            let(:user) { create(:user, :data_provider, organisation:, email: "choreographer@owtluk.com") }
-
-            it "exports the CSV with all values correct" do
-              expected_content = CSV.read("spec/fixtures/files/lettings_log_csv_export_non_support_labels_24.csv")
-              values_to_delete = %w[id]
-              values_to_delete.each do |attribute|
-                index = attribute_line.index(attribute)
-                content_line[index] = nil
-              end
-              expect(csv).to eq expected_content
-            end
-          end
-        end
-
-        context "when exporting values as codes" do
-          let(:export_type) { "codes" }
-
-          context "when the current user is a support user" do
-            let(:user) { create(:user, :support, organisation:, email: "s.port@jeemayle.com") }
-
-            it "exports the CSV with all values correct" do
-              expected_content = CSV.read("spec/fixtures/files/lettings_log_csv_export_codes_24.csv")
-              values_to_delete = %w[id]
-              values_to_delete.each do |attribute|
-                index = attribute_line.index(attribute)
-                content_line[index] = nil
-              end
-              expect(csv).to eq expected_content
-            end
-          end
-
-          context "when the current user is not a support user" do
-            let(:user) { create(:user, :data_provider, organisation:, email: "choreographer@owtluk.com") }
-
-            it "exports the CSV with all values correct" do
-              expected_content = CSV.read("spec/fixtures/files/lettings_log_csv_export_non_support_codes_24.csv")
               values_to_delete = %w[id]
               values_to_delete.each do |attribute|
                 index = attribute_line.index(attribute)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,14 +123,6 @@ RSpec.configure do |config|
     RequestHelper.real_http_requests
     Singleton.__init__(FormHandler)
   end
-
-  config.around do |example|
-    Timecop.travel(Time.zone.local(2026, 7, 31))
-    Singleton.__init__(FormHandler)
-    example.run
-    Timecop.travel(Time.zone.local(2026, 7, 31))
-    Singleton.__init__(FormHandler)
-  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,10 +125,10 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    Timecop.travel(Time.zone.local(2026, 8, 1))
+    Timecop.travel(Time.zone.local(2026, 8, 2))
     Singleton.__init__(FormHandler)
     example.run
-    Timecop.travel(Time.zone.local(2026, 8, 1))
+    Timecop.travel(Time.zone.local(2026, 8, 2))
     Singleton.__init__(FormHandler)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,10 +125,10 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    Timecop.travel(Time.zone.local(2026, 8, 2))
+    Timecop.travel(Time.zone.local(2026, 7, 31))
     Singleton.__init__(FormHandler)
     example.run
-    Timecop.travel(Time.zone.local(2026, 8, 2))
+    Timecop.travel(Time.zone.local(2026, 7, 31))
     Singleton.__init__(FormHandler)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,6 +123,14 @@ RSpec.configure do |config|
     RequestHelper.real_http_requests
     Singleton.__init__(FormHandler)
   end
+
+  config.around do |example|
+    Timecop.travel(Time.zone.local(2026, 8, 1))
+    Singleton.__init__(FormHandler)
+    example.run
+    Timecop.travel(Time.zone.local(2026, 8, 1))
+    Singleton.__init__(FormHandler)
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
closes [CLDC-4363](https://mhclgdigital.atlassian.net/browse/CLDC-4363)

testing pipelines on gh

in most cases of conflict removed the 2024 test as they are no longer needed

looks to be all passing, see last pipeline runs

[CLDC-4363]: https://mhclgdigital.atlassian.net/browse/CLDC-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ