### PR TITLE
CLDC-4395: Fix staircasing sale wording

### DIFF
--- a/config/locales/forms/2024/sales/sale_information.en.yml
+++ b/config/locales/forms/2024/sales/sale_information.en.yml
@@ -57,7 +57,7 @@ en:
               check_answer_label: "Part of a back-to-back staircasing transaction"
               check_answer_prompt: "Tell us if this is part of a back-to-back staircasing transaction"
               hint_text: ""
-              question_text: "Is this transaction part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
+              question_text: "Was this part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
 
           resale:
             page_header: ""

--- a/config/locales/forms/2025/sales/sale_information.en.yml
+++ b/config/locales/forms/2025/sales/sale_information.en.yml
@@ -53,7 +53,7 @@ en:
             check_answer_label: "Part of a back-to-back staircasing transaction"
             check_answer_prompt: "Tell us if this is part of a back-to-back staircasing transaction"
             hint_text: "Back-to-back staircasing transactions are used as a way for shared owners who own less than 100% of their property to sell on the open market. It involves the shared owner purchasing the remaining share from their landlord and immediately selling 100% of the property to a buyer on the open market. The landlord is then reimbursed for the staircasing transaction through the proceeds of sale to the buyer."
-            question_text: "Is this transaction part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
+            question_text: "Was this part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
 
           firststair:
             page_header: ""

--- a/config/locales/forms/2026/sales/sale_information.en.yml
+++ b/config/locales/forms/2026/sales/sale_information.en.yml
@@ -53,7 +53,7 @@ en:
             check_answer_label: "Part of a back-to-back staircasing transaction"
             check_answer_prompt: "Tell us if this is part of a back-to-back staircasing transaction"
             hint_text: "Back-to-back staircasing transactions are used as a way for shared owners who own less than 100% of their property to sell on the open market. It involves the shared owner purchasing the remaining share from their landlord and immediately selling 100% of the property to a buyer on the open market. The landlord is then reimbursed for the staircasing transaction through the proceeds of sale to the buyer."
-            question_text: "Is this transaction part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
+            question_text: "Was this part of a back-to-back staircasing transaction to facilitate sale of the home on the open market?"
 
           firststair:
             page_header: ""


### PR DESCRIPTION
closes [CLDC-4395](https://mhclgdigital.atlassian.net/browse/CLDC-4395)

fixes wording for all years. I'm not 100% if the 2024 wording can show but better to be safe

<img alt="Q100 staircasing back to back" src="https://github.com/user-attachments/assets/5c0c1f2e-2a0b-4c11-a19d-6b99049e678a" />

[CLDC-4395]: https://mhclgdigital.atlassian.net/browse/CLDC-4395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ