### PR TITLE
CLDC-4436: use liberal parsing for sales log with purchid in quotes

### DIFF
--- a/lib/tasks/log_la_fix.rake
+++ b/lib/tasks/log_la_fix.rake
@@ -79,10 +79,10 @@ namespace :log_la_fix do
     File.readlines(file).each do |line|
       line = line.strip
       if line.start_with?("#lettings#")
-        row = CSV.parse_line(line.delete_prefix("#lettings#"))
+        row = CSV.parse_line(line.delete_prefix("#lettings#"), liberal_parsing: true)
         lettings_csv << row
       elsif line.start_with?("#sales#")
-        row = CSV.parse_line(line.delete_prefix("#sales#"))
+        row = CSV.parse_line(line.delete_prefix("#sales#"), liberal_parsing: true)
         sales_csv << row
       end
     end


### PR DESCRIPTION
Updates the rake task to what was actually run post-release for [CLDC-4436](https://mhclgdigital.atlassian.net/browse/CLDC-4436). 
This change was only required for one log, because its purchaser code contained double quotes. But all the same, we're allowing it as input so the rake task should be able to handle it (just in case anyone runs it again in the future).



[CLDC-4436]: https://mhclgdigital.atlassian.net/browse/CLDC-4436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ