### PR TITLE
CLDC-4435: Always show LA question if it can't be derived

### DIFF
--- a/app/models/form/lettings/pages/property_local_authority.rb
+++ b/app/models/form/lettings/pages/property_local_authority.rb
@@ -3,8 +3,8 @@ class Form::Lettings::Pages::PropertyLocalAuthority < ::Form::Page
     super
     @id = "property_local_authority"
     @depends_on = [
-      { "is_la_inferred" => false, "is_general_needs?" => true, "form.start_year_2024_or_later?" => false },
-      { "is_la_inferred" => false, "is_general_needs?" => true, "form.start_year_2024_or_later?" => true, "address_search_given?" => true },
+      { "is_la_inferred" => false, "is_general_needs?" => true, "form.start_year_2025_or_later?" => false, "address_search_given?" => true },
+      { "is_la_inferred" => false, "is_general_needs?" => true, "form.start_year_2025_or_later?" => true },
     ]
   end
 

--- a/app/models/form/sales/pages/property_local_authority.rb
+++ b/app/models/form/sales/pages/property_local_authority.rb
@@ -3,8 +3,8 @@ class Form::Sales::Pages::PropertyLocalAuthority < ::Form::Page
     super
     @id = "property_local_authority"
     @depends_on = [
-      { "is_la_inferred" => false, "form.start_year_2024_or_later?" => false },
-      { "is_la_inferred" => false, "form.start_year_2024_or_later?" => true, "address_search_given?" => true },
+      { "is_la_inferred" => false, "form.start_year_2025_or_later?" => false, "address_search_given?" => true },
+      { "is_la_inferred" => false, "form.start_year_2025_or_later?" => true },
     ]
   end
 

--- a/spec/models/form/lettings/pages/property_local_authority_spec.rb
+++ b/spec/models/form/lettings/pages/property_local_authority_spec.rb
@@ -35,66 +35,26 @@ RSpec.describe Form::Lettings::Pages::PropertyLocalAuthority, type: :model do
   context "when routing to the page" do
     let(:log) { build(:lettings_log) }
 
-    context "with form before 2024" do
-      before do
-        allow(form).to receive(:start_year_2024_or_later?).and_return(false)
-      end
-
-      it "is routed to when la is not inferred and it is general needs log" do
-        log.needstype = 1
-        log.is_la_inferred = false
-        expect(page).to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when la is inferred" do
-        log.needstype = 1
-        log.is_la_inferred = true
-        expect(page).not_to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when it's a supported housing log" do
-        log.needstype = 2
-        log.is_la_inferred = false
-        expect(page).not_to be_routed_to(log, nil)
-      end
+    before do
+      allow(form).to receive(:start_year_2025_or_later?).and_return(true)
     end
 
-    context "with form after 2024" do
-      before do
-        allow(form).to receive(:start_year_2024_or_later?).and_return(true)
-      end
+    it "is routed to when la is not inferred and it is general needs log" do
+      log.needstype = 1
+      log.is_la_inferred = false
+      expect(page).to be_routed_to(log, nil)
+    end
 
-      it "is routed to when la is not inferred, it is general needs log and address search has been given" do
-        log.needstype = 1
-        log.is_la_inferred = false
-        log.address_line1_input = "1"
-        log.postcode_full_input = "A11AA"
-        expect(page).to be_routed_to(log, nil)
-      end
+    it "is not routed to when la is inferred" do
+      log.needstype = 1
+      log.is_la_inferred = true
+      expect(page).not_to be_routed_to(log, nil)
+    end
 
-      it "is not routed to when la is inferred" do
-        log.needstype = 1
-        log.is_la_inferred = true
-        log.address_line1_input = "1"
-        log.postcode_full_input = "A11AA"
-        expect(page).not_to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when it's a supported housing log" do
-        log.needstype = 2
-        log.is_la_inferred = false
-        log.address_line1_input = "1"
-        log.postcode_full_input = "A11AA"
-        expect(page).not_to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when address search is not given" do
-        log.needstype = 1
-        log.is_la_inferred = false
-        log.address_line1_input = nil
-        log.postcode_full_input = "A11AA"
-        expect(page).not_to be_routed_to(log, nil)
-      end
+    it "is not routed to when it's a supported housing log" do
+      log.needstype = 2
+      log.is_la_inferred = false
+      expect(page).not_to be_routed_to(log, nil)
     end
   end
 end

--- a/spec/models/form/sales/pages/property_local_authority_spec.rb
+++ b/spec/models/form/sales/pages/property_local_authority_spec.rb
@@ -17,18 +17,8 @@ RSpec.describe Form::Sales::Pages::PropertyLocalAuthority, type: :model do
     expect(page.subsection).to eq(subsection)
   end
 
-  describe "has correct questions" do
-    context "when 2023" do
-      let(:start_date) { Time.utc(2023, 2, 8) }
-
-      it "has correct questions" do
-        expect(page.questions.map(&:id)).to eq(
-          %w[
-            la
-          ],
-        )
-      end
-    end
+  it "has correct questions" do
+    expect(page.questions.map(&:id)).to eq(%w[la])
   end
 
   it "has the correct id" do

--- a/spec/models/form/sales/pages/property_local_authority_spec.rb
+++ b/spec/models/form/sales/pages/property_local_authority_spec.rb
@@ -42,47 +42,18 @@ RSpec.describe Form::Sales::Pages::PropertyLocalAuthority, type: :model do
   context "when routing to the page" do
     let(:log) { build(:sales_log) }
 
-    context "with form before 2024" do
-      before do
-        allow(form).to receive(:start_year_2024_or_later?).and_return(false)
-      end
-
-      it "is routed to when la is not inferred" do
-        log.is_la_inferred = false
-        expect(page).to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when la is inferred" do
-        log.is_la_inferred = true
-        expect(page).not_to be_routed_to(log, nil)
-      end
+    before do
+      allow(form).to receive(:start_year_2025_or_later?).and_return(true)
     end
 
-    context "with form after 2024" do
-      before do
-        allow(form).to receive(:start_year_2024_or_later?).and_return(true)
-      end
+    it "is routed to when la is not inferred" do
+      log.is_la_inferred = false
+      expect(page).to be_routed_to(log, nil)
+    end
 
-      it "is routed to when la is not inferred and address search has been given" do
-        log.is_la_inferred = false
-        log.address_line1_input = "1"
-        log.postcode_full_input = "A11AA"
-        expect(page).to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when la is inferred" do
-        log.is_la_inferred = true
-        log.address_line1_input = "1"
-        log.postcode_full_input = "A11AA"
-        expect(page).not_to be_routed_to(log, nil)
-      end
-
-      it "is not routed to when address search is not given" do
-        log.is_la_inferred = false
-        log.address_line1_input = nil
-        log.postcode_full_input = "A11AA"
-        expect(page).not_to be_routed_to(log, nil)
-      end
+    it "is not routed to when la is inferred" do
+      log.is_la_inferred = true
+      expect(page).not_to be_routed_to(log, nil)
     end
   end
 end

--- a/spec/requests/check_errors_controller_spec.rb
+++ b/spec/requests/check_errors_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe CheckErrorsController, type: :request do
         end
 
         it "displays correct clear and change links" do
-          expect(page.all(:button, value: "Clear").count).to eq(1)
+          expect(page.all(:button, value: "Clear").count).to eq(2)
           expect(page).to have_link("Change", count: 1)
           expect(page).to have_button("Clear all")
         end


### PR DESCRIPTION
closes [CLDC-4435](https://mhclgdigital.atlassian.net/browse/CLDC-4435)

the `address_search_given?` method doesn't seem to be useful for 25 and later. always have LA in the flow if it couldn't be derived

updates test (removes pre 2025 ones)

[CLDC-4435]: https://mhclgdigital.atlassian.net/browse/CLDC-4435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ