### PR TITLE
CLDC-4406: Add a script to delete logs in batches

### DIFF
--- a/lib/tasks/delete_logs_before_year.rake
+++ b/lib/tasks/delete_logs_before_year.rake
@@ -1,0 +1,34 @@
+desc "Deletes all logs in a given collection year and earlier. Note that this operation is PERMANENT and this will bypass callbacks/paper trail. Use only as instructed in a yearly cleanup task."
+task :delete_logs_before_year, %i[year] => :environment do |_task, args|
+  year = args[:year].to_i
+
+  if year < 2020
+    raise ArgumentError, "Year must be above 2020. Make sure you've written out the entire year"
+  end
+
+  if year > Time.zone.now.year - 3
+    raise ArgumentError, "Year cannot be the last 3 years, as these may contain visible logs"
+  end
+
+  puts "Deleting Logs before #{year}"
+
+  puts "Deleting Sales Logs in batches of 10000"
+  logs = SalesLog.filter_by_year_or_earlier(year)
+
+  logs.in_batches(of: 10_000).each_with_index do |logs, i|
+    puts "Deleting batch #{i + 1}"
+    logs.delete_all
+  end
+  puts "Done deleting Sales Logs"
+
+  puts "Deleting Lettings Logs in batches of 10000"
+  logs = LettingsLog.filter_by_year_or_earlier(year)
+
+  logs.in_batches(of: 10_000).each_with_index do |logs, i|
+    puts "Deleting batch #{i + 1}"
+    logs.delete_all
+  end
+  puts "Done deleting Lettings Logs"
+
+  puts "Done deleting Logs before #{year}"
+end


### PR DESCRIPTION
closes [CLDC-4406](https://mhclgdigital.atlassian.net/browse/CLDC-4406)

we're not able to complete this operation in the interactive console so we must instead use a rake task. adds lots of logging to this script so we can monitor its progress

adds some validation on the year to try and combat user error

[CLDC-4406]: https://mhclgdigital.atlassian.net/browse/CLDC-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ