### PR TITLE
CLDC-4329: Add support role description

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -54,7 +54,7 @@
             options: { disabled: [""], selected: @organisation_id ? answer_options.first : "" } %>
       <% end %>
 
-      <% hints_for_roles = { data_provider: ["Can view and submit logs for this organisation"], data_coordinator: ["Can view and submit logs for this organisation and any of its managing agents", "Can manage details for this organisation", "Can manage users for this organisation"], support: nil } %>
+      <% hints_for_roles = { data_provider: ["Can view and submit logs for this organisation"], data_coordinator: ["Can view and submit logs for this organisation and any of its managing agents", "Can manage details for this organisation", "Can manage users for this organisation"], support: ["Can only be created for the MHCLG organisation in the CORE service, to be used by MHCLG and its contractor staff", "Has access to all organisations' data across the CORE service", "Cannot be created for users in housing organisations as this would be a data protection breach"] } %>
 
       <% roles_with_hints = current_user.assignable_roles.map { |key, _| OpenStruct.new(id: key, name: key.to_s.humanize, description: hints_for_roles[key.to_sym]) } %>
 


### PR DESCRIPTION
closes [CLDC-4329](https://mhclgdigital.atlassian.net/browse/CLDC-4329)

adds copy as requested

<img alt="invite user role picker" src="https://github.com/user-attachments/assets/8a488f05-5f96-4778-b336-edb270aa285b" />

[CLDC-4329]: https://mhclgdigital.atlassian.net/browse/CLDC-4329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ