### PR TITLE
CLDC-4430: Make dev containers mac compatible

### DIFF
--- a/aws-devcontainer/.devcontainer/Dockerfile
+++ b/aws-devcontainer/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
 FROM homebrew/brew
 
 RUN brew install aws-vault && brew install awscli
-RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && sudo dpkg -i session-manager-plugin.deb
+RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+      ARCH="ubuntu_arm64"; \
+    else \
+      ARCH="ubuntu_64bit"; \
+    fi && \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/${ARCH}/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
+    sudo dpkg -i session-manager-plugin.deb
 
 ENV AWS_VAULT_BACKEND=file
 ENV AWS_VAULT_FILE_DIR=./vault


### PR DESCRIPTION
Closes [CLDC-4430](https://mhclgdigital.atlassian.net/browse/CLDC-4430).

Updates the dev container setup to switch on architecture type.
Tested and confirmed on both Apple silicon and Windows.

[CLDC-4430]: https://mhclgdigital.atlassian.net/browse/CLDC-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ