### PR TITLE
CLDC-4330: Stop login count resetting on deactivation

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -5,8 +5,8 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      # previously we reset sign in count to indicate that a user was deactivated and so needs to reset their password on confirming their email post reactivation.
-      # now we have a specific flag for this.
+      # previously we reset sign_in_count to indicate that a user was deactivated and so needs to reset their password on confirming their email post reactivation.
+      # now we have a specific flag for this as resetting sign in count was difficult for auditing.
       # though for backwards compatability we need to ensure previous users with a reset sign in count still will see the password reset screen
       if resource.reset_password_on_confirmation || resource.sign_in_count.zero?
         token = resource.send(:set_reset_password_token)

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -9,7 +9,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
       # this would force a password reset both if it was your very first log in, and on your first login after reactivation.
       # now we have a specific flag for the latter case as resetting sign_in_count was difficult for auditing.
       # note that some deactivated users will have a sign_in_count of 0 and not have this flag set if they were deactivated before we made this change.
-      if resource.reset_password_on_confirmation || resource.sign_in_count.zero?
+      if resource.force_reset_password_on_confirmation || resource.sign_in_count.zero?
         token = resource.send(:set_reset_password_token)
         redirect_to "#{edit_user_password_url}?reset_password_token=#{token}&confirmation=true"
       else

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -5,7 +5,10 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      if resource.sign_in_count.zero?
+      # previously we reset sign in count to indicate that a user was deactivated and so needs to reset their password on confirming their email post reactivation.
+      # now we have a specific flag for this.
+      # though for backwards compatability we need to ensure previous users with a reset sign in count still will see the password reset screen
+      if resource.reset_password_on_confirmation || resource.sign_in_count.zero?
         token = resource.send(:set_reset_password_token)
         redirect_to "#{edit_user_password_url}?reset_password_token=#{token}&confirmation=true"
       else

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -5,9 +5,10 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      # previously we reset sign_in_count to indicate that a user was deactivated and so needs to reset their password on confirming their email post reactivation.
-      # now we have a specific flag for this as resetting sign in count was difficult for auditing.
-      # though for backwards compatability we need to ensure previous users with a reset sign in count still will see the password reset screen
+      # previously we reset sign_in_count on deactivation and had only the .zero? check here.
+      # this would force a password reset both if it was your very first log in, and on your first login after reactivation.
+      # now we have a specific flag for the latter case as resetting sign_in_count was difficult for auditing.
+      # note that some deactivated users will have a sign_in_count of 0 and not have this flag set if they were deactivated before we made this change.
       if resource.reset_password_on_confirmation || resource.sign_in_count.zero?
         token = resource.send(:set_reset_password_token)
         redirect_to "#{edit_user_password_url}?reset_password_token=#{token}&confirmation=true"

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -37,6 +37,7 @@ class Auth::PasswordsController < Devise::PasswordsController
 
     if resource.errors.empty?
       resource.unlock_access! if resource.respond_to?(:unlock_access!)
+      resource.reset_password_on_confirmation = false if resource.reset_password_on_confirmation
       if Devise.sign_in_after_reset_password
         set_flash_message!(:notice, password_update_flash_message)
         resource.after_database_authentication

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -37,7 +37,7 @@ class Auth::PasswordsController < Devise::PasswordsController
 
     if resource.errors.empty?
       resource.unlock_access! if resource.respond_to?(:unlock_access!)
-      resource.reset_password_on_confirmation = false if resource.reset_password_on_confirmation
+      resource.force_reset_password_on_confirmation = false if resource.force_reset_password_on_confirmation
       if Devise.sign_in_after_reset_password
         set_flash_message!(:notice, password_update_flash_message)
         resource.after_database_authentication

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -37,7 +37,7 @@ class Auth::PasswordsController < Devise::PasswordsController
 
     if resource.errors.empty?
       resource.unlock_access! if resource.respond_to?(:unlock_access!)
-      resource.force_reset_password_on_confirmation = false if resource.force_reset_password_on_confirmation
+      resource.force_reset_password_on_confirmation = false
       if Devise.sign_in_after_reset_password
         set_flash_message!(:notice, password_update_flash_message)
         resource.after_database_authentication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,7 +179,7 @@ class User < ApplicationRecord
     update!(
       active: false,
       confirmed_at: nil,
-      reset_password_on_confirmation: true,
+      force_reset_password_on_confirmation: true,
       initial_confirmation_sent: false,
       reactivate_with_organisation:,
       unconfirmed_email: nil,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,7 +179,7 @@ class User < ApplicationRecord
     update!(
       active: false,
       confirmed_at: nil,
-      sign_in_count: 0,
+      reset_password_on_confirmation: true,
       initial_confirmation_sent: false,
       reactivate_with_organisation:,
       unconfirmed_email: nil,

--- a/db/migrate/20260420151627_add_force_reset_password_on_confirmation_to_users.rb
+++ b/db/migrate/20260420151627_add_force_reset_password_on_confirmation_to_users.rb
@@ -1,0 +1,5 @@
+class AddForceResetPasswordOnConfirmationToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :force_reset_password_on_confirmation, :boolean, default: false
+  end
+end

--- a/db/migrate/20260420151627_add_reset_password_on_confirmation_to_users.rb
+++ b/db/migrate/20260420151627_add_reset_password_on_confirmation_to_users.rb
@@ -1,5 +1,0 @@
-class AddResetPasswordOnConfirmationToUsers < ActiveRecord::Migration[7.2]
-  def change
-    add_column :users, :reset_password_on_confirmation, :boolean, default: false
-  end
-end

--- a/db/migrate/20260420151627_add_reset_password_on_confirmation_to_users.rb
+++ b/db/migrate/20260420151627_add_reset_password_on_confirmation_to_users.rb
@@ -1,0 +1,5 @@
+class AddResetPasswordOnConfirmationToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :reset_password_on_confirmation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -924,7 +924,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_151627) do
     t.datetime "discarded_at"
     t.string "phone_extension"
     t.datetime "values_updated_at"
-    t.boolean "reset_password_on_confirmation", default: false
+    t.boolean "force_reset_password_on_confirmation", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_05_095832) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_20_151627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -924,6 +924,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_05_095832) do
     t.datetime "discarded_at"
     t.string "phone_extension"
     t.datetime "values_updated_at"
+    t.boolean "reset_password_on_confirmation", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true


### PR DESCRIPTION
closes [CLDC-4330](https://mhclgdigital.atlassian.net/browse/CLDC-4330)

rather than piggybacking on existing devise properties, use our own flag

this will handle users reset under the old system and the new system

[CLDC-4330]: https://mhclgdigital.atlassian.net/browse/CLDC-4330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ