### PR TITLE
CLDC-4473: Add pipeline steps for SBOM tracking and upload

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "dependency-track@skillwire": true
+  }
+}

--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -20,3 +20,12 @@ jobs:
       release_tag: ${{ needs.test.outputs.releasetag }}
     permissions:
       id-token: write
+
+  sbom:
+    name: Upload SBOM
+    needs: [aws_deploy]
+    uses: ./.github/workflows/upload-sbom.yml
+    with:
+      projectversion: prod
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}

--- a/.github/workflows/production_pipeline.yml
+++ b/.github/workflows/production_pipeline.yml
@@ -24,6 +24,8 @@ jobs:
   sbom:
     name: Upload SBOM
     needs: [aws_deploy]
+    permissions:
+      contents: read
     uses: ./.github/workflows/upload-sbom.yml
     with:
       projectversion: prod

--- a/.github/workflows/staging_pipeline.yml
+++ b/.github/workflows/staging_pipeline.yml
@@ -32,6 +32,15 @@ jobs:
     permissions:
       id-token: write
 
+  sbom:
+    name: Upload SBOM
+    needs: [aws_deploy]
+    uses: ./.github/workflows/upload-sbom.yml
+    with:
+      projectversion: staging
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+
   performance:
     needs: [aws_deploy]
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-sbom.yml
+++ b/.github/workflows/upload-sbom.yml
@@ -15,6 +15,9 @@ on:
       DTRACK_API_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   sbom:
     name: Generate and upload SBOM

--- a/.github/workflows/upload-sbom.yml
+++ b/.github/workflows/upload-sbom.yml
@@ -1,0 +1,49 @@
+name: Upload SBOM
+
+# Generates a CycloneDX SBOM with Syft (auto-detects both the Ruby gems in
+# Gemfile.lock and the Node packages in yarn.lock) and uploads it to
+# Dependency-Track. Called from the staging and production pipelines after a
+# successful deploy.
+
+on:
+  workflow_call:
+    inputs:
+      projectversion:
+        required: true
+        type: string
+    secrets:
+      DTRACK_API_KEY:
+        required: true
+
+jobs:
+  sbom:
+    name: Generate and upload SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          echo "SYFT_VERSION=v1.45.0" >> "$GITHUB_ENV"
+          echo "SYFT_SCRIPT_SHA=9673f867e50398b5d25ec97ff051a451c46d262c" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/syft
+          key: syft-${{ env.SYFT_VERSION }}
+
+      - name: Install Syft
+        run: |
+          [ -f /usr/local/bin/syft ] || \
+            curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_SCRIPT_SHA}/install.sh" | sh -s -- -b /usr/local/bin "$SYFT_VERSION"
+
+      - run: syft . -o cyclonedx-xml=bom.xml
+
+      - uses: DependencyTrack/gh-upload-sbom@v3
+        with:
+          serverhostname: api-deps.softwire.com
+          apikey: ${{ secrets.DTRACK_API_KEY }}
+          autocreate: true
+          projectname: CORE
+          projectversion: ${{ inputs.projectversion }}
+          parentname: Support
+          bomfilename: bom.xml


### PR DESCRIPTION
Closes [CLDC-4473](https://mhclgdigital.atlassian.net/browse/CLDC-4473).

Adds a CI pipeline step for SBOM tracking and upload to https://deps.softwire.com

Summary from our claude skill that generated this:
```
Changes

  New file — .github/workflows/upload-sbom.yml (reusable workflow)
  - Generates a CycloneDX SBOM with Syft v1.45.0 (install script pinned to commit 9673f867…), which auto-detects both Gemfile.lock (Ruby) and yarn.lock (Node) in one scan.
  - Uploads to api-deps.softwire.com with projectname: CORE, parentname: Support, autocreate: true, and the projectversion passed in by the caller.
  - Syft binary is cached by version.
  
  staging_pipeline.yml — added sbom job: needs: [aws_deploy], projectversion: staging.

  production_pipeline.yml — added sbom job: needs: [aws_deploy], projectversion: prod.

  Each runs only after its deploy succeeds, so SBOMs aren't uploaded on PR branches or failed deploys.                                                                                       
```

[CLDC-4473]: https://mhclgdigital.atlassian.net/browse/CLDC-4473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ