### PR TITLE
CLDC-4332: Check that a support user can only be in certain orgs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -224,7 +224,7 @@ private
     if user_params.key?(:organisation_id)
       if user_params[:organisation_id].blank?
         @user.errors.add :organisation_id, :blank
-      elsif !@user.role_is_allowed_to_be_in_organisation?(override_organisation_id: user_params[:organisation_id].to_i)
+      elsif !@user.role_is_allowed_to_be_in_organisation?(override_organisation_id: user_params[:organisation_id].to_i) && @user.id != nil
         # this will also be flagged by the validation in user.rb.
         # for convenience we show the error early before they go through the change org flow (involves reassigning logs).
         @user.errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_organisation")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -221,8 +221,14 @@ private
       @user.errors.add :phone
     end
 
-    if user_params.key?(:organisation_id) && user_params[:organisation_id].blank?
-      @user.errors.add :organisation_id, :blank
+    if user_params.key?(:organisation_id)
+      if user_params[:organisation_id].blank?
+        @user.errors.add :organisation_id, :blank
+      elsif !@user.role_is_allowed_to_be_in_organisation?(override_organisation_id: user_params[:organisation_id].to_i)
+        # this will also be flagged by the validation in user.rb.
+        # for convenience we show the error early before they go through the change org flow (involves reassigning logs).
+        @user.errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_organisation")
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -224,7 +224,7 @@ private
     if user_params.key?(:organisation_id)
       if user_params[:organisation_id].blank?
         @user.errors.add :organisation_id, :blank
-      elsif !@user.role_is_allowed_to_be_in_organisation?(override_organisation_id: user_params[:organisation_id].to_i) && @user.id != nil
+      elsif !@user.role_is_allowed_to_be_in_organisation?(override_organisation_id: user_params[:organisation_id].to_i) && @user.id.present?
         # this will also be flagged by the validation in user.rb.
         # for convenience we show the error early before they go through the change org flow (involves reassigning logs).
         @user.errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_organisation")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
 
   validates :organisation_id, presence: true
   validate :organisation_not_merged
+  validate :support_user_is_in_correct_organisation
 
   has_paper_trail ignore: %w[last_sign_in_at
                              current_sign_in_at
@@ -390,6 +391,11 @@ class User < ApplicationRecord
     end
   end
 
+  def role_is_allowed_to_be_in_organisation?(override_organisation_id: nil)
+    return true unless support? && FeatureToggle.support_organisation_allow_list.present?
+    FeatureToggle.support_organisation_allow_list.include?(override_organisation_id || organisation_id)
+  end
+
 protected
 
   # Checks whether a password is needed or not. For validations only.
@@ -404,6 +410,16 @@ private
   def organisation_not_merged
     if organisation&.merge_date.present? && organisation.merge_date < Time.zone.now
       errors.add :organisation_id, I18n.t("validations.organisation.merged")
+    end
+  end
+
+  def support_user_is_in_correct_organisation
+    return if role_is_allowed_to_be_in_organisation?
+
+    if role_changed?
+      errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_role")
+    else
+      errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_organisation")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -418,7 +418,7 @@ private
     return if role_is_allowed_to_be_in_organisation?
 
     if role_changed?
-      errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_role")
+      errors.add :role, I18n.t("validations.user.support_user_in_wrong_organisation.change_role")
     else
       errors.add :organisation_id, I18n.t("validations.user.support_user_in_wrong_organisation.change_organisation")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -393,6 +393,7 @@ class User < ApplicationRecord
 
   def role_is_allowed_to_be_in_organisation?(override_organisation_id: nil)
     return true unless support? && FeatureToggle.support_organisation_allow_list.present?
+
     FeatureToggle.support_organisation_allow_list.include?(override_organisation_id || organisation_id)
   end
 

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -38,6 +38,6 @@ class FeatureToggle
   # IDs of organisations a user must be in to be allowed the support role
   # if nil this feature will be disabled
   def self.support_organisation_allow_list
-    return [1] if Rails.env.production?
+    [1] if Rails.env.production?
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -38,8 +38,6 @@ class FeatureToggle
   # IDs of organisations a user must be in to be allowed the support role
   # if nil this feature will be disabled
   def self.support_organisation_allow_list
-    return [1] if Rails.env.production?
-
-    [Organisation.find_by(name: "MHCLG").id] if Rails.env.review?
+    [1] if Rails.env.production?
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -39,6 +39,5 @@ class FeatureToggle
   # if nil this feature will be disabled
   def self.support_organisation_allow_list
     return [1] if Rails.env.production?
-    return [1] if Rails.env.development?
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -34,4 +34,11 @@ class FeatureToggle
   def self.sales_export_enabled?
     Time.zone.now >= Time.zone.local(2025, 4, 1) || (Rails.env.review? || Rails.env.staging?)
   end
+
+  # IDs of organisations a user must be in to be allowed the support role
+  # if nil this feature will be disabled
+  def self.support_organisation_allow_list
+    return [1] if Rails.env.production?
+    return [1] if Rails.env.development?
+  end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -38,6 +38,8 @@ class FeatureToggle
   # IDs of organisations a user must be in to be allowed the support role
   # if nil this feature will be disabled
   def self.support_organisation_allow_list
-    [1] if Rails.env.production?
+    return [1] if Rails.env.production?
+
+    [Organisation.find_by(name: "MHCLG").id] if Rails.env.review?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,10 @@ en:
       blank: "Enter an email address."
     role:
       invalid: "Role must be data accessor, data provider or data coordinator."
+    user:
+      support_user_in_wrong_organisation:
+        change_role: "You cannot create a support account type for a user in this organisation. Support accounts should only be created for MHCLG and contractor staff as they are administrator level accounts with access to all organisations' data. Any support accounts for housing organisations would be a data protection breach."
+        change_organisation: "You cannot move a user with a support account to a non-MHCLG organisation. If you need to move the user, change their role type to data coordinator or data provider."
 
     setup:
       saledate:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -540,6 +540,53 @@ RSpec.describe User, type: :model do
           .to raise_error(ActiveRecord::RecordInvalid, error_message)
       end
     end
+
+    describe "#support_user_is_in_correct_organisation" do
+      let(:organisation) { create(:organisation) }
+
+      context "when the user is not a support user" do
+        let(:user) { build(:user, :data_coordinator, organisation:) }
+
+        it "is valid regardless of the allow list" do
+          allow(FeatureToggle).to receive(:support_organisation_allow_list).and_return([999])
+          expect(user).to be_valid
+        end
+      end
+
+      context "when the user is a support user" do
+        let(:user) { build(:user, :support, organisation:) }
+
+        context "and the allow list is nil" do
+          before do
+            allow(FeatureToggle).to receive(:support_organisation_allow_list).and_return(nil)
+          end
+
+          it "is valid" do
+            expect(user).to be_valid
+          end
+        end
+
+        context "and the organisation is in the allow list" do
+          before do
+            allow(FeatureToggle).to receive(:support_organisation_allow_list).and_return([organisation.id])
+          end
+
+          it "is valid" do
+            expect(user).to be_valid
+          end
+        end
+
+        context "and the organisation is not in the allow list" do
+          before do
+            allow(FeatureToggle).to receive(:support_organisation_allow_list).and_return([organisation.id + 1])
+          end
+
+          it "is not valid" do
+            expect(user).not_to be_valid
+          end
+        end
+      end
+    end
   end
 
   describe "delete" do


### PR DESCRIPTION
closes [CLDC-4332](https://mhclgdigital.atlassian.net/browse/CLDC-4332)

adds a validation to user.rb that ensures support users can only be in org ID 1

left the ID in featuretoggles. it could potentially be in the DB too but I'm happy that this number will change so infrequently we can handle it changing with a release

note that the logic around changing an organisation is complex and makes this work a bit difficult. namely I'm aware of two potential issues:

- user is non support non mhclg. update to support mhclg. this should be valid but you will see an error
- user is non support mhclg. update to support non mhclg. this will be blocked but you will not see an error

fixing these however is quite difficult as changing an organisation is its own special flow where you reassign logs and we must ensure the user is never invalid at any point on that flow. for the primary use case (creating support users in the wrong org) it works fine. I'm cautious against overcomplicating the system and potentially introducing bugs that leaving this reliable check which should always block invalid data

happy to hear thoughts on this before presenting to client

[CLDC-4332]: https://mhclgdigital.atlassian.net/browse/CLDC-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ