### PR TITLE
CLDC-4432: Skip invalid field errors if the question is not routed to

### DIFF
--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -1037,7 +1037,7 @@ private
     invalid_fields.each do |field|
       # ensure questions not routed to are not included in error report
       error_questions_ids = field_mapping_for_errors
-                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .select { |_k, fields| fields.map(&:to_s).include?(field.to_s) }
                               .keys
                               .map(&:to_s)
       error_questions = questions.select { |question| error_questions_ids.include?(question.id) }

--- a/app/services/bulk_upload/lettings/year2025/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2025/row_parser.rb
@@ -1035,6 +1035,14 @@ private
 
   def add_errors_for_invalid_fields
     invalid_fields.each do |field|
+      # ensure questions not routed to are not included in error report
+      error_questions_ids = field_mapping_for_errors
+                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .keys
+                              .map(&:to_s)
+      error_questions = questions.select { |question| error_questions_ids.include?(question.id) }
+      next if error_questions.none? { |question| question.page.routed_to?(log, nil) }
+
       errors.delete(field) # take precedence over any other errors as this is a BU format issue
       errors.add(field, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: QUESTIONS[field.to_sym]))
     end

--- a/app/services/bulk_upload/lettings/year2026/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2026/row_parser.rb
@@ -1113,6 +1113,14 @@ private
 
   def add_errors_for_invalid_fields
     invalid_fields.each do |field|
+      # ensure questions not routed to are not included in error report
+      error_questions_ids = field_mapping_for_errors
+                       .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                       .keys
+                       .map(&:to_s)
+      error_questions = questions.select { |question| error_questions_ids.include?(question.id) }
+      next if error_questions.none? { |question| question.page.routed_to?(log, nil) }
+
       errors.delete(field) # take precedence over any other errors as this is a BU format issue
       errors.add(field, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: QUESTIONS[field.to_sym]))
     end

--- a/app/services/bulk_upload/lettings/year2026/row_parser.rb
+++ b/app/services/bulk_upload/lettings/year2026/row_parser.rb
@@ -1115,7 +1115,7 @@ private
     invalid_fields.each do |field|
       # ensure questions not routed to are not included in error report
       error_questions_ids = field_mapping_for_errors
-                       .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                       .select { |_k, fields| fields.map(&:to_s).include?(field.to_s) }
                        .keys
                        .map(&:to_s)
       error_questions = questions.select { |question| error_questions_ids.include?(question.id) }

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -689,6 +689,14 @@ private
 
   def add_errors_for_invalid_fields
     invalid_fields.each do |field|
+      # ensure questions not routed to are not included in error report
+      error_questions_ids = field_mapping_for_errors
+                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .keys
+                              .map(&:to_s)
+      error_questions = questions.select { |question| error_questions_ids.include?(question.id) }
+      next if error_questions.none? { |question| question.page.routed_to?(log, nil) }
+
       errors.delete(field) # take precedence over any other errors as this is a BU format issue
       errors.add(field, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: QUESTIONS[field.to_sym]))
     end

--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -691,7 +691,7 @@ private
     invalid_fields.each do |field|
       # ensure questions not routed to are not included in error report
       error_questions_ids = field_mapping_for_errors
-                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .select { |_k, fields| fields.map(&:to_s).include?(field.to_s) }
                               .keys
                               .map(&:to_s)
       error_questions = questions.select { |question| error_questions_ids.include?(question.id) }

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -750,6 +750,14 @@ private
 
   def add_errors_for_invalid_fields
     invalid_fields.each do |field|
+      # ensure questions not routed to are not included in error report
+      error_questions_ids = field_mapping_for_errors
+                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .keys
+                              .map(&:to_s)
+      error_questions = questions.select { |question| error_questions_ids.include?(question.id) }
+      next if error_questions.none? { |question| question.page.routed_to?(log, nil) }
+
       errors.delete(field) # take precedence over any other errors as this is a BU format issue
       errors.add(field, I18n.t("#{ERROR_BASE_KEY}.invalid_option", question: QUESTIONS[field.to_sym]))
     end

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -752,7 +752,7 @@ private
     invalid_fields.each do |field|
       # ensure questions not routed to are not included in error report
       error_questions_ids = field_mapping_for_errors
-                              .select { |_k,  fields| fields.map(&:to_s).include?(field.to_s) }
+                              .select { |_k, fields| fields.map(&:to_s).include?(field.to_s) }
                               .keys
                               .map(&:to_s)
       error_questions = questions.select { |question| error_questions_ids.include?(question.id) }

--- a/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2025/row_parser_spec.rb
@@ -646,9 +646,9 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
         end
 
         describe "invalid fields" do
-          let(:attributes) { setup_section_params.merge({ field_45: 0 }) }
-
           context "when a field has been marked as invalid" do
+            let(:attributes) { setup_section_params.merge({ field_45: 0 }) }
+
             before do
               parser.add_invalid_field("field_45")
             end
@@ -657,6 +657,19 @@ RSpec.describe BulkUpload::Lettings::Year2025::RowParser do
               parser.valid?
               expect(parser.errors[:field_45].size).to eq(1)
               expect(parser.errors[:field_45]).to include(I18n.t("validations.lettings.2025.bulk_upload.invalid_option", question: "What is the lead tenant’s nationality?"))
+            end
+          end
+
+          context "when a field has been marked as invalid but it is not routed to" do
+            let(:attributes) { setup_section_params.merge({ field_117: 2 }) }
+
+            before do
+              parser.add_invalid_field("field_118")
+            end
+
+            it "does not set an error on that field" do
+              parser.valid?
+              expect(parser.errors[:field_118].size).to eq(0)
             end
           end
         end

--- a/spec/services/bulk_upload/lettings/year2026/row_parser_spec.rb
+++ b/spec/services/bulk_upload/lettings/year2026/row_parser_spec.rb
@@ -538,9 +538,9 @@ RSpec.describe BulkUpload::Lettings::Year2026::RowParser do
       end
 
       describe "invalid fields" do
-        let(:attributes) { setup_section_params.merge({ field_46: 0 }) }
-
         context "when a field has been marked as invalid" do
+          let(:attributes) { setup_section_params.merge({ field_46: 0 }) }
+
           before do
             parser.add_invalid_field("field_46")
           end
@@ -549,6 +549,19 @@ RSpec.describe BulkUpload::Lettings::Year2026::RowParser do
             parser.valid?
             expect(parser.errors[:field_46].size).to eq(1)
             expect(parser.errors[:field_46]).to include(match(I18n.t("validations.lettings.2026.bulk_upload.invalid_option", question: "What is the lead tenant’s nationality?")))
+          end
+        end
+
+        context "when a field has been marked as invalid but it is not routed to" do
+          let(:attributes) { setup_section_params.merge({ field_135: 2 }) }
+
+          before do
+            parser.add_invalid_field("field_136")
+          end
+
+          it "does not set an error on that field" do
+            parser.valid?
+            expect(parser.errors[:field_136].size).to eq(0)
           end
         end
       end

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
 
         describe "invalid fields" do
           context "when a field has been marked as invalid" do
+            # field_34 nationality is only shown if field_10 staircasing is no
             let(:attributes) { setup_section_params.merge({ field_10: 2, field_31: 0 }) }
 
             before do

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -338,9 +338,9 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
         end
 
         describe "invalid fields" do
-          let(:attributes) { setup_section_params.merge({ field_31: 0 }) }
-
           context "when a field has been marked as invalid" do
+            let(:attributes) { setup_section_params.merge({ field_10: 2, field_31: 0 }) }
+
             before do
               parser.add_invalid_field("field_31")
             end
@@ -349,6 +349,19 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
               parser.valid?
               expect(parser.errors[:field_31].size).to eq(1)
               expect(parser.errors[:field_31]).to include(match(I18n.t("validations.sales.2025.bulk_upload.invalid_option", question: "What is buyer 1’s nationality?")))
+            end
+          end
+
+          context "when a field has been marked as invalid but it is not routed to" do
+            let(:attributes) { setup_section_params.merge({ field_10: 1, field_31: 0 }) }
+
+            before do
+              parser.add_invalid_field("field_31")
+            end
+
+            it "does not set an error on that field" do
+              parser.valid?
+              expect(parser.errors[:field_31].size).to eq(0)
             end
           end
         end

--- a/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
@@ -344,9 +344,9 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
         end
 
         describe "invalid fields" do
-          let(:attributes) { setup_section_params.merge({ field_34: 0 }) }
-
           context "when a field has been marked as invalid" do
+            let(:attributes) { setup_section_params.merge({ field_10: "2", field_34: 0 }) }
+
             before do
               parser.add_invalid_field("field_34")
             end
@@ -355,6 +355,19 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
               parser.valid?
               expect(parser.errors[:field_34].size).to eq(1)
               expect(parser.errors[:field_34]).to include(match(I18n.t("validations.sales.2026.bulk_upload.invalid_option", question: "What is buyer 1's nationality?")))
+            end
+          end
+
+          context "when a field has been marked as invalid but it is not routed to" do
+            let(:attributes) { setup_section_params.merge({ field_10: "1", field_34: 0 }) }
+
+            before do
+              parser.add_invalid_field("field_34")
+            end
+
+            it "does not set an error on that field" do
+              parser.valid?
+              expect(parser.errors[:field_34].size).to eq(0)
             end
           end
         end

--- a/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
@@ -345,7 +345,8 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
 
         describe "invalid fields" do
           context "when a field has been marked as invalid" do
-            let(:attributes) { setup_section_params.merge({ field_10: "2", field_34: 0 }) }
+            # field_34 nationality is only shown if field_10 staircasing is no
+            let(:attributes) { setup_section_params.merge({ field_10: 2, field_34: 0 }) }
 
             before do
               parser.add_invalid_field("field_34")
@@ -359,7 +360,7 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
           end
 
           context "when a field has been marked as invalid but it is not routed to" do
-            let(:attributes) { setup_section_params.merge({ field_10: "1", field_34: 0 }) }
+            let(:attributes) { setup_section_params.merge({ field_10: 1, field_34: 0 }) }
 
             before do
               parser.add_invalid_field("field_34")


### PR DESCRIPTION
closes [CLDC-4332](https://mhclgdigital.atlassian.net/browse/CLDC-4332)

adds an additional check when adding invalid field errors that at least one question related to that field is routed to

since the BU success depends on the log being marked as complete & not error presence, this should not be a functional change. it should only mean it such that fewer errors are shown on the error report

[CLDC-4332]: https://mhclgdigital.atlassian.net/browse/CLDC-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ