### PR TITLE
CLDC-4365: Reduce size of soft validation success box

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -25,6 +25,7 @@ class FormController < ApplicationController
           updated_question = @page.questions.reject { |question| question.check_answer_label.blank? }.first
           updated_question_string = [updated_question&.question_number_string, updated_question&.check_answer_label.to_s.downcase].compact.join(": ")
           flash[:notice] = "You have successfully updated #{updated_question_string}"
+          flash[:notification_banner_two_thirds] = true
         end
 
         update_duplication_tracking

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
       success: true,
       title_heading_level: 3,
       title_id: "flash-notice",
-      role: "alert"
+      role: "alert",
     ) do |notification_banner|
       notification_banner.with_heading(text: flash.notice.html_safe)
       if flash[:notification_banner_body]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,20 @@ module ApplicationHelper
     !request.path.match?(/\/notifications\/\d+$/) && (authenticated_user_has_notifications? || unauthenticated_user_has_notifications?)
   end
 
+  def notification_banner
+    govuk_notification_banner(
+      title_text: "Success",
+      success: true, title_heading_level: 3,
+      title_id: "flash-notice",
+      role: "alert"
+    ) do |notification_banner|
+      notification_banner.with_heading(text: flash.notice.html_safe)
+      if flash[:notification_banner_body]
+        tag.p flash[:notification_banner_body]&.html_safe
+      end
+    end
+  end
+
 private
 
   def paginated_title(title, pagy)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,7 +35,8 @@ module ApplicationHelper
   def notification_banner
     govuk_notification_banner(
       title_text: "Success",
-      success: true, title_heading_level: 3,
+      success: true,
+      title_heading_level: 3,
       title_id: "flash-notice",
       role: "alert"
     ) do |notification_banner|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -120,15 +120,11 @@
 
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <% if flash.notice && !flash.notice.include?("translation missing") %>
-          <% if flash[:notification_banner_two_thirds] %>
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-two-thirds-from-desktop">
-                <%= notification_banner %>
-              </div>
+          <div class="govuk-grid-row">
+            <div class="<%= flash[:notification_banner_two_thirds] ? 'govuk-grid-column-two-thirds-from-desktop' : 'govuk-grid-column-full' %>">
+              <%= notification_banner %>
             </div>
-          <% else %>
-            <%= notification_banner %>
-          <% end %>
+          </div>
         <% end %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -120,17 +120,15 @@
 
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <% if flash.notice && !flash.notice.include?("translation missing") %>
-          <%= govuk_notification_banner(
-            title_text: "Success",
-            success: true, title_heading_level: 3,
-            title_id: "flash-notice",
-            role: "alert"
-          ) do |notification_banner|
-            notification_banner.with_heading(text: flash.notice.html_safe)
-            if flash[:notification_banner_body]
-              tag.p flash[:notification_banner_body]&.html_safe
-            end
-          end %>
+          <% if flash[:notification_banner_two_thirds] %>
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds-from-desktop">
+                <%= notification_banner %>
+              </div>
+            </div>
+          <% else %>
+            <%= notification_banner %>
+          <% end %>
         <% end %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,7 +121,7 @@
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <% if flash.notice && !flash.notice.include?("translation missing") %>
           <div class="govuk-grid-row">
-            <div class="<%= flash[:notification_banner_two_thirds] ? 'govuk-grid-column-two-thirds-from-desktop' : 'govuk-grid-column-full' %>">
+            <div class="<%= flash[:notification_banner_two_thirds] ? "govuk-grid-column-two-thirds-from-desktop" : "govuk-grid-column-full" %>">
               <%= notification_banner %>
             </div>
           </div>


### PR DESCRIPTION
closes [CLDC-4365](https://mhclgdigital.atlassian.net/browse/CLDC-4365)

adds an option to make the notification be two thirds in desired cases

don't want this to be universal as not all pages are two thirds

<img alt="pregnancy soft validation with two thirds success message" src="https://github.com/user-attachments/assets/af704b82-70b7-4886-8c38-c040b271a89f" />

I'm happy enough leaving this as the only fix for now. there are other two third pages we could touch but none with such an obvious two thirds box. don't think it'd be worth the time to research further

[CLDC-4365]: https://mhclgdigital.atlassian.net/browse/CLDC-4365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ