### PR TITLE
CLDC-4373: Fix pregnancy check appearing twice

### DIFF
--- a/app/models/form/lettings/pages/no_household_member_likely_to_be_pregnant_check.rb
+++ b/app/models/form/lettings/pages/no_household_member_likely_to_be_pregnant_check.rb
@@ -2,7 +2,8 @@ class Form::Lettings::Pages::NoHouseholdMemberLikelyToBePregnantCheck < ::Form::
   def initialize(id, hsh, subsection, person_index: 0)
     super(id, hsh, subsection)
     @copy_key = "lettings.soft_validations.pregnancy_value_check.no_household_member_likely_to_be_pregnant_check"
-    @depends_on = [{ "no_household_member_likely_to_be_pregnant?" => true }]
+    @person_index = person_index
+    @depends_on = depends_on
     @title_text = {
       "translation" => "forms.#{form.start_date.year}.#{@copy_key}.title_text",
       "arguments" => [],
@@ -11,7 +12,14 @@ class Form::Lettings::Pages::NoHouseholdMemberLikelyToBePregnantCheck < ::Form::
       "translation" => "forms.#{form.start_date.year}.#{@copy_key}.informative_text",
       "arguments" => [],
     }
-    @person_index = person_index
+  end
+
+  def depends_on
+    if @person_index >= 2
+      [{ "no_household_member_likely_to_be_pregnant?" => true, "details_known_#{@person_index}" => 0 }]
+    else
+      [{ "no_household_member_likely_to_be_pregnant?" => true }]
+    end
   end
 
   def questions

--- a/app/models/form/lettings/subsections/household_characteristics.rb
+++ b/app/models/form/lettings/subsections/household_characteristics.rb
@@ -16,7 +16,7 @@ class Form::Lettings::Subsections::HouseholdCharacteristics < ::Form::Subsection
       Form::Lettings::Pages::LeadTenantAge.new(nil, nil, self),
       (Form::Lettings::Pages::NoFemalesPregnantHouseholdLeadAgeValueCheck.new(nil, nil, self) unless form.start_year_2026_or_later?),
       (Form::Lettings::Pages::FemalesInSoftAgeRangeInPregnantHouseholdLeadAgeValueCheck.new(nil, nil, self) unless form.start_year_2026_or_later?),
-      (Form::Lettings::Pages::NoHouseholdMemberLikelyToBePregnantCheck.new("no_household_member_likely_to_be_pregnant_lead_age_check", nil, self) if form.start_year_2026_or_later?),
+      (Form::Lettings::Pages::NoHouseholdMemberLikelyToBePregnantCheck.new("no_household_member_likely_to_be_pregnant_lead_age_check", nil, self, person_index: 1) if form.start_year_2026_or_later?),
       Form::Lettings::Pages::LeadTenantUnderRetirementValueCheck.new("age_lead_tenant_under_retirement_value_check", nil, self),
       Form::Lettings::Pages::LeadTenantOverRetirementValueCheck.new("age_lead_tenant_over_retirement_value_check", nil, self),
       (Form::Lettings::Pages::LeadTenantSexRegisteredAtBirth.new(nil, nil, self) if form.start_year_2026_or_later?),


### PR DESCRIPTION
closes [CLDC-4373](https://mhclgdigital.atlassian.net/browse/CLDC-4373)

the `NoHouseholdMemberLikelyToBePregnantCheck` after the lead tenant age was missing a person_index set, this would cause it to appear outside of any person box at the top of the section

<img alt="old household characteristics with double pregnancy check" src="https://github.com/user-attachments/assets/d2940e93-4e2c-4c0e-9800-1901089163fa" />

setting the person index places this second `NoHouseholdMemberLikelyToBePregnantCheck` correctly after lead tenant age

<img alt="new household characteristics with a pregnancy check after age and only one after household count" src="https://github.com/user-attachments/assets/7dd3529a-94e6-47d9-b7d6-b369a2868ee3" />

[CLDC-4373]: https://mhclgdigital.atlassian.net/browse/CLDC-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ