### PR TITLE
CLDC-4234: Allow 'R' as an input for prevten

### DIFF
--- a/app/services/bulk_upload/sales/year2025/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2025/row_parser.rb
@@ -154,6 +154,7 @@ class BulkUpload::Sales::Year2025::RowParser
     :field_52, # Gender identity of person 5
     :field_56, # Gender identity of person 6
 
+    :field_58, # What was buyer 1’s previous tenure?
     :field_64, # What was buyer 2’s previous tenure?
 
     :field_75, # What is the total amount the buyers had in savings before they paid any deposit for the property?
@@ -227,7 +228,7 @@ class BulkUpload::Sales::Year2025::RowParser
   attribute :field_56, :string
   attribute :field_57, :integer
 
-  attribute :field_58, :integer
+  attribute :field_58, :string
   attribute :field_59, :integer
   attribute :field_60, :string
   attribute :field_61, :string
@@ -561,6 +562,15 @@ private
     CASE_INSENSITIVE_FIELDS.each do |field|
       value = send(field)
       send("#{field}=", value.upcase) if value.present?
+    end
+  end
+
+  def prevten
+    case field_58
+    when "R"
+      0
+    else
+      field_58
     end
   end
 
@@ -902,7 +912,7 @@ private
     attributes["savings"] = field_75.to_i if attributes["savingsnk"]&.zero? && field_75&.match(/\A\d+\z/)
     attributes["prevown"] = field_76
 
-    attributes["prevten"] = field_58
+    attributes["prevten"] = prevten
     attributes["prevloc"] = field_62
     attributes["previous_la_known"] = previous_la_known
     attributes["ppcodenk"] = previous_postcode_known
@@ -1283,7 +1293,7 @@ private
   def infer_soctenant_from_prevten_and_prevtenbuy2
     return unless shared_ownership?
 
-    if [1, 2].include?(field_58) || [1, 2].include?(field_64.to_i)
+    if [1, 2].include?(field_58.to_i) || [1, 2].include?(field_64.to_i)
       1
     else
       2

--- a/app/services/bulk_upload/sales/year2026/row_parser.rb
+++ b/app/services/bulk_upload/sales/year2026/row_parser.rb
@@ -169,6 +169,7 @@ class BulkUpload::Sales::Year2026::RowParser
     :field_61, # Person 5's sex, as registered at birth
     :field_67, # Person 6's sex, as registered at birth
 
+    :field_71, # What was buyer 1’s previous tenure?
     :field_77, # What was buyer 2’s previous tenure?
 
     :field_88, # What is the total amount the buyers had in savings before they paid any deposit for the property?
@@ -263,7 +264,7 @@ class BulkUpload::Sales::Year2026::RowParser
   attribute :field_69, :string
   attribute :field_70, :integer
 
-  attribute :field_71, :integer
+  attribute :field_71, :string
   attribute :field_72, :integer
   attribute :field_73, :string
   attribute :field_74, :string
@@ -618,6 +619,15 @@ private
     CASE_INSENSITIVE_FIELDS.each do |field|
       value = send(field)
       send("#{field}=", value.upcase) if value.present?
+    end
+  end
+
+  def prevten
+    case field_71
+    when "R"
+      0
+    else
+      field_71
     end
   end
 
@@ -995,7 +1005,7 @@ private
     attributes["savings"] = field_88.to_i if attributes["savingsnk"]&.zero? && field_88&.match(/\A\d+\z/)
     attributes["prevown"] = field_89
 
-    attributes["prevten"] = field_71
+    attributes["prevten"] = prevten
     attributes["prevloc"] = field_75
     attributes["previous_la_known"] = previous_la_known
     attributes["ppcodenk"] = previous_postcode_known
@@ -1416,7 +1426,7 @@ private
   def infer_soctenant_from_prevten_and_prevtenbuy2
     return unless shared_ownership?
 
-    if [1, 2].include?(field_71) || [1, 2].include?(field_77.to_i)
+    if [1, 2].include?(field_71.to_i) || [1, 2].include?(field_77.to_i)
       1
     else
       2

--- a/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2025/row_parser_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
 
         context "and case insensitive fields are set to lowercase" do
           let(:case_insensitive_fields) { %w[field_29 field_36 field_44 field_48 field_52 field_56] }
-          let(:case_insensitive_integer_fields_with_r_option) { %w[field_28 field_35 field_43 field_47 field_51 field_55 field_64 field_75 field_70 field_72] }
+          let(:case_insensitive_integer_fields_with_r_option) { %w[field_28 field_35 field_43 field_47 field_51 field_55 field_58 field_64 field_75 field_70 field_72] }
           let(:attributes) do
             valid_attributes
               .merge(case_insensitive_fields.each_with_object({}) { |field, h| h[field.to_sym] = valid_attributes[field.to_sym]&.downcase })
@@ -1761,6 +1761,14 @@ RSpec.describe BulkUpload::Sales::Year2025::RowParser do
 
       it "is correctly set" do
         expect(parser.log.buy2living).to be(1)
+      end
+    end
+
+    describe "#prevten" do
+      let(:attributes) { setup_section_params.merge({ field_58: "R" }) }
+
+      it "is correctly set" do
+        expect(parser.log.prevten).to be(0)
       end
     end
 

--- a/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
+++ b/spec/services/bulk_upload/sales/year2026/row_parser_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
 
         context "and case insensitive fields are set to lowercase" do
           let(:case_insensitive_fields) { %w[field_30 field_39 field_49 field_55 field_61 field_67] }
-          let(:case_insensitive_integer_fields_with_r_option) { %w[field_29 field_38 field_48 field_54 field_60 field_66 field_77 field_88 field_83 field_85 field_103 field_107 field_125 field_126 field_133 field_136] }
+          let(:case_insensitive_integer_fields_with_r_option) { %w[field_29 field_38 field_48 field_54 field_60 field_66 field_71 field_77 field_88 field_83 field_85 field_103 field_107 field_125 field_126 field_133 field_136] }
           let(:attributes) do
             valid_attributes
               .merge(case_insensitive_fields.each_with_object({}) { |field, h| h[field.to_sym] = valid_attributes[field.to_sym]&.downcase })
@@ -1823,6 +1823,14 @@ RSpec.describe BulkUpload::Sales::Year2026::RowParser do
 
       it "is correctly set" do
         expect(parser.log.buy2living).to be(1)
+      end
+    end
+
+    describe "#prevten" do
+      let(:attributes) { setup_section_params.merge({ field_71: "R" }) }
+
+      it "is correctly set" do
+        expect(parser.log.prevten).to be(0)
       end
     end
 


### PR DESCRIPTION
closes [CLDC-4234](https://mhclgdigital.atlassian.net/browse/CLDC-4234)

changes field 71 (58 in 2025) to be a string such that it can accept 'R'

then convert back to the don't know option '0' when 'R' is entered

add to case insensitive fields

update tests

[CLDC-4234]: https://mhclgdigital.atlassian.net/browse/CLDC-4234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ