### PR TITLE
CLDC-4328: Update wrong field numbers error

### DIFF
--- a/config/locales/validations/lettings/2025/bulk_upload.en.yml
+++ b/config/locales/validations/lettings/2025/bulk_upload.en.yml
@@ -12,7 +12,7 @@ en:
           wrong_template:
             wrong_template: "Incorrect start dates, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
           owning_organisation:
             not_found: "The owning organisation code is incorrect."

--- a/config/locales/validations/lettings/2025/bulk_upload.en.yml
+++ b/config/locales/validations/lettings/2025/bulk_upload.en.yml
@@ -12,7 +12,7 @@ en:
           wrong_template:
             wrong_template: "Incorrect start dates, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for lettings 2025."
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
           owning_organisation:
             not_found: "The owning organisation code is incorrect."

--- a/config/locales/validations/lettings/2026/bulk_upload.en.yml
+++ b/config/locales/validations/lettings/2026/bulk_upload.en.yml
@@ -12,7 +12,7 @@ en:
           wrong_template:
             wrong_template: "Incorrect start dates, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
           owning_organisation:
             not_found: "The owning organisation code is incorrect."

--- a/config/locales/validations/lettings/2026/bulk_upload.en.yml
+++ b/config/locales/validations/lettings/2026/bulk_upload.en.yml
@@ -12,7 +12,7 @@ en:
           wrong_template:
             wrong_template: "Incorrect start dates, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for lettings 2026."
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
           owning_organisation:
             not_found: "The owning organisation code is incorrect."

--- a/config/locales/validations/sales/2025/bulk_upload.en.yml
+++ b/config/locales/validations/sales/2025/bulk_upload.en.yml
@@ -11,7 +11,7 @@ en:
           wrong_template:
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for sales 2025."
             wrong_template: "Incorrect sale dates, please ensure you have used the correct template."
           numeric:
             within_range: "%{field} must be between %{min} and %{max}."

--- a/config/locales/validations/sales/2025/bulk_upload.en.yml
+++ b/config/locales/validations/sales/2025/bulk_upload.en.yml
@@ -11,7 +11,7 @@ en:
           wrong_template:
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
             wrong_template: "Incorrect sale dates, please ensure you have used the correct template."
           numeric:
             within_range: "%{field} must be between %{min} and %{max}."

--- a/config/locales/validations/sales/2026/bulk_upload.en.yml
+++ b/config/locales/validations/sales/2026/bulk_upload.en.yml
@@ -11,7 +11,7 @@ en:
           wrong_template:
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the correct template."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
             wrong_template: "Incorrect sale dates, please ensure you have used the correct template."
           numeric:
             within_range: "%{field} must be between %{min} and %{max}."

--- a/config/locales/validations/sales/2026/bulk_upload.en.yml
+++ b/config/locales/validations/sales/2026/bulk_upload.en.yml
@@ -11,7 +11,7 @@ en:
           wrong_template:
             over_max_column_count: "Too many columns, please ensure you have used the correct template."
             no_headers: "Your file does not contain the required header rows. Add or check the header rows and upload your file again. [Read more about using the template headers](%{guidance_link})."
-            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."
+            wrong_field_numbers_count: "Incorrect number of fields, please ensure you have used the template for sales 2026."
             wrong_template: "Incorrect sale dates, please ensure you have used the correct template."
           numeric:
             within_range: "%{field} must be between %{min} and %{max}."

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
         it "is not valid" do
           expect(validator).not_to be_valid
-          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template."])
+          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."])
         end
       end
 
@@ -72,7 +72,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
         it "is not valid" do
           expect(validator).not_to be_valid
-          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the correct template."])
+          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."])
         end
       end
     end

--- a/spec/services/bulk_upload/lettings/validator_spec.rb
+++ b/spec/services/bulk_upload/lettings/validator_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
         it "is not valid" do
           expect(validator).not_to be_valid
-          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."])
+          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for lettings #{year}."])
         end
       end
 
@@ -72,7 +72,7 @@ RSpec.describe BulkUpload::Lettings::Validator do
 
         it "is not valid" do
           expect(validator).not_to be_valid
-          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for the correct type (lettings or sales) and year."])
+          expect(validator.errors["base"]).to eql(["Incorrect number of fields, please ensure you have used the template for lettings #{year}."])
         end
       end
     end


### PR DESCRIPTION
close [CLDC-4328](https://mhclgdigital.atlassian.net/browse/CLDC-4328)

CORE already has the functionality to add a description for critical failures. we will need to update notify to start showing them again. see `BulkUploadMailer#send_bulk_upload_failed_service_error_mail`

updates wording as requested

[CLDC-4328]: https://mhclgdigital.atlassian.net/browse/CLDC-4328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ