### PR TITLE
CLDC-4406: Update rake name to delete old logs

### DIFF
--- a/lib/tasks/delete_logs_in_collection_year_and_earlier.rake
+++ b/lib/tasks/delete_logs_in_collection_year_and_earlier.rake
@@ -1,5 +1,5 @@
 desc "Deletes all logs in a given collection year and earlier. Note that this operation is PERMANENT and this will bypass callbacks/paper trail. Use only as instructed in a yearly cleanup task."
-task :delete_logs_before_year, %i[year] => :environment do |_task, args|
+task :delete_logs_in_collection_year_and_earlier, %i[year] => :environment do |_task, args|
   year = args[:year].to_i
 
   if year < 2020


### PR DESCRIPTION
extra work after completing [CLDC-4406](https://mhclgdigital.atlassian.net/browse/CLDC-4406)

considering this is a very dangerous script best not to leave the name slightly ambiguous (since it deletes from the given year and before). noticed this when running the script this year

have updated [docs](https://mhclgdigital.atlassian.net/wiki/spaces/MC/pages/890110057/Remove+old+logs+from+the+service)

[CLDC-4406]: https://mhclgdigital.atlassian.net/browse/CLDC-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ