### PR TITLE
CLDC-4389: BU validation prioritisation

### DIFF
--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -461,7 +461,6 @@ class BulkUpload::Lettings::Year2025::RowParser
   validate :validate_uprn_exists_if_any_key_address_fields_are_blank, on: :after_log, unless: -> { supported_housing? }
   validate :validate_address_fields, on: :after_log, unless: -> { supported_housing? }
 
-  validate :validate_incomplete_soft_validations, on: :after_log
   validate :validate_nationality, on: :after_log
   validate :validate_reasonpref_reason_values, on: :after_log
   validate :validate_prevten_value_when_renewal, on: :after_log
@@ -505,6 +504,8 @@ class BulkUpload::Lettings::Year2025::RowParser
         end
       end
     end
+
+    validate_incomplete_soft_validations
 
     add_errors_for_invalid_fields
 

--- a/app/services/bulk_upload/lettings/year2026/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2026/row_parser.rb
@@ -496,7 +496,6 @@ class BulkUpload::Lettings::Year2026::RowParser
   validate :validate_uprn_exists_if_any_key_address_fields_are_blank, on: :after_log
   validate :validate_address_fields, on: :after_log
 
-  validate :validate_incomplete_soft_validations, on: :after_log
   validate :validate_nationality, on: :after_log
   validate :validate_reasonpref_reason_values, on: :after_log
   validate :validate_prevten_value_when_renewal, on: :after_log
@@ -540,6 +539,8 @@ class BulkUpload::Lettings::Year2026::RowParser
         end
       end
     end
+
+    validate_incomplete_soft_validations
 
     add_errors_for_invalid_fields
 

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -438,8 +438,6 @@ class BulkUpload::Sales::Year2025::RowParser
   validate :validate_assigned_to_when_support, on: :after_log
   validate :validate_managing_org_related, on: :after_log
   validate :validate_relevant_collection_window, on: :after_log
-  validate :validate_incomplete_soft_validations, on: :after_log
-
   validate :validate_uprn_exists_if_any_key_address_fields_are_blank, on: :after_log
   validate :validate_address_fields, on: :after_log
   validate :validate_if_log_already_exists, on: :after_log, if: -> { FeatureToggle.bulk_upload_duplicate_log_check_enabled? }
@@ -502,6 +500,8 @@ class BulkUpload::Sales::Year2025::RowParser
         end
       end
     end
+
+    validate_incomplete_soft_validations
 
     add_errors_for_invalid_fields
 
@@ -1501,7 +1501,7 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
             errors.add(field, message: error_message, category: :soft_validation)
           end

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -492,7 +492,6 @@ class BulkUpload::Sales::Year2026::RowParser
   validate :validate_assigned_to_when_support, on: :after_log
   validate :validate_managing_org_related, on: :after_log
   validate :validate_relevant_collection_window, on: :after_log
-  validate :validate_incomplete_soft_validations, on: :after_log
 
   validate :validate_uprn_exists_if_any_key_address_fields_are_blank, on: :after_log
   validate :validate_address_fields, on: :after_log
@@ -559,6 +558,8 @@ class BulkUpload::Sales::Year2026::RowParser
         end
       end
     end
+
+    validate_incomplete_soft_validations
 
     add_errors_for_invalid_fields
 
@@ -1654,7 +1655,7 @@ private
         next if log.form.questions.none? { |q| q.id == interruption_screen_question_id && q.page.routed_to?(log, nil) }
 
         field_mapping_for_errors[interruption_screen_question_id.to_sym]&.each do |field|
-          if errors.none? { |e| e.options[:category] == :soft_validation && field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
+          if errors.none? { |e| field_mapping_for_errors[interruption_screen_question_id.to_sym].include?(e.attribute) }
             error_message = [display_title_text(question.page.title_text, log), display_informative_text(question.page.informative_text, log)].reject(&:empty?).join(" ")
             errors.add(field, message: error_message, category: :soft_validation)
           end


### PR DESCRIPTION
Closes [CLDC-4389](https://mhclgdigital.atlassian.net/browse/CLDC-4389).

Ensures all soft validations are added to the error report only after all hard validations have been added, and do not override existing hard validations that have already been added.


e.g. field_128 now only shows in "critical errors", not "confirmation needed" when it is is affected by hard and soft validations, previously was only showing in "confirmation needed":

<img width="970" height="1165" alt="image" src="https://github.com/user-attachments/assets/f014e72d-64ee-4943-be69-5cf5e11aa114" />
<img width="918" height="419" alt="image" src="https://github.com/user-attachments/assets/1c0a648e-b230-4569-985d-1a9770e580c1" />


[CLDC-4389]: https://mhclgdigital.atlassian.net/browse/CLDC-4389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ